### PR TITLE
Use "next generation" string

### DIFF
--- a/kiwi/cli.py
+++ b/kiwi/cli.py
@@ -65,7 +65,7 @@ class Cli(object):
     def __init__(self):
         self.all_args = docopt(
             __doc__,
-            version='kiwi version ' + __version__,
+            version='KIWI (next generation) version ' + __version__,
             options_first=True
         )
         self.command_args = self.all_args['<args>']


### PR DESCRIPTION
This is something really minor, but I think it's a (small) improvement of usability.

To distinguish between old and new KIWI, I would suggest to add a decent version string which advertise the new KIWI correctly (I've used "next generation" as it is consistent with the README). Especially if you have the old and new version on one system.
