### PR TITLE
Tox spell fix

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -13,10 +13,10 @@ extensions = [
 ]
 
 
-spelling_lang='en_US'
+spelling_lang = 'en_US'
 spelling_show_suggestions = True
 spelling_ignore_pypi_package_names = True
-spelling_word_list_filename='spelling_wordlist.txt'
+spelling_word_list_filename = 'spelling_wordlist.txt'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['.templates']

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -16,7 +16,7 @@ extensions = [
 spelling_lang='en_US'
 spelling_show_suggestions = True
 spelling_ignore_pypi_package_names = True
-# spelling_word_list_filename='spelling_wordlist.txt'
+spelling_word_list_filename='spelling_wordlist.txt'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['.templates']

--- a/doc/source/spelling_wordlist.txt
+++ b/doc/source/spelling_wordlist.txt
@@ -1,7 +1,29 @@
+# Spellchecking Wordlist
+# NOTE: Do NOT add empty lines!
+#
+# Sort this file by using (and overwrite the result after line 6):
+# cat doc/source/spelling_wordlist.txt | sed 1,6d | sort
+#
+args
 Buildservice
 chroot
+compat
+config
+dir
+filename
+http
+ibs
+Indices
+iso
 ISO
+opensuse
+pxe
 PXE
+sha
 SHA
+suse
 SUSE
+uniq
+xml
 XML
+xz

--- a/doc/source/spelling_wordlist.txt
+++ b/doc/source/spelling_wordlist.txt
@@ -5,4 +5,3 @@ PXE
 SHA
 SUSE
 XML
-


### PR DESCRIPTION
Avoids the following error message:

```
CRITICAL **: enchant_is_title_case: assertion `word && *word' failed
```

