### PR TITLE
Add requirements section in Quick Start

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -132,6 +132,7 @@ todo_include_todos = True
 extlinks = {
     'issue': ('https://github.com/SUSE/kiwi/issues/%s', '#'),
     'pr': ('https://github.com/SUSE/kiwi/pull/%s', 'PR #'),
+    'ghkiwi': ('https://github.com/SUSE/kiwi/blob/master/%s', '')
 }
 
 

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -7,6 +7,24 @@ KIWI Development Quick Start
    an OS appliance builder.
    This description applies for version |version|.
 
+Requirements
+------------
+
+KIWI requires the following Python packages to run:
+
+* :mod:`lxml`
+* :mod:`docopt`
+* :mod:`xattr`
+
+Further requirements include header files and compilers:
+
+* XML processing with libxml2 and libxslt (for :mod:`lxml`)
+* Foreign function interface library (libffi48)
+* GCC
+
+For development, KIWI uses the additional packages from
+:ghkiwi:`.virtualenv.dev-requirements.txt`.
+
 
 Installation
 ------------


### PR DESCRIPTION
Changes proposed in this pull request:
* Describe what KIWI needs to run, further requirements, and for development
* Introduce `ghkiwi` as prefix in "extlinks" to shorten external links and
  to make linking to KIWI's GitHub repository more intuitive and consistent.
  For example, the following string is replaced:
  ```
:ghkiwi:`tox.ini` -> https://github.com/SUSE/kiwi/blob/master/tox.ini
```

@schaefi I wasn't sure if there are more requirements than libxml2/libxslt/libffi. Feel free to amend it, if necessary.

I mainly introduced this section to avoid surprises when a user clones this repo and tries to execute the script without knowing some requirements.