### PR TITLE
Six iterator instead of object builtin

### DIFF
--- a/kiwi/command.py
+++ b/kiwi/command.py
@@ -19,6 +19,10 @@ import select
 import os
 import subprocess
 from collections import namedtuple
+
+# In python2 bytes is string which is different from
+# the bytes type in python3. The bytes type from the
+# builtins generalizes this type to be bytes always
 from builtins import bytes
 
 # project

--- a/kiwi/command_process.py
+++ b/kiwi/command_process.py
@@ -15,12 +15,12 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
-# project
+import six
+from builtins import bytes
 
-from builtins import object
+# project
 from .logger import log
 from collections import namedtuple
-from builtins import bytes
 
 from .exceptions import (
     KiwiCommandError
@@ -139,7 +139,7 @@ class CommandProcess(object):
             self.command.kill()
 
 
-class CommandIterator(object):
+class CommandIterator(six.Iterator):
     """
     Implements Iterator for Instances of Command
     """

--- a/kiwi/command_process.py
+++ b/kiwi/command_process.py
@@ -16,6 +16,10 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import six
+
+# In python2 bytes is string which is different from
+# the bytes type in python3. The bytes type from the
+# builtins generalizes this type to be bytes always
 from builtins import bytes
 
 # project

--- a/kiwi/iso.py
+++ b/kiwi/iso.py
@@ -22,6 +22,10 @@ import collections
 import platform
 from tempfile import NamedTemporaryFile
 from collections import namedtuple
+
+# In python2 bytes is string which is different from
+# the bytes type in python3. The bytes type from the
+# builtins generalizes this type to be bytes always
 from builtins import bytes
 
 # project

--- a/kiwi/xml_description.py
+++ b/kiwi/xml_description.py
@@ -19,6 +19,10 @@ from lxml import etree
 from tempfile import NamedTemporaryFile
 import os
 from six import BytesIO
+
+# In python2 bytes is string which is different from
+# the bytes type in python3. The bytes type from the
+# builtins generalizes this type to be bytes always
 from builtins import bytes
 
 # project


### PR DESCRIPTION
__Use six.Iterator instead of global object builtin__
    
The use of six.Iterator as base class for the CommandIterator  seems more clear and explicit compared to the global object type overwritten by the builtins import. Fixes Smell reported by landscape

__Explain why bytes type is redefined__
    
In python2 bytes is string which is different from the bytes type in python3. The bytes type from the builtins generalizes this type to be bytes always. However the redefinition of the bytes type is marked as Smell in landscape. Thus the code  should at least inform why this is done


