### PR TITLE
Fixing gce format build

### DIFF
--- a/kiwi/storage/subformat/gce.py
+++ b/kiwi/storage/subformat/gce.py
@@ -54,21 +54,27 @@ class DiskFormatGce(DiskFormatBase):
         """
         Create GCE disk format and manifest
         """
+        gce_tar_ball_file_list = []
         self.temp_image_dir = mkdtemp(
             prefix='kiwi_gce_subformat.', dir=self.target_dir
         )
         diskname = ''.join(
             [
                 self.target_dir, '/',
-                self.xml_state.xml_data.get_name(), '.raw'
+                self.xml_state.xml_data.get_name(),
+                '.' + self.arch,
+                '-' + self.xml_state.get_image_version(),
+                '.raw'
             ]
         )
         Command.run(
             ['cp', diskname, self.temp_image_dir + '/disk.raw']
         )
+        gce_tar_ball_file_list.append('disk.raw')
         if self.tag:
             with open(self.temp_image_dir + '/manifest.json', 'w') as manifest:
                 manifest.write('{"licenses": ["%s"]}' % self.tag)
+            gce_tar_ball_file_list.append('manifest.json')
 
         archive_name = self.get_target_name_for_format(self.image_format)
 
@@ -78,7 +84,7 @@ class DiskFormatGce(DiskFormatBase):
 
         archive = ArchiveTar(
             filename=self.target_dir + '/' + archive_name,
-            file_list=['manifest.json', 'disk.raw']
+            file_list=gce_tar_ball_file_list
         )
         archive.create_gnu_gzip_compressed(
             self.temp_image_dir

--- a/test/unit/storage_subformat_gce_test.py
+++ b/test/unit/storage_subformat_gce_test.py
@@ -54,7 +54,10 @@ class TestDiskFormatGce(object):
         self.disk_format.create_image_format()
 
         mock_command.assert_called_once_with(
-            ['cp', 'target_dir/some-disk-image.raw', 'tmpdir/disk.raw']
+            [
+                'cp', 'target_dir/some-disk-image.x86_64-0.8.15.raw',
+                'tmpdir/disk.raw'
+            ]
         )
         assert mock_open.call_args_list == [
             call('tmpdir/manifest.json', 'w')
@@ -64,7 +67,7 @@ class TestDiskFormatGce(object):
         ]
         mock_archive.assert_called_once_with(
             filename='target_dir/distribution-guest-gce-0.8.15.tar',
-            file_list=['manifest.json', 'disk.raw']
+            file_list=['disk.raw', 'manifest.json']
         )
         archive.create_gnu_gzip_compressed.assert_called_once_with(
             'tmpdir'


### PR DESCRIPTION
__Changes proposed in this pull request:__

The patch is two fold, first it fixes the name of the raw disk
when it is copied as disk.raw. Second it fixes the content list
of the tarball to be dynamicly build instead of a static allocation.
Reason for this change is that the list of files depends on the
XML description whether or not a gce disk tag is configured.
Fixes #113