### PR TITLE
Fixup cleanup of intermediate config files

### DIFF
--- a/kiwi/system/root_bind.py
+++ b/kiwi/system/root_bind.py
@@ -16,6 +16,7 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
+import shutil
 
 # project
 from ..command import Command
@@ -200,6 +201,19 @@ class RootBind(object):
             log.warning(
                 'Failed to remove intermediate config files: %s', format(e)
             )
+
+        self._restore_intermediate_config_rpmnew_variants()
+
+    def _restore_intermediate_config_rpmnew_variants(self):
+        """
+        check for rpmnew variants of the config files. if the package
+        installed an rpmnew variant of the config file it needs to be
+        moved to the original file name
+        """
+        for config in self.config_files:
+            config_rpm_new = self.root_dir + config + '.rpmnew'
+            if os.path.exists(config_rpm_new):
+                shutil.move(config_rpm_new, self.root_dir + config)
 
     def _cleanup_mount_stack(self):
         for mount in reversed(self.mount_stack):

--- a/test/unit/system_root_bind_test.py
+++ b/test/unit/system_root_bind_test.py
@@ -116,17 +116,23 @@ class TestRootBind(object):
     @patch('kiwi.system.root_bind.Command.run')
     @patch('kiwi.system.root_bind.Path.remove_hierarchy')
     @patch('os.path.islink')
+    @patch('os.path.exists')
+    @patch('shutil.move')
     def test_cleanup(
-        self, mock_islink, mock_remove_hierarchy,
+        self, mock_move, mock_exists, mock_islink, mock_remove_hierarchy,
         mock_command, mock_is_mounted
     ):
         mock_is_mounted.return_value = False
+        mock_exists.return_value = True
         mock_islink.return_value = True
         self.bind_root.cleanup()
         self.mount_manager.umount_lazy.assert_called_once_with()
         mock_remove_hierarchy.assert_called_once_with('root-dir/mountpoint')
         mock_command.assert_called_once_with(
            ['rm', '-f', 'root-dir/foo.kiwi', 'root-dir/foo']
+        )
+        mock_move.assert_called_once_with(
+            'root-dir/foo.rpmnew', 'root-dir/foo'
         )
 
     @patch('os.path.islink')


### PR DESCRIPTION
__Fixup cleanup of intermediate config files__

kiwi uses e.g etc/hosts from the host system for proper name resolution during the build. The temporary variant of that file will be deleted by kiwi at the end of the installation process. However depending on the package manager and the distribution it could happen that the intermediate config
file added by kiwi is treated as existing config variant. In case of rpm a .rpmnew file variant of the config file is created and that needs to be handled by kiwi. Therefore this patch adds a private restore method for the .rpmnew case. It might be needed to add other restore methods to deal with this issue depending on how other (non rpm) based package managers handles the situation. Fixes #104