### PR TITLE
Use tox in .travis.yml, remove .travis.script

### DIFF
--- a/.travis.requirements.txt
+++ b/.travis.requirements.txt
@@ -2,3 +2,4 @@ flake8
 docopt
 coverage
 lxml
+tox

--- a/.travis.script
+++ b/.travis.script
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-flake8 kiwi
-nosetests --with-coverage --cover-erase --cover-package=kiwi --cover-xml --cover-min-percentage=100

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,16 @@
 language: python
 
-python:
-  - "3.4"
+branches:
+    except:
+        - gh-pages
+
+matrix:
+    include:
+        - python: 3.4
+          env: TOXENV=3.4
+        - python: 3.5
+          env: TOXENV=3.5
+
 
 before_install:
     - sudo apt-get update -qq
@@ -9,6 +18,7 @@ before_install:
     - sudo apt-get install -y genisoimage
 
 install:
-  - pip install -r .travis.requirements.txt
+    - pip install -r .travis.requirements.txt
 
-script: ./.travis.script
+script:
+    - tox

--- a/tox.ini
+++ b/tox.ini
@@ -16,23 +16,30 @@ skipsdist = True
 envlist =
     check,
     3.4,
+    3.5,
     doc
 
 
 [testenv]
+basepython =
+    3.4: python3.4
+    3.5: python3.5
 whitelist_externals =
     /usr/bin/make
     /bin/bash
 setenv =
     PYTHONPATH={toxinidir}/test
     PYTHONUNBUFFERED=yes
+    WITH_COVERAGE=yes
 passenv =
     *
+usedevelop = True
 deps =
     -r.virtualenv.dev-requirements.txt
 commands =
     make kiwi/schema/kiwi.rng
-    {posargs:nosetests test --debug-log={envdir}/nosetest.log }
+    {posargs:nosetests --with-coverage --cover-min-percentage=100 --cover-erase --cover-package=kiwi}
+
 
 
 [testenv:doc]
@@ -113,12 +120,7 @@ commands =
 
 [testenv:3.4]
 basepython = {env:TOXPYTHON:python3.4}
-deps =
-    {[testenv]deps}
-setenv =
-    {[testenv]setenv}
-    WITH_COVERAGE=yes
-usedevelop = True
-commands =
-    make kiwi/schema/kiwi.rng
-    {posargs:nosetests --with-coverage --cover-min-percentage=100 --cover-erase --cover-package=kiwi}
+
+[testenv:3.5]
+basepython = {env:TOXPYTHON:python3.5}
+


### PR DESCRIPTION
I've "merged" Tox and Travis. That way, you can use tox in Travis.

Changes:

* `.travis.script` is obsolete with this commit as everything is done by tox now
* Support Python 3.5
* Move most of the content from the `testenv:3.4` section into `testenv`; this helps to overwrite the Python interpreter in `testenv:3.4` and `testenv:3.5`. Makes it a snap and easier to add future interpreters.

Not sure if you like it. Feel free to ignore/close it if the former was better for your needs.

TODO:
* Probably we should adapt the file `.travis.requirements.txt` as some requirements are installed both with `pip` and with `tox`.