### PR TITLE
Improve tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,10 @@ envlist =
 whitelist_externals =
     /usr/bin/make
     /bin/bash
+basepython =
+    {check,doc,doc_travis,doc_travis_deploy}: python3.4
+    {3.4,3.4_single}: python3.4
+    3.5: python3.5
 setenv =
     PYTHONPATH={toxinidir}/test
     PYTHONUNBUFFERED=yes
@@ -38,16 +42,7 @@ commands =
     py.test --no-cov-on-fail --cov=kiwi --cov-report=term-missing --cov-fail-under=100
 
 
-[testenv:3.4]
-basepython = {env:TOXPYTHON:python3.4}
-
-
-[testenv:3.5]
-basepython = {env:TOXPYTHON:python3.5}
-
-
 [testenv:doc]
-basepython = {env:TOXPYTHON:python3.4}
 skip_install = True
 usedevelop = True
 deps =
@@ -66,7 +61,6 @@ commands =
 
 
 [testenv:doc_travis]
-basepython={env:TOXPYTHON:python3.4}
 skip_install = True
 usedevelop = True
 deps =
@@ -82,7 +76,6 @@ commands =
 
 
 [testenv:doc_travis_deploy]
-basepython={env:TOXPYTHON:python3.4}
 skip_install = True
 usedevelop = True
 deps =
@@ -132,7 +125,6 @@ commands =
 
 
 [testenv:check]
-basepython = {env:TOXPYTHON:python3}
 deps =
     flake8
 skip_install = True
@@ -142,7 +134,6 @@ commands =
 
 
 [testenv:3.4_single]
-basepython = {env:TOXPYTHON:python3}
 deps =
     {[testenv]deps}
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,10 @@ basepython =
     {check,doc,doc_travis,doc_travis_deploy}: python3.4
     {3.4,3.4_single}: python3.4
     3.5: python3.5
+# {toxworkdir} defaults to .tox
+envdir =
+    {3.4,3.4_single,check,doc,doc_travis,doc_travis_deploy}: {toxworkdir}/3.4
+    3.5: {toxworkdir}/3.5
 setenv =
     PYTHONPATH={toxinidir}/test
     PYTHONUNBUFFERED=yes


### PR DESCRIPTION
Changes proposed in this pull request:
* Use more compact config for `tox.ini`. Rewrite basepython to make it more compact.
* Reuse env in `tox.ini`. Reuse virtualenv directory with `envdir`. Should speed up things a bit.
