### PR TITLE
Added support for hybrid GPT

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -68,6 +68,7 @@ class DiskBuilder(object):
         self.volumes = xml_state.get_volumes()
         self.volume_group_name = xml_state.get_volume_group_name()
         self.mdraid = xml_state.build_type.get_mdraid()
+        self.hybrid_mbr = xml_state.build_type.get_gpt_hybrid_mbr()
         self.luks = xml_state.build_type.get_luks()
         self.luks_os = xml_state.build_type.get_luksOS()
         self.machine = xml_state.get_build_type_machine_section()
@@ -439,6 +440,10 @@ class DiskBuilder(object):
         if self.firmware.ofw_mode():
             log.info('--> setting active flag to primary PReP partition')
             self.disk.activate_boot_partition()
+
+        if self.hybrid_mbr:
+            log.info('--> converting partition table to hybrid GPT/MBR')
+            self.disk.create_hybrid_mbr()
 
         self.disk.map_partitions()
         return self.disk.get_device()

--- a/kiwi/partitioner/base.py
+++ b/kiwi/partitioner/base.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2015 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+
+
+class PartitionerBase(object):
+    """
+        base class for partitioners
+    """
+    def __init__(self, disk_provider):
+        self.disk_device = disk_provider.get_device()
+        self.partition_id = 0
+
+        # initial partition type/flag map
+        self.flag_map = None
+
+        self.post_init()
+
+    def post_init(self):
+        pass
+
+    def get_id(self):
+        return self.partition_id
+
+    def create(self, name, mbsize, type_name, flags=None):
+        raise NotImplementedError
+
+    def set_flag(self, partition_id, flag_name):
+        raise NotImplementedError
+
+    def set_hybrid_mbr(self):
+        raise NotImplementedError

--- a/kiwi/partitioner/dasd.py
+++ b/kiwi/partitioner/dasd.py
@@ -15,20 +15,19 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+from tempfile import NamedTemporaryFile
+
 # project
 from ..command import Command
 from ..logger import log
-from tempfile import NamedTemporaryFile
+from .base import PartitionerBase
 
 
-class PartitionerDasd(object):
+class PartitionerDasd(PartitionerBase):
     """
         implement fdasd partition setup
     """
-    def __init__(self, disk_provider):
-        self.disk_device = disk_provider.get_device()
-        self.partition_id = 0
-
+    def post_init(self):
         # fdasd partition type/flag map
         self.flag_map = {
             'f.active': None,
@@ -38,9 +37,6 @@ class PartitionerDasd(object):
             't.efi': None,
             't.csm': None
         }
-
-    def get_id(self):
-        return self.partition_id
 
     def create(self, name, mbsize, type_name, flags=None):
         self.partition_id += 1
@@ -68,7 +64,3 @@ class PartitionerDasd(object):
             # are not able to detect real errors with the fdasd operation at
             # that point.
             log.debug('potential fdasd errors were ignored')
-
-    def set_flag(self, partition_id, flag_name):
-        # on an s390 dasd device there are no such flags
-        pass

--- a/kiwi/partitioner/msdos.py
+++ b/kiwi/partitioner/msdos.py
@@ -15,24 +15,23 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+from tempfile import NamedTemporaryFile
+
 # project
 from ..command import Command
 from ..logger import log
-from tempfile import NamedTemporaryFile
+from .base import PartitionerBase
 
 from ..exceptions import (
     KiwiPartitionerMsDosFlagError
 )
 
 
-class PartitionerMsDos(object):
+class PartitionerMsDos(PartitionerBase):
     """
         implement old style msdos partition setup
     """
-    def __init__(self, disk_provider):
-        self.disk_device = disk_provider.get_device()
-        self.partition_id = 0
-
+    def post_init(self):
         # sfdisk partition type/flag map
         self.flag_map = {
             'f.active': True,
@@ -43,9 +42,6 @@ class PartitionerMsDos(object):
             't.csm': None,
             't.prep': '41'
         }
-
-    def get_id(self):
-        return self.partition_id
 
     def create(self, name, mbsize, type_name, flags=None):
         self.partition_id += 1

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1737,6 +1737,10 @@ div {
         attribute hybridpersistent_filesystem {
             "btrfs" | "fat" | "exfat" | "ext4" | "xfs"
         }
+    k.type.gpt_hybrid_mbr =
+        ## for gpt disk types only:
+        ## create a hybrid GPT/MBR partition table
+        attribute gpt_hybrid_mbr { xsd:boolean }
     k.type.initrd_system.attribute =
         ## specify which initrd builder to use, default is kiwi's
         ## builtin architecture. Be aware that the dracut initrd
@@ -1852,6 +1856,7 @@ div {
         k.type.hybrid.attribute? &
         k.type.hybridpersistent.attribute? &
         k.type.hybridpersistent_filesystem.attribute? &
+        k.type.gpt_hybrid_mbr? &
         k.type.initrd_system.attribute? &
         k.type.image.attribute &
         k.type.installboot.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2334,6 +2334,13 @@ the btrfs filesystem is used</a:documentation>
         </choice>
       </attribute>
     </define>
+    <define name="k.type.gpt_hybrid_mbr">
+      <attribute name="gpt_hybrid_mbr">
+        <a:documentation>for gpt disk types only:
+create a hybrid GPT/MBR partition table</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+    </define>
     <define name="k.type.initrd_system.attribute">
       <attribute name="initrd_system">
         <a:documentation>specify which initrd builder to use, default is kiwi's
@@ -2566,6 +2573,9 @@ are available on the host. Default timeout is 3 seconds</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.hybridpersistent_filesystem.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.gpt_hybrid_mbr"/>
         </optional>
         <optional>
           <ref name="k.type.initrd_system.attribute"/>

--- a/kiwi/storage/disk.py
+++ b/kiwi/storage/disk.py
@@ -120,6 +120,9 @@ class Disk(DeviceProvider):
         if partition_id:
             self.partitioner.set_flag(partition_id, 'f.active')
 
+    def create_hybrid_mbr(self):
+        self.partitioner.set_hybrid_mbr()
+
     def wipe(self):
         """
             Zap (destroy) any GPT and MBR data structures if present

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Fri Mar 18 11:20:19 2016 by generateDS.py version 2.19b.
+# Generated Fri Mar 18 15:33:01 2016 by generateDS.py version 2.19b.
 #
 # Command line options:
 #   ('-f', '')
@@ -2546,7 +2546,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, checkprebuilt=None, compressed=None, container=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsnocheck=None, fsmountoptions=None, gcelicense=None, hybrid=None, hybridpersistent=None, hybridpersistent_filesystem=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, primary=None, ramonly=None, target_blocksize=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, checkprebuilt=None, compressed=None, container=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsnocheck=None, fsmountoptions=None, gcelicense=None, hybrid=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, primary=None, ramonly=None, target_blocksize=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2575,6 +2575,7 @@ class type_(GeneratedsSuper):
         self.hybrid = _cast(bool, hybrid)
         self.hybridpersistent = _cast(bool, hybridpersistent)
         self.hybridpersistent_filesystem = _cast(None, hybridpersistent_filesystem)
+        self.gpt_hybrid_mbr = _cast(bool, gpt_hybrid_mbr)
         self.initrd_system = _cast(None, initrd_system)
         self.image = _cast(None, image)
         self.installboot = _cast(None, installboot)
@@ -2712,6 +2713,8 @@ class type_(GeneratedsSuper):
     def set_hybridpersistent(self, hybridpersistent): self.hybridpersistent = hybridpersistent
     def get_hybridpersistent_filesystem(self): return self.hybridpersistent_filesystem
     def set_hybridpersistent_filesystem(self, hybridpersistent_filesystem): self.hybridpersistent_filesystem = hybridpersistent_filesystem
+    def get_gpt_hybrid_mbr(self): return self.gpt_hybrid_mbr
+    def set_gpt_hybrid_mbr(self, gpt_hybrid_mbr): self.gpt_hybrid_mbr = gpt_hybrid_mbr
     def get_initrd_system(self): return self.initrd_system
     def set_initrd_system(self, initrd_system): self.initrd_system = initrd_system
     def get_image(self): return self.image
@@ -2860,6 +2863,9 @@ class type_(GeneratedsSuper):
         if self.hybridpersistent_filesystem is not None and 'hybridpersistent_filesystem' not in already_processed:
             already_processed.add('hybridpersistent_filesystem')
             outfile.write(' hybridpersistent_filesystem=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.hybridpersistent_filesystem), input_name='hybridpersistent_filesystem')), ))
+        if self.gpt_hybrid_mbr is not None and 'gpt_hybrid_mbr' not in already_processed:
+            already_processed.add('gpt_hybrid_mbr')
+            outfile.write(' gpt_hybrid_mbr="%s"' % self.gds_format_boolean(self.gpt_hybrid_mbr, input_name='gpt_hybrid_mbr'))
         if self.initrd_system is not None and 'initrd_system' not in already_processed:
             already_processed.add('initrd_system')
             outfile.write(' initrd_system=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.initrd_system), input_name='initrd_system')), ))
@@ -3101,6 +3107,15 @@ class type_(GeneratedsSuper):
             already_processed.add('hybridpersistent_filesystem')
             self.hybridpersistent_filesystem = value
             self.hybridpersistent_filesystem = ' '.join(self.hybridpersistent_filesystem.split())
+        value = find_attr_value_('gpt_hybrid_mbr', node)
+        if value is not None and 'gpt_hybrid_mbr' not in already_processed:
+            already_processed.add('gpt_hybrid_mbr')
+            if value in ('true', '1'):
+                self.gpt_hybrid_mbr = True
+            elif value in ('false', '0'):
+                self.gpt_hybrid_mbr = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
         value = find_attr_value_('initrd_system', node)
         if value is not None and 'initrd_system' not in already_processed:
             already_processed.add('initrd_system')

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -430,6 +430,19 @@ class TestDiskBuilder(object):
     @patch('kiwi.builder.disk.FileSystem')
     @patch('builtins.open')
     @patch('kiwi.builder.disk.Command.run')
+    def test_create_hybrid_gpt_requested(
+        self, mock_command, mock_open, mock_fs
+    ):
+        filesystem = mock.Mock()
+        mock_fs.return_value = filesystem
+        self.disk_builder.install_media = False
+        self.disk_builder.hybrid_mbr = True
+        self.disk_builder.create()
+        self.disk.create_hybrid_mbr.assert_called_once_with()
+
+    @patch('kiwi.builder.disk.FileSystem')
+    @patch('builtins.open')
+    @patch('kiwi.builder.disk.Command.run')
     def test_create_with_image_format(self, mock_command, mock_open, mock_fs):
         filesystem = mock.Mock()
         mock_fs.return_value = filesystem

--- a/test/unit/partitioner_base_test.py
+++ b/test/unit/partitioner_base_test.py
@@ -1,0 +1,33 @@
+
+from mock import patch
+
+import mock
+
+from .test_helper import *
+
+from kiwi.partitioner.base import PartitionerBase
+from kiwi.exceptions import *
+
+
+class TestPartitionerBase(object):
+    def setup(self):
+        disk_provider = mock.Mock()
+        disk_provider.get_device = mock.Mock(
+            return_value='/dev/loop0'
+        )
+        self.partitioner = PartitionerBase(disk_provider)
+
+    def test_get_id(self):
+        assert self.partitioner.get_id() == 0
+
+    @raises(NotImplementedError)
+    def test_create(self):
+        self.partitioner.create('name', 100, 'type', ['flag'])
+
+    @raises(NotImplementedError)
+    def test_set_flag(self):
+        self.partitioner.set_flag(1, 'flag')
+
+    @raises(NotImplementedError)
+    def test_set_hybrid_mbr(self):
+        self.partitioner.set_hybrid_mbr()

--- a/test/unit/partitioner_dasd_test.py
+++ b/test/unit/partitioner_dasd_test.py
@@ -35,9 +35,6 @@ class TestPartitionerDasd(object):
 
         self.partitioner = PartitionerDasd(disk_provider)
 
-    def test_get_id(self):
-        assert self.partitioner.get_id() == 0
-
     @patch('kiwi.partitioner.dasd.Command.run')
     @patch('kiwi.partitioner.dasd.NamedTemporaryFile')
     @patch('builtins.open')
@@ -71,8 +68,3 @@ class TestPartitionerDasd(object):
         self.file_mock.write.assert_called_once_with(
             'n\np\n\n\nw\nq\n'
         )
-
-    def test_set_flag(self):
-        # This is a noop for fdasd, just does nothing but has to
-        # exist to complete the partitioner interface
-        self.partitioner.set_flag('id', 'flag_name')

--- a/test/unit/partitioner_gpt_test.py
+++ b/test/unit/partitioner_gpt_test.py
@@ -17,9 +17,6 @@ class TestPartitionerGpt(object):
         )
         self.partitioner = PartitionerGpt(disk_provider)
 
-    def test_get_id(self):
-        assert self.partitioner.get_id() == 0
-
     @patch('kiwi.partitioner.gpt.Command.run')
     @patch('kiwi.partitioner.gpt.PartitionerGpt.set_flag')
     def test_create(self, mock_flag, mock_command):
@@ -57,3 +54,11 @@ class TestPartitionerGpt(object):
     def test_set_flag_ignored(self, mock_warn):
         self.partitioner.set_flag(1, 'f.active')
         assert mock_warn.called
+
+    @patch('kiwi.partitioner.gpt.Command.run')
+    def test_set_hybrid_mbr(self, mock_command):
+        self.partitioner.partition_id = 3
+        self.partitioner.set_hybrid_mbr()
+        mock_command.assert_called_once_with(
+            ['sgdisk', '-h', '1:2:3', '/dev/loop0']
+        )

--- a/test/unit/partitioner_msdos_test.py
+++ b/test/unit/partitioner_msdos_test.py
@@ -18,9 +18,6 @@ class TestPartitionerMsDos(object):
         )
         self.partitioner = PartitionerMsDos(disk_provider)
 
-    def test_get_id(self):
-        assert self.partitioner.get_id() == 0
-
     @patch('kiwi.partitioner.msdos.Command.run')
     @patch('kiwi.partitioner.msdos.PartitionerMsDos.set_flag')
     @patch('kiwi.partitioner.msdos.NamedTemporaryFile')

--- a/test/unit/storage_disk_test.py
+++ b/test/unit/storage_disk_test.py
@@ -218,3 +218,7 @@ class TestDisk(object):
 
     def test_get_partition_id_map(self):
         assert self.disk.get_partition_id_map() == {}
+
+    def test_create_hybrid_mbr(self):
+        self.disk.create_hybrid_mbr()
+        self.partitioner.set_hybrid_mbr.assert_called_once_with()


### PR DESCRIPTION
Embedding an MBR into a GPT is required for a collection of
boards, e.g arm rapberry PI. The kiwi configuration provides
a new attribute called

    <type ... gpt_hybrid_mbr="true|false"

which allows to control if the GPT should be hybrid or not.
On build procedures which do not create a GPT the attribute
has no effect. This references Issue #17