### PR TITLE
Used :returncode: for sphinxcontrib-programoutput

### DIFF
--- a/doc/source/manual/kiwi.rst
+++ b/doc/source/manual/kiwi.rst
@@ -5,6 +5,7 @@ SYNOPSIS
 --------
 
 .. program-output:: kiwi-ng
+   :returncode: 1
 
 
 DESCRIPTION


### PR DESCRIPTION
Fixes a warning when trying to display output of `kiwi-ng` command.

Changes proposed in this pull request:
* Added `:returncode:` line to avoid failing `kiwi-ng` command.

Fix a warning when calling "kiwi-ng". As the script returns 1, it is considered to have failed by the program-output directive. 

See more info here: https://pythonhosted.org/sphinxcontrib-programoutput/#error-handling