### PR TITLE
Repo setup

### DIFF
--- a/kiwi/repository/yum.py
+++ b/kiwi/repository/yum.py
@@ -115,27 +115,23 @@ class RepositoryYum(RepositoryBase):
         """
         repo_file = self.shared_yum_dir['reposd-dir'] + '/' + name + '.repo'
         self.repo_names.append(name + '.repo')
-        if 'kiwi_iso_mount' in uri:
-            # iso mount point is a tmpdir, thus different each time we build
-            Path.wipe(repo_file)
         if os.path.exists(uri):
             # yum requires local paths to take the file: type
             uri = 'file://' + uri
-        if not os.path.exists(repo_file):
-            repo_config = ConfigParser()
-            repo_config.add_section(name)
+        repo_config = ConfigParser()
+        repo_config.add_section(name)
+        repo_config.set(
+            name, 'name', name
+        )
+        repo_config.set(
+            name, 'baseurl', uri
+        )
+        if prio:
             repo_config.set(
-                name, 'name', name
+                name, 'priority', format(prio)
             )
-            repo_config.set(
-                name, 'baseurl', uri
-            )
-            if prio:
-                repo_config.set(
-                    name, 'priority', format(prio)
-                )
-            with open(repo_file, 'w') as repo:
-                repo_config.write(repo)
+        with open(repo_file, 'w') as repo:
+            repo_config.write(repo)
 
     def delete_repo(self, name):
         """

--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -157,29 +157,31 @@ class RepositoryZypper(RepositoryBase):
         """
         repo_file = self.shared_zypper_dir['reposd-dir'] + '/' + name + '.repo'
         self.repo_names.append(name + '.repo')
-        if 'kiwi_iso_mount' in uri:
-            # iso mount point is a tmpdir, thus different each time we build
+
+        if os.path.exists(repo_file):
             Path.wipe(repo_file)
-        if not os.path.exists(repo_file):
+
+        Command.run(
+            ['zypper'] + self.zypper_args + [
+                '--root', self.root_dir,
+                'addrepo',
+                '--refresh',
+                '--type', self.__translate_repo_type(repo_type),
+                '--keep-packages',
+                '-C',
+                uri,
+                name
+            ],
+            self.command_env
+        )
+        if prio:
             Command.run(
                 ['zypper'] + self.zypper_args + [
                     '--root', self.root_dir,
-                    'addrepo', '-f',
-                    '--type', self.__translate_repo_type(repo_type),
-                    '--keep-packages',
-                    uri,
-                    name
+                    'modifyrepo', '--priority', format(prio), name
                 ],
                 self.command_env
             )
-            if prio:
-                Command.run(
-                    ['zypper'] + self.zypper_args + [
-                        '--root', self.root_dir,
-                        'modifyrepo', '-p', format(prio), name
-                    ],
-                    self.command_env
-                )
 
     def delete_repo(self, name):
         """

--- a/test/unit/repository_yum_test.py
+++ b/test/unit/repository_yum_test.py
@@ -78,23 +78,12 @@ class TestRepositoryYum(object):
     @patch('kiwi.repository.yum.ConfigParser')
     @patch('os.path.exists')
     @patch('builtins.open')
-    @patch('kiwi.repository.yum.Path.wipe')
-    def test_add_repo(self, mock_path, mock_open, mock_exists, mock_config):
+    def test_add_repo(self, mock_open, mock_exists, mock_config):
         repo_config = mock.Mock()
         mock_config.return_value = repo_config
-
-        exists_results = [False, True]
-
-        def side_effect(arg):
-            return exists_results.pop()
-
-        mock_exists.side_effect = side_effect
+        mock_exists.return_value = True
 
         self.repo.add_repo('foo', 'kiwi_iso_mount/uri', 'rpm-md', 42)
-
-        mock_path.assert_called_once_with(
-            '/shared-dir/yum/repos/foo.repo'
-        )
 
         repo_config.add_section.assert_called_once_with('foo')
         assert repo_config.set.call_args_list == [

--- a/test/unit/repository_zypper_test.py
+++ b/test/unit/repository_zypper_test.py
@@ -57,7 +57,7 @@ class TestRepositoryZypper(object):
     @patch('kiwi.repository.zypper.Path.wipe')
     @patch('os.path.exists')
     def test_add_repo(self, mock_exists, mock_wipe, mock_command):
-        mock_exists.return_value = False
+        mock_exists.return_value = True
         self.repo.add_repo('foo', 'kiwi_iso_mount/uri', 'rpm-md', 42)
         mock_wipe.assert_called_once_with(
             '../data/shared-dir/zypper/repos/foo.repo'
@@ -66,9 +66,10 @@ class TestRepositoryZypper(object):
             call(
                 ['zypper'] + self.repo.zypper_args + [
                     '--root', '../data',
-                    'addrepo', '-f',
+                    'addrepo', '--refresh',
                     '--type', 'YUM',
                     '--keep-packages',
+                    '-C',
                     'kiwi_iso_mount/uri',
                     'foo'
                 ], self.repo.command_env
@@ -76,7 +77,7 @@ class TestRepositoryZypper(object):
             call(
                 ['zypper'] + self.repo.zypper_args + [
                     '--root', '../data',
-                    'modifyrepo', '-p', '42', 'foo'
+                    'modifyrepo', '--priority', '42', 'foo'
                 ], self.repo.command_env
             )
         ]


### PR DESCRIPTION
Fixes repo setup for yum and zypper managers

Existing repo files were just re-used however if the repo definition in the XML has changed those changes were not used if a repo of the specified alias or source already existed