### PR TITLE
Add handling for OPAL firmware setup on ppc64

### DIFF
--- a/kiwi/firmware.py
+++ b/kiwi/firmware.py
@@ -57,6 +57,11 @@ class FirmWare(object):
                 return 'dasd'
             else:
                 return 'msdos'
+        elif 'ppc64' in self.host_architecture:
+            if self.opal_mode():
+                return 'gpt'
+            else:
+                return 'msdos'
         elif self.efi_mode():
             return 'gpt'
         else:
@@ -84,6 +89,12 @@ class FirmWare(object):
 
     def ofw_mode(self):
         if self.firmware == 'ofw':
+            return True
+        else:
+            return False
+
+    def opal_mode(self):
+        if self.firmware == 'opal':
             return True
         else:
             return False

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -423,3 +423,14 @@ class TestDiskBuilder(object):
         self.disk_builder.image_format = 'vmdk'
         self.disk_builder.create()
         assert mock_log_warn.called
+
+    @patch('kiwi.builder.disk.FileSystem')
+    @patch('builtins.open')
+    @patch('kiwi.builder.disk.Command.run')
+    def test_create_ppc_opal_mode(self, mock_command, mock_open, mock_fs):
+        self.disk_builder.arch = 'ppc64'
+        self.disk_builder.firmware.opal_mode = mock.Mock(
+            return_value=True
+        )
+        self.disk_builder.create()
+        assert self.bootloader_install.install.called is False

--- a/test/unit/firmware_test.py
+++ b/test/unit/firmware_test.py
@@ -33,6 +33,8 @@ class TestFirmWare(object):
         mock_platform.return_value = 'ppc64le'
         xml_state.build_type.get_firmware.return_value = 'ofw'
         self.firmware_ofw = FirmWare(xml_state)
+        xml_state.build_type.get_firmware.return_value = 'opal'
+        self.firmware_opal = FirmWare(xml_state)
 
     @raises(KiwiNotImplementedError)
     def test_firmware_unsupported(self):
@@ -48,7 +50,12 @@ class TestFirmWare(object):
         assert self.firmware_s390_ldl.get_partition_table_type() == 'dasd'
         assert self.firmware_s390_cdl.get_partition_table_type() == 'dasd'
         assert self.firmware_s390_scsi.get_partition_table_type() == 'msdos'
+
+    def test_get_partition_table_type_ppc_ofw_mode(self):
         assert self.firmware_ofw.get_partition_table_type() == 'msdos'
+
+    def test_get_partition_table_type_ppc_opal_mode(self):
+        assert self.firmware_opal.get_partition_table_type() == 'gpt'
 
     def test_legacy_bios_mode(self):
         assert self.firmware_bios.legacy_bios_mode() is False
@@ -68,7 +75,9 @@ class TestFirmWare(object):
 
     def test_ofw_mode(self):
         assert self.firmware_ofw.ofw_mode() is True
-        assert self.firmware_efi.bios_mode() is False
+
+    def test_opal_mode(self):
+        assert self.firmware_opal.opal_mode() is True
 
     def test_get_legacy_bios_partition_size(self):
         assert self.firmware_bios.get_legacy_bios_partition_size() == 0


### PR DESCRIPTION
This adds a capability of creating an image for Bare metal POWER
platform, where firmware parses grub2.cfg and simply kexecs into
an image kernel