### PR TITLE
Bootloader console

### DIFF
--- a/kiwi/boot/arch/arm/oemboot/preinit
+++ b/kiwi/boot/arch/arm/oemboot/preinit
@@ -99,7 +99,6 @@ if [ "$LOCAL_BOOT" = "no" ] && [ ! -z "$kiwi_oemrecovery" ];then
         /etc/sysconfig/kernel \
         /etc/sysconfig/bootloader \
         /etc/grub.conf \
-        /etc/lilo.conf \
         /etc/default/grub \
         /etc/grub.d/40_custom
     do

--- a/kiwi/boot/arch/ppc/oemboot/preinit
+++ b/kiwi/boot/arch/ppc/oemboot/preinit
@@ -99,7 +99,6 @@ if [ "$LOCAL_BOOT" = "no" ] && [ ! -z "$kiwi_oemrecovery" ];then
         /etc/sysconfig/kernel \
         /etc/sysconfig/bootloader \
         /etc/grub.conf \
-        /etc/lilo.conf \
         /etc/default/grub \
         /etc/grub.d/40_custom
     do

--- a/kiwi/boot/arch/s390/oemboot/preinit
+++ b/kiwi/boot/arch/s390/oemboot/preinit
@@ -112,7 +112,6 @@ if [ "$LOCAL_BOOT" = "no" ] && [ ! -z "$kiwi_oemrecovery" ];then
         /etc/sysconfig/kernel \
         /etc/sysconfig/bootloader \
         /etc/grub.conf \
-        /etc/lilo.conf \
         /etc/default/grub \
         /etc/grub.d/40_custom
     do

--- a/kiwi/boot/arch/x86_64/oemboot/preinit
+++ b/kiwi/boot/arch/x86_64/oemboot/preinit
@@ -99,7 +99,6 @@ if [ "$LOCAL_BOOT" = "no" ] && [ ! -z "$kiwi_oemrecovery" ];then
         /etc/sysconfig/kernel \
         /etc/sysconfig/bootloader \
         /etc/grub.conf \
-        /etc/lilo.conf \
         /etc/default/grub \
         /etc/grub.d/40_custom
     do

--- a/kiwi/boot/functions.sh
+++ b/kiwi/boot/functions.sh
@@ -1978,10 +1978,14 @@ EOF
     #======================================
     # set terminal mode
     #--------------------------------------
-    if [ -e $unifont ];then
-        echo "GRUB_TERMINAL=gfxterm"  >> $inst_default_grub
-    else
-        echo "GRUB_TERMINAL=console"  >> $inst_default_grub
+    if [ -z "$kiwi_bootloader_console" ];then
+        kiwi_bootloader_console=gfxterm
+    fi
+    echo "GRUB_TERMINAL=$kiwi_bootloader_console"  >> $inst_default_grub
+    if [ "$kiwi_bootloader_console" = "serial" ];then
+        local serial
+        serial="serial --speed=38400 --unit=0 --word=8 --parity=no --stop=1"
+        echo "GRUB_SERIAL_COMMAND=\"$serial\"" >> $inst_default_grub
     fi
     #======================================
     # write etc/default/grub_installdevice

--- a/kiwi/boot/functions.sh
+++ b/kiwi/boot/functions.sh
@@ -1201,7 +1201,6 @@ function installBootLoaderGrub2 {
     local confFile_grub=$confFile_grub_bios
     local bios_grub=/boot/grub2/i386-pc
     local product=/etc/products.d/baseproduct
-    local elilo_efi=/usr/lib64/efi/elilo.efi
     local grub_efi=/boot/efi/EFI/BOOT/grub.efi
     local isEFI=0
     #======================================
@@ -1217,110 +1216,6 @@ function installBootLoaderGrub2 {
                 return 1
             fi
             isEFI=1
-        fi
-    fi
-    #======================================
-    # check for elilo compat mode
-    #--------------------------------------
-    export elilo_compat=0
-    if [ $isEFI -eq 1 ] && [ -e $product ] && [ -e $elilo_efi ];then
-        local product=$(readlink $product)
-        local vendor=SuSE
-        local efipath=/boot/efi/EFI
-        if [[ "$product" =~ "SUSE_SLE" ]];then
-            #======================================
-            # check for recovery uuid
-            #--------------------------------------
-            if [ -z "$reco_uuid" ]; then
-                reco_uuid=$(blkid -o value -s UUID -t LABEL=recovery)
-            fi
-            #======================================
-            # check for bootloader displayname
-            #--------------------------------------
-            if [ -z "$kiwi_oemtitle" ] && [ ! -z "$kiwi_displayname" ];then
-                kiwi_oemtitle=$kiwi_displayname
-            fi
-            #======================================
-            # write elilo.conf
-            #--------------------------------------
-            . /etc/default/grub
-            local timeout=10
-            if [ ! -z "$kiwi_boot_timeout" ];then
-                timeout=$kiwi_boot_timeout
-            fi
-cat > /etc/elilo.conf << EOF
-# Modified by YaST2.
-timeout = $timeout
-##YaST - boot_efilabel = "$kiwi_oemtitle"
-vendor-directory = $vendor
-secure-boot = on
-prompt
-image  = /boot/vmlinuz
-###Don't change this comment - YaST2 identifier: Original name: linux###
-initrd = /boot/initrd
-label  = linux
-append = "$GRUB_CMDLINE_LINUX_DEFAULT"
-description = "$kiwi_oemtitle"
-root = $(getDiskID $imageRootDevice)
-EOF
-            #====================================================
-            # setup kernel symlinks
-            #----------------------------------------------------
-            local kversion=$(uname -r)
-            ln -sf /boot/vmlinuz-$kversion /boot/vmlinuz
-            ln -sf /boot/initrd-$kversion /boot/initrd
-            #====================================================
-            # create vendor directory
-            #----------------------------------------------------
-            mkdir -p $efipath/$vendor
-            #======================================
-            # update sysconfig/bootloader
-            #--------------------------------------
-            sed -i -e s'@LOADER_TYPE.*@LOADER_TYPE="elilo"@' \
-                /etc/sysconfig/bootloader
-            #======================================
-            # set up boot files and configurations
-            #--------------------------------------
-            # create elilo.conf and grub.cfg and
-            # copy boot files to /boot/efi
-            # ----
-            elilo -vv
-            #====================================================
-            # Append recovery entry to elilo written grub.cfg
-            #----------------------------------------------------
-            if [ "$kiwi_oemrecovery" = "true" ];then
-cat >> $efipath/$vendor/grub.cfg << EOF
-menuentry 'Recovery' --class os {
-    search --no-floppy --fs-uuid --set=root $reco_uuid
-    configfile /boot/grub2/grub.cfg
-}
-EOF
-            fi
-            #======================================
-            # write efi variable to NvRam
-            #--------------------------------------
-            # this is for the efi boot manager to show a better
-            # title for this system
-            # ----
-            elilo --refresh-EBM -vv
-            #====================================================
-            # create versionized kernel/initrd
-            #----------------------------------------------------
-            cp -a $efipath/$vendor/vmlinuz $efipath/$vendor/vmlinuz-$kversion
-            cp -a $efipath/$vendor/initrd $efipath/$vendor/initrd-$kversion
-            #====================================================
-            # sync vendor directory with standard boot path
-            #----------------------------------------------------
-            cp -a $efipath/$vendor/* $efipath/BOOT
-            #======================================
-            # set flag to indicate elilo is used
-            #--------------------------------------
-            elilo_compat=1
-            #======================================
-            # return early for elilo case
-            #--------------------------------------
-            mountpoint -q /boot/efi && umount /boot/efi
-            return 0
         fi
     fi
     if ! lookup $confTool &>/dev/null;then
@@ -1411,16 +1306,6 @@ function installBootLoaderGrub2Recovery {
             fi
             isEFI=1
         fi
-    fi
-    #======================================
-    # check for elilo compat mode
-    #--------------------------------------
-    if [ "$elilo_compat" -eq 1 ];then
-        # the recovery menu entry has been appended already
-        # as part of the regular installBootLoaderGrub2. This is
-        # done to ensure the entry is recreated after a recovery
-        # run because elilo doesn't support that
-        return 0
     fi
     #======================================
     # check tool status

--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -195,6 +195,7 @@ class BootImageBase(object):
         type_attributes = [
             'bootkernel',
             'bootloader',
+            'bootloader_console',
             'bootprofile',
             'boottimeout',
             'btrfs_root_is_snapshot',

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -114,7 +114,8 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 'host architecture %s not supported for grub2 setup' % arch
             )
 
-        self.terminal = 'gfxterm'
+        self.terminal = self.xml_state.build_type.get_bootloader_console() \
+            or 'gfxterm'
         self.gfxmode = self.get_gfxmode('grub2')
         self.bootpath = self.get_boot_path()
         self.theme = self.get_boot_theme()
@@ -507,6 +508,8 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 )
             else:
                 log.warning('Theme %s not found', theme_dir)
+                log.warning('Set bootloader terminal to console mode')
+                self.terminal = 'console'
 
     def _copy_efi_modules_to_boot_directory(self, lookup_path):
         self._copy_modules_to_boot_directory_from(

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -493,8 +493,9 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                     'Unicode font %s not found' % unicode_font
                 )
 
-        boot_theme_dir = self.root_dir + '/boot/' + \
-            self.boot_directory_name + '/themes'
+        boot_theme_dir = os.sep.join(
+            [self.root_dir, 'boot', self.boot_directory_name, 'themes']
+        )
         if self.theme and not os.path.exists(boot_theme_dir):
             Path.create(boot_theme_dir)
             theme_dir = self._find_grub_data(lookup_path + '/usr/share') + \
@@ -506,7 +507,18 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 data.sync_data(
                     options=['-z', '-a']
                 )
-            else:
+
+        self._check_boot_theme_exists(lookup_path)
+
+    def _check_boot_theme_exists(self, lookup_path):
+        if self.theme:
+            theme_dir = os.sep.join(
+                [
+                    self.root_dir, 'boot', self.boot_directory_name,
+                    'themes', self.theme
+                ]
+            )
+            if not os.path.exists(theme_dir):
                 log.warning('Theme %s not found', theme_dir)
                 log.warning('Set bootloader terminal to console mode')
                 self.terminal = 'console'

--- a/kiwi/bootloader/template/grub2.py
+++ b/kiwi/bootloader/template/grub2.py
@@ -59,6 +59,11 @@ class BootLoaderTemplateGrub2(object):
             terminal_output serial
         ''').strip() + os.linesep
 
+        self.header_textconsole = dedent('''
+            terminal_input console
+            terminal_output console
+        ''').strip() + os.linesep
+
         self.header_theme = dedent('''
             set font=($$root)${bootpath}/unicode.pf2
             # Try loading some extra fonts
@@ -93,7 +98,6 @@ class BootLoaderTemplateGrub2(object):
         self.menu_entry_hybrid = dedent('''
             menuentry "${title}" --class os --unrestricted {
                 echo Loading kernel...
-                set gfxpayload=${gfxmode}
                 $$linux ($$root)${bootpath}/${kernel_file} ${boot_options}
                 echo Loading initrd...
                 $$initrd ($$root)${bootpath}/${initrd_file}
@@ -105,7 +109,6 @@ class BootLoaderTemplateGrub2(object):
                 echo Loading hypervisor...
                 multiboot ${bootpath}/${hypervisor} dummy
                 echo Loading kernel...
-                set gfxpayload=${gfxmode}
                 module ${bootpath}/${kernel_file} dummy ${boot_options}
                 echo Loading initrd...
                 module ${bootpath}/${initrd_file} dummy
@@ -115,7 +118,6 @@ class BootLoaderTemplateGrub2(object):
         self.menu_entry = dedent('''
             menuentry "${title}" --class os --unrestricted {
                 echo Loading kernel...
-                set gfxpayload=${gfxmode}
                 linux ($$root)${bootpath}/${kernel_file} ${boot_options}
                 echo Loading initrd...
                 initrd ($$root)${bootpath}/${initrd_file}
@@ -125,7 +127,6 @@ class BootLoaderTemplateGrub2(object):
         self.menu_entry_failsafe_hybrid = dedent('''
             menuentry "Failsafe -- ${title}" --class os --unrestricted {
                 echo Loading kernel...
-                set gfxpayload=${gfxmode}
                 $$linux ($$root)${bootpath}/${kernel_file} ${failsafe_boot_options}
                 echo Loading initrd...
                 $$initrd ($$root)${bootpath}/${initrd_file}
@@ -137,7 +138,6 @@ class BootLoaderTemplateGrub2(object):
                 echo Loading hypervisor...
                 multiboot ${bootpath}/${hypervisor} dummy
                 echo Loading kernel...
-                set gfxpayload=${gfxmode}
                 module ${bootpath}/${kernel_file} dummy ${failsafe_boot_options}
                 echo Loading initrd...
                 module ${bootpath}/${initrd_file} dummy
@@ -147,7 +147,6 @@ class BootLoaderTemplateGrub2(object):
         self.menu_entry_failsafe = dedent('''
             menuentry "Failsafe -- ${title}" --class os --unrestricted {
                 echo Loading kernel...
-                set gfxpayload=${gfxmode}
                 linux ($$root)${bootpath}/${kernel_file} ${failsafe_boot_options}
                 echo Loading initrd...
                 initrd ($$root)${bootpath}/${initrd_file}
@@ -157,7 +156,6 @@ class BootLoaderTemplateGrub2(object):
         self.menu_install_entry_hybrid = dedent('''
             menuentry "Install ${title}" --class os --unrestricted {
                 echo Loading kernel...
-                set gfxpayload=${gfxmode}
                 $$linux ($$root)${bootpath}/${kernel_file} cdinst=1 ${boot_options}
                 echo Loading initrd...
                 $$initrd ($$root)${bootpath}/${initrd_file}
@@ -169,7 +167,6 @@ class BootLoaderTemplateGrub2(object):
                 echo Loading hypervisor...
                 multiboot ${bootpath}/${hypervisor} dummy
                 echo Loading kernel...
-                set gfxpayload=${gfxmode}
                 module ${bootpath}/${kernel_file} dummy cdinst=1 ${failsafe_boot_options}
                 echo Loading initrd...
                 module ${bootpath}/${initrd_file} dummy
@@ -179,7 +176,6 @@ class BootLoaderTemplateGrub2(object):
         self.menu_install_entry = dedent('''
             menuentry "Install ${title}" --class os --unrestricted {
                 echo Loading kernel...
-                set gfxpayload=${gfxmode}
                 linux ($$root)${bootpath}/${kernel_file} cdinst=1 ${boot_options}
                 echo Loading initrd...
                 initrd ($$root)${bootpath}/${initrd_file}
@@ -189,7 +185,6 @@ class BootLoaderTemplateGrub2(object):
         self.menu_install_entry_failsafe_hybrid = dedent('''
             menuentry "Failsafe -- Install ${title}" --class os --unrestricted {
                 echo Loading kernel...
-                set gfxpayload=${gfxmode}
                 $$linux ($$root)${bootpath}/${kernel_file} cdinst=1 ${failsafe_boot_options}
                 echo Loading initrd...
                 $$initrd ($$root)${bootpath}/${initrd_file}
@@ -201,7 +196,6 @@ class BootLoaderTemplateGrub2(object):
                 echo Loading hypervisor...
                 multiboot ${bootpath}/${hypervisor} dummy
                 echo Loading kernel...
-                set gfxpayload=${gfxmode}
                 module ${bootpath}/${kernel_file} dummy cdinst=1 ${failsafe_boot_options}
                 echo Loading initrd...
                 module ${bootpath}/${initrd_file} dummy
@@ -211,7 +205,6 @@ class BootLoaderTemplateGrub2(object):
         self.menu_install_entry_failsafe = dedent('''
             menuentry "Failsafe -- Install ${title}" --class os --unrestricted {
                 echo Loading kernel...
-                set gfxpayload=${gfxmode}
                 linux ($$root)${bootpath}/${kernel_file} cdinst=1 ${failsafe_boot_options}
                 echo Loading initrd...
                 initrd ($$root)${bootpath}/${initrd_file}
@@ -242,9 +235,11 @@ class BootLoaderTemplateGrub2(object):
             template_data += '\n' + self.header_hybrid
         if terminal == 'gfxterm':
             template_data += self.header_gfxterm
-        else:
+            template_data += self.header_theme
+        elif terminal == 'serial':
             template_data += self.header_serial
-        template_data += self.header_theme
+        else:
+            template_data += self.header_textconsole
         if hybrid:
             template_data += self.menu_entry_hybrid
             if failsafe:
@@ -272,9 +267,11 @@ class BootLoaderTemplateGrub2(object):
         template_data = self.header
         if terminal == 'gfxterm':
             template_data += self.header_gfxterm
-        else:
+            template_data += self.header_theme
+        elif terminal == 'serial':
             template_data += self.header_serial
-        template_data += self.header_theme
+        else:
+            template_data += self.header_textconsole
         template_data += self.menu_entry_multiboot
         if failsafe:
             template_data += self.menu_entry_failsafe_multiboot
@@ -299,9 +296,11 @@ class BootLoaderTemplateGrub2(object):
             template_data += self.header_hybrid
         if terminal == 'gfxterm':
             template_data += self.header_gfxterm
-        else:
+            template_data += self.header_theme_iso
+        elif terminal == 'serial':
             template_data += self.header_serial
-        template_data += self.header_theme_iso
+        else:
+            template_data += self.header_textconsole
         if hybrid:
             template_data += self.menu_entry_hybrid
             if failsafe:
@@ -330,9 +329,11 @@ class BootLoaderTemplateGrub2(object):
         template_data = self.header
         if terminal == 'gfxterm':
             template_data += self.header_gfxterm
-        else:
+            template_data += self.header_theme_iso
+        elif terminal == 'serial':
             template_data += self.header_serial
-        template_data += self.header_theme_iso
+        else:
+            template_data += self.header_textconsole
         template_data += self.menu_entry_multiboot
         if failsafe:
             template_data += self.menu_entry_failsafe_multiboot
@@ -358,9 +359,11 @@ class BootLoaderTemplateGrub2(object):
             template_data += self.header_hybrid
         if terminal == 'gfxterm':
             template_data += self.header_gfxterm
-        else:
+            template_data += self.header_theme_iso
+        elif terminal == 'serial':
             template_data += self.header_serial
-        template_data += self.header_theme_iso
+        else:
+            template_data += self.header_textconsole
         template_data += self.menu_iso_harddisk_entry
         if hybrid:
             template_data += self.menu_install_entry_hybrid
@@ -389,9 +392,11 @@ class BootLoaderTemplateGrub2(object):
         template_data = self.header
         if terminal == 'gfxterm':
             template_data += self.header_gfxterm
-        else:
+            template_data += self.header_theme_iso
+        elif terminal == 'serial':
             template_data += self.header_serial
-        template_data += self.header_theme_iso
+        else:
+            template_data += self.header_textconsole
         template_data += self.menu_iso_harddisk_entry
         template_data += self.menu_install_entry_multiboot
         if failsafe:

--- a/kiwi/bootloader/template/grub2.py
+++ b/kiwi/bootloader/template/grub2.py
@@ -64,25 +64,43 @@ class BootLoaderTemplateGrub2(object):
             terminal_output console
         ''').strip() + os.linesep
 
-        self.header_theme = dedent('''
+        self.fonts = dedent('''
             set font=($$root)${bootpath}/unicode.pf2
-            # Try loading some extra fonts
-            loadfont ($$root)${bootpath}/grub2/themes/${theme}/ascii.pf2;then
-            loadfont ($$root)${bootpath}/grub2/themes/${theme}/DejaVuSans-Bold14.pf2
-            loadfont ($$root)${bootpath}/grub2/themes/${theme}/DejaVuSans10.pf2
-            loadfont ($$root)${bootpath}/grub2/themes/${theme}/DejaVuSans12.pf2
-            loadfont ($$root)${bootpath}/grub2/themes/${theme}/ascii.pf2
+            set ascii_font=grub2/themes/${theme}/ascii.pf2
+            set sans_bold_14_font=grub2/themes/${theme}/DejaVuSans-Bold14.pf2
+            set sans_10_font=grub2/themes/${theme}/DejaVuSans10.pf2
+            set sans_12_font=grub2/themes/${theme}/DejaVuSans12.pf2
+        ''').strip() + os.linesep
+
+        self.header_theme = self.fonts + dedent('''
+            if [ -f ($$root)${bootpath}/$${ascii_font} ];then
+                loadfont ($$root)${bootpath}/$${ascii_font}
+            fi
+            if [ -f ($$root)${bootpath}/$${sans_bold_14_font} ];then
+                loadfont ($$root)${bootpath}/$${sans_bold_14_font}
+            fi
+            if [ -f ($$root)${bootpath}/$${sans_10_font} ];then
+                loadfont ($$root)${bootpath}/$${sans_10_font}
+            fi
+            if [ -f ($$root)${bootpath}/$${sans_12_font} ];then
+                loadfont ($$root)${bootpath}/$${sans_12_font}
+            fi
             set theme=($$root)${bootpath}/grub2/themes/${theme}/theme.txt
         ''').strip() + os.linesep
 
-        self.header_theme_iso = dedent('''
-            set font=($$root)/boot/unicode.pf2
-            # Try loading some extra fonts
-            loadfont ($$root)/boot/grub2/themes/${theme}/ascii.pf2;then
-            loadfont ($$root)/boot/grub2/themes/${theme}/DejaVuSans-Bold14.pf2
-            loadfont ($$root)/boot/grub2/themes/${theme}/DejaVuSans10.pf2
-            loadfont ($$root)/boot/grub2/themes/${theme}/DejaVuSans12.pf2
-            loadfont ($$root)/boot/grub2/themes/${theme}/ascii.pf2
+        self.header_theme_iso = self.fonts + dedent('''
+            if [ -f ($$root)/boot/$${ascii_font} ];then
+                loadfont ($$root)/boot/$${ascii_font}
+            fi
+            if [ -f ($$root)/boot/$${sans_bold_14_font} ];then
+                loadfont ($$root)/boot/$${sans_bold_14_font}
+            fi
+            if [ -f ($$root)/boot/$${sans_10_font} ];then
+                loadfont ($$root)/boot/$${sans_10_font}
+            fi
+            if [ -f ($$root)/boot/$${sans_12_font} ];then
+                loadfont ($$root)/boot/$${sans_12_font}
+            fi
             set theme=($$root)/boot/grub2/themes/${theme}/theme.txt
         ''').strip() + os.linesep
 

--- a/kiwi/bootloader/template/grub2.py
+++ b/kiwi/bootloader/template/grub2.py
@@ -115,6 +115,7 @@ class BootLoaderTemplateGrub2(object):
 
         self.menu_entry_hybrid = dedent('''
             menuentry "${title}" --class os --unrestricted {
+                set gfxpayload=keep
                 echo Loading kernel...
                 $$linux ($$root)${bootpath}/${kernel_file} ${boot_options}
                 echo Loading initrd...
@@ -124,6 +125,7 @@ class BootLoaderTemplateGrub2(object):
 
         self.menu_entry_multiboot = dedent('''
             menuentry "${title}" --class os --unrestricted {
+                set gfxpayload=keep
                 echo Loading hypervisor...
                 multiboot ${bootpath}/${hypervisor} dummy
                 echo Loading kernel...
@@ -135,6 +137,7 @@ class BootLoaderTemplateGrub2(object):
 
         self.menu_entry = dedent('''
             menuentry "${title}" --class os --unrestricted {
+                set gfxpayload=keep
                 echo Loading kernel...
                 linux ($$root)${bootpath}/${kernel_file} ${boot_options}
                 echo Loading initrd...
@@ -144,6 +147,7 @@ class BootLoaderTemplateGrub2(object):
 
         self.menu_entry_failsafe_hybrid = dedent('''
             menuentry "Failsafe -- ${title}" --class os --unrestricted {
+                set gfxpayload=keep
                 echo Loading kernel...
                 $$linux ($$root)${bootpath}/${kernel_file} ${failsafe_boot_options}
                 echo Loading initrd...
@@ -153,6 +157,7 @@ class BootLoaderTemplateGrub2(object):
 
         self.menu_entry_failsafe_multiboot = dedent('''
             menuentry "Failsafe -- ${title}" --class os --unrestricted {
+                set gfxpayload=keep
                 echo Loading hypervisor...
                 multiboot ${bootpath}/${hypervisor} dummy
                 echo Loading kernel...
@@ -164,6 +169,7 @@ class BootLoaderTemplateGrub2(object):
 
         self.menu_entry_failsafe = dedent('''
             menuentry "Failsafe -- ${title}" --class os --unrestricted {
+                set gfxpayload=keep
                 echo Loading kernel...
                 linux ($$root)${bootpath}/${kernel_file} ${failsafe_boot_options}
                 echo Loading initrd...
@@ -173,6 +179,7 @@ class BootLoaderTemplateGrub2(object):
 
         self.menu_install_entry_hybrid = dedent('''
             menuentry "Install ${title}" --class os --unrestricted {
+                set gfxpayload=keep
                 echo Loading kernel...
                 $$linux ($$root)${bootpath}/${kernel_file} cdinst=1 ${boot_options}
                 echo Loading initrd...
@@ -182,6 +189,7 @@ class BootLoaderTemplateGrub2(object):
 
         self.menu_install_entry_multiboot = dedent('''
             menuentry "Install -- ${title}" --class os --unrestricted {
+                set gfxpayload=keep
                 echo Loading hypervisor...
                 multiboot ${bootpath}/${hypervisor} dummy
                 echo Loading kernel...
@@ -193,6 +201,7 @@ class BootLoaderTemplateGrub2(object):
 
         self.menu_install_entry = dedent('''
             menuentry "Install ${title}" --class os --unrestricted {
+                set gfxpayload=keep
                 echo Loading kernel...
                 linux ($$root)${bootpath}/${kernel_file} cdinst=1 ${boot_options}
                 echo Loading initrd...
@@ -202,6 +211,7 @@ class BootLoaderTemplateGrub2(object):
 
         self.menu_install_entry_failsafe_hybrid = dedent('''
             menuentry "Failsafe -- Install ${title}" --class os --unrestricted {
+                set gfxpayload=keep
                 echo Loading kernel...
                 $$linux ($$root)${bootpath}/${kernel_file} cdinst=1 ${failsafe_boot_options}
                 echo Loading initrd...
@@ -211,6 +221,7 @@ class BootLoaderTemplateGrub2(object):
 
         self.menu_install_entry_failsafe_multiboot = dedent('''
             menuentry "Failsafe -- Install ${title}" --class os --unrestricted {
+                set gfxpayload=keep
                 echo Loading hypervisor...
                 multiboot ${bootpath}/${hypervisor} dummy
                 echo Loading kernel...
@@ -222,6 +233,7 @@ class BootLoaderTemplateGrub2(object):
 
         self.menu_install_entry_failsafe = dedent('''
             menuentry "Failsafe -- Install ${title}" --class os --unrestricted {
+                set gfxpayload=keep
                 echo Loading kernel...
                 linux ($$root)${bootpath}/${kernel_file} cdinst=1 ${failsafe_boot_options}
                 echo Loading initrd...

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1595,6 +1595,13 @@ div {
         attribute bootloader {
             "grub2" | "zipl" | "grub2_s390x_emu"
         }
+    k.type.bootloader_console.attribute =
+        ## Specifies the bootloader console.
+        ## The value only has an effect for the grub bootloader.
+        ## By default a graphics console setup is used
+        attribute bootloader_console {
+            "console" | "gfxterm" | "serial"
+        }
     k.type.btrfs_root_is_snapshot =
         ## Tell kiwi to install the system into a btrfs snapshot
         ## The snapshot layout is compatible with the snapper management
@@ -1848,6 +1855,7 @@ div {
         k.type.firmware.attribute? &
         k.type.bootkernel.attribute? &
         k.type.bootloader.attribute? &
+        k.type.bootloader_console.attribute? &
         k.type.zipl_targettype.attribute? &
         k.type.bootpartition.attribute? &
         k.type.bootpartsize.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2085,6 +2085,18 @@ At the moment grub, zipl and sys|extlinux are supported</a:documentation>
         </choice>
       </attribute>
     </define>
+    <define name="k.type.bootloader_console.attribute">
+      <attribute name="bootloader_console">
+        <a:documentation>Specifies the bootloader console.
+The value only has an effect for the grub bootloader.
+By default a graphics console setup is used</a:documentation>
+        <choice>
+          <value>console</value>
+          <value>gfxterm</value>
+          <value>serial</value>
+        </choice>
+      </attribute>
+    </define>
     <define name="k.type.btrfs_root_is_snapshot">
       <attribute name="btrfs_root_is_snapshot">
         <a:documentation>Tell kiwi to install the system into a btrfs snapshot
@@ -2526,6 +2538,9 @@ are available on the host. Default timeout is 3 seconds</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.bootloader.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.bootloader_console.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.zipl_targettype.attribute"/>

--- a/kiwi/system/profile.py
+++ b/kiwi/system/profile.py
@@ -267,6 +267,7 @@ class Profile(object):
         # kiwi_cmdline
         # kiwi_firmware
         # kiwi_bootloader
+        # kiwi_bootloader_console
         # kiwi_devicepersistency
         # kiwi_installboot
         # kiwi_bootkernel
@@ -301,6 +302,8 @@ class Profile(object):
             type_section.get_firmware()
         self.dot_profile['kiwi_bootloader'] = \
             type_section.get_bootloader()
+        self.dot_profile['kiwi_bootloader_console'] = \
+            type_section.get_bootloader_console()
         self.dot_profile['kiwi_btrfs_root_is_snapshot'] = \
             type_section.get_btrfs_root_is_snapshot()
         self.dot_profile['kiwi_gpt_hybrid_mbr'] = \

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Fri Jun  3 11:59:04 2016 by generateDS.py version 2.19b.
+# Generated Mon Jun 20 17:54:01 2016 by generateDS.py version 2.19b.
 #
 # Command line options:
 #   ('-f', '')
@@ -2546,13 +2546,14 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, checkprebuilt=None, compressed=None, container=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsnocheck=None, fsmountoptions=None, gcelicense=None, hybrid=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, target_blocksize=None, vbootsize=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, checkprebuilt=None, compressed=None, container=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsnocheck=None, fsmountoptions=None, gcelicense=None, hybrid=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, target_blocksize=None, vbootsize=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
         self.firmware = _cast(None, firmware)
         self.bootkernel = _cast(None, bootkernel)
         self.bootloader = _cast(None, bootloader)
+        self.bootloader_console = _cast(None, bootloader_console)
         self.zipl_targettype = _cast(None, zipl_targettype)
         self.bootpartition = _cast(bool, bootpartition)
         self.bootpartsize = _cast(int, bootpartsize)
@@ -2672,6 +2673,8 @@ class type_(GeneratedsSuper):
     def set_bootkernel(self, bootkernel): self.bootkernel = bootkernel
     def get_bootloader(self): return self.bootloader
     def set_bootloader(self, bootloader): self.bootloader = bootloader
+    def get_bootloader_console(self): return self.bootloader_console
+    def set_bootloader_console(self, bootloader_console): self.bootloader_console = bootloader_console
     def get_zipl_targettype(self): return self.zipl_targettype
     def set_zipl_targettype(self, zipl_targettype): self.zipl_targettype = zipl_targettype
     def get_bootpartition(self): return self.bootpartition
@@ -2806,6 +2809,9 @@ class type_(GeneratedsSuper):
         if self.bootloader is not None and 'bootloader' not in already_processed:
             already_processed.add('bootloader')
             outfile.write(' bootloader=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.bootloader), input_name='bootloader')), ))
+        if self.bootloader_console is not None and 'bootloader_console' not in already_processed:
+            already_processed.add('bootloader_console')
+            outfile.write(' bootloader_console=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.bootloader_console), input_name='bootloader_console')), ))
         if self.zipl_targettype is not None and 'zipl_targettype' not in already_processed:
             already_processed.add('zipl_targettype')
             outfile.write(' zipl_targettype=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.zipl_targettype), input_name='zipl_targettype')), ))
@@ -2986,6 +2992,11 @@ class type_(GeneratedsSuper):
             already_processed.add('bootloader')
             self.bootloader = value
             self.bootloader = ' '.join(self.bootloader.split())
+        value = find_attr_value_('bootloader_console', node)
+        if value is not None and 'bootloader_console' not in already_processed:
+            already_processed.add('bootloader_console')
+            self.bootloader_console = value
+            self.bootloader_console = ' '.join(self.bootloader_console.split())
         value = find_attr_value_('zipl_targettype', node)
         if value is not None and 'zipl_targettype' not in already_processed:
             already_processed.add('zipl_targettype')

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -628,6 +628,7 @@ class TestBootLoaderConfigGrub2(object):
         mock_exists.side_effect = side_effect
         self.bootloader.setup_install_boot_images(self.mbrid)
         assert mock_warn.called
+        assert self.bootloader.terminal == 'console'
 
     @patch('kiwi.bootloader.config.grub2.BootLoaderConfigGrub2.setup_install_boot_images')
     def test_setup_live_boot_images(self, mock_setup_install_boot_images):

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -565,6 +565,7 @@ class TestBootLoaderConfigGrub2(object):
         self.bootloader.theme = 'some-theme'
         self.os_exists['root_dir/boot/grub2/themes'] = False
         self.os_exists['root_dir/usr/share/grub2/themes/some-theme'] = True
+        self.os_exists['root_dir/boot/grub2/themes/some-theme'] = True
 
         def side_effect(arg):
             return self.os_exists[arg]
@@ -621,6 +622,7 @@ class TestBootLoaderConfigGrub2(object):
         mock_machine.return_value = 'x86_64'
         self.bootloader.theme = 'some-theme'
         self.os_exists['root_dir/usr/share/grub2/themes/some-theme'] = False
+        self.os_exists['root_dir/boot/grub2/themes/some-theme'] = False
 
         def side_effect(arg):
             return self.os_exists[arg]

--- a/test/unit/bootloader_template_grub2_test.py
+++ b/test/unit/bootloader_template_grub2_test.py
@@ -27,6 +27,21 @@ class TestBootLoaderTemplateGrub2(object):
             bootpath='/boot'
         )
 
+    def test_get_disk_template_console(self):
+        assert self.grub2.get_disk_template(
+            terminal='console'
+        ).substitute(
+            search_params='--fs-uuid --set=root 0815',
+            default_boot='0',
+            kernel_file='boot/linux.vmx',
+            initrd_file='boot/initrd.vmx',
+            boot_options='splash',
+            failsafe_boot_options='splash',
+            boot_timeout='10',
+            title='LimeJeOS-SLE12-Community [ VMX ]',
+            bootpath='/boot'
+        )
+
     def test_get_disk_template_serial_no_hybird(self):
         assert self.grub2.get_disk_template(
             terminal='serial',
@@ -38,8 +53,6 @@ class TestBootLoaderTemplateGrub2(object):
             initrd_file='boot/initrd.vmx',
             boot_options='splash',
             failsafe_boot_options='splash',
-            gfxmode='800x600',
-            theme='SLE',
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community [ VMX ]',
             bootpath='/boot'
@@ -61,6 +74,22 @@ class TestBootLoaderTemplateGrub2(object):
             hypervisor='xen.gz'
         )
 
+    def test_get_multiboot_disk_template_console(self):
+        assert self.grub2.get_multiboot_disk_template(
+            terminal='console'
+        ).substitute(
+            search_params='--fs-uuid --set=root 0815',
+            default_boot='0',
+            kernel_file='linux.vmx',
+            initrd_file='initrd.vmx',
+            boot_options='splash',
+            failsafe_boot_options='splash',
+            boot_timeout='10',
+            title='LimeJeOS-SLE12-Community [ VMX ]',
+            bootpath='/boot',
+            hypervisor='xen.gz'
+        )
+
     def test_get_multiboot_disk_template_serial(self):
         assert self.grub2.get_multiboot_disk_template(
             terminal='serial'
@@ -71,8 +100,6 @@ class TestBootLoaderTemplateGrub2(object):
             initrd_file='initrd.vmx',
             boot_options='splash',
             failsafe_boot_options='splash',
-            gfxmode='800x600',
-            theme='SLE',
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community [ VMX ]',
             bootpath='/boot',
@@ -95,6 +122,22 @@ class TestBootLoaderTemplateGrub2(object):
             hypervisor='xen.gz'
         )
 
+    def test_get_multiboot_install_template_console(self):
+        assert self.grub2.get_multiboot_install_template(
+            terminal='console'
+        ).substitute(
+            search_params='--fs-uuid --set=root 0815',
+            default_boot='0',
+            kernel_file='linux.vmx',
+            initrd_file='initrd.vmx',
+            boot_options='splash',
+            failsafe_boot_options='splash',
+            boot_timeout='10',
+            title='LimeJeOS-SLE12-Community [ VMX ]',
+            bootpath='/boot',
+            hypervisor='xen.gz'
+        )
+
     def test_get_multiboot_install_template_serial(self):
         assert self.grub2.get_multiboot_install_template(
             terminal='serial'
@@ -105,8 +148,6 @@ class TestBootLoaderTemplateGrub2(object):
             initrd_file='initrd.vmx',
             boot_options='splash',
             failsafe_boot_options='splash',
-            gfxmode='800x600',
-            theme='SLE',
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community [ VMX ]',
             bootpath='/boot',
@@ -128,6 +169,22 @@ class TestBootLoaderTemplateGrub2(object):
             bootpath='/boot'
         )
 
+    def test_get_install_template_console_no_hybrid(self):
+        assert self.grub2.get_install_template(
+            terminal='console',
+            hybrid=False
+        ).substitute(
+            search_params='--file --set=root /boot/0xd305fb7d',
+            default_boot='0',
+            kernel_file='boot/linux.vmx',
+            initrd_file='boot/initrd.vmx',
+            boot_options='cdinst=1 splash',
+            failsafe_boot_options='cdinst=1 splash',
+            boot_timeout='10',
+            title='LimeJeOS-SLE12-Community [ VMX ]',
+            bootpath='/boot'
+        )
+
     def test_get_install_template_serial_no_hybrid(self):
         assert self.grub2.get_install_template(
             terminal='serial',
@@ -139,8 +196,6 @@ class TestBootLoaderTemplateGrub2(object):
             initrd_file='boot/initrd.vmx',
             boot_options='cdinst=1 splash',
             failsafe_boot_options='cdinst=1 splash',
-            gfxmode='800x600',
-            theme='SLE',
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community [ VMX ]',
             bootpath='/boot'
@@ -161,6 +216,22 @@ class TestBootLoaderTemplateGrub2(object):
             bootpath='/boot'
         )
 
+    def test_get_iso_template_console_no_hybrid(self):
+        assert self.grub2.get_iso_template(
+            terminal='console',
+            hybrid=False
+        ).substitute(
+            search_params='--file --set=root /boot/0xd305fb7d',
+            default_boot='0',
+            kernel_file='boot/linux.vmx',
+            initrd_file='boot/initrd.vmx',
+            boot_options='splash',
+            failsafe_boot_options='splash',
+            boot_timeout='10',
+            title='LimeJeOS-SLE12-Community',
+            bootpath='/boot'
+        )
+
     def test_get_iso_template_serial_no_hybrid(self):
         assert self.grub2.get_iso_template(
             terminal='serial',
@@ -172,8 +243,6 @@ class TestBootLoaderTemplateGrub2(object):
             initrd_file='boot/initrd.vmx',
             boot_options='splash',
             failsafe_boot_options='splash',
-            gfxmode='800x600',
-            theme='SLE',
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community',
             bootpath='/boot'
@@ -195,6 +264,22 @@ class TestBootLoaderTemplateGrub2(object):
             hypervisor='xen.gz'
         )
 
+    def test_get_multiboot_iso_template_console(self):
+        assert self.grub2.get_multiboot_iso_template(
+            terminal='console'
+        ).substitute(
+            search_params='--fs-uuid --set=root 0815',
+            default_boot='0',
+            kernel_file='linux.vmx',
+            initrd_file='initrd.vmx',
+            boot_options='splash',
+            failsafe_boot_options='splash',
+            boot_timeout='10',
+            title='LimeJeOS-SLE12-Community',
+            bootpath='/boot',
+            hypervisor='xen.gz'
+        )
+
     def test_get_multiboot_iso_template_serial(self):
         assert self.grub2.get_multiboot_iso_template(
             terminal='serial'
@@ -205,8 +290,6 @@ class TestBootLoaderTemplateGrub2(object):
             initrd_file='initrd.vmx',
             boot_options='splash',
             failsafe_boot_options='splash',
-            gfxmode='800x600',
-            theme='SLE',
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community',
             bootpath='/boot',

--- a/test/unit/system_profile_test.py
+++ b/test/unit/system_profile_test.py
@@ -42,6 +42,7 @@ class TestProfile(object):
             'kiwi_compressed': None,
             'kiwi_delete': '',
             'kiwi_devicepersistency': None,
+            'kiwi_bootloader_console': None,
             'kiwi_displayname': 'LimeJeOS-openSUSE-13.2',
             'kiwi_drivers': '',
             'kiwi_firmware': 'efi',


### PR DESCRIPTION
Added support for setting the bootloader console
    
Some bootloader e.g grub supports graphics, text and also
serial consoles to hand over the output of the bootloader
menu. With this patch we allow to customize the console
used by the bootloader. So far only grub makes use of the
new attribute
    
*    ```<type ... bootloader_console="serial|console|gfxterm"/>```
    
This references Trello:
    
*    https://trello.com/c/q9EhNKKV/155-support-for-grub2-serial-console

