### PR TITLE
Fix VMWare disk tagging

### DIFF
--- a/kiwi/storage/subformat/vmdk.py
+++ b/kiwi/storage/subformat/vmdk.py
@@ -216,7 +216,8 @@ class DiskFormatVmdk(DiskFormatBase):
         vmdk_descriptor_call = Command.run(
             ['dd', 'if=' + vmdk_image_name, 'bs=1', 'count=1024', 'skip=512']
         )
-        vmdk_descriptor_lines = vmdk_descriptor_call.output.split('\n')
+        vmdk_descriptor_lines = \
+            vmdk_descriptor_call.output.strip('\0').split('\n')
         vmdk_descriptor_lines.insert(0, 'encoding="UTF-8"')
         vmdk_descriptor_lines.append(
             'ddb.toolsInstallType = "%s"' % vmdk_tools_install_type

--- a/kiwi/storage/subformat/vmdk.py
+++ b/kiwi/storage/subformat/vmdk.py
@@ -218,7 +218,8 @@ class DiskFormatVmdk(DiskFormatBase):
         )
         vmdk_descriptor_lines = \
             vmdk_descriptor_call.output.strip('\0').split('\n')
-        vmdk_descriptor_lines.insert(0, 'encoding="UTF-8"')
+        if (vmdk_descriptor_lines[0] != 'encoding="UTF-8"'):
+            vmdk_descriptor_lines.insert(0, 'encoding="UTF-8"')
         vmdk_descriptor_lines.append(
             'ddb.toolsInstallType = "%s"' % vmdk_tools_install_type
         )

--- a/test/unit/storage_subformat_vmdk_test.py
+++ b/test/unit/storage_subformat_vmdk_test.py
@@ -202,7 +202,7 @@ class TestDiskFormatVmdk(object):
         vmtoolsd_result.output = \
             'VMware Tools daemon, version 9.4.6.33107 (build-0815)'
         dd_result = mock.Mock()
-        dd_result.output = 'dd-out'
+        dd_result.output = 'dd-out\0\0\0\0\0'
 
         command_results = [
             dd_result, vmtoolsd_result, qemu_img_result
@@ -228,7 +228,7 @@ class TestDiskFormatVmdk(object):
         vmtoolsd_result.output = \
             'VMware Tools daemon, version 9.4.6.33107 (build-0815)'
         dd_result = mock.Mock()
-        dd_result.output = 'dd-out'
+        dd_result.output = 'dd-out\0\0\0\0\0'
 
         command_results = [
             dd_result, vmtoolsd_result, qemu_img_result


### PR DESCRIPTION
Fixes [BSC#988086](https://bugzilla.suse.com/show_bug.cgi?id=988086), [BSC#988087](https://bugzilla.suse.com/show_bug.cgi?id=988087)

The current implementation had a few issues resulting in nonfunctional VMDKs.

Changes proposed in this PR:

* strip null characters off the `dd` output.
* add the encoding prefix only if it's not already present