### PR TITLE
Selinux context

### DIFF
--- a/kiwi/boot/image/kiwi.py
+++ b/kiwi/boot/image/kiwi.py
@@ -118,7 +118,7 @@ class BootImageKiwi(BootImageBase):
             # during the process of creating an image but not when the
             # image is actually booting with this initrd
             exclude_from_archive = [
-                '/var/cache', '/image', '/usr/lib/grub2'
+                '/var/cache', '/image', '/usr/lib/grub*'
             ]
             cpio.create(
                 source_dir=self.temp_boot_root_directory,

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -519,15 +519,9 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             )
 
     def __find_grub_data(self, lookup_path):
-        """
-            depending on the distribution grub could be installed below
-            a grub2 or grub directory. Therefore this information needs
-            to be dynamically looked up
-        """
-        for grub_name in ['grub2', 'grub']:
-            grub_path = lookup_path + '/' + grub_name
-            if os.path.exists(grub_path):
-                return grub_path
+        grub_path = Defaults.get_grub_path(lookup_path)
+        if grub_path:
+            return grub_path
 
         raise KiwiBootLoaderGrubDataError(
             'No grub2 installation found in %s' % lookup_path

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -367,6 +367,9 @@ class DiskBuilder(object):
             self.disk.storage_provider
         )
 
+        # set SELinux file security contexts if context exists
+        self.__setup_selinux_file_contexts()
+
         # syncing system data to disk image
         log.info('Syncing system to image')
         if self.system_efi:
@@ -460,6 +463,13 @@ class DiskBuilder(object):
         )
 
         return self.result
+
+    def __setup_selinux_file_contexts(self):
+        security_context = '/etc/selinux/targeted/contexts/files/file_contexts'
+        if os.path.exists(self.root_dir + security_context):
+            self.system_setup.set_selinux_file_contexts(
+                security_context
+            )
 
     def __install_image_requested(self):
         if self.install_iso or self.install_stick or self.install_pxe:

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -15,9 +15,12 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+import os
 from collections import namedtuple
 import platform
 from pkg_resources import resource_filename
+
+# project
 from .version import __githash__
 
 
@@ -221,6 +224,23 @@ class Defaults(object):
             'boot'
         ]
         return modules
+
+    @classmethod
+    def get_grub_path(self, lookup_path):
+        """
+        Depending on the distribution grub could be installed below
+        a grub2 or grub directory. Therefore this information needs
+        to be dynamically looked up
+
+        :param string lookup_path: path name
+
+        :return: grub2 install directory path name
+        :rtype: string
+        """
+        for grub_name in ['grub2', 'grub']:
+            grub_path = lookup_path + '/' + grub_name
+            if os.path.exists(grub_path):
+                return grub_path
 
     @classmethod
     def get_preparer(self):

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -396,6 +396,21 @@ class SystemSetup(object):
             with open(image_id_file, 'w') as identifier:
                 identifier.write('%s\n' % image_id)
 
+    def set_selinux_file_contexts(self, security_context_file):
+        """
+        Initialize the security context fields (extended attributes)
+        on the files matching the security_context_file
+
+        :param string security_context_file: path file name
+        """
+        log.info('Processing SELinux file security contexts')
+        Command.run(
+            [
+                'chroot', self.root_dir,
+                'setfiles', security_context_file, '/', '-v'
+            ]
+        )
+
     def export_modprobe_setup(self, target_root_dir):
         """
         Export etc/modprobe.d to given root_dir

--- a/test/unit/boot_image_kiwi_test.py
+++ b/test/unit/boot_image_kiwi_test.py
@@ -123,6 +123,6 @@ class TestBootImageKiwi(object):
         )
         cpio.create.assert_called_once_with(
             source_dir=self.boot_image.temp_boot_root_directory,
-            exclude=['/var/cache', '/image', '/usr/lib/grub2']
+            exclude=['/var/cache', '/image', '/usr/lib/grub*']
         )
         compress.xz.assert_called_once_with()

--- a/test/unit/bootloader_install_grub2_test.py
+++ b/test/unit/bootloader_install_grub2_test.py
@@ -67,14 +67,27 @@ class TestBootLoaderInstallGrub2(object):
             'root_dir', device_provider, self.custom_args
         )
 
+    @patch('kiwi.bootloader.install.grub2.Defaults.get_grub_path')
     @raises(KiwiBootLoaderGrubInstallError)
-    def test_post_init_ppc_no_prep_device(self):
+    def test_post_init_ppc_no_prep_device(self, mock_grub_path):
         self.bootloader.arch = 'ppc64'
         del self.custom_args['prep_device']
         self.bootloader.install()
 
+    @patch('kiwi.bootloader.install.grub2.Command.run')
+    @patch('kiwi.bootloader.install.grub2.MountManager')
+    @patch('kiwi.bootloader.install.grub2.Defaults.get_grub_path')
+    @raises(KiwiBootLoaderGrubDataError)
+    def test_grub2_bootloader_not_installed(
+        self, mock_grub_path, mock_mount_manager, mock_command
+    ):
+        mock_grub_path.return_value = None
+        self.bootloader.arch = 'x86_64'
+        self.bootloader.install()
+
+    @patch('kiwi.bootloader.install.grub2.Defaults.get_grub_path')
     @raises(KiwiBootLoaderGrubPlatformError)
-    def test_unsupported_platform(self):
+    def test_unsupported_platform(self, mock_grub_path):
         self.bootloader.arch = 'unsupported'
         self.bootloader.install()
 
@@ -109,9 +122,12 @@ class TestBootLoaderInstallGrub2(object):
 
     @patch('kiwi.bootloader.install.grub2.Command.run')
     @patch('kiwi.bootloader.install.grub2.MountManager')
+    @patch('kiwi.bootloader.install.grub2.Defaults.get_grub_path')
     def test_install_with_extra_boot_partition(
-        self, mock_mount_manager, mock_command
+        self, mock_grub_path, mock_mount_manager, mock_command
     ):
+        mock_grub_path.return_value = \
+            self.root_mount.mountpoint + '/usr/lib/grub2'
 
         def side_effect(device, mountpoint=None):
             return self.mount_managers.pop()
@@ -136,9 +152,12 @@ class TestBootLoaderInstallGrub2(object):
 
     @patch('kiwi.bootloader.install.grub2.Command.run')
     @patch('kiwi.bootloader.install.grub2.MountManager')
+    @patch('kiwi.bootloader.install.grub2.Defaults.get_grub_path')
     def test_install_ppc_ieee1275(
-        self, mock_mount_manager, mock_command
+        self, mock_grub_path, mock_mount_manager, mock_command
     ):
+        mock_grub_path.return_value = \
+            self.root_mount.mountpoint + '/usr/lib/grub2'
         self.bootloader.arch = 'ppc64'
 
         def side_effect(device, mountpoint=None):
@@ -164,7 +183,10 @@ class TestBootLoaderInstallGrub2(object):
 
     @patch('kiwi.bootloader.install.grub2.Command.run')
     @patch('kiwi.bootloader.install.grub2.MountManager')
-    def test_install(self, mock_mount_manager, mock_command):
+    @patch('kiwi.bootloader.install.grub2.Defaults.get_grub_path')
+    def test_install(self, mock_grub_path, mock_mount_manager, mock_command):
+        mock_grub_path.return_value = \
+            self.root_mount.mountpoint + '/usr/lib/grub2'
         self.boot_mount.device = self.root_mount.device
 
         def side_effect(device, mountpoint=None):
@@ -188,9 +210,12 @@ class TestBootLoaderInstallGrub2(object):
 
     @patch('kiwi.bootloader.install.grub2.Command.run')
     @patch('kiwi.bootloader.install.grub2.MountManager')
+    @patch('kiwi.bootloader.install.grub2.Defaults.get_grub_path')
     def test_install_secure_boot(
-        self, mock_mount_manager, mock_command
+        self, mock_grub_path, mock_mount_manager, mock_command
     ):
+        mock_grub_path.return_value = \
+            self.root_mount.mountpoint + '/usr/lib/grub2'
         self.firmware.efi_mode.return_value = 'uefi'
         self.boot_mount.device = self.root_mount.device
 
@@ -235,7 +260,8 @@ class TestBootLoaderInstallGrub2(object):
 
     @patch('kiwi.bootloader.install.grub2.Command.run')
     @patch('kiwi.bootloader.install.grub2.MountManager')
-    def test_destructor(self, mock_mount_manager, mock_command):
+    @patch('kiwi.bootloader.install.grub2.Defaults.get_grub_path')
+    def test_destructor(self, mock_grub_path, mock_mount_manager, mock_command):
         self.firmware.efi_mode.return_value = 'uefi'
 
         def side_effect(device, mountpoint=None):

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -191,6 +191,9 @@ class TestDiskBuilder(object):
         self.setup.export_modprobe_setup.assert_called_once_with(
             'boot_dir'
         )
+        self.setup.set_selinux_file_contexts.assert_called_once_with(
+            '/etc/selinux/targeted/contexts/files/file_contexts'
+        )
         self.disk_setup.get_disksize_mbytes.assert_called_once_with()
         self.loop_provider.create.assert_called_once_with()
         self.disk.wipe.assert_called_once_with()

--- a/test/unit/system_setup_test.py
+++ b/test/unit/system_setup_test.py
@@ -639,3 +639,13 @@ class TestSystemSetup(object):
         mock_open.assert_called_once_with(
             'target_dir/some-image.x86_64-1.2.3.verified', 'w'
         )
+
+    @patch('kiwi.system.setup.Command.run')
+    def test_set_selinux_file_contexts(self, mock_command):
+        self.setup.set_selinux_file_contexts('security_context_file')
+        mock_command.assert_called_once_with(
+            [
+                'chroot', 'root_dir',
+                'setfiles', 'security_context_file', '/', '-v'
+            ]
+        )


### PR DESCRIPTION
Added support for SELinux file security contexts
    
Systems using SELinux require the filesystem data to be labeled
according to a security context configuration. kiwi now checks
for the presence of /etc/selinux/targeted/contexts/files/file_contexts
and labels accordingly if it exists. This Fixes #52

