### PR TITLE
Add Python 3.5 to be consistent with Travis

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ config = {
        'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
        'Operating System :: POSIX :: Linux',
        'Programming Language :: Python :: 3.4',
+       'Programming Language :: Python :: 3.5',
        'Topic :: System :: Operating System',
     ],
 }


### PR DESCRIPTION
Changes proposed in this pull request:
* Just stated the support of 3.5 in the Trove category list to make it consistent with Travis

