### PR TITLE
Support Tox with interactively positional arguments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ deps =
     -r.virtualenv.dev-requirements.txt
 changedir=test/unit
 commands =
-    py.test --no-cov-on-fail --cov=kiwi --cov-report=term-missing --cov-fail-under=100
+    py.test {posargs:--no-cov-on-fail --cov=kiwi --cov-report=term-missing --cov-fail-under=100}
 
 
 [testenv:doc]


### PR DESCRIPTION
This is a small patch for `tox.ini` only.

Changes proposed in this pull request:
* Use posargs for py.test, see http://tox.readthedocs.io/en/latest/example/general.html

Makes it easier to select just one test case by using:

```
$ tox -e 3.4 -- test/unit/filesystem_ext2_test.py
```
