### PR TITLE
Fix #4: support bumpversion with .bumpversion.cfg

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,6 @@
+[bumpversion]
+current_version = 8.10.0
+commit = True
+tag = True
+
+[bumpversion:file:kiwi/version.py]


### PR DESCRIPTION
Add configuration file for [bumpversion](https://pypi.python.org/pypi/bumpversion). Currently, only `kiwi/version.py` is bumped, I couldn't find other version strings.

When bumping, the configuration creates automatically a commit and tag. If you don't like that, change the keywords `commit` or `tag` to `False`.

If you would like to add more files, this is not a problem: amend the config file if necessary. The library provides an extensive setup.