### PR TITLE
State Python 2.7 in setup.py

### DIFF
--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -37,7 +37,7 @@ The Python project uses :command:`pyvenv` to setup a development environment
 for the desired Python version. The script :command:`pyvenv` is already
 installed when using Python 3.3 and higher (see
 https://docs.python.org/3.3/whatsnew/3.3.html#pep-405-virtual-environments
-for details).
+for details). For Python 2.7 use :command:`virtualenv`.
 
 The following procedure describes how to create such an environment:
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -56,7 +56,8 @@ Feature Highlights
 
 * Distribution independent design
 * GPL v2 license
-* Complete rewrite from Perl to Python3
+* Complete rewrite from Perl to Python
+* Supports Python 2.7 and 3
 * openSUSE, SLES, RHEL [CentOS] supported
 * Build images for private and public clouds, e.g Amazon EC2
 * Build images for data center deployment

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -118,10 +118,10 @@ the next generation KIWI over the legacy version. Thus adding the
 Builder repository inherits this project setup and activates building
 with the next generation KIWI.
 
-Using KIWI NG in a python3 project
+Using KIWI NG in a Python Project
 ----------------------------------
 
-KIWI NG can also function as a module for other python3 projects.
+KIWI NG can also function as a module for other Python projects.
 The following example demonstrates how to read an existing image
 description, add a new repository definition and export the
 modified description on stdout.

--- a/setup.py
+++ b/setup.py
@@ -155,6 +155,7 @@ config = {
        'Intended Audience :: Developers',
        'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
        'Operating System :: POSIX :: Linux',
+       'Programming Language :: Python :: 2.7',
        'Programming Language :: Python :: 3.4',
        'Programming Language :: Python :: 3.5',
        'Topic :: System :: Operating System',


### PR DESCRIPTION
Changes proposed in this pull request:
*  As KIWI can now be used with Python 2.7, state Python 2.7 in Trove classifier of `setup.py`

