### PR TITLE
Overlay disk images

### DIFF
--- a/kiwi/boot/arch/arm/oemboot/suse-linuxrc
+++ b/kiwi/boot/arch/arm/oemboot/suse-linuxrc
@@ -133,29 +133,26 @@ function setupInitialDeviceNames {
     #======================================
     # Probe root filesystem type
     #--------------------------------------
-    probeFileSystem $imageRootDevice
+    fstype=$(probeFileSystem $imageRootDevice)
     #======================================
     # Check for LUKS extension on root fs
     #--------------------------------------
-    if [ "$FSTYPE" = "luks" ];then
+    if [ "$fstype" = "luks" ];then
         luksOpen $imageRootDevice
         imageRootDevice=$luksDeviceOpened
         if [ -e /dev/$kiwi_lvmgroup/LVComp ];then
             imageRODevice=$imageRootDevice
         fi
-        probeFileSystem $imageRootDevice
         export haveLuks=yes
     fi
     #======================================
     # Check for LUKS extension on rw fs
     #--------------------------------------
-    if isFSTypeReadOnly;then
-        FSTYPE_OLD=$FSTYPE
-        probeFileSystem $imageRWDevice
-        if [ "$FSTYPE" = "luks" ];then
+    if [ ! -z "$kiwi_ROPart" ];then
+        fstype=$(probeFileSystem $imageRWDevice)
+        if [ "$fstype" = "luks" ];then
             export haveLuks=yes
         fi
-        FSTYPE=$FSTYPE_OLD
     fi
 }
 
@@ -257,7 +254,7 @@ setupInitialDeviceNames
 #======================================
 # 11) Check for read-only filesystem
 #--------------------------------------
-if isFSTypeReadOnly;then
+if [ ! -z "$kiwi_ROPart" ];then
     setupUnionFS $imageRWDevice $imageRODevice $unionFST
 fi
 
@@ -271,11 +268,11 @@ fi
 #======================================
 # 13) Resize filesystem to full space
 #--------------------------------------
-Echo "Filesystem of OEM system is: $FSTYPE -> $imageRootDevice"
+fstypeRootFS=$(probeFileSystem $imageRootDevice)
+Echo "Filesystem of OEM system is: $fstypeRootFS -> $imageRootDevice"
 if [ "$LOCAL_BOOT" = "no" ];then
     deviceResize=$imageRootDevice
-    fstypeRootFS=$FSTYPE
-    if isFSTypeReadOnly;then
+    if [ ! -z "$kiwi_ROPart" ];then
         deviceResize=$imageIOWRDevice
         KIWI_INITRD_PARAMS="UNIONFS_CONFIG=yes"
         probeFileSystem $deviceResize
@@ -311,7 +308,6 @@ if [ "$LOCAL_BOOT" = "no" ];then
             KIWI_INITRD_PARAMS="$KIWI_INITRD_PARAMS LOCAL_BOOT=yes"
         fi
     fi
-    FSTYPE=$fstypeRootFS
 fi
 
 #======================================
@@ -377,13 +373,13 @@ if [ ! -z "$KIWI_RECOVERY" ];then
         #--------------------------------------
         if [ ! -z "$RESTORE" ];then
             getText "Clean sweep..." > /progress
-            export FSTYPE=$(cat /reco-save/recovery.tar.filesystem)
-            createFilesystem $imageRootDevice "" $(cat /reco-save/root.uuid)
+            fstype=$(cat /reco-save/recovery.tar.filesystem)
+            createFilesystem $imageRootDevice $fstype "" $(cat /reco-save/root.uuid)
             if ! mountSystem $imageRootDevice;then
                 Echo "Failed to mount root filesystem"
                 exit 1
             fi
-            if [ "$FSTYPE" = "btrfs" ];then
+            if [ "$fstype" = "btrfs" ];then
                 if ! restoreBtrfsSubVolumes /mnt;then
                     Echo "Failed to restore btrfs subvolumes"
                     exit 1
@@ -549,8 +545,9 @@ if [ ! -z "$KIWI_RECOVERY" ];then
             imageBootMountP=$(echo $imageBootDevice | cut -f2 -d:)
             imageBootDevice=$(echo $imageBootDevice | cut -f1 -d:)
             rm -rf /mnt/boot
-            probeFileSystem $imageBootDevice
-            createFilesystem $imageBootDevice "" $(cat /reco-save/boot.uuid)
+            fstype_boot=$(probeFileSystem $imageBootDevice)
+            createFilesystem \
+                $imageBootDevice $fstype_boot "" $(cat /reco-save/boot.uuid)
             mkdir -p /mnt/$imageBootMountP
             mount $imageBootDevice /mnt/$imageBootMountP
             pushd /mnt/$imageBootMountP >/dev/null

--- a/kiwi/boot/arch/arm/oemboot/suse-linuxrc
+++ b/kiwi/boot/arch/arm/oemboot/suse-linuxrc
@@ -255,7 +255,7 @@ setupInitialDeviceNames
 # 11) Check for read-only filesystem
 #--------------------------------------
 if [ ! -z "$kiwi_ROPart" ];then
-    setupUnionFS $imageRWDevice $imageRODevice $unionFST
+    setupUnionFS $imageRWDevice $imageRODevice overlay
 fi
 
 #======================================

--- a/kiwi/boot/arch/arm/oemboot/suse-repart
+++ b/kiwi/boot/arch/arm/oemboot/suse-repart
@@ -619,7 +619,7 @@ function OEMRepart {
         OEMPartitionInstall
     elif [ ! -z "$haveLVM" ];then
         OEMRepartLVM
-    elif isFSTypeReadOnly;then
+    elif [ ! -z "$kiwi_ROPart" ];then
         OEMRepartSplit
     else
         OEMRepartStandard
@@ -636,14 +636,13 @@ function OEMRepart {
         createLuksMaps
     fi
     #======================================
-    # find fstype for root partition
+    # wait for root device to appear
     #--------------------------------------
     if ! waitForStorageDevice $imageRootDevice &>/dev/null;then
         systemException \
             "Device $imageRootDevice doesn't appear... fatal !" \
         "reboot"
     fi
-    probeFileSystem $imageRootDevice
     #======================================
     # Activate swap space
     #--------------------------------------
@@ -875,7 +874,7 @@ function createLuksMaps {
         export imageRootDevice=$luksDeviceOpened
         luksResize
     fi
-    if isFSTypeReadOnly;then
+    if [ ! -z "$kiwi_ROPart" ];then
         luksOpen $imageIOWRDevice luksReadWrite
         export imageIOWRDevice=$luksDeviceOpened
         export imageRWDevice=$imageIOWRDevice
@@ -918,7 +917,6 @@ function resizeLVMVolumes {
             lvextend -L +${volume_size}M /dev/$kiwi_lvmgroup/$volume_name
         fi
         if [ $? = 0 ];then
-            unset FSTYPE
             resizeFilesystem /dev/$kiwi_lvmgroup/$volume_name
         else
             Echo "Warning: requested size cannot be reached !"

--- a/kiwi/boot/arch/arm/vmxboot/suse-linuxrc
+++ b/kiwi/boot/arch/arm/vmxboot/suse-linuxrc
@@ -192,15 +192,15 @@ fi
 #======================================
 # 10) Get filesystem type
 #--------------------------------------
-probeFileSystem $imageRootDevice
-if [ "$FSTYPE" = "luks" ];then
+fstype=$(probeFileSystem $imageRootDevice)
+if [ "$fstype" = "luks" ];then
     luksOpen $imageRootDevice
     imageRootDevice=$luksDeviceOpened
     imageRODevice=$imageRootDevice
-    probeFileSystem $imageRootDevice
+    fstype=$(probeFileSystem $imageRootDevice)
     export haveLuks=yes
 fi
-if [ "$FSTYPE" = "unknown" ];then
+if [ "$fstype" = "unknown" ];then
     systemException \
         "Couldn't determine filesystem type... abort" \
     "reboot"
@@ -209,8 +209,8 @@ fi
 #======================================
 # 11) Check filesystem
 #--------------------------------------
-Echo "Filesystem of VMX system is: $FSTYPE -> $imageRootDevice"
-if isFSTypeReadOnly;then
+Echo "Filesystem of VMX system is: $fstype -> $imageRootDevice"
+if [ ! -z "$kiwi_ROPart" ];then
     setupUnionFS $imageRWDevice $imageRODevice $unionFST
 fi
 

--- a/kiwi/boot/arch/arm/vmxboot/suse-linuxrc
+++ b/kiwi/boot/arch/arm/vmxboot/suse-linuxrc
@@ -211,7 +211,7 @@ fi
 #--------------------------------------
 Echo "Filesystem of VMX system is: $fstype -> $imageRootDevice"
 if [ ! -z "$kiwi_ROPart" ];then
-    setupUnionFS $imageRWDevice $imageRODevice $unionFST
+    setupUnionFS $imageRWDevice $imageRODevice overlay
 fi
 
 #======================================

--- a/kiwi/boot/arch/ppc/netboot/suse-linuxrc
+++ b/kiwi/boot/arch/ppc/netboot/suse-linuxrc
@@ -972,7 +972,7 @@ if [ $LOCAL_BOOT = "no" ] || [ ! -z "$RELOAD_CONFIG" ];then
             export PXE_KIWI_INITRD=yes
         fi
         if [ ! -z "$UNIONFS_CONFIG" ]; then
-            unionFST=`echo $UNIONFS_CONFIG | cut -d , -f 3`
+            unionFST=$(echo $UNIONFS_CONFIG | cut -d , -f 3)
             UNIONED="UNIONFS_CONFIG=$unionFST"
             KIWI_INITRD_PARAMS="$KIWI_INITRD_PARAMS $UNIONED"
         fi

--- a/kiwi/boot/arch/ppc/netboot/suse-linuxrc
+++ b/kiwi/boot/arch/ppc/netboot/suse-linuxrc
@@ -320,13 +320,12 @@ if [ $LOCAL_BOOT = "no" ] && [ $haveDisk = "1" ];then
         done
         updateNeeded initialize
         if [ "$partOK" = "1" ] ;then
-            probeFileSystem $imageDevice
-            if [ "$FSTYPE" = "luks" ];then
+            fstype=$(probeFileSystem $imageDevice)
+            if [ "$fstype" = "luks" ];then
                 luks_open_can_fail=yes
                 if luksOpen $imageDevice ; then
                     imageDevice=$luksDeviceOpened
                     imageRODevice=$imageDevice
-                    probeFileSystem $imageRootDevice
                     export haveLuks=yes
                 fi
                 unset luks_open_can_fail
@@ -447,7 +446,8 @@ then
     if [ -z "$RAID" ];then
         export imageBootDevice=$(pxeBootDevice)
         if [ ! -z "$imageBootDevice" ];then
-            createFilesystem $imageBootDevice
+            fstype_boot=$(probeFileSystem $imageBootDevice)
+            createFilesystem $imageBootDevice $fstype_boot
         fi
     fi
     runHook postpartition
@@ -648,11 +648,10 @@ else
         fi
         imageRootName="NFSRoot-System"
         systemIntegrity="clean"
-        export FSTYPE=nfs
         if [ ! -z "$UNIONFS_CONFIG" ];then
-            imageRWDevice=`echo $UNIONFS_CONFIG | cut -d , -f 1`
-            imageRODevice=`echo $UNIONFS_CONFIG | cut -d , -f 2`
-            unionFST=`echo $UNIONFS_CONFIG | cut -d , -f 3`
+            imageRWDevice=$(echo $UNIONFS_CONFIG | cut -d , -f 1)
+            imageRODevice=$(echo $UNIONFS_CONFIG | cut -d , -f 2)
+            unionFST=$(echo $UNIONFS_CONFIG | cut -d , -f 3)
             if [ "$unionFST" = "clicfs" ];then
                 systemException "clicfs over NFSROOT is not supported" "reboot"
             fi
@@ -662,7 +661,7 @@ else
     # 15.4) Check for NBD root
     #--------------------------------------
     if [ ! -z "$NBDROOT" ];then
-        unionFST=`echo $UNIONFS_CONFIG | cut -d , -f 3`
+        unionFST=$(echo $UNIONFS_CONFIG | cut -d , -f 3)
         if ! modprobe nbd;then
             systemException "Failed to load network blk device module" "reboot"
         fi
@@ -697,18 +696,18 @@ else
         fi
         waitForBlockDevice $nbdDevice
         if [ ! -b $nbdDevice ];then
-            systemException "Device $nbdDevice doesn't appear" "reboot"
+            systemException "Device $nbdDevice does not appear" "reboot"
         fi
         if [ ! -z "$nbdwriteName" ];then
             waitForBlockDevice $nbdwriteDevice
             if [ ! -b $nbdwriteDevice ];then
-                systemException "Device $nbdwriteDevice doesn't appear" "reboot"
+                systemException "Device $nbdwriteDevice does not appear" "reboot"
             fi
         fi
         if [ ! -z "$nbdswapName" ];then
             waitForBlockDevice $nbdswapDevice
             if [ ! -b $nbdswapDevice ];then
-                systemException "Device $nbdswapDevice doesn't appear" "reboot"
+                systemException "Device $nbdswapDevice does not appear" "reboot"
             fi
         fi
         # /.../
@@ -753,7 +752,9 @@ else
         # ----
         Echo "Mounting NBD root system: $nbdServer [$nbdName] [$nbdDevice]..."
         if ! nbd-client -N $nbdName $nbdServer $nbdDevice -persist;then
-            systemException "Failed to setup $nbdDevice device" "reboot"
+            systemException \
+                "Failed to setup $nbdDevice device" \
+            "reboot"
         fi
         # /.../
         # setup union if basic root filesystem is read-only
@@ -768,9 +769,9 @@ else
     # 15.5) Check for AOE root
     #--------------------------------------
     if [ ! -z "$AOEROOT" ];then
-        aoeRODevice=`echo $AOEROOT | cut -d , -f 1`
-        aoeRWDevice=`echo $AOEROOT | cut -d , -f 2`
-        unionFST=`echo $UNIONFS_CONFIG | cut -d , -f 3`
+        aoeRODevice=$(echo $AOEROOT | cut -d , -f 1)
+        aoeRWDevice=$(echo $AOEROOT | cut -d , -f 2)
+        unionFST=$(echo $UNIONFS_CONFIG | cut -d , -f 3)
         if [ -z "$aoeRWDevice" ] || [ "$aoeRODevice" = "$aoeRWDevice" ];then
             aoeRWDevice=/dev/ram1
         fi
@@ -805,15 +806,15 @@ runHook postdownload
 # 16) Get filesystem type
 #--------------------------------------
 if [ -b $imageRootDevice ];then
-    probeFileSystem $imageRootDevice
-    if [ "$FSTYPE" = "luks" ];then
+    fstype=$(probeFileSystem $imageRootDevice)
+    if [ "$fstype" = "luks" ];then
         luksOpen $imageRootDevice
         imageRootDevice=$luksDeviceOpened
         imageRODevice=$imageRootDevice
-        probeFileSystem $imageRootDevice
+        fstype=$(probeFileSystem $imageRootDevice)
         export haveLuks=yes
     fi
-    if [ "$FSTYPE" = "unknown" ];then
+    if [ "$fstype" = "unknown" ];then
         systemException \
             "Couldn't determine filesystem type... abort" \
         "reboot"
@@ -832,8 +833,8 @@ fi
 #======================================
 # 18) Check filesystem
 #--------------------------------------
-Echo "Filesystem of PXE system is: $FSTYPE -> $imageRootDevice"
-if isFSTypeReadOnly || [ ! -z "$UNIONFS_CONFIG" ]; then
+Echo "Filesystem of PXE system is: $fstype -> $imageRootDevice"
+if [ ! -z "$kiwi_ROPart" ] || [ ! -z "$UNIONFS_CONFIG" ]; then
     if [ ! -z "$imageRWDevice" ] && [ ! -z "$imageRODevice" ];then
         setupUnionFS $imageRWDevice $imageRODevice $unionFST
     fi
@@ -980,12 +981,9 @@ fi
 runHook postconfig
 
 #======================================
-# 21) check filesystem and kernels
+# 21) check kernels
 #--------------------------------------
 if [ $LOCAL_BOOT = "no" ] && [ $systemIntegrity = "clean" ];then
-    if [ "$FSTYPE" != "nfs" ];then
-        probeFileSystem $imageRootDevice
-    fi
     kernelList /mnt
 fi
 

--- a/kiwi/boot/arch/ppc/oemboot/suse-linuxrc
+++ b/kiwi/boot/arch/ppc/oemboot/suse-linuxrc
@@ -255,7 +255,7 @@ setupInitialDeviceNames
 # 11) Check for read-only filesystem
 #--------------------------------------
 if [ ! -z "$kiwi_ROPart" ];then
-    setupUnionFS $imageRWDevice $imageRODevice $unionFST
+    setupUnionFS $imageRWDevice $imageRODevice overlay
 fi
 
 #======================================

--- a/kiwi/boot/arch/ppc/oemboot/suse-linuxrc
+++ b/kiwi/boot/arch/ppc/oemboot/suse-linuxrc
@@ -133,29 +133,26 @@ function setupInitialDeviceNames {
     #======================================
     # Probe root filesystem type
     #--------------------------------------
-    probeFileSystem $imageRootDevice
+    local fstype=$(probeFileSystem $imageRootDevice)
     #======================================
     # Check for LUKS extension on root fs
     #--------------------------------------
-    if [ "$FSTYPE" = "luks" ];then
+    if [ "$fstype" = "luks" ];then
         luksOpen $imageRootDevice
         imageRootDevice=$luksDeviceOpened
         if [ -e /dev/$kiwi_lvmgroup/LVComp ];then
             imageRODevice=$imageRootDevice
         fi
-        probeFileSystem $imageRootDevice
         export haveLuks=yes
     fi
     #======================================
     # Check for LUKS extension on rw fs
     #--------------------------------------
-    if isFSTypeReadOnly;then
-        FSTYPE_OLD=$FSTYPE
-        probeFileSystem $imageRWDevice
-        if [ "$FSTYPE" = "luks" ];then
+    if [ ! -z "$kiwi_ROPart" ];then
+        fstype=$(probeFileSystem $imageRWDevice)
+        if [ "$fstype" = "luks" ];then
             export haveLuks=yes
         fi
-        FSTYPE=$FSTYPE_OLD
     fi
 }
 
@@ -257,7 +254,7 @@ setupInitialDeviceNames
 #======================================
 # 11) Check for read-only filesystem
 #--------------------------------------
-if isFSTypeReadOnly;then
+if [ ! -z "$kiwi_ROPart" ];then
     setupUnionFS $imageRWDevice $imageRODevice $unionFST
 fi
 
@@ -271,14 +268,13 @@ fi
 #======================================
 # 13) Resize filesystem to full space
 #--------------------------------------
-Echo "Filesystem of OEM system is: $FSTYPE -> $imageRootDevice"
+fstypeRootFS=$(probeFileSystem $imageRootDevice)
+Echo "Filesystem of OEM system is: $fstypeRootFS -> $imageRootDevice"
 if [ "$LOCAL_BOOT" = "no" ];then
     deviceResize=$imageRootDevice
-    fstypeRootFS=$FSTYPE
-    if isFSTypeReadOnly;then
+    if [ ! -z "$kiwi_ROPart" ];then
         deviceResize=$imageIOWRDevice
         KIWI_INITRD_PARAMS="UNIONFS_CONFIG=yes"
-        probeFileSystem $deviceResize
         export KIWI_INITRD_PARAMS
     fi
     if [ "$haveLVM" = "yes" ] && [ ! -z "$allFreeVolume" ];then
@@ -311,7 +307,6 @@ if [ "$LOCAL_BOOT" = "no" ];then
             KIWI_INITRD_PARAMS="$KIWI_INITRD_PARAMS LOCAL_BOOT=yes"
         fi
     fi
-    FSTYPE=$fstypeRootFS
 fi
 
 #======================================
@@ -377,13 +372,13 @@ if [ ! -z "$KIWI_RECOVERY" ];then
         #--------------------------------------
         if [ ! -z "$RESTORE" ];then
             getText "Clean sweep..." > /progress
-            export FSTYPE=$(cat /reco-save/recovery.tar.filesystem)
-            createFilesystem $imageRootDevice "" $(cat /reco-save/root.uuid)
+            fstype=$(cat /reco-save/recovery.tar.filesystem)
+            createFilesystem $imageRootDevice $fstype "" $(cat /reco-save/root.uuid)
             if ! mountSystem $imageRootDevice;then
                 Echo "Failed to mount root filesystem"
                 exit 1
             fi
-            if [ "$FSTYPE" = "btrfs" ];then
+            if [ "$fstype" = "btrfs" ];then
                 if ! restoreBtrfsSubVolumes /mnt;then
                     Echo "Failed to restore btrfs subvolumes"
                     exit 1
@@ -549,8 +544,9 @@ if [ ! -z "$KIWI_RECOVERY" ];then
             imageBootMountP=$(echo $imageBootDevice | cut -f2 -d:)
             imageBootDevice=$(echo $imageBootDevice | cut -f1 -d:)
             rm -rf /mnt/boot
-            probeFileSystem $imageBootDevice
-            createFilesystem $imageBootDevice "" $(cat /reco-save/boot.uuid)
+            fstype_boot=$(probeFileSystem $imageBootDevice)
+            createFilesystem \
+                $imageBootDevice $fstype_boot "" $(cat /reco-save/boot.uuid)
             mkdir -p /mnt/$imageBootMountP
             mount $imageBootDevice /mnt/$imageBootMountP
             pushd /mnt/$imageBootMountP >/dev/null

--- a/kiwi/boot/arch/ppc/oemboot/suse-repart
+++ b/kiwi/boot/arch/ppc/oemboot/suse-repart
@@ -619,7 +619,7 @@ function OEMRepart {
         OEMPartitionInstall
     elif [ ! -z "$haveLVM" ];then
         OEMRepartLVM
-    elif isFSTypeReadOnly;then
+    elif [ ! -z "$kiwi_ROPart" ];then
         OEMRepartSplit
     else
         OEMRepartStandard
@@ -636,14 +636,13 @@ function OEMRepart {
         createLuksMaps
     fi
     #======================================
-    # find fstype for root partition
+    # wait for root device to appear
     #--------------------------------------
     if ! waitForStorageDevice $imageRootDevice &>/dev/null;then
         systemException \
             "Device $imageRootDevice doesn't appear... fatal !" \
         "reboot"
     fi
-    probeFileSystem $imageRootDevice
     #======================================
     # Activate swap space
     #--------------------------------------
@@ -871,7 +870,7 @@ function createLuksMaps {
         export imageRootDevice=$luksDeviceOpened
         luksResize
     fi
-    if isFSTypeReadOnly;then
+    if [ ! -z "$kiwi_ROPart" ];then
         luksOpen $imageIOWRDevice luksReadWrite
         export imageIOWRDevice=$luksDeviceOpened
         export imageRWDevice=$imageIOWRDevice
@@ -914,7 +913,6 @@ function resizeLVMVolumes {
             lvextend -L +${volume_size}M /dev/$kiwi_lvmgroup/$volume_name
         fi
         if [ $? = 0 ];then
-            unset FSTYPE
             resizeFilesystem /dev/$kiwi_lvmgroup/$volume_name
         else
             Echo "Warning: requested size cannot be reached !"

--- a/kiwi/boot/arch/ppc/vmxboot/suse-linuxrc
+++ b/kiwi/boot/arch/ppc/vmxboot/suse-linuxrc
@@ -192,15 +192,15 @@ fi
 #======================================
 # 10) Get filesystem type
 #--------------------------------------
-probeFileSystem $imageRootDevice
-if [ "$FSTYPE" = "luks" ];then
+fstype=$(probeFileSystem $imageRootDevice)
+if [ "$fstype" = "luks" ];then
     luksOpen $imageRootDevice
     imageRootDevice=$luksDeviceOpened
     imageRODevice=$imageRootDevice
-    probeFileSystem $imageRootDevice
+    fstype=$(probeFileSystem $imageRootDevice)
     export haveLuks=yes
 fi
-if [ "$FSTYPE" = "unknown" ];then
+if [ "$fstype" = "unknown" ];then
     systemException \
         "Couldn't determine filesystem type... abort" \
     "reboot"
@@ -209,8 +209,8 @@ fi
 #======================================
 # 11) Check filesystem
 #--------------------------------------
-Echo "Filesystem of VMX system is: $FSTYPE -> $imageRootDevice"
-if isFSTypeReadOnly;then
+Echo "Filesystem of VMX system is: $fstype -> $imageRootDevice"
+if [ ! -z "$kiwi_ROPart" ];then
     setupUnionFS $imageRWDevice $imageRODevice $unionFST
 fi
 

--- a/kiwi/boot/arch/ppc/vmxboot/suse-linuxrc
+++ b/kiwi/boot/arch/ppc/vmxboot/suse-linuxrc
@@ -211,7 +211,7 @@ fi
 #--------------------------------------
 Echo "Filesystem of VMX system is: $fstype -> $imageRootDevice"
 if [ ! -z "$kiwi_ROPart" ];then
-    setupUnionFS $imageRWDevice $imageRODevice $unionFST
+    setupUnionFS $imageRWDevice $imageRODevice overlay
 fi
 
 #======================================

--- a/kiwi/boot/arch/s390/netboot/suse-linuxrc
+++ b/kiwi/boot/arch/s390/netboot/suse-linuxrc
@@ -335,13 +335,12 @@ if [ $LOCAL_BOOT = "no" ] && [ $haveDisk = "1" ];then
         done
         updateNeeded initialize
         if [ "$partOK" = "1" ] ;then
-            probeFileSystem $imageDevice
-            if [ "$FSTYPE" = "luks" ];then
+            fstype=$(probeFileSystem $imageDevice)
+            if [ "$fstype" = "luks" ];then
                 luks_open_can_fail=yes
                 if luksOpen $imageDevice ; then
                     imageDevice=$luksDeviceOpened
                     imageRODevice=$imageDevice
-                    probeFileSystem $imageRootDevice
                     export haveLuks=yes
                 fi
                 unset luks_open_can_fail
@@ -414,12 +413,12 @@ then
         #--------------------------------------
         if ! waitForStorageDevice $raidDiskFirst;then
             systemException \
-                "Disk $raidDiskFirst doesn't appear... fatal !" \
+                "Disk $raidDiskFirst does not appear... fatal !" \
             "reboot"
         fi
         if ! waitForStorageDevice $raidDiskSecond;then
             systemException \
-                "Disk $raidDiskSecond doesn't appear... fatal !" \
+                "Disk $raidDiskSecond does not appear... fatal !" \
             "reboot"
         fi
         #======================================
@@ -464,7 +463,8 @@ then
     if [ -z "$RAID" ];then
         export imageBootDevice=$(pxeBootDevice)
         if [ ! -z "$imageBootDevice" ];then
-            createFilesystem $imageBootDevice
+            fstype_boot=$(probeFileSystem $imageBootDevice)
+            createFilesystem $imageBootDevice $fstype_boot
         fi
     fi
     runHook postpartition
@@ -665,11 +665,10 @@ else
         fi
         imageRootName="NFSRoot-System"
         systemIntegrity="clean"
-        export FSTYPE=nfs
         if [ ! -z "$UNIONFS_CONFIG" ];then
-            imageRWDevice=`echo $UNIONFS_CONFIG | cut -d , -f 1`
-            imageRODevice=`echo $UNIONFS_CONFIG | cut -d , -f 2`
-            unionFST=`echo $UNIONFS_CONFIG | cut -d , -f 3`
+            imageRWDevice=$(echo $UNIONFS_CONFIG | cut -d , -f 1)
+            imageRODevice=$(echo $UNIONFS_CONFIG | cut -d , -f 2)
+            unionFST=$(echo $UNIONFS_CONFIG | cut -d , -f 3)
             if [ "$unionFST" = "clicfs" ];then
                 systemException "clicfs over NFSROOT is not supported" "reboot"
             fi
@@ -679,7 +678,7 @@ else
     # 15.4) Check for NBD root
     #--------------------------------------
     if [ ! -z "$NBDROOT" ];then
-        unionFST=`echo $UNIONFS_CONFIG | cut -d , -f 3`
+        unionFST=$(echo $UNIONFS_CONFIG | cut -d , -f 3)
         if ! modprobe nbd;then
             systemException "Failed to load network blk device module" "reboot"
         fi
@@ -714,18 +713,18 @@ else
         fi
         waitForBlockDevice $nbdDevice
         if [ ! -b $nbdDevice ];then
-            systemException "Device $nbdDevice doesn't appear" "reboot"
+            systemException "Device $nbdDevice does not appear" "reboot"
         fi
         if [ ! -z "$nbdwriteName" ];then
             waitForBlockDevice $nbdwriteDevice
             if [ ! -b $nbdwriteDevice ];then
-                systemException "Device $nbdwriteDevice doesn't appear" "reboot"
+                systemException "Device $nbdwriteDevice does not appear" "reboot"
             fi
         fi
         if [ ! -z "$nbdswapName" ];then
             waitForBlockDevice $nbdswapDevice
             if [ ! -b $nbdswapDevice ];then
-                systemException "Device $nbdswapDevice doesn't appear" "reboot"
+                systemException "Device $nbdswapDevice does not appear" "reboot"
             fi
         fi
         # /.../
@@ -770,7 +769,9 @@ else
         # ----
         Echo "Mounting NBD root system: $nbdServer [$nbdName] [$nbdDevice]..."
         if ! nbd-client -N $nbdName $nbdServer $nbdDevice -persist;then
-            systemException "Failed to setup $nbdDevice device" "reboot"
+            systemException \
+                "Failed to setup $nbdDevice device" \
+            "reboot"
         fi
         # /.../
         # setup union if basic root filesystem is read-only
@@ -785,9 +786,9 @@ else
     # 15.5) Check for AOE root
     #--------------------------------------
     if [ ! -z "$AOEROOT" ];then
-        aoeRODevice=`echo $AOEROOT | cut -d , -f 1`
-        aoeRWDevice=`echo $AOEROOT | cut -d , -f 2`
-        unionFST=`echo $UNIONFS_CONFIG | cut -d , -f 3`
+        aoeRODevice=$(echo $AOEROOT | cut -d , -f 1)
+        aoeRWDevice=$(echo $AOEROOT | cut -d , -f 2)
+        unionFST=$(echo $UNIONFS_CONFIG | cut -d , -f 3)
         if [ -z "$aoeRWDevice" ] || [ "$aoeRODevice" = "$aoeRWDevice" ];then
             aoeRWDevice=/dev/ram1
         fi
@@ -796,7 +797,7 @@ else
         fi
         waitForBlockDevice $aoeRODevice
         if [ ! -b $aoeRODevice ];then
-            systemException "Device $aoeRODevice doesn't appear" "reboot"
+            systemException "Device $aoeRODevice does not appear" "reboot"
         fi
         # /.../
         # check ram space, if we don't have more than 62MB
@@ -822,15 +823,15 @@ runHook postdownload
 # 16) Get filesystem type
 #--------------------------------------
 if [ -b $imageRootDevice ];then
-    probeFileSystem $imageRootDevice
-    if [ "$FSTYPE" = "luks" ];then
+    fstype=$(probeFileSystem $imageRootDevice)
+    if [ "$fstype" = "luks" ];then
         luksOpen $imageRootDevice
         imageRootDevice=$luksDeviceOpened
         imageRODevice=$imageRootDevice
-        probeFileSystem $imageRootDevice
+        fstype=$(probeFileSystem $imageRootDevice)
         export haveLuks=yes
     fi
-    if [ "$FSTYPE" = "unknown" ];then
+    if [ "$fstype" = "unknown" ];then
         systemException \
             "Couldn't determine filesystem type... abort" \
         "reboot"
@@ -849,8 +850,8 @@ fi
 #======================================
 # 18) Check filesystem
 #--------------------------------------
-Echo "Filesystem of PXE system is: $FSTYPE -> $imageRootDevice"
-if isFSTypeReadOnly || [ ! -z "$UNIONFS_CONFIG" ]; then
+Echo "Filesystem of PXE system is: $fstype -> $imageRootDevice"
+if [ ! -z "$kiwi_ROPart" ] || [ ! -z "$UNIONFS_CONFIG" ]; then
     if [ ! -z "$imageRWDevice" ] && [ ! -z "$imageRODevice" ];then
         setupUnionFS $imageRWDevice $imageRODevice $unionFST
     fi
@@ -997,12 +998,9 @@ fi
 runHook postconfig
 
 #======================================
-# 21) check filesystem and kernels
+# 21) check kernels
 #--------------------------------------
 if [ $LOCAL_BOOT = "no" ] && [ $systemIntegrity = "clean" ];then
-    if [ "$FSTYPE" != "nfs" ];then
-        probeFileSystem $imageRootDevice
-    fi
     kernelList /mnt
 fi
 

--- a/kiwi/boot/arch/s390/oemboot/suse-linuxrc
+++ b/kiwi/boot/arch/s390/oemboot/suse-linuxrc
@@ -259,7 +259,7 @@ setupInitialDeviceNames
 # 11) Check for read-only filesystem
 #--------------------------------------
 if [ ! -z "$kiwi_ROPart" ];then
-    setupUnionFS $imageRWDevice $imageRODevice $unionFST
+    setupUnionFS $imageRWDevice $imageRODevice overlay
 fi
 
 #======================================

--- a/kiwi/boot/arch/s390/oemboot/suse-linuxrc
+++ b/kiwi/boot/arch/s390/oemboot/suse-linuxrc
@@ -133,29 +133,26 @@ function setupInitialDeviceNames {
     #======================================
     # Probe root filesystem type
     #--------------------------------------
-    probeFileSystem $imageRootDevice
+    fstype=$(probeFileSystem $imageRootDevice)
     #======================================
     # Check for LUKS extension on root fs
     #--------------------------------------
-    if [ "$FSTYPE" = "luks" ];then
+    if [ "$fstype" = "luks" ];then
         luksOpen $imageRootDevice
         imageRootDevice=$luksDeviceOpened
         if [ -e /dev/$kiwi_lvmgroup/LVComp ];then
             imageRODevice=$imageRootDevice
         fi
-        probeFileSystem $imageRootDevice
         export haveLuks=yes
     fi
     #======================================
     # Check for LUKS extension on rw fs
     #--------------------------------------
-    if isFSTypeReadOnly;then
-        FSTYPE_OLD=$FSTYPE
-        probeFileSystem $imageRWDevice
-        if [ "$FSTYPE" = "luks" ];then
+    if [ ! -z "$kiwi_ROPart" ];then
+        fstype=$(probeFileSystem $imageRWDevice)
+        if [ "$fstype" = "luks" ];then
             export haveLuks=yes
         fi
-        FSTYPE=$FSTYPE_OLD
     fi
 }
 
@@ -261,7 +258,7 @@ setupInitialDeviceNames
 #======================================
 # 11) Check for read-only filesystem
 #--------------------------------------
-if isFSTypeReadOnly;then
+if [ ! -z "$kiwi_ROPart" ];then
     setupUnionFS $imageRWDevice $imageRODevice $unionFST
 fi
 
@@ -275,11 +272,11 @@ fi
 #======================================
 # 13) Resize filesystem to full space
 #--------------------------------------
-Echo "Filesystem of OEM system is: $FSTYPE -> $imageRootDevice"
+fstypeRootFS=$(probeFileSystem $imageRootDevice)
+Echo "Filesystem of OEM system is: $fstypeRootFS -> $imageRootDevice"
 if [ "$LOCAL_BOOT" = "no" ];then
     deviceResize=$imageRootDevice
-    fstypeRootFS=$FSTYPE
-    if isFSTypeReadOnly;then
+    if [ ! -z "$kiwi_ROPart" ];then
         deviceResize=$imageIOWRDevice
         KIWI_INITRD_PARAMS="UNIONFS_CONFIG=yes"
         probeFileSystem $deviceResize
@@ -315,7 +312,6 @@ if [ "$LOCAL_BOOT" = "no" ];then
             KIWI_INITRD_PARAMS="$KIWI_INITRD_PARAMS LOCAL_BOOT=yes"
         fi
     fi
-    FSTYPE=$fstypeRootFS
 fi
 
 #======================================
@@ -381,13 +377,13 @@ if [ ! -z "$KIWI_RECOVERY" ];then
         #--------------------------------------
         if [ ! -z "$RESTORE" ];then
             getText "Clean sweep..." > /progress
-            export FSTYPE=$(cat /reco-save/recovery.tar.filesystem)
-            createFilesystem $imageRootDevice "" $(cat /reco-save/root.uuid)
+            fstype=$(cat /reco-save/recovery.tar.filesystem)
+            createFilesystem $imageRootDevice $fstype "" $(cat /reco-save/root.uuid)
             if ! mountSystem $imageRootDevice;then
                 Echo "Failed to mount root filesystem"
                 exit 1
             fi
-            if [ "$FSTYPE" = "btrfs" ];then
+            if [ "$fstype" = "btrfs" ];then
                 if ! restoreBtrfsSubVolumes /mnt;then
                     Echo "Failed to restore btrfs subvolumes"
                     exit 1
@@ -553,8 +549,9 @@ if [ ! -z "$KIWI_RECOVERY" ];then
             imageBootMountP=$(echo $imageBootDevice | cut -f2 -d:)
             imageBootDevice=$(echo $imageBootDevice | cut -f1 -d:)
             rm -rf /mnt/boot
-            probeFileSystem $imageBootDevice
-            createFilesystem $imageBootDevice "" $(cat /reco-save/boot.uuid)
+            fstype_boot=$(probeFileSystem $imageBootDevice)
+            createFilesystem \
+                $imageBootDevice $fstype_boot "" $(cat /reco-save/boot.uuid)
             mkdir -p /mnt/$imageBootMountP
             mount $imageBootDevice /mnt/$imageBootMountP
             pushd /mnt/$imageBootMountP >/dev/null

--- a/kiwi/boot/arch/s390/oemboot/suse-repart
+++ b/kiwi/boot/arch/s390/oemboot/suse-repart
@@ -620,7 +620,7 @@ function OEMRepart {
         OEMPartitionInstall
     elif [ ! -z "$haveLVM" ];then
         OEMRepartLVM
-    elif isFSTypeReadOnly;then
+    elif [ ! -z "$kiwi_ROPart" ];then
         OEMRepartSplit
     else
         OEMRepartStandard
@@ -637,14 +637,13 @@ function OEMRepart {
         createLuksMaps
     fi
     #======================================
-    # find fstype for root partition
+    # wait for root device to appear
     #--------------------------------------
     if ! waitForStorageDevice $imageRootDevice &>/dev/null;then
         systemException \
             "Device $imageRootDevice doesn't appear... fatal !" \
         "reboot"
     fi
-    probeFileSystem $imageRootDevice
     #======================================
     # Activate swap space
     #--------------------------------------
@@ -898,7 +897,7 @@ function createLuksMaps {
         export imageRootDevice=$luksDeviceOpened
         luksResize
     fi
-    if isFSTypeReadOnly;then
+    if [ ! -z "$kiwi_ROPart" ];then
         luksOpen $imageIOWRDevice luksReadWrite
         export imageIOWRDevice=$luksDeviceOpened
         export imageRWDevice=$imageIOWRDevice
@@ -941,7 +940,6 @@ function resizeLVMVolumes {
             lvextend -L +${volume_size}M /dev/$kiwi_lvmgroup/$volume_name
         fi
         if [ $? = 0 ];then
-            unset FSTYPE
             resizeFilesystem /dev/$kiwi_lvmgroup/$volume_name
         else
             Echo "Warning: requested size cannot be reached !"

--- a/kiwi/boot/arch/s390/vmxboot/suse-linuxrc
+++ b/kiwi/boot/arch/s390/vmxboot/suse-linuxrc
@@ -214,8 +214,8 @@ fi
 # 11) Check filesystem
 #--------------------------------------
 Echo "Filesystem of VMX system is: $fstype -> $imageRootDevice"
-if isFSTypeReadOnly $fstype;then
-    setupUnionFS $imageRWDevice $imageRODevice $unionFST
+if [ ! -z "$kiwi_ROPart" ];then
+    setupUnionFS $imageRWDevice $imageRODevice overlay
 fi
 
 #======================================

--- a/kiwi/boot/arch/s390/vmxboot/suse-linuxrc
+++ b/kiwi/boot/arch/s390/vmxboot/suse-linuxrc
@@ -196,15 +196,15 @@ fi
 #======================================
 # 10) Get filesystem type
 #--------------------------------------
-probeFileSystem $imageRootDevice
-if [ "$FSTYPE" = "luks" ];then
+fstype=$(probeFileSystem $imageRootDevice)
+if [ "$fstype" = "luks" ];then
     luksOpen $imageRootDevice
     imageRootDevice=$luksDeviceOpened
     imageRODevice=$imageRootDevice
-    probeFileSystem $imageRootDevice
+    fstype=$(probeFileSystem $imageRootDevice)
     export haveLuks=yes
 fi
-if [ "$FSTYPE" = "unknown" ];then
+if [ "$fstype" = "unknown" ];then
     systemException \
         "Couldn't determine filesystem type... abort" \
     "reboot"
@@ -213,8 +213,8 @@ fi
 #======================================
 # 11) Check filesystem
 #--------------------------------------
-Echo "Filesystem of VMX system is: $FSTYPE -> $imageRootDevice"
-if isFSTypeReadOnly;then
+Echo "Filesystem of VMX system is: $fstype -> $imageRootDevice"
+if isFSTypeReadOnly $fstype;then
     setupUnionFS $imageRWDevice $imageRODevice $unionFST
 fi
 

--- a/kiwi/boot/arch/x86_64/isoboot/rhel-linuxrc
+++ b/kiwi/boot/arch/x86_64/isoboot/rhel-linuxrc
@@ -189,11 +189,10 @@ CDUmount
 # 10) Get filesystem type
 #--------------------------------------
 if [ -z "$UNIONFS_CONFIG" ] && [ -e "$imageDevice" ];then
-    probeFileSystem $imageDevice
-    if [ "$FSTYPE" = "luks" ];then
+    fstype=$(probeFileSystem $imageDevice)
+    if [ "$fstype" = "luks" ];then
         luksOpen $imageDevice
         imageDevice=$luksDeviceOpened
-        probeFileSystem $imageDevice
         export haveLuks=yes
     fi
     resizeFilesystem $imageDevice

--- a/kiwi/boot/arch/x86_64/isoboot/suse-linuxrc
+++ b/kiwi/boot/arch/x86_64/isoboot/suse-linuxrc
@@ -189,11 +189,10 @@ CDUmount
 # 10) Get filesystem type
 #--------------------------------------
 if [ -z "$UNIONFS_CONFIG" ] && [ -e "$imageDevice" ];then
-    probeFileSystem $imageDevice
-    if [ "$FSTYPE" = "luks" ];then
+    fstype=$(probeFileSystem $imageDevice)
+    if [ "$fstype" = "luks" ];then
         luksOpen $imageDevice
         imageDevice=$luksDeviceOpened
-        probeFileSystem $imageDevice
         export haveLuks=yes
     fi
     resizeFilesystem $imageDevice

--- a/kiwi/boot/arch/x86_64/netboot/suse-linuxrc
+++ b/kiwi/boot/arch/x86_64/netboot/suse-linuxrc
@@ -320,13 +320,12 @@ if [ $LOCAL_BOOT = "no" ] && [ $haveDisk = "1" ];then
         done
         updateNeeded initialize
         if [ "$partOK" = "1" ] ;then
-            probeFileSystem $imageDevice
-            if [ "$FSTYPE" = "luks" ];then
+            fstype=$(probeFileSystem $imageDevice)
+            if [ "$fstype" = "luks" ];then
                 luks_open_can_fail=yes
                 if luksOpen $imageDevice ; then
                     imageDevice=$luksDeviceOpened
                     imageRODevice=$imageDevice
-                    probeFileSystem $imageRootDevice
                     export haveLuks=yes
                 fi
                 unset luks_open_can_fail
@@ -398,12 +397,12 @@ then
         #--------------------------------------
         if ! waitForStorageDevice $raidDiskFirst;then
             systemException \
-                "Disk $raidDiskFirst doesn't appear... fatal !" \
+                "Disk $raidDiskFirst does not appear... fatal !" \
             "reboot"
         fi
         if ! waitForStorageDevice $raidDiskSecond;then
             systemException \
-                "Disk $raidDiskSecond doesn't appear... fatal !" \
+                "Disk $raidDiskSecond does not appear... fatal !" \
             "reboot"
         fi
         #======================================
@@ -447,7 +446,8 @@ then
     if [ -z "$RAID" ];then
         export imageBootDevice=$(pxeBootDevice)
         if [ ! -z "$imageBootDevice" ];then
-            createFilesystem $imageBootDevice
+            fstype_boot=$(probeFileSystem $imageBootDevice)
+            createFilesystem $imageBootDevice $fstype_boot
         fi
     fi
     runHook postpartition
@@ -648,11 +648,10 @@ else
         fi
         imageRootName="NFSRoot-System"
         systemIntegrity="clean"
-        export FSTYPE=nfs
         if [ ! -z "$UNIONFS_CONFIG" ];then
-            imageRWDevice=`echo $UNIONFS_CONFIG | cut -d , -f 1`
-            imageRODevice=`echo $UNIONFS_CONFIG | cut -d , -f 2`
-            unionFST=`echo $UNIONFS_CONFIG | cut -d , -f 3`
+            imageRWDevice=$(echo $UNIONFS_CONFIG | cut -d , -f 1)
+            imageRODevice=$(echo $UNIONFS_CONFIG | cut -d , -f 2)
+            unionFST=$(echo $UNIONFS_CONFIG | cut -d , -f 3)
             if [ "$unionFST" = "clicfs" ];then
                 systemException "clicfs over NFSROOT is not supported" "reboot"
             fi
@@ -662,7 +661,7 @@ else
     # 15.4) Check for NBD root
     #--------------------------------------
     if [ ! -z "$NBDROOT" ];then
-        unionFST=`echo $UNIONFS_CONFIG | cut -d , -f 3`
+        unionFST=$(echo $UNIONFS_CONFIG | cut -d , -f 3)
         if ! modprobe nbd;then
             systemException "Failed to load network blk device module" "reboot"
         fi
@@ -697,18 +696,18 @@ else
         fi
         waitForBlockDevice $nbdDevice
         if [ ! -b $nbdDevice ];then
-            systemException "Device $nbdDevice doesn't appear" "reboot"
+            systemException "Device $nbdDevice does not appear" "reboot"
         fi
         if [ ! -z "$nbdwriteName" ];then
             waitForBlockDevice $nbdwriteDevice
             if [ ! -b $nbdwriteDevice ];then
-                systemException "Device $nbdwriteDevice doesn't appear" "reboot"
+                systemException "Device $nbdwriteDevice does not appear" "reboot"
             fi
         fi
         if [ ! -z "$nbdswapName" ];then
             waitForBlockDevice $nbdswapDevice
             if [ ! -b $nbdswapDevice ];then
-                systemException "Device $nbdswapDevice doesn't appear" "reboot"
+                systemException "Device $nbdswapDevice does not appear" "reboot"
             fi
         fi
         # /.../
@@ -753,7 +752,9 @@ else
         # ----
         Echo "Mounting NBD root system: $nbdServer [$nbdName] [$nbdDevice]..."
         if ! nbd-client -N $nbdName $nbdServer $nbdDevice -persist;then
-            systemException "Failed to setup $nbdDevice device" "reboot"
+            systemException \
+                "Failed to setup $nbdDevice device" \
+            "reboot"
         fi
         # /.../
         # setup union if basic root filesystem is read-only
@@ -768,9 +769,9 @@ else
     # 15.5) Check for AOE root
     #--------------------------------------
     if [ ! -z "$AOEROOT" ];then
-        aoeRODevice=`echo $AOEROOT | cut -d , -f 1`
-        aoeRWDevice=`echo $AOEROOT | cut -d , -f 2`
-        unionFST=`echo $UNIONFS_CONFIG | cut -d , -f 3`
+        aoeRODevice=$(echo $AOEROOT | cut -d , -f 1)
+        aoeRWDevice=$(echo $AOEROOT | cut -d , -f 2)
+        unionFST=$(echo $UNIONFS_CONFIG | cut -d , -f 3)
         if [ -z "$aoeRWDevice" ] || [ "$aoeRODevice" = "$aoeRWDevice" ];then
             aoeRWDevice=/dev/ram1
         fi
@@ -779,7 +780,7 @@ else
         fi
         waitForBlockDevice $aoeRODevice
         if [ ! -b $aoeRODevice ];then
-            systemException "Device $aoeRODevice doesn't appear" "reboot"
+            systemException "Device $aoeRODevice does not appear" "reboot"
         fi
         # /.../
         # check ram space, if we don't have more than 62MB
@@ -805,15 +806,15 @@ runHook postdownload
 # 16) Get filesystem type
 #--------------------------------------
 if [ -b $imageRootDevice ];then
-    probeFileSystem $imageRootDevice
-    if [ "$FSTYPE" = "luks" ];then
+    fstype=$(probeFileSystem $imageRootDevice)
+    if [ "$fstype" = "luks" ];then
         luksOpen $imageRootDevice
         imageRootDevice=$luksDeviceOpened
         imageRODevice=$imageRootDevice
-        probeFileSystem $imageRootDevice
+        fstype=$(probeFileSystem $imageRootDevice)
         export haveLuks=yes
     fi
-    if [ "$FSTYPE" = "unknown" ];then
+    if [ "$fstype" = "unknown" ];then
         systemException \
             "Couldn't determine filesystem type... abort" \
         "reboot"
@@ -832,8 +833,8 @@ fi
 #======================================
 # 18) Check filesystem
 #--------------------------------------
-Echo "Filesystem of PXE system is: $FSTYPE -> $imageRootDevice"
-if isFSTypeReadOnly || [ ! -z "$UNIONFS_CONFIG" ]; then
+Echo "Filesystem of PXE system is: $fstype -> $imageRootDevice"
+if [ ! -z "$kiwi_ROPart" ] || [ ! -z "$UNIONFS_CONFIG" ]; then
     if [ ! -z "$imageRWDevice" ] && [ ! -z "$imageRODevice" ];then
         setupUnionFS $imageRWDevice $imageRODevice $unionFST
     fi
@@ -980,12 +981,9 @@ fi
 runHook postconfig
 
 #======================================
-# 21) check filesystem and kernels
+# 21) check kernels
 #--------------------------------------
 if [ $LOCAL_BOOT = "no" ] && [ $systemIntegrity = "clean" ];then
-    if [ "$FSTYPE" != "nfs" ];then
-        probeFileSystem $imageRootDevice
-    fi
     kernelList /mnt
 fi
 

--- a/kiwi/boot/arch/x86_64/oemboot/rhel-linuxrc
+++ b/kiwi/boot/arch/x86_64/oemboot/rhel-linuxrc
@@ -133,29 +133,26 @@ function setupInitialDeviceNames {
     #======================================
     # Probe root filesystem type
     #--------------------------------------
-    probeFileSystem $imageRootDevice
+    fstype=$(probeFileSystem $imageRootDevice)
     #======================================
     # Check for LUKS extension on root fs
     #--------------------------------------
-    if [ "$FSTYPE" = "luks" ];then
+    if [ "$fstype" = "luks" ];then
         luksOpen $imageRootDevice
         imageRootDevice=$luksDeviceOpened
         if [ -e /dev/$kiwi_lvmgroup/LVComp ];then
             imageRODevice=$imageRootDevice
         fi
-        probeFileSystem $imageRootDevice
         export haveLuks=yes
     fi
     #======================================
     # Check for LUKS extension on rw fs
     #--------------------------------------
-    if isFSTypeReadOnly;then
-        FSTYPE_OLD=$FSTYPE
-        probeFileSystem $imageRWDevice
-        if [ "$FSTYPE" = "luks" ];then
+    if [ ! -z "$kiwi_ROPart" ];then
+        fstype=$(probeFileSystem $imageRWDevice)
+        if [ "$fstype" = "luks" ];then
             export haveLuks=yes
         fi
-        FSTYPE=$FSTYPE_OLD
     fi
 }
 
@@ -256,7 +253,7 @@ setupInitialDeviceNames
 #======================================
 # 11) Check for read-only filesystem
 #--------------------------------------
-if isFSTypeReadOnly;then
+if [ ! -z "$kiwi_ROPart" ];then
     setupUnionFS $imageRWDevice $imageRODevice $unionFST
 fi
 
@@ -270,14 +267,13 @@ fi
 #======================================
 # 13) Resize filesystem to full space
 #--------------------------------------
-Echo "Filesystem of OEM system is: $FSTYPE -> $imageRootDevice"
+fstypeRootFS=$(probeFileSystem $imageRootDevice)
+Echo "Filesystem of OEM system is: $fstypeRootFS -> $imageRootDevice"
 if [ "$LOCAL_BOOT" = "no" ];then
     deviceResize=$imageRootDevice
-    fstypeRootFS=$FSTYPE
-    if isFSTypeReadOnly;then
+    if [ ! -z "$kiwi_ROPart" ];then
         deviceResize=$imageIOWRDevice
         KIWI_INITRD_PARAMS="UNIONFS_CONFIG=yes"
-        probeFileSystem $deviceResize
         export KIWI_INITRD_PARAMS
     fi
     if [ "$haveLVM" = "yes" ] && [ ! -z "$allFreeVolume" ];then
@@ -310,7 +306,6 @@ if [ "$LOCAL_BOOT" = "no" ];then
             KIWI_INITRD_PARAMS="$KIWI_INITRD_PARAMS LOCAL_BOOT=yes"
         fi
     fi
-    FSTYPE=$fstypeRootFS
 fi
 
 #======================================
@@ -376,13 +371,13 @@ if [ ! -z "$KIWI_RECOVERY" ];then
         #--------------------------------------
         if [ ! -z "$RESTORE" ];then
             getText "Clean sweep..." > /progress
-            export FSTYPE=$(cat /reco-save/recovery.tar.filesystem)
-            createFilesystem $imageRootDevice "" $(cat /reco-save/root.uuid)
+            fstype=$(cat /reco-save/recovery.tar.filesystem)
+            createFilesystem $imageRootDevice $fstype "" $(cat /reco-save/root.uuid)
             if ! mountSystem $imageRootDevice;then
                 Echo "Failed to mount root filesystem"
                 exit 1
             fi
-            if [ "$FSTYPE" = "btrfs" ];then
+            if [ "$fstype" = "btrfs" ];then
                 if ! restoreBtrfsSubVolumes /mnt;then
                     Echo "Failed to restore btrfs subvolumes"
                     exit 1
@@ -540,8 +535,9 @@ if [ ! -z "$KIWI_RECOVERY" ];then
             imageBootMountP=$(echo $imageBootDevice | cut -f2 -d:)
             imageBootDevice=$(echo $imageBootDevice | cut -f1 -d:)
             rm -rf /mnt/boot
-            probeFileSystem $imageBootDevice
-            createFilesystem $imageBootDevice "" $(cat /reco-save/boot.uuid)
+            fstype_boot=$(probeFileSystem $imageBootDevice)
+            createFilesystem \
+                $imageBootDevice $fstype_boot "" $(cat /reco-save/boot.uuid)
             mkdir -p /mnt/$imageBootMountP
             mount $imageBootDevice /mnt/$imageBootMountP
             pushd /mnt/$imageBootMountP >/dev/null

--- a/kiwi/boot/arch/x86_64/oemboot/rhel-linuxrc
+++ b/kiwi/boot/arch/x86_64/oemboot/rhel-linuxrc
@@ -254,7 +254,7 @@ setupInitialDeviceNames
 # 11) Check for read-only filesystem
 #--------------------------------------
 if [ ! -z "$kiwi_ROPart" ];then
-    setupUnionFS $imageRWDevice $imageRODevice $unionFST
+    setupUnionFS $imageRWDevice $imageRODevice overlay
 fi
 
 #======================================

--- a/kiwi/boot/arch/x86_64/oemboot/rhel-repart
+++ b/kiwi/boot/arch/x86_64/oemboot/rhel-repart
@@ -218,7 +218,7 @@ function OEMRepartStandard {
 #--------------------------------------
 function OEMRepartSplit {
     # /.../
-    # repartition disk for overlay systems with
+    # repartition disk for overlay systems
     # Initial partition table layout is:
     # =====================================
     # pX:   ( boot )
@@ -619,7 +619,7 @@ function OEMRepart {
         OEMPartitionInstall
     elif [ ! -z "$haveLVM" ];then
         OEMRepartLVM
-    elif isFSTypeReadOnly;then
+    elif [ ! -z "$kiwi_ROPart" ];then
         OEMRepartSplit
     else
         OEMRepartStandard
@@ -636,14 +636,13 @@ function OEMRepart {
         createLuksMaps
     fi
     #======================================
-    # find fstype for root partition
+    # wait for root device to appear
     #--------------------------------------
     if ! waitForStorageDevice $imageRootDevice &>/dev/null;then
         systemException \
             "Device $imageRootDevice doesn't appear... fatal !" \
         "reboot"
     fi
-    probeFileSystem $imageRootDevice
     #======================================
     # Activate swap space
     #--------------------------------------
@@ -871,7 +870,7 @@ function createLuksMaps {
         export imageRootDevice=$luksDeviceOpened
         luksResize
     fi
-    if isFSTypeReadOnly;then
+    if [ ! -z "$kiwi_ROPart" ];then
         luksOpen $imageIOWRDevice luksReadWrite
         export imageIOWRDevice=$luksDeviceOpened
         export imageRWDevice=$imageIOWRDevice
@@ -914,7 +913,6 @@ function resizeLVMVolumes {
             lvextend -L +${volume_size}M /dev/$kiwi_lvmgroup/$volume_name
         fi
         if [ $? = 0 ];then
-            unset FSTYPE
             resizeFilesystem /dev/$kiwi_lvmgroup/$volume_name
         else
             Echo "Warning: requested size cannot be reached !"

--- a/kiwi/boot/arch/x86_64/oemboot/suse-linuxrc
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-linuxrc
@@ -133,29 +133,26 @@ function setupInitialDeviceNames {
     #======================================
     # Probe root filesystem type
     #--------------------------------------
-    probeFileSystem $imageRootDevice
+    local fstype=$(probeFileSystem $imageRootDevice)
     #======================================
     # Check for LUKS extension on root fs
     #--------------------------------------
-    if [ "$FSTYPE" = "luks" ];then
+    if [ "$fstype" = "luks" ];then
         luksOpen $imageRootDevice
         imageRootDevice=$luksDeviceOpened
         if [ -e /dev/$kiwi_lvmgroup/LVComp ];then
             imageRODevice=$imageRootDevice
         fi
-        probeFileSystem $imageRootDevice
         export haveLuks=yes
     fi
     #======================================
     # Check for LUKS extension on rw fs
     #--------------------------------------
-    if isFSTypeReadOnly;then
-        FSTYPE_OLD=$FSTYPE
-        probeFileSystem $imageRWDevice
-        if [ "$FSTYPE" = "luks" ];then
+    if [ ! -z "$kiwi_ROPart" ];then
+        fstype=$(probeFileSystem $imageRWDevice)
+        if [ "$fstype" = "luks" ];then
             export haveLuks=yes
         fi
-        FSTYPE=$FSTYPE_OLD
     fi
 }
 
@@ -257,7 +254,7 @@ setupInitialDeviceNames
 #======================================
 # 11) Check for read-only filesystem
 #--------------------------------------
-if isFSTypeReadOnly;then
+if [ ! -z "$kiwi_ROPart" ];then
     setupUnionFS $imageRWDevice $imageRODevice $unionFST
 fi
 
@@ -271,14 +268,13 @@ fi
 #======================================
 # 13) Resize filesystem to full space
 #--------------------------------------
-Echo "Filesystem of OEM system is: $FSTYPE -> $imageRootDevice"
+fstypeRootFS=$(probeFileSystem $imageRootDevice)
+Echo "Filesystem of OEM system is: $fstypeRootFS -> $imageRootDevice"
 if [ "$LOCAL_BOOT" = "no" ];then
     deviceResize=$imageRootDevice
-    fstypeRootFS=$FSTYPE
-    if isFSTypeReadOnly;then
+    if [ ! -z "$kiwi_ROPart" ];then
         deviceResize=$imageIOWRDevice
         KIWI_INITRD_PARAMS="UNIONFS_CONFIG=yes"
-        probeFileSystem $deviceResize
         export KIWI_INITRD_PARAMS
     fi
     if [ "$haveLVM" = "yes" ] && [ ! -z "$allFreeVolume" ];then
@@ -311,7 +307,6 @@ if [ "$LOCAL_BOOT" = "no" ];then
             KIWI_INITRD_PARAMS="$KIWI_INITRD_PARAMS LOCAL_BOOT=yes"
         fi
     fi
-    FSTYPE=$fstypeRootFS
 fi
 
 #======================================
@@ -377,13 +372,13 @@ if [ ! -z "$KIWI_RECOVERY" ];then
         #--------------------------------------
         if [ ! -z "$RESTORE" ];then
             getText "Clean sweep..." > /progress
-            export FSTYPE=$(cat /reco-save/recovery.tar.filesystem)
-            createFilesystem $imageRootDevice "" $(cat /reco-save/root.uuid)
+            fstype=$(cat /reco-save/recovery.tar.filesystem)
+            createFilesystem $imageRootDevice $fstype "" $(cat /reco-save/root.uuid)
             if ! mountSystem $imageRootDevice;then
                 Echo "Failed to mount root filesystem"
                 exit 1
             fi
-            if [ "$FSTYPE" = "btrfs" ];then
+            if [ "$fstype" = "btrfs" ];then
                 if ! restoreBtrfsSubVolumes /mnt;then
                     Echo "Failed to restore btrfs subvolumes"
                     exit 1
@@ -549,8 +544,8 @@ if [ ! -z "$KIWI_RECOVERY" ];then
             imageBootMountP=$(echo $imageBootDevice | cut -f2 -d:)
             imageBootDevice=$(echo $imageBootDevice | cut -f1 -d:)
             rm -rf /mnt/boot
-            probeFileSystem $imageBootDevice
-            createFilesystem $imageBootDevice "" $(cat /reco-save/boot.uuid)
+            fstype=$(probeFileSystem $imageBootDevice)
+            createFilesystem $imageBootDevice $fstype "" $(cat /reco-save/boot.uuid)
             mkdir -p /mnt/$imageBootMountP
             mount $imageBootDevice /mnt/$imageBootMountP
             pushd /mnt/$imageBootMountP >/dev/null

--- a/kiwi/boot/arch/x86_64/oemboot/suse-linuxrc
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-linuxrc
@@ -255,7 +255,7 @@ setupInitialDeviceNames
 # 11) Check for read-only filesystem
 #--------------------------------------
 if [ ! -z "$kiwi_ROPart" ];then
-    setupUnionFS $imageRWDevice $imageRODevice $unionFST
+    setupUnionFS $imageRWDevice $imageRODevice overlay
 fi
 
 #======================================

--- a/kiwi/boot/arch/x86_64/oemboot/suse-repart
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-repart
@@ -619,7 +619,7 @@ function OEMRepart {
         OEMPartitionInstall
     elif [ ! -z "$haveLVM" ];then
         OEMRepartLVM
-    elif isFSTypeReadOnly;then
+    elif [ ! -z "$kiwi_ROPart" ];then
         OEMRepartSplit
     else
         OEMRepartStandard
@@ -636,14 +636,13 @@ function OEMRepart {
         createLuksMaps
     fi
     #======================================
-    # find fstype for root partition
+    # wait for root device to appear
     #--------------------------------------
     if ! waitForStorageDevice $imageRootDevice &>/dev/null;then
         systemException \
             "Device $imageRootDevice doesn't appear... fatal !" \
         "reboot"
     fi
-    probeFileSystem $imageRootDevice
     #======================================
     # Activate swap space
     #--------------------------------------
@@ -871,7 +870,7 @@ function createLuksMaps {
         export imageRootDevice=$luksDeviceOpened
         luksResize
     fi
-    if isFSTypeReadOnly;then
+    if [ ! -z "$kiwi_ROPart" ];then
         luksOpen $imageIOWRDevice luksReadWrite
         export imageIOWRDevice=$luksDeviceOpened
         export imageRWDevice=$imageIOWRDevice
@@ -914,7 +913,6 @@ function resizeLVMVolumes {
             lvextend -L +${volume_size}M /dev/$kiwi_lvmgroup/$volume_name
         fi
         if [ $? = 0 ];then
-            unset FSTYPE
             resizeFilesystem /dev/$kiwi_lvmgroup/$volume_name
         else
             Echo "Warning: requested size cannot be reached !"

--- a/kiwi/boot/arch/x86_64/vmxboot/rhel-linuxrc
+++ b/kiwi/boot/arch/x86_64/vmxboot/rhel-linuxrc
@@ -191,15 +191,15 @@ fi
 #======================================
 # 10) Get filesystem type
 #--------------------------------------
-probeFileSystem $imageRootDevice
-if [ "$FSTYPE" = "luks" ];then
+fstype=$(probeFileSystem $imageRootDevice)
+if [ "$fstype" = "luks" ];then
     luksOpen $imageRootDevice
     imageRootDevice=$luksDeviceOpened
     imageRODevice=$imageRootDevice
-    probeFileSystem $imageRootDevice
+    fstype=$(probeFileSystem $imageRootDevice)
     export haveLuks=yes
 fi
-if [ "$FSTYPE" = "unknown" ];then
+if [ "$fstype" = "unknown" ];then
     systemException \
         "Couldn't determine filesystem type... abort" \
     "reboot"
@@ -208,8 +208,8 @@ fi
 #======================================
 # 11) Check filesystem
 #--------------------------------------
-Echo "Filesystem of VMX system is: $FSTYPE -> $imageRootDevice"
-if isFSTypeReadOnly;then
+Echo "Filesystem of VMX system is: $fstype -> $imageRootDevice"
+if [ ! -z "$kiwi_ROPart" ];then
     setupUnionFS $imageRWDevice $imageRODevice $unionFST
 fi
 

--- a/kiwi/boot/arch/x86_64/vmxboot/rhel-linuxrc
+++ b/kiwi/boot/arch/x86_64/vmxboot/rhel-linuxrc
@@ -210,7 +210,7 @@ fi
 #--------------------------------------
 Echo "Filesystem of VMX system is: $fstype -> $imageRootDevice"
 if [ ! -z "$kiwi_ROPart" ];then
-    setupUnionFS $imageRWDevice $imageRODevice $unionFST
+    setupUnionFS $imageRWDevice $imageRODevice overlay
 fi
 
 #======================================

--- a/kiwi/boot/arch/x86_64/vmxboot/suse-linuxrc
+++ b/kiwi/boot/arch/x86_64/vmxboot/suse-linuxrc
@@ -192,15 +192,15 @@ fi
 #======================================
 # 10) Get filesystem type
 #--------------------------------------
-probeFileSystem $imageRootDevice
-if [ "$FSTYPE" = "luks" ];then
+fstype=$(probeFileSystem $imageRootDevice)
+if [ "$fstype" = "luks" ];then
     luksOpen $imageRootDevice
     imageRootDevice=$luksDeviceOpened
     imageRODevice=$imageRootDevice
-    probeFileSystem $imageRootDevice
+    fstype=$(probeFileSystem $imageRootDevice)
     export haveLuks=yes
 fi
-if [ "$FSTYPE" = "unknown" ];then
+if [ "$fstype" = "unknown" ];then
     systemException \
         "Couldn't determine filesystem type... abort" \
     "reboot"
@@ -209,8 +209,8 @@ fi
 #======================================
 # 11) Check filesystem
 #--------------------------------------
-Echo "Filesystem of VMX system is: $FSTYPE -> $imageRootDevice"
-if isFSTypeReadOnly;then
+Echo "Filesystem of VMX system is: $fstype -> $imageRootDevice"
+if [ ! -z "$kiwi_ROPart" ];then
     setupUnionFS $imageRWDevice $imageRODevice $unionFST
 fi
 

--- a/kiwi/boot/arch/x86_64/vmxboot/suse-linuxrc
+++ b/kiwi/boot/arch/x86_64/vmxboot/suse-linuxrc
@@ -211,7 +211,7 @@ fi
 #--------------------------------------
 Echo "Filesystem of VMX system is: $fstype -> $imageRootDevice"
 if [ ! -z "$kiwi_ROPart" ];then
-    setupUnionFS $imageRWDevice $imageRODevice $unionFST
+    setupUnionFS $imageRWDevice $imageRODevice overlay
 fi
 
 #======================================

--- a/kiwi/boot/functions.sh
+++ b/kiwi/boot/functions.sh
@@ -4907,22 +4907,6 @@ function umountSystem {
     return $retval
 }
 #======================================
-# isFSTypeReadOnly
-#--------------------------------------
-function isFSTypeReadOnly {
-    local IFS=$IFS_ORIG
-    local fstype=$1
-    if [ "$fstype" = "squashfs" ];then
-        export unionFST=overlay
-        return 0
-    fi
-    if [ "$fstype" = "clicfs" ];then
-        export unionFST=clicfs
-        return 0
-    fi
-    return 1
-}
-#======================================
 # kiwiMount
 #--------------------------------------
 function kiwiMount {
@@ -9103,10 +9087,8 @@ function setupBootPartitionPXE {
     # standard /boot mount when the bootloader will be
     # installed in preinit.
     # ---
-    if ! isFSTypeReadOnly $fstype_boot;then
-        rm -rf $prefix/boot
-        mkdir $prefix/boot
-    fi
+    rm -rf $prefix/boot
+    mkdir $prefix/boot
     mkdir $prefix/$mpoint
     mount $imageBootDevice $prefix/$mpoint
     mount --bind \
@@ -9177,10 +9159,8 @@ function setupBootPartition {
     # standard /boot mount when the bootloader will be
     # installed in preinit.
     # ---
-    if ! isFSTypeReadOnly $bootPartitionFSType;then
-        rm -rf $prefix/boot
-        mkdir $prefix/boot
-    fi
+    rm -rf $prefix/boot
+    mkdir $prefix/boot
     mkdir $prefix/$mpoint
     mount $imageBootDevice $prefix/$mpoint
     mount --bind \

--- a/kiwi/boot/functions.sh
+++ b/kiwi/boot/functions.sh
@@ -6784,8 +6784,8 @@ function setupUnionFS {
     # devices are stores by disk ID if possible
     # ----
     local IFS=$IFS_ORIG
-    local rwDevice=`getDiskID $1`
-    local roDevice=`getDiskID $2`
+    local rwDevice=$(getDiskID $1)
+    local roDevice=$(getDiskID $2)
     local unionFST=$3
     if [[ "$roDevice" =~ aoe|nbd ]]; then
         roDevice=$imageRootDevice

--- a/kiwi/boot/functions.sh
+++ b/kiwi/boot/functions.sh
@@ -6728,10 +6728,10 @@ function bootImage {
         exec chroot . /sbin/halt -fihp
     fi
     if lookup switch_root &>/dev/null;then
-        exec switch_root . $init $option
+        exec switch_root . $init $option &>/dev/null
     else
         if lookup pivot_root &>/dev/null;then
-            pivot_root . run/initramfs
+            pivot_root . run/initramfs &>/dev/null
         fi
         exec chroot . $init $option
     fi

--- a/kiwi/boot/functions.sh
+++ b/kiwi/boot/functions.sh
@@ -1881,6 +1881,7 @@ function setupBootLoaderS390Grub {
     local title
     local cmdline
     local vesa
+    local fstype=$(probeFileSystem $rdev)
     #======================================
     # setup path names
     #--------------------------------------
@@ -1950,7 +1951,7 @@ EOF
     #======================================
     # enable rollback capability
     #--------------------------------------
-    if [ "$FSTYPE" = "btrfs" ];then
+    if [ "$fstype" = "btrfs" ];then
         echo "SUSE_BTRFS_SNAPSHOT_BOOTING=true" >> $inst_default_grub
     fi
     #======================================
@@ -2002,6 +2003,7 @@ function setupBootLoaderGrub2 {
     local timeout
     local vesa
     local loader_type="grub2"
+    local fstype=$(probeFileSystem $rdev)
     #======================================
     # vesa hex => resolution table
     #--------------------------------------
@@ -2163,7 +2165,7 @@ EOF
     #======================================
     # enable rollback capability
     #--------------------------------------
-    if [ "$FSTYPE" = "btrfs" ];then
+    if [ "$fstype" = "btrfs" ];then
         echo "SUSE_BTRFS_SNAPSHOT_BOOTING=true" >> $inst_default_grub
     fi
     #======================================
@@ -2252,6 +2254,7 @@ function updateRootDeviceFstab {
     local rdev=$2
     local nfstab=$config_tmp/etc/fstab
     local diskByID=$(getDiskID $rdev)
+    local fstype=$(probeFileSystem $rdev)
     local opts=defaults
     local devicepersistency="by-uuid"
     if [ ! -z "$kiwi_devicepersistency" ];then
@@ -2276,7 +2279,7 @@ function updateRootDeviceFstab {
     # check for device by ID
     #--------------------------------------
     if [ -z "$UNIONFS_CONFIG" ]; then
-        echo "$diskByID / $FSTYPE $opts 1 1" >> $nfstab
+        echo "$diskByID / $fstype $opts 1 1" >> $nfstab
     else
         echo "/dev/root / auto defaults 1 1" >> $nfstab
     fi
@@ -2298,9 +2301,9 @@ function updateRootDeviceFstab {
             fi
             mount_point=$(getVolumeMountPoint $i)
             mount_device="/dev/$kiwi_lvmgroup/$volume_name"
-            echo "$mount_device /$mount_point $FSTYPE $opts 1 2" >> $nfstab
+            echo "$mount_device /$mount_point $fstype $opts 1 2" >> $nfstab
         done
-    elif [ "$FSTYPE" = "btrfs" ];then
+    elif [ "$fstype" = "btrfs" ];then
         if [ "$kiwi_btrfs_root_is_snapshot" = "true" ];then
             if [ $devicepersistency = "by-label" ];then
                 local device="LABEL=$(blkid $rdev -s LABEL -o value)"
@@ -2341,23 +2344,18 @@ function updateBootDeviceFstab {
     local nfstab=$config_tmp/etc/fstab
     local mount=boot_bind
     local prefix=/mnt
+    local fstype
     #======================================
     # Store boot entry
     #--------------------------------------
     if [ -e $prefix/$mount ];then
         local diskByID=$(getDiskID $sdev)
-        if [ ! -z "$FSTYPE" ];then
-            FSTYPE_SAVE=$FSTYPE
+        fstype=$(probeFileSystem $sdev)
+        if [ "$fstype" = "unknown" ];then
+            fstype=auto
         fi
-        probeFileSystem $sdev
-        if [ -z "$FSTYPE" ] || [ "$FSTYPE" = "unknown" ];then
-            FSTYPE="auto"
-        fi
-        echo "$diskByID /$mount $FSTYPE defaults 1 2" >> $nfstab
+        echo "$diskByID /$mount $fstype defaults 1 2" >> $nfstab
         echo "/$mount/boot /boot none bind 0 0" >> $nfstab
-        if [ ! -z "$FSTYPE_SAVE" ];then
-            FSTYPE=$FSTYPE_SAVE
-        fi
     fi
     #======================================
     # Store boot/efi entry
@@ -2394,6 +2392,7 @@ function updateOtherDeviceFstab {
     local count=0
     local device
     local diskByID
+    local fstype
     local IFS=","
     if [ -z "$prefix" ];then
         prefix=/mnt
@@ -2419,13 +2418,13 @@ function updateOtherDeviceFstab {
             else
                 device=$(ddn $DISK $count)
             fi
-            probeFileSystem $device
-            if [ ! "$FSTYPE" = "luks" ] && [ ! "$FSTYPE" = "unknown" ];then
+            fstype=$(probeFileSystem $device)
+            if [ ! "$fstype" = "luks" ] && [ ! "$fstype" = "unknown" ];then
                 if [ ! -d $prefix/$partMount ];then
                     mkdir -p $prefix/$partMount
                 fi
                 diskByID=$(getDiskID $device)
-                echo "$diskByID $partMount $FSTYPE defaults 0 0" >> $nfstab
+                echo "$diskByID $partMount $fstype defaults 0 0" >> $nfstab
             fi
         fi
     done
@@ -2505,43 +2504,30 @@ function setupKernelModules {
 #--------------------------------------
 function probeFileSystem {
     # /.../
-    # probe for the filesystem type. The function will
-    # read 128 kB of the given device and check the
-    # filesystem header data to detect the type of the
-    # filesystem
+    # probe for the filesystem type. The function uses the
+    # result from blkid. If blkid could not detect the
+    # filesystem type the first 128 kB of the given device
+    # are read and checked for a known signature
     # ----
     local IFS=$IFS_ORIG
-    FSTYPE=unknown
-    FSTYPE=$(blkid $1 -s TYPE -o value)
-    case $FSTYPE in
-        btrfs)       FSTYPE=btrfs ;;
-        ext4)        FSTYPE=ext4 ;;
-        ext3)        FSTYPE=ext3 ;;
-        ext2)        FSTYPE=ext2 ;;
-        squashfs)    FSTYPE=squashfs ;;
-        luks)        FSTYPE=luks ;;
-        crypto_LUKS) FSTYPE=luks ;;
-        vfat)        FSTYPE=vfat ;;
-        clicfs)      FSTYPE=clicfs ;;
-        xfs)         FSTYPE=xfs ;;
-        udf)         FSTYPE=udf ;;
-        exfat)       FSTYPE=exfat ;;
-        *)
-            FSTYPE=unknown
-        ;;
-    esac
-    if [ $FSTYPE = "unknown" ];then
-        dd if=$1 of=/tmp/filesystem-$$ bs=128k count=1 >/dev/null
+    local fstype
+    fstype=$(blkid $1 -s TYPE -o value)
+    if [ -z "$fstype" ];then
+        fstype=unknown
     fi
-    if [ $FSTYPE = "unknown" ];then
+    if [ "$fstype" = "crypto_LUKS" ];then
+        fstype=luks
+    fi
+    if [ $fstype = "unknown" ];then
+        dd if=$1 of=/tmp/filesystem-$$ bs=128k count=1 >/dev/null
         if grep -q ^CLIC /tmp/filesystem-$$;then
-            FSTYPE=clicfs
+            fstype=clicfs
         fi
         if grep -q ^hsqs /tmp/filesystem-$$;then
-            FSTYPE=squashfs
+            fstype=squashfs
         fi
     fi
-    export FSTYPE
+    echo $fstype
 }
 #======================================
 # getSystemIntegrity
@@ -3363,12 +3349,13 @@ function searchVolumeGroup {
     local IFS=$IFS_ORIG
     local vg_count=0
     local vg_found
+    local fstype
     if [ ! "$kiwi_lvm" = "true" ];then
         return 1
     fi
     local rootdevice=$(ddn $imageDiskDevice $kiwi_RootPart)
-    probeFileSystem $rootdevice
-    if [ "$FSTYPE" = "luks" ];then
+    fstype=$(probeFileSystem $rootdevice)
+    if [ "$fstype" = "luks" ];then
         luksOpen $rootdevice
         export haveLuks=yes
     fi
@@ -4924,11 +4911,12 @@ function umountSystem {
 #--------------------------------------
 function isFSTypeReadOnly {
     local IFS=$IFS_ORIG
-    if [ "$FSTYPE" = "squashfs" ];then
+    local fstype=$1
+    if [ "$fstype" = "squashfs" ];then
         export unionFST=overlay
         return 0
     fi
-    if [ "$FSTYPE" = "clicfs" ];then
+    if [ "$fstype" = "clicfs" ];then
         export unionFST=clicfs
         return 0
     fi
@@ -4943,16 +4931,11 @@ function kiwiMount {
     local dst=$2
     local opt=$3
     local lop=$4
+    local fstype
     #======================================
     # load not autoloadable fs modules
     #--------------------------------------
     modprobe squashfs &>/dev/null
-    #======================================
-    # store old FSTYPE value
-    #--------------------------------------
-    if [ ! -z "$FSTYPE" ];then
-        FSTYPE_SAVE=$FSTYPE
-    fi
     #======================================
     # decide for a mount method
     #--------------------------------------
@@ -4973,17 +4956,16 @@ function kiwiMount {
     #======================================
     # probe filesystem
     #--------------------------------------
-    if [ ! "$FSTYPE" = "nfs" ];then
-        probeFileSystem $src
+    if [ ! -z "$NFSROOT" ];then
+        fstype=nfs
+    else
+        fstype=$(probeFileSystem $src)
     fi
-    if [ -z "$FSTYPE" ] || [ "$FSTYPE" = "unknown" ];then
-        FSTYPE="auto"
+    if [ "$fstyoe" = "unknown" ];then
+        fstype="auto"
     fi
-    if ! mount -t $FSTYPE $opt $src $dst >/dev/null;then
+    if ! mount -t $fstype $opt $src $dst >/dev/null;then
         return 1
-    fi
-    if [ ! -z "$FSTYPE_SAVE" ];then
-        FSTYPE=$FSTYPE_SAVE
     fi
     return 0
 }
@@ -5028,7 +5010,7 @@ function setupReadWrite {
     if [ "$create_hybrid" = "yes" ];then
         Echo "Creating filesystem for RW data on $rwDevice..."
         if ! createFilesystem \
-            "$rwDevice" "" "" "hybrid" "false" "$hybrid_fs" "$fs_opts"
+            "$rwDevice" "$hybrid_fs" "" "" "hybrid" "false" "$fs_opts"
         then
             Echo "Failed to create ${hybrid_fs} filesystem"
             return 1
@@ -5359,11 +5341,8 @@ function mountSystemStandard {
     local mpoint
     local mppath
     local prefix=/mnt
-    if \
-        [ ! -z $FSTYPE ] && \
-        [ ! $FSTYPE = "unknown" ] && \
-        [ ! $FSTYPE = "auto" ]
-    then
+    local fstype=$(probeFileSystem $mountDevice)
+    if [ ! $fstype = "unknown" ]; then
         kiwiMount "$mountDevice" "$prefix"
     else
         mount $mountDevice $prefix >/dev/null
@@ -5386,7 +5365,7 @@ function mountSystemStandard {
             mkdir -p $prefix/$mount_point
             kiwiMount "$mount_device" "$prefix/$mount_point"
         done
-    elif [ "$FSTYPE" = "btrfs" ];then
+    elif [ "$fstype" = "btrfs" ];then
         if [ "$kiwi_btrfs_root_is_snapshot" = "true" ];then
             mountBtrfsSubVolumes $mountDevice $prefix
         fi
@@ -7564,7 +7543,7 @@ function createHybridPersistent {
         fs_opts="$HYBRID_EXT4_OPTS"
     fi
     if ! createFilesystem \
-        $hybrid_device "" "" "hybrid" "false" "$hybrid_fs" "$fs_opts"
+        $hybrid_device "$hybrid_fs" "" "" "hybrid" "false" "$fs_opts"
     then
         Echo "Failed to create hybrid persistent filesystem"
         Echo "Persistent writing deactivated"
@@ -7628,7 +7607,7 @@ function setupHybridCowDevice {
         fi
         qemu-img create "$hybrid_cow_filename" "$cowsize"
         if ! createFilesystem \
-            "$hybrid_cow_filename" "" "" "" "false" "ext4" "$HYBRID_EXT4_OPTS"
+            "$hybrid_cow_filename" "ext4" "" "" "" "false" "$HYBRID_EXT4_OPTS"
         then
             Echo "Failed to create hybrid persistent cow filesystem"
             return 1
@@ -8112,27 +8091,22 @@ function reloadKernel {
 #--------------------------------------
 function checkFilesystem {
     local device=$1
-    local FSTYPE_SAVE=$FS_TYPE
-    if [ -z "$FSTYPE" ];then
-        probeFileSystem $device
-    fi
-    if [ "$FSTYPE" = "ext2" ];then
-        e2fsck -p -f $device
-    elif [ "$FSTYPE" = "ext3" ];then
-        e2fsck -p -f $device
-    elif [ "$FSTYPE" = "ext4" ];then
-        e2fsck -p -f $device
-    elif [ "$FSTYPE" = "btrfs" ];then
-        btrfsck $device
-    elif [ "$FSTYPE" = "xfs" ];then
-        xfs_repair -n $device
-    else
-        FSTYPE=$FSTYPE_SAVE
-        # don't know how to check this filesystem
-        Echo "Don't know how to check ${FSTYPE}... skip it"
-        return
-    fi
-    FSTYPE=$FSTYPE_SAVE
+    local fstype=$(probeFileSystem $device)
+    case $fstype in
+        ext2|ext3|ext4)
+            e2fsck -p -f $device
+        ;;
+        btrfs)
+            btrfsck $device
+        ;;
+        xfs)
+            xfs_repair -n $device
+        ;;
+        *)
+            # don't know how to check this filesystem
+            Echo "Don't know how to check ${fstype}... skip it"
+        ;;
+    esac
 }
 #======================================
 # resizeFilesystem
@@ -8146,50 +8120,43 @@ function resizeFilesystem {
     local check
     local mpoint=/fs-resize
     udevPending
+    local fstype=$(probeFileSystem $deviceResize)
     mkdir -p $mpoint
     if echo $deviceResize | grep -qi "/dev/ram";then
         ramdisk=1
     fi
-    if [ -z "$FSTYPE" ];then
-        probeFileSystem $deviceResize
-    fi
-    if [ "$FSTYPE" = "ext2" ];then
-        resize_fs="resize2fs -f -p $deviceResize"
-        if [ $ramdisk -eq 1 ];then
-            resize_fs="resize2fs -f $deviceResize"
-        fi
-    elif [ "$FSTYPE" = "ext3" ];then
-        resize_fs="resize2fs -f -p $deviceResize"
-        if [ $ramdisk -eq 1 ];then
-            resize_fs="resize2fs -f $deviceResize"
-        fi
-    elif [ "$FSTYPE" = "ext4" ];then
-        resize_fs="resize2fs -f -p $deviceResize"
-        if [ $ramdisk -eq 1 ];then
-            resize_fs="resize2fs -f $deviceResize"
-        fi
-    elif [ "$FSTYPE" = "btrfs" ];then
-        resize_fs="mount $deviceResize $mpoint &&"
-        if lookup btrfs &>/dev/null;then
-            resize_fs="$resize_fs btrfs filesystem resize max $mpoint"
-            resize_fs="$resize_fs;umount $mpoint"
-        else
-            resize_fs="$resize_fs btrfsctl -r max $mpoint;umount $mpoint"
-        fi
-    elif [ "$FSTYPE" = "xfs" ];then
-        resize_fs="mount $deviceResize $mpoint &&"
-        resize_fs="$resize_fs xfs_growfs $mpoint;umount $mpoint"
-    else
-        # don't know how to resize this filesystem
-        Echo "Don't know how to resize ${FSTYPE}... skip it"
-        return
-    fi
+    case $fstype in
+        ext2|ext3|ext4)
+            resize_fs="resize2fs -f -p $deviceResize"
+            if [ $ramdisk -eq 1 ];then
+                resize_fs="resize2fs -f $deviceResize"
+            fi
+        ;;
+        btrfs)
+            resize_fs="mount $deviceResize $mpoint &&"
+            if lookup btrfs &>/dev/null;then
+                resize_fs="$resize_fs btrfs filesystem resize max $mpoint"
+                resize_fs="$resize_fs;umount $mpoint"
+            else
+                resize_fs="$resize_fs btrfsctl -r max $mpoint;umount $mpoint"
+            fi
+        ;;
+        xfs)
+            resize_fs="mount $deviceResize $mpoint &&"
+            resize_fs="$resize_fs xfs_growfs $mpoint;umount $mpoint"
+        ;;
+        *)
+            # don't know how to resize this filesystem
+            Echo "Don't know how to resize ${fstype}... skip it"
+            return
+        ;;
+    esac
     if [ -z "$callme" ];then
         if [ $ramdisk -eq 0 ]; then
-            Echo "Checking $FSTYPE filesystem on ${deviceResize}..."
+            Echo "Checking $fstype filesystem on ${deviceResize}..."
             checkFilesystem $deviceResize
         fi
-        Echo "Resizing $FSTYPE filesystem on ${deviceResize}..."
+        Echo "Resizing $fstype filesystem on ${deviceResize}..."
         eval $resize_fs
         if [ ! $? = 0 ];then
             systemException \
@@ -8205,7 +8172,7 @@ function resizeFilesystem {
 #--------------------------------------
 function resetMountCounter {
     local IFS=$IFS_ORIG
-    local curtype=$FSTYPE
+    local fstype
     local command
     for device in \
         $imageRootDevice $imageBootDevice \
@@ -8214,20 +8181,18 @@ function resetMountCounter {
         if [ ! -e $device ];then
             continue
         fi
-        probeFileSystem $device
-        if [ "$FSTYPE" = "ext2" ];then
-            command="tune2fs -c -1 -i 0"
-        elif [ "$FSTYPE" = "ext3" ];then
-            command="tune2fs -c -1 -i 0"
-        elif [ "$FSTYPE" = "ext4" ];then
-            command="tune2fs -c -1 -i 0"
-        else
-            # nothing to do here...
-            continue
-        fi
+        fstype=$(probeFileSystem $device)
+        case $fstype in
+            ext2|ext3|ext4)
+                command="tune2fs -c -1 -i 0"
+            ;;
+            *)
+                # nothing to do here...
+                continue
+            ;;
+        esac
         eval $command $device 1>&2
     done
-    FSTYPE=$curtype
 }
 #======================================
 # createFilesystem
@@ -8235,15 +8200,12 @@ function resetMountCounter {
 function createFilesystem {
     local IFS=$IFS_ORIG
     local deviceCreate=$1
-    local blocks=$2
-    local uuid=$3
-    local label=$4
-    local exception_handling=$5
-    local filesystem=$6
+    local filesystem=$2
+    local blocks=$3
+    local uuid=$4
+    local label=$5
+    local exception_handling=$6
     local opts=$7
-    if [ -z "$filesystem" ];then
-        filesystem=$FSTYPE
-    fi
     if [ -z "$exception_handling" ];then
         exception_handling="true"
     else
@@ -9038,8 +9000,7 @@ function setupBootPartitionPXE {
     # Variable setup
     #--------------------------------------
     local IFS=$IFS_ORIG
-    local fs_type
-    local FSTYPE_SAVE=$FSTYPE
+    local fstype
     local mpoint=boot_bind
     unset NETBOOT_ONLY
     local prefix=/mnt
@@ -9093,13 +9054,12 @@ function setupBootPartitionPXE {
     #======================================
     # Probe boot/root filesystem
     #--------------------------------------
-    probeFileSystem $imageRootDevice
-    fs_type=$FSTYPE ; FSTYPE=$FSTYPE_SAVE
+    fstype=$(probeFileSystem $imageRootDevice)
     #======================================
     # return if no extra boot partition
     #--------------------------------------
     if [ $imageBootDevice = $imageRootDevice ];then
-        if [ $fs_type = "unknown" ] || [ "$haveLuks" = "yes" ];then
+        if [ $fstype = "unknown" ] || [ "$haveLuks" = "yes" ];then
             # /.../
             # there is no extra boot device and the root device has an
             # unsupported boot filesystem or layer, mark as netboot only
@@ -9112,17 +9072,18 @@ function setupBootPartitionPXE {
     #======================================
     # Check boot partition filesystem
     #--------------------------------------
-    if [ $fs_type = "unknown" ];then
+    local fstype_boot=$(probeFileSystem $imageBootDevice)
+    if [ $fstype_boot = "unknown" ];then
         # /.../
         # there is a boot device with an unknown filesystem
         # create boot filesystem
         # ----
-        createFilesystem $imageBootDevice
+        createFilesystem $imageBootDevice $fstype
     fi
     #======================================
     # export bootpart relevant variables
     #--------------------------------------
-    export bootPartitionFSType=$fs_type
+    export bootPartitionFSType=$fstype
     export kiwi_BootPart=$bootid
     #======================================
     # copy boot data from image to bootpart
@@ -9142,7 +9103,7 @@ function setupBootPartitionPXE {
     # standard /boot mount when the bootloader will be
     # installed in preinit.
     # ---
-    if ! isFSTypeReadOnly;then
+    if ! isFSTypeReadOnly $fstype_boot;then
         rm -rf $prefix/boot
         mkdir $prefix/boot
     fi
@@ -9161,8 +9122,7 @@ function setupBootPartition {
     local IFS=$IFS_ORIG
     local label=undef
     local mpoint=boot_bind
-    local FSTYPE_SAVE=$FSTYPE
-    local fs_type=undef
+    local fstype
     local BID=1
     local prefix=/mnt
     #======================================
@@ -9185,9 +9145,8 @@ function setupBootPartition {
     #======================================
     # Probe boot partition filesystem
     #--------------------------------------
-    probeFileSystem $(ddn $imageDiskDevice $BID)
-    fs_type=$FSTYPE ; FSTYPE=$FSTYPE_SAVE
-    export bootPartitionFSType=$fs_type
+    fstype=$(probeFileSystem $(ddn $imageDiskDevice $BID))
+    export bootPartitionFSType=$fstype
     #======================================
     # Export bootid if not yet done
     #--------------------------------------
@@ -9218,7 +9177,7 @@ function setupBootPartition {
     # standard /boot mount when the bootloader will be
     # installed in preinit.
     # ---
-    if ! isFSTypeReadOnly;then
+    if ! isFSTypeReadOnly $bootPartitionFSType;then
         rm -rf $prefix/boot
         mkdir $prefix/boot
     fi
@@ -9534,7 +9493,7 @@ function setupKernelLinks {
     #--------------------------------------
     if  [ "$kiwi_oemkboot" = "true" ] || \
         [ "$PXE_KIWI_INITRD" = "yes" ] || \
-        isFSTypeReadOnly
+        [ ! -z "$kiwi_ROPart" ]
     then
         # /.../
         # we are using a special root setup based on an overlay

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -173,10 +173,7 @@ class DiskBuilder(object):
         self.root_dir = root_dir
         self.target_dir = target_dir
         self.xml_state = xml_state
-
-        # FIXME: needs to be set by an XML attribute
-        self.root_filesystem_is_overlay = True
-
+        self.root_filesystem_is_overlay = xml_state.build_type.get_overlayroot()
         self.custom_root_mount_args = xml_state.get_fs_mount_option_list()
         self.build_type_name = xml_state.get_build_type_name()
         self.image_format = xml_state.build_type.get_format()

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -298,7 +298,7 @@ class Defaults(object):
         :return: mbsize
         :rtype: int
         """
-        return 200
+        return 300
 
     @classmethod
     def get_default_vboot_mbytes(self):

--- a/kiwi/filesystem/base.py
+++ b/kiwi/filesystem/base.py
@@ -102,7 +102,7 @@ class FileSystemBase(object):
         """
         raise NotImplementedError
 
-    def create_on_file(self, filename, label=None):
+    def create_on_file(self, filename, label=None, exclude=None):
         """
         Create filesystem from root data tree
 
@@ -111,6 +111,7 @@ class FileSystemBase(object):
 
         :param string filename: result file path name
         :param string label: label name
+        :param list exclude: list of exclude dirs/files
         """
         raise NotImplementedError
 
@@ -118,7 +119,7 @@ class FileSystemBase(object):
         """
         Copy root data tree into filesystem
 
-        :param list exclude: list of items to exclude
+        :param list exclude: list of exclude dirs/files
         """
         if not self.root_dir:
             raise KiwiFileSystemSyncError(

--- a/kiwi/filesystem/clicfs.py
+++ b/kiwi/filesystem/clicfs.py
@@ -47,15 +47,19 @@ class FileSystemClicFs(FileSystemBase):
         """
         self.container_dir = None
 
-    def create_on_file(self, filename, label=None):
+    def create_on_file(self, filename, label=None, exclude=None):
         """
         Create clicfs filesystem from data tree
 
         There is no label which could be set for clicfs
         thus this parameter is not used
 
+        There is no option to exclude data from clicfs
+        thus this parameter is not used
+
         :param string filename: result file path name
         :param string label: unused
+        :param list exclude: unused
         """
         self.container_dir = mkdtemp(prefix='kiwi_clicfs.')
         clicfs_container_filesystem = self.container_dir + '/fsdata.ext4'

--- a/kiwi/filesystem/squashfs.py
+++ b/kiwi/filesystem/squashfs.py
@@ -24,22 +24,30 @@ class FileSystemSquashFs(FileSystemBase):
     """
     Implements creation of squashfs filesystem
     """
-    def create_on_file(self, filename, label=None):
+    def create_on_file(self, filename, label=None, exclude=None):
         """
         Create squashfs filesystem from data tree
 
-        There is no label which could be set for clicfs
+        There is no label which could be set for squashfs
         thus this parameter is not used
 
         :param string filename: result file path name
         :param string label: unused
+        :param list exclude: list of exclude dirs/files
         """
+        exclude_options = []
+
         if '-comp' not in self.custom_args['create_options']:
             self.custom_args['create_options'].append('-comp')
             self.custom_args['create_options'].append('xz')
 
+        if exclude:
+            exclude_options.append('-e')
+            for item in exclude:
+                exclude_options.append(item)
+
         Command.run(
             [
-                'mksquashfs', self.root_dir, filename
-            ] + self.custom_args['create_options']
+                'mksquashfs', self.root_dir, filename, '-noappend'
+            ] + self.custom_args['create_options'] + exclude_options
         )

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1666,9 +1666,15 @@ div {
     k.type.filesystem.attribute = 
         ## Specifies the root filesystem type
         attribute filesystem {
-            "btrfs" | "clicfs" | "ext2" | "ext3" | "ext4" |
-            "overlayfs" | "squashfs" | "xfs"
+            "btrfs" | "ext2" | "ext3" | "ext4" | "squashfs" | "xfs"
         }
+    k.type.overlayroot.attribute =
+        ## Specifies to use an overlay root system consisting
+        ## out of a squashfs compressed read-only root system
+        ## overlayed using the overlayfs filesystem into an
+        ## extra read-write partition. Available for the disk
+        ## image types, vmx and oem
+        attribute overlayroot { xsd:boolean }
     k.type.firmware.attribute =
         ## Specifies the boot firmware of the system. Most systems
         ## uses a standard BIOS but there are also other firmware
@@ -1876,6 +1882,7 @@ div {
         k.type.luks.attribute? &
         k.type.luksOS.attribute? &
         k.type.mdraid.attribute? &
+        k.type.overlayroot.attribute? &
         k.type.primary.attribute? &
         k.type.ramonly.attribute? &
         k.type.rootfs_label.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2202,14 +2202,22 @@ structure</a:documentation>
         <a:documentation>Specifies the root filesystem type</a:documentation>
         <choice>
           <value>btrfs</value>
-          <value>clicfs</value>
           <value>ext2</value>
           <value>ext3</value>
           <value>ext4</value>
-          <value>overlayfs</value>
           <value>squashfs</value>
           <value>xfs</value>
         </choice>
+      </attribute>
+    </define>
+    <define name="k.type.overlayroot.attribute">
+      <attribute name="overlayroot">
+        <a:documentation>Specifies to use an overlay root system consisting
+out of a squashfs compressed read-only root system
+overlayed using the overlayfs filesystem into an
+extra read-write partition. Available for the disk
+image types, vmx and oem</a:documentation>
+        <data type="boolean"/>
       </attribute>
     </define>
     <define name="k.type.firmware.attribute">
@@ -2620,6 +2628,9 @@ are available on the host. Default timeout is 3 seconds</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.mdraid.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.overlayroot.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.primary.attribute"/>

--- a/kiwi/storage/disk.py
+++ b/kiwi/storage/disk.py
@@ -108,6 +108,8 @@ class Disk(DeviceProvider):
         self.partitioner.create('p.lxroot', mbsize, 't.linux')
         self.__add_to_map('root')
         self.__add_to_public_id_map('kiwi_RootPart')
+        if 'kiwi_ROPart' in self.public_partition_id_map:
+            self.__add_to_public_id_map('kiwi_RWPart')
         if 'kiwi_BootPart' not in self.public_partition_id_map:
             self.__add_to_public_id_map('kiwi_BootPart')
 
@@ -139,6 +141,21 @@ class Disk(DeviceProvider):
         self.__add_to_public_id_map('kiwi_RootPart')
         self.__add_to_public_id_map('kiwi_RaidPart')
         self.__add_to_public_id_map('kiwi_RaidDev', '/dev/md0')
+
+    def create_root_readonly_partition(self, mbsize):
+        """
+        Create root readonly partition for use with overlayfs
+
+        Populates kiwi_ReadOnlyPart(id), the partition is meant to
+        contain a squashfs readonly filesystem. The partition size
+        should be the size of the squashfs filesystem in order to
+        avoid wasting disk space
+
+        :param int mbsize: partition size
+        """
+        self.partitioner.create('p.lxreadonly', mbsize, 't.linux')
+        self.__add_to_map('readonly')
+        self.__add_to_public_id_map('kiwi_ROPart')
 
     def create_boot_partition(self, mbsize):
         """

--- a/kiwi/storage/setup.py
+++ b/kiwi/storage/setup.py
@@ -78,6 +78,8 @@ class DiskSetup(object):
         Instance of XMLState
     """
     def __init__(self, xml_state, root_dir):
+        # FIXME: needs to be set by an XML attribute
+        self.root_filesystem_is_overlay = True
         self.configured_size = xml_state.get_build_type_size()
         self.build_type_name = xml_state.get_build_type_name()
         self.filesystem = xml_state.build_type.get_filesystem()
@@ -224,6 +226,8 @@ class DiskSetup(object):
         if self.filesystem == 'btrfs':
             return True
         if self.filesystem == 'xfs':
+            return True
+        if self.root_filesystem_is_overlay:
             return True
         if self.bootloader == 'grub2_s390x_emu':
             return True

--- a/kiwi/storage/setup.py
+++ b/kiwi/storage/setup.py
@@ -78,8 +78,7 @@ class DiskSetup(object):
         Instance of XMLState
     """
     def __init__(self, xml_state, root_dir):
-        # FIXME: needs to be set by an XML attribute
-        self.root_filesystem_is_overlay = True
+        self.root_filesystem_is_overlay = xml_state.build_type.get_overlayroot()
         self.configured_size = xml_state.get_build_type_size()
         self.build_type_name = xml_state.get_build_type_name()
         self.filesystem = xml_state.build_type.get_filesystem()

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Fri Apr 29 16:16:24 2016 by generateDS.py version 2.19b.
+# Generated Tue May 31 17:33:14 2016 by generateDS.py version 2.19b.
 #
 # Command line options:
 #   ('-f', '')
@@ -2546,7 +2546,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, checkprebuilt=None, compressed=None, container=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsnocheck=None, fsmountoptions=None, gcelicense=None, hybrid=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, primary=None, ramonly=None, rootfs_label=None, target_blocksize=None, vbootsize=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, checkprebuilt=None, compressed=None, container=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsnocheck=None, fsmountoptions=None, gcelicense=None, hybrid=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, target_blocksize=None, vbootsize=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2587,6 +2587,7 @@ class type_(GeneratedsSuper):
         self.luks = _cast(None, luks)
         self.luksOS = _cast(None, luksOS)
         self.mdraid = _cast(None, mdraid)
+        self.overlayroot = _cast(bool, overlayroot)
         self.primary = _cast(bool, primary)
         self.ramonly = _cast(bool, ramonly)
         self.rootfs_label = _cast(None, rootfs_label)
@@ -2739,6 +2740,8 @@ class type_(GeneratedsSuper):
     def set_luksOS(self, luksOS): self.luksOS = luksOS
     def get_mdraid(self): return self.mdraid
     def set_mdraid(self, mdraid): self.mdraid = mdraid
+    def get_overlayroot(self): return self.overlayroot
+    def set_overlayroot(self, overlayroot): self.overlayroot = overlayroot
     def get_primary(self): return self.primary
     def set_primary(self, primary): self.primary = primary
     def get_ramonly(self): return self.ramonly
@@ -2905,6 +2908,9 @@ class type_(GeneratedsSuper):
         if self.mdraid is not None and 'mdraid' not in already_processed:
             already_processed.add('mdraid')
             outfile.write(' mdraid=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.mdraid), input_name='mdraid')), ))
+        if self.overlayroot is not None and 'overlayroot' not in already_processed:
+            already_processed.add('overlayroot')
+            outfile.write(' overlayroot="%s"' % self.gds_format_boolean(self.overlayroot, input_name='overlayroot'))
         if self.primary is not None and 'primary' not in already_processed:
             already_processed.add('primary')
             outfile.write(' primary="%s"' % self.gds_format_boolean(self.primary, input_name='primary'))
@@ -3197,6 +3203,15 @@ class type_(GeneratedsSuper):
             already_processed.add('mdraid')
             self.mdraid = value
             self.mdraid = ' '.join(self.mdraid.split())
+        value = find_attr_value_('overlayroot', node)
+        if value is not None and 'overlayroot' not in already_processed:
+            already_processed.add('overlayroot')
+            if value in ('true', '1'):
+                self.overlayroot = True
+            elif value in ('false', '0'):
+                self.overlayroot = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
         value = find_attr_value_('primary', node)
         if value is not None and 'primary' not in already_processed:
             already_processed.add('primary')

--- a/test/data/example_pxe_config.xml
+++ b/test/data/example_pxe_config.xml
@@ -19,7 +19,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="pxe" filesystem="overlayfs" boot="netboot/suse-13.2">
+        <type image="pxe" filesystem="squashfs" boot="netboot/suse-13.2">
             <pxedeploy server="192.168.100.2" blocksize="4096">
                 <partitions device="/dev/sda">
                     <partition type="swap" number="1" size="5"/>

--- a/test/unit/filesystem_squashfs_test.py
+++ b/test/unit/filesystem_squashfs_test.py
@@ -19,5 +19,15 @@ class TestFileSystemSquashfs(object):
     def test_create_on_file(self, mock_command):
         self.squashfs.create_on_file('myimage', 'label')
         mock_command.assert_called_once_with(
-            ['mksquashfs', 'root_dir', 'myimage', '-comp', 'xz']
+            ['mksquashfs', 'root_dir', 'myimage', '-noappend', '-comp', 'xz']
+        )
+
+    @patch('kiwi.filesystem.squashfs.Command.run')
+    def test_create_on_file_exclude_data(self, mock_command):
+        self.squashfs.create_on_file('myimage', 'label', ['foo'])
+        mock_command.assert_called_once_with(
+            [
+                'mksquashfs', 'root_dir', 'myimage',
+                '-noappend', '-comp', 'xz', '-e', 'foo'
+            ]
         )

--- a/test/unit/storage_disk_test.py
+++ b/test/unit/storage_disk_test.py
@@ -54,13 +54,22 @@ class TestDisk(object):
             'p.lxroot', 100, 't.linux'
         )
 
-    def test_create_root_and_boot_partition(self):
+    def test_create_root_which_is_also_boot_partition(self):
         self.disk.create_root_partition(200)
         self.partitioner.create.assert_called_once_with(
             'p.lxroot', 200, 't.linux'
         )
         assert self.disk.public_partition_id_map['kiwi_RootPart'] == 1
         assert self.disk.public_partition_id_map['kiwi_BootPart'] == 1
+
+    def test_create_root_which_is_also_read_write_partition(self):
+        self.disk.public_partition_id_map['kiwi_ROPart'] = 1
+        self.disk.create_root_partition(200)
+        self.partitioner.create.assert_called_once_with(
+            'p.lxroot', 200, 't.linux'
+        )
+        assert self.disk.public_partition_id_map['kiwi_RootPart'] == 1
+        assert self.disk.public_partition_id_map['kiwi_RWPart'] == 1
 
     def test_create_root_lvm_partition(self):
         self.disk.create_root_lvm_partition(100)
@@ -78,6 +87,13 @@ class TestDisk(object):
         assert self.disk.public_partition_id_map['kiwi_RootPart'] == 1
         assert self.disk.public_partition_id_map['kiwi_RaidPart'] == 1
         assert self.disk.public_partition_id_map['kiwi_RaidDev'] == '/dev/md0'
+
+    def test_create_root_readonly_partition(self):
+        self.disk.create_root_readonly_partition(100)
+        self.partitioner.create.assert_called_once_with(
+            'p.lxreadonly', 100, 't.linux'
+        )
+        assert self.disk.public_partition_id_map['kiwi_ROPart'] == 1
 
     def test_create_boot_partition(self):
         self.disk.create_boot_partition(100)

--- a/test/unit/storage_setup_test.py
+++ b/test/unit/storage_setup_test.py
@@ -94,6 +94,11 @@ class TestDiskSetup(object):
         self.setup.volume_manager = 'lvm'
         assert self.setup.need_boot_partition() is True
 
+    def test_need_boot_partition_overlay(self):
+        self.__init_bootpart_check()
+        self.setup.root_filesystem_is_overlay = True
+        assert self.setup.need_boot_partition() is True
+
     def test_need_boot_partition_btrfs(self):
         self.__init_bootpart_check()
         self.setup.filesystem = 'btrfs'
@@ -209,6 +214,7 @@ class TestDiskSetup(object):
         assert self.setup_ppc.get_root_label() == 'MYLABEL'
 
     def __init_bootpart_check(self):
+        self.setup.root_filesystem_is_overlay = None
         self.setup.bootpart_requested = None
         self.setup.mdraid = None
         self.setup.volume_manager = None


### PR DESCRIPTION
overlay disk images uses a readonly root partition and are overlayed using overlayfs to hook in a cow based read-write space. This commit implements the basic disk setup. Implementation to boot such a disk in the kiwi boot code is still missing, as well as the investigation if dracut  is able to boot such a disk too. References #65