### PR TITLE
Integrate version string from placeholder

### DIFF
--- a/doc/source/api/kiwi.rst
+++ b/doc/source/api/kiwi.rst
@@ -1,5 +1,6 @@
-KIWI API Documentation
-======================
+KIWI API Documentation |version|
+================================
+
 
 Subpackages
 -----------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,7 +1,7 @@
 .. kiwi documentation master file
 
-KIWI Appliance Builder
-======================
+KIWI Appliance Builder |version|
+================================
 
 After some coffee, lots of hacking hours and peanuts later, I'm happy to
 introduce this Next Generation KIWI project.

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -5,6 +5,7 @@ KIWI Development Quickstart
 
    This document describes the development process of KIWI,
    an OS appliance builder.
+   This description applies for version |version|.
 
 
 Installation


### PR DESCRIPTION
Changes proposed in this pull request:
*  Use `|version|` placeholder mostly in titles so no bumpversion etc. is needed.

This makes it clear(er) which version is the current version.

If you don't like the version string in titles, I can move them into a separate block.