### PR TITLE
Remove xsltproc dependency

### DIFF
--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -131,6 +131,10 @@ class KiwiDataStructureError(KiwiError):
     pass
 
 
+class KiwiDescriptionConflict(KiwiError):
+    pass
+
+
 class KiwiDescriptionInvalid(KiwiError):
     pass
 

--- a/kiwi/xml_description.py
+++ b/kiwi/xml_description.py
@@ -22,7 +22,6 @@ from six import BytesIO
 from builtins import bytes
 
 # project
-from .command import Command
 from .defaults import Defaults
 from . import xml_parse
 
@@ -116,4 +115,3 @@ class XMLDescription(object):
         transform = etree.XSLT(etree.parse(Defaults.get_xsl_stylesheet_file()))
         with open(self.description_xslt_processed.name, "wb") as xsltout:
             xsltout.write(etree.tostring(transform(etree.parse(self.description))))
-

--- a/kiwi/xml_description.py
+++ b/kiwi/xml_description.py
@@ -129,9 +129,8 @@ class XMLDescription(object):
             etree.parse(Defaults.get_xsl_stylesheet_file())
         )
 
-        xml_source = self.description
-        if self.xml_content:
-            xml_source = BytesIO(bytes(self.xml_content))
+        xml_source = self.description if self.description else \
+            BytesIO(bytes(self.xml_content))
 
         with open(self.description_xslt_processed.name, "wb") as xsltout:
             xsltout.write(

--- a/kiwi/xml_description.py
+++ b/kiwi/xml_description.py
@@ -18,6 +18,7 @@
 from lxml import etree
 from tempfile import NamedTemporaryFile
 import os
+from six import BytesIO
 
 # project
 from .command import Command
@@ -52,9 +53,9 @@ class XMLDescription(object):
         path to base XML description file
 
     """
-    def __init__(self, description, derived_from=None):
+    def __init__(self, description=None, derived_from=None, content=None):
         self.description_xslt_processed = NamedTemporaryFile()
-        self.description = description
+        self.description = content and BytesIO(content) or description
         self.derived_from = derived_from
 
     def load(self):
@@ -66,7 +67,7 @@ class XMLDescription(object):
         :return: instance of XML toplevel domain (image)
         :rtype: object
         """
-        self.__xsltproc()
+        self._xsltproc()
         try:
             relaxng = etree.RelaxNG(
                 etree.parse(Defaults.get_schema_file())

--- a/kiwi/xml_description.py
+++ b/kiwi/xml_description.py
@@ -107,11 +107,11 @@ class XMLDescription(object):
             )
 
     def _xsltproc(self):
-        '''
+        """
         Transform XML description with the Kiwi rules.
 
         :return:
-        '''
+        """
         transform = etree.XSLT(etree.parse(Defaults.get_xsl_stylesheet_file()))
         with open(self.description_xslt_processed.name, "w") as xsltout:
             xsltout.write(etree.tostring(transform(etree.parse(self.description))))

--- a/kiwi/xml_description.py
+++ b/kiwi/xml_description.py
@@ -105,11 +105,13 @@ class XMLDescription(object):
                 '%s: %s' % (type(e).__name__, format(e))
             )
 
-    def __xsltproc(self):
-        Command.run(
-            [
-                'xsltproc', '-o', self.description_xslt_processed.name,
-                Defaults.get_xsl_stylesheet_file(),
-                self.description
-            ]
-        )
+    def _xsltproc(self):
+        '''
+        Transform XML description with the Kiwi rules.
+
+        :return:
+        '''
+        transform = etree.XSLT(etree.parse(Defaults.get_xsl_stylesheet_file()))
+        with open(self.description_xslt_processed.name, "w") as xsltout:
+            xsltout.write(etree.tostring(transform(etree.parse(self.description))))
+

--- a/kiwi/xml_description.py
+++ b/kiwi/xml_description.py
@@ -19,6 +19,7 @@ from lxml import etree
 from tempfile import NamedTemporaryFile
 import os
 from six import BytesIO
+from builtins import bytes
 
 # project
 from .command import Command
@@ -55,7 +56,7 @@ class XMLDescription(object):
     """
     def __init__(self, description=None, derived_from=None, content=None):
         self.description_xslt_processed = NamedTemporaryFile()
-        self.description = content and BytesIO(content) or description
+        self.description = content and BytesIO(bytes(content)) or description
         self.derived_from = derived_from
 
     def load(self):
@@ -113,6 +114,6 @@ class XMLDescription(object):
         :return:
         """
         transform = etree.XSLT(etree.parse(Defaults.get_xsl_stylesheet_file()))
-        with open(self.description_xslt_processed.name, "w") as xsltout:
+        with open(self.description_xslt_processed.name, "wb") as xsltout:
             xsltout.write(etree.tostring(transform(etree.parse(self.description))))
 

--- a/kiwi/xml_description.py
+++ b/kiwi/xml_description.py
@@ -96,7 +96,9 @@ class XMLDescription(object):
             )
         if not validation_ok:
             if self.description:
-                message = 'Schema validation for %s failed' % self.description
+                message = 'Schema validation for {description} failed'.format(
+                    description=self.description
+                )
             else:
                 message = 'Schema validation for XML content failed'
             raise KiwiDescriptionInvalid(message)

--- a/package/python3-kiwi-spec-template
+++ b/package/python3-kiwi-spec-template
@@ -70,7 +70,6 @@ Requires:       parted
 Requires:       multipath-tools
 Requires:       grub2
 Requires:       mtools
-Requires:       libxslt-tools
 %ifarch %arm aarch64
 Requires:       u-boot-tools
 %endif

--- a/test/unit/profile_test.py
+++ b/test/unit/profile_test.py
@@ -129,9 +129,8 @@ class TestProfile(object):
         ]
 
     @patch('kiwi.system.profile.NamedTemporaryFile')
-    @patch_open
     @patch('kiwi.system.shell.Shell.quote_key_value_file')
-    def test_create_cpio(self, mock_shell_quote, mock_open, mock_temp):
+    def test_create_cpio(self, mock_shell_quote, mock_temp):
         mock_temp.return_value = self.tmpfile
         description = XMLDescription('../data/example_dot_profile_config.xml')
         profile = Profile(

--- a/test/unit/profile_test.py
+++ b/test/unit/profile_test.py
@@ -129,14 +129,14 @@ class TestProfile(object):
         ]
 
     @patch('kiwi.system.profile.NamedTemporaryFile')
-    @patch('kiwi.system.shell.Shell.quote_key_value_file')
-    def test_create_cpio(self, mock_shell_quote, mock_temp):
+    def test_create_cpio(self, mock_temp):
         mock_temp.return_value = self.tmpfile
         description = XMLDescription('../data/example_dot_profile_config.xml')
         profile = Profile(
             XMLState(description.load(), None, 'cpio')
         )
         profile.create()
+        os.remove(self.tmpfile.name)
         assert profile.dot_profile['kiwi_cpio_name'] == 'LimeJeOS-openSUSE-13.2'
 
     def test_add(self):

--- a/test/unit/xml_description_test.py
+++ b/test/unit/xml_description_test.py
@@ -1,5 +1,6 @@
 import mock
 from builtins import bytes
+from lxml import etree
 
 from .test_helper import *
 
@@ -43,8 +44,15 @@ class TestSchema(object):
         XMLDescription(description='description', xml_content='content')
 
     def test_load_schema_from_xml_content(self):
+        schema = etree.parse('../../kiwi/schema/kiwi.rng')
+        lookup = '{http://relaxng.org/ns/structure/1.0}attribute'
+        for attribute in schema.iter(lookup):
+            if attribute.get('name') == 'schemaversion':
+                schemaversion = attribute.find(
+                    '{http://relaxng.org/ns/structure/1.0}value'
+                ).text
         parsed = self.description_from_data.load()
-        assert parsed.get_schemaversion() == '6.3'
+        assert parsed.get_schemaversion() == schemaversion
 
     @raises(KiwiSchemaImportError)
     @patch('lxml.etree.RelaxNG')

--- a/test/unit/xml_description_test.py
+++ b/test/unit/xml_description_test.py
@@ -1,6 +1,5 @@
 
-from mock import patch
-
+import lxml
 import mock
 
 from .test_helper import *
@@ -16,11 +15,15 @@ from kiwi.xml_description import XMLDescription
 
 class TestSchema(object):
     def setup(self):
-        self.description = XMLDescription('description')
+        test_xml = """<?xml version="1.0" encoding="utf-8"?>
+<image schemaversion="6.3" name="LimeJeOS-Leap-42.1">
+</image>
+"""
+        self.description = XMLDescription(content=test_xml)
 
     @raises(KiwiSchemaImportError)
     @patch('lxml.etree.RelaxNG')
-    @patch('kiwi.command.Command.run')
+    @patch.object(XMLDescription, '_xsltproc')
     def test_load_schema_import_error(self, mock_xslt, mock_relax):
         mock_relax.side_effect = KiwiSchemaImportError(
             'ImportError'
@@ -30,7 +33,7 @@ class TestSchema(object):
     @raises(KiwiValidationError)
     @patch('lxml.etree.RelaxNG')
     @patch('lxml.etree.parse')
-    @patch('kiwi.command.Command.run')
+    @patch.object(XMLDescription, '_xsltproc')
     def test_load_schema_validation_error(
         self, mock_xslt, mock_parse, mock_relax
     ):
@@ -44,7 +47,7 @@ class TestSchema(object):
     @raises(KiwiDescriptionInvalid)
     @patch('lxml.etree.RelaxNG')
     @patch('lxml.etree.parse')
-    @patch('kiwi.command.Command.run')
+    @patch.object(XMLDescription, '_xsltproc')
     def test_load_schema_description_invalid(
         self, mock_xslt, mock_parse, mock_relax
     ):
@@ -59,9 +62,9 @@ class TestSchema(object):
     @patch('lxml.etree.RelaxNG')
     @patch('lxml.etree.parse')
     @patch('kiwi.xml_parse.parse')
-    @patch('kiwi.command.Command.run')
+    @patch.object(XMLDescription, '_xsltproc')
     def test_load_data_structure_error(
-        self, mock_xslt, mock_xml_parse, mock_etree_parse, mock_relax
+        self, mock_xsltproc, mock_xml_parse, mock_etree_parse, mock_relax
     ):
         mock_validate = mock.Mock()
         mock_validate.validate = mock.Mock(

--- a/test/unit/xml_description_test.py
+++ b/test/unit/xml_description_test.py
@@ -1,6 +1,5 @@
-
-import lxml
 import mock
+from builtins import bytes
 
 from .test_helper import *
 
@@ -15,10 +14,10 @@ from kiwi.xml_description import XMLDescription
 
 class TestSchema(object):
     def setup(self):
-        test_xml = """<?xml version="1.0" encoding="utf-8"?>
+        test_xml = bytes(b"""<?xml version="1.0" encoding="utf-8"?>
 <image schemaversion="6.3" name="LimeJeOS-Leap-42.1">
 </image>
-"""
+""")
         self.description = XMLDescription(content=test_xml)
 
     @raises(KiwiSchemaImportError)

--- a/test/unit/xml_description_test.py
+++ b/test/unit/xml_description_test.py
@@ -3,7 +3,13 @@ from builtins import bytes
 
 from .test_helper import *
 
-from kiwi.exceptions import *
+from kiwi.exceptions import (
+    KiwiSchemaImportError,
+    KiwiValidationError,
+    KiwiDescriptionInvalid,
+    KiwiDataStructureError,
+    KiwiDescriptionConflict
+)
 from kiwi.xml_description import XMLDescription
 
 


### PR DESCRIPTION
Changes proposed in this pull request:
* Do not call 3rd party XPath processor (`xsltproc`) but use Python library instead
* Allow XMLDescription to be loaded also from the XML in the string, instead of just a physical file
