### PR TITLE
Remove kiwi.logger.init() function

### DIFF
--- a/kiwi/kiwi.py
+++ b/kiwi/kiwi.py
@@ -50,7 +50,6 @@ def main():
     backtrace
     """
     docopt.__dict__['extras'] = extras
-    logger.init()
     try:
         App()
     except KiwiError as e:

--- a/kiwi/logger.py
+++ b/kiwi/logger.py
@@ -349,18 +349,15 @@ class Logger(logging.Logger):
         self.console_handlers[handler_type] = handler
 
 
-def init():
-    """
-    Create an application global log instance
+# Create an application global log instance
+#
+# Set the highest log level possible as the default log level
+# in the main Logger class. This is needed to allow any logfile
+# handler to log all messages by default and to allow custom log
+# levels per handler. Our own implementation in Logger::setLogLevel
+# will then set the log level on a handler basis
 
-    Set the highest log level possible as the default log level
-    in the main Logger class. This is needed to allow any logfile
-    handler to log all messages by default and to allow custom log
-    levels per handler. Our own implementation in Logger::setLogLevel
-    will then set the log level on a handler basis
-    """
-    global log
-    logging.setLoggerClass(Logger)
-    log = logging.getLogger("kiwi")
+logging.setLoggerClass(Logger)
+log = logging.getLogger("kiwi")
 
-    log.setLevel(logging.DEBUG)
+log.setLevel(logging.DEBUG)

--- a/test/unit/test_helper.py
+++ b/test/unit/test_helper.py
@@ -3,7 +3,6 @@ from functools import wraps
 import kiwi.logger
 import logging
 
-kiwi.logger.init()
 
 kiwi.logger.log.setLevel(logging.WARN)
 


### PR DESCRIPTION
Changes proposed in this pull request:
* The `init()` function is mostly unneccessary and can be directly created in the `kiwi.logger` module.