### PR TITLE
Archive tar extension

### DIFF
--- a/kiwi/archive/tar.py
+++ b/kiwi/archive/tar.py
@@ -26,6 +26,12 @@ class ArchiveTar(object):
     """
     Extraction/Creation of tar archives
 
+    The tarfile python module is not used by that class,
+    since it does not provide support for some relevant features
+    in comparison to the GNU tar command (e.g. numeric-owner).
+    Moreover tarfile lacks support for xz compression under
+    Python v2.7.
+
     Attributes
 
     * :attr:`filename`

--- a/kiwi/archive/tar.py
+++ b/kiwi/archive/tar.py
@@ -19,6 +19,7 @@ import os
 
 # project
 from ..command import Command
+from ..exceptions import KiwiArchiveTarError
 
 
 class ArchiveTar(object):
@@ -41,6 +42,13 @@ class ArchiveTar(object):
         self.create_from_file_list = create_from_file_list
         self.file_list = file_list
 
+        if self._does_tar_command_support_xattrs():
+            self.xattrs_options = [
+                '--xattrs', '--xattrs-include=*'
+            ]
+        else:
+            self.xattrs_options = []
+
     def create(self, source_dir, exclude=None, options=None):
         """
         Create uncompressed tar archive
@@ -54,10 +62,28 @@ class ArchiveTar(object):
         Command.run(
             [
                 'tar', '-C', source_dir
-            ] + options + [
-                '--xattrs', '--xattrs-include=*', '-c', '-f',
-                self.filename
+            ] + options +
+            self.xattrs_options + [
+                '-c', '-f', self.filename
             ] + self._get_archive_items(source_dir, exclude)
+        )
+
+    def append_files(self, source_dir, files_to_append, options=None):
+        """
+        Append files to an already existing uncompressed tar archive
+
+        :param string source_dir: data source directory
+        :param list files_to_append: list of items to append
+        :param list options: custom options
+        """
+        if not options:
+            options = []
+        Command.run(
+            [
+                'tar', '-C', source_dir, '-r',
+                '--file=' + self.filename
+            ] + options +
+            self.xattrs_options + files_to_append
         )
 
     def create_xz_compressed(self, source_dir, exclude=None, options=None):
@@ -73,9 +99,9 @@ class ArchiveTar(object):
         Command.run(
             [
                 'tar', '-C', source_dir
-            ] + options + [
-                '--xattrs', '--xattrs-include=*', '-c', '-J', '-f',
-                self.filename + '.xz'
+            ] + options +
+            self.xattrs_options + [
+                '-c', '-J', '-f', self.filename + '.xz'
             ] + self._get_archive_items(source_dir, exclude)
         )
 
@@ -133,3 +159,15 @@ class ArchiveTar(object):
             archive_items.append('--exclude')
             archive_items.append('./' + exclude)
         return archive_items
+
+    def _does_tar_command_support_xattrs(self):
+        command = Command.run(['tar', '--version'])
+
+        try:
+            version_line = command.output.splitlines()[0]
+            version_string = version_line.split()[-1]
+            version_info = tuple(int(elt) for elt in version_string.split('.'))
+        except:
+            raise KiwiArchiveTarError(
+                "Unable to parse tar version string")
+        return version_info >= (1, 27)

--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -41,6 +41,13 @@ class KiwiArchiveSetupError(KiwiError):
     """
 
 
+class KiwiArchiveTarError(KiwiError):
+    """
+    Exception raised if impossible to determine which tar command
+    version is installed on the underlying system
+    """
+
+
 class KiwiBootImageSetupError(KiwiError):
     """
     Exception raised if an unsupported initrd system type is used.

--- a/test/unit/archive_tar_test.py
+++ b/test/unit/archive_tar_test.py
@@ -1,5 +1,5 @@
 
-from mock import patch
+from mock import patch, call
 
 import mock
 
@@ -9,7 +9,19 @@ from kiwi.archive.tar import ArchiveTar
 
 
 class TestArchiveTar(object):
-    def setup(self):
+    @patch('kiwi.archive.tar.Command.run')
+    def setup(self, mock_command):
+        command = mock.Mock()
+        command.output = 'version 1.27.0'
+        mock_command.return_value = command
+        self.archive = ArchiveTar('foo.tar')
+
+    @raises(kiwi.exceptions.KiwiArchiveTarError)
+    @patch('kiwi.archive.tar.Command.run')
+    def test_invalid_tar_command_version(self, mock_command):
+        command = mock.Mock()
+        command.output = 'version cannot be parsed'
+        mock_command.return_value = command
         self.archive = ArchiveTar('foo.tar')
 
     @patch('kiwi.archive.tar.Command.run')
@@ -33,16 +45,73 @@ class TestArchiveTar(object):
         )
 
     @patch('kiwi.archive.tar.Command.run')
-    def test_create_from_dir_with_excludes(self, mock_command):
-        archive = ArchiveTar('foo.tar', False)
-        archive.create('source-dir', ['foo', 'bar'])
+    def test_append_files(self, mock_command):
+        self.archive.append_files('source-dir', ['foo', 'bar'])
         mock_command.assert_called_once_with(
             [
-                'tar', '-C', 'source-dir', '--xattrs', '--xattrs-include=*',
-                '-c', '-f', 'foo.tar', '.',
-                '--exclude', './foo', '--exclude', './bar'
+                'tar', '-C', 'source-dir', '-r',
+                '--file=' + self.archive.filename,
+                '--xattrs', '--xattrs-include=*',
+                'foo', 'bar'
             ]
         )
+
+    @patch('kiwi.archive.tar.Command.run')
+    @patch('os.listdir')
+    def test_create_with_options(self, mock_os_dir, mock_command):
+        mock_os_dir.return_value = ['foo', 'bar']
+        self.archive.create('source-dir', options=[
+            '--fake-option', 'fake_arg'
+        ])
+        mock_command.assert_called_once_with(
+            [
+                'tar', '-C', 'source-dir',
+                '--fake-option', 'fake_arg',
+                '--xattrs', '--xattrs-include=*',
+                '-c', '-f', 'foo.tar', 'foo', 'bar'
+            ]
+        )
+
+    @patch('kiwi.archive.tar.Command.run')
+    @patch('os.listdir')
+    def test_create_with_old_tar_version(self, mock_os_dir, mock_command):
+        command = mock.Mock()
+        command.output = 'version 1.26.1'
+        mock_command.return_value = command
+        archive = ArchiveTar('foo.tar')
+        mock_os_dir.return_value = ['foo', 'bar']
+        archive.create('source-dir')
+        calls = [
+            call(['tar', '--version']),
+            call(
+                [
+                    'tar', '-C', 'source-dir',
+                    '-c', '-f', 'foo.tar', 'foo', 'bar'
+                ]
+            )
+        ] 
+        mock_command.assert_has_calls(calls)
+        assert mock_command.call_count == 2
+
+    @patch('kiwi.archive.tar.Command.run')
+    def test_create_from_dir_with_excludes(self, mock_command):
+        command = mock.Mock()
+        command.output = 'version 1.27.0'
+        mock_command.return_value = command
+        archive = ArchiveTar('foo.tar', False)
+        archive.create('source-dir', ['foo', 'bar'])
+        calls = [
+            call(['tar', '--version']),
+            call(
+                [
+                    'tar', '-C', 'source-dir', '--xattrs', '--xattrs-include=*',
+                    '-c', '-f', 'foo.tar', '.',
+                    '--exclude', './foo', '--exclude', './bar'
+                ]
+            )
+        ] 
+        mock_command.assert_has_calls(calls)
+        assert mock_command.call_count == 2
 
     @patch('kiwi.archive.tar.Command.run')
     @patch('os.listdir')


### PR DESCRIPTION
**Changes proposed in this pull request:**

From one side it includes the tar version validation already posted in #99, just with some minor changes in order to test the version just once in constructor and not in every command run. It also includes some small extension to provide files appending features that might handy to support lxd container format as seen in #99. Finally a comment is included in class description in order to justify why kiwi is no using tarfile python module.