### PR TITLE
Fix small Tox issues

### DIFF
--- a/.travis.requirements.txt
+++ b/.travis.requirements.txt
@@ -1,5 +1,1 @@
-flake8
-docopt
-coverage
-lxml
 tox

--- a/tox.ini
+++ b/tox.ini
@@ -98,6 +98,7 @@ commands =
 
 
 [testenv:check]
+basepython = {env:TOXPYTHON:python3}
 deps =
     flake8
 skip_install = True
@@ -107,7 +108,7 @@ commands =
 
 
 [testenv:3.4_single]
-basepython = {env:TOXPYTHON:python3.4}
+basepython = {env:TOXPYTHON:python3}
 deps =
     {[testenv]deps}
 setenv =


### PR DESCRIPTION
* `check` target didn't contain a basepython line, creating therefore a Tox error output.
*  Remove unecessary Travis requirements (will be installed by tox anyway).

=> I could reduce total time from appr. 6min to 3min