### PR TITLE
Fix Codesmells

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,12 @@ kiwi/schema/kiwi.revision
 __pycache__/
 *.py[cod]
 
+# Backup files
+*~
+*.kate-swp
+*.~
+
+
 # C extensions
 *.so
 

--- a/kiwi/bootloader_config_base.py
+++ b/kiwi/bootloader_config_base.py
@@ -245,6 +245,6 @@ class BootLoaderConfigBase(object):
                 return 'root=UUID=%s' % format(uuid)
             else:
                 log.warning(
-                    '%s firmware needs a root device but no uuid was given' %
+                    '%s firmware needs a root device but no uuid was given',
                     firmware
                 )

--- a/kiwi/bootloader_config_zipl.py
+++ b/kiwi/bootloader_config_zipl.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
-import os
+
 import platform
 import re
 
@@ -159,7 +159,7 @@ class BootLoaderConfigZipl(BootLoaderConfigBase):
             fdasd_output = fdasd_call.output
             try:
                 start_track = int(fdasd_output.split(' ')[2].lstrip())
-            except Exception as e:
+            except Exception:
                 raise KiwiDiskGeometryError(
                     'unknown partition format: %s' % fdasd_output
                 )
@@ -208,7 +208,7 @@ class BootLoaderConfigZipl(BootLoaderConfigBase):
         fdasd_output = fdasd_call.output
         try:
             return int(fdasd_output.split(':')[1].lstrip())
-        except Exception as e:
+        except Exception:
             raise KiwiDiskGeometryError(
                 'unknown format for disk geometry: %s' % fdasd_output
             )

--- a/kiwi/container_image_docker.py
+++ b/kiwi/container_image_docker.py
@@ -16,7 +16,6 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 # project
-from .command import Command
 from .archive_tar import ArchiveTar
 
 

--- a/kiwi/container_setup_base.py
+++ b/kiwi/container_setup_base.py
@@ -58,7 +58,7 @@ class ContainerSetupBase(object):
             initialize an empty fstab file, mount processes in a
             container are controlled by the container infrastructure
         """
-        with open(self.root_dir + '/etc/fstab', 'w') as fstab:
+        with open(self.root_dir + '/etc/fstab', 'w'):
             pass
 
     def deactivate_bootloader_setup(self):
@@ -116,7 +116,7 @@ class ContainerSetupBase(object):
         """
         securetty = self.root_dir + '/etc/securetty'
         if not os.path.exists(securetty):
-            with open(securetty, 'w') as empty_securetty:
+            with open(securetty, 'w'):
                 pass
         self.__update_config(
             securetty,

--- a/kiwi/container_setup_docker.py
+++ b/kiwi/container_setup_docker.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
-import os
 
 # project
 from .path import Path

--- a/kiwi/disk_format_vmdk.py
+++ b/kiwi/disk_format_vmdk.py
@@ -59,7 +59,7 @@ class DiskFormatVmdk(DiskFormatBase):
         vmdk_vmtoolsd = self.root_dir + '/usr/bin/vmtoolsd'
         if not os.path.exists(vmdk_vmtoolsd):
             log.warning(
-                'Could not find vmtoolsd in image root %s' % self.root_dir
+                'Could not find vmtoolsd in image root %s', self.root_dir
             )
             log.warning(
                 'Update of VMDK metadata skipped'

--- a/kiwi/install_image_builder.py
+++ b/kiwi/install_image_builder.py
@@ -16,7 +16,6 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 from tempfile import mkdtemp
-import os
 import platform
 
 # project

--- a/kiwi/iso.py
+++ b/kiwi/iso.py
@@ -335,7 +335,7 @@ class Iso(object):
                 boot_catalog = Iso.__read_iso_sector(
                     boot_catalog_sector, iso
                 )
-            except Exception as e:
+            except Exception:
                 # validation happens in __validate_iso_metadata
                 boot_catalog = None
 

--- a/kiwi/luks_device.py
+++ b/kiwi/luks_device.py
@@ -77,7 +77,7 @@ class LuksDevice(DeviceProvider):
                     'no custom option configuration found for OS %s' % os
                 )
         storage_device = self.storage_provider.get_device()
-        log.info('Creating crypto LUKS on %s' % storage_device)
+        log.info('Creating crypto LUKS on %s', storage_device)
         log.info('--> Randomizing...')
         storage_size_mbytes = self.storage_provider.get_byte_size(
             storage_device

--- a/kiwi/repository_yum.py
+++ b/kiwi/repository_yum.py
@@ -23,10 +23,6 @@ from tempfile import NamedTemporaryFile
 from .repository_base import RepositoryBase
 from .path import Path
 
-from .exceptions import (
-    KiwiRepoTypeUnknown
-)
-
 
 class RepositoryYum(RepositoryBase):
     """


### PR DESCRIPTION
Fixing code smells from Landscape.io:

https://landscape.io/github/SUSE/kiwi/161/messages/smell

## Fixed issues
* Unused imports
* Unused variables
* Specify string format arguments as logging function parameters;
  good for lazy evaluation: `log.warning("%s bla" % x)` -> `log.warning("%s bla", x)`

## Issues which were not fixed
* complexity
* Arguments in function not used

## Bonus
Additionally, enhanced `.gitignore` to ignore backup files.
