### PR TITLE
Fix user schema layout

### DIFF
--- a/kiwi/boot/arch/arm/oemboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/arm/oemboot/suse-SLES12/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-oemboot-suse-SLES12">
+<image schemaversion="6.4" name="initrd-oemboot-suse-SLES12">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/arm/oemboot/suse-leap42.1/config.xml
+++ b/kiwi/boot/arch/arm/oemboot/suse-leap42.1/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-oemboot-suse-leap-42.1">
+<image schemaversion="6.4" name="initrd-oemboot-suse-leap-42.1">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/arm/oemboot/suse-leap42.2/config.xml
+++ b/kiwi/boot/arch/arm/oemboot/suse-leap42.2/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-oemboot-suse-leap-42.2">
+<image schemaversion="6.4" name="initrd-oemboot-suse-leap-42.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/arm/oemboot/suse-tumbleweed/config.xml
+++ b/kiwi/boot/arch/arm/oemboot/suse-tumbleweed/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-oemboot-suse-tumbleweed">
+<image schemaversion="6.4" name="initrd-oemboot-suse-tumbleweed">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/arm/vmxboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/arm/vmxboot/suse-SLES12/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-vmxboot-suse-SLES12">
+<image schemaversion="6.4" name="initrd-vmxboot-suse-SLES12">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/arm/vmxboot/suse-leap42.1/config.xml
+++ b/kiwi/boot/arch/arm/vmxboot/suse-leap42.1/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-vmxboot-suse-leap-42.1">
+<image schemaversion="6.4" name="initrd-vmxboot-suse-leap-42.1">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/arm/vmxboot/suse-leap42.2/config.xml
+++ b/kiwi/boot/arch/arm/vmxboot/suse-leap42.2/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-vmxboot-suse-leap-42.2">
+<image schemaversion="6.4" name="initrd-vmxboot-suse-leap-42.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/arm/vmxboot/suse-tumbleweed/config.xml
+++ b/kiwi/boot/arch/arm/vmxboot/suse-tumbleweed/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-vmxboot-suse-tumbleweed">
+<image schemaversion="6.4" name="initrd-vmxboot-suse-tumbleweed">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/ppc/netboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/ppc/netboot/suse-SLES12/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-netboot-suse-SLES12">
+<image schemaversion="6.4" name="initrd-netboot-suse-SLES12">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/ppc/oemboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/ppc/oemboot/suse-SLES12/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-oemboot-suse-SLES12">
+<image schemaversion="6.4" name="initrd-oemboot-suse-SLES12">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/ppc/vmxboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/ppc/vmxboot/suse-SLES12/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-vmxboot-suse-SLES12">
+<image schemaversion="6.4" name="initrd-vmxboot-suse-SLES12">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/s390/netboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/s390/netboot/suse-SLES12/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-netboot-suse-SLES12">
+<image schemaversion="6.4" name="initrd-netboot-suse-SLES12">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/s390/oemboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/s390/oemboot/suse-SLES12/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-oemboot-suse-SLES12">
+<image schemaversion="6.4" name="initrd-oemboot-suse-SLES12">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/s390/vmxboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/s390/vmxboot/suse-SLES12/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-vmxboot-suse-SLES12">
+<image schemaversion="6.4" name="initrd-vmxboot-suse-SLES12">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/x86_64/isoboot/rhel-07.0/config.xml
+++ b/kiwi/boot/arch/x86_64/isoboot/rhel-07.0/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-isoboot-rhel-07.0">
+<image schemaversion="6.4" name="initrd-isoboot-rhel-07.0">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/x86_64/isoboot/suse-13.2/config.xml
+++ b/kiwi/boot/arch/x86_64/isoboot/suse-13.2/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-isoboot-suse-13.2">
+<image schemaversion="6.4" name="initrd-isoboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/x86_64/isoboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/x86_64/isoboot/suse-SLES12/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-isoboot-suse-SLES12">
+<image schemaversion="6.4" name="initrd-isoboot-suse-SLES12">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/x86_64/isoboot/suse-leap42.1/config.xml
+++ b/kiwi/boot/arch/x86_64/isoboot/suse-leap42.1/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-isoboot-suse-leap-42.1">
+<image schemaversion="6.4" name="initrd-isoboot-suse-leap-42.1">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/isoboot/suse-leap42.2/config.xml
+++ b/kiwi/boot/arch/x86_64/isoboot/suse-leap42.2/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-isoboot-suse-leap-42.2">
+<image schemaversion="6.4" name="initrd-isoboot-suse-leap-42.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/isoboot/suse-tumbleweed/config.xml
+++ b/kiwi/boot/arch/x86_64/isoboot/suse-tumbleweed/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-isoboot-suse-tumbleweed">
+<image schemaversion="6.4" name="initrd-isoboot-suse-tumbleweed">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/x86_64/isoboot/ubuntu-xenial/config.xml
+++ b/kiwi/boot/arch/x86_64/isoboot/ubuntu-xenial/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-isoboot-ubuntu-xenial">
+<image schemaversion="6.4" name="initrd-isoboot-ubuntu-xenial">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/netboot/suse-13.2/config.xml
+++ b/kiwi/boot/arch/x86_64/netboot/suse-13.2/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-netboot-suse-13.2">
+<image schemaversion="6.4" name="initrd-netboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/x86_64/netboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/x86_64/netboot/suse-SLES12/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-netboot-suse-SLES12">
+<image schemaversion="6.4" name="initrd-netboot-suse-SLES12">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/x86_64/netboot/suse-leap42.1/config.xml
+++ b/kiwi/boot/arch/x86_64/netboot/suse-leap42.1/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-netboot-suse-leap-42.1">
+<image schemaversion="6.4" name="initrd-netboot-suse-leap-42.1">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/netboot/suse-leap42.2/config.xml
+++ b/kiwi/boot/arch/x86_64/netboot/suse-leap42.2/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-netboot-suse-leap-42.2">
+<image schemaversion="6.4" name="initrd-netboot-suse-leap-42.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/netboot/suse-tumbleweed/config.xml
+++ b/kiwi/boot/arch/x86_64/netboot/suse-tumbleweed/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-netboot-suse-tumbleweed">
+<image schemaversion="6.4" name="initrd-netboot-suse-tumbleweed">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/x86_64/oemboot/rhel-07.0/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/rhel-07.0/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-oemboot-rhel-07.0">
+<image schemaversion="6.4" name="initrd-oemboot-rhel-07.0">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/oemboot/suse-13.2/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-13.2/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-oemboot-suse-13.2">
+<image schemaversion="6.4" name="initrd-oemboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/x86_64/oemboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-SLES12/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-oemboot-suse-SLES12">
+<image schemaversion="6.4" name="initrd-oemboot-suse-SLES12">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/x86_64/oemboot/suse-leap42.1/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-leap42.1/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-oemboot-suse-leap-42.1">
+<image schemaversion="6.4" name="initrd-oemboot-suse-leap-42.1">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/oemboot/suse-leap42.2/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-leap42.2/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-oemboot-suse-leap-42.2">
+<image schemaversion="6.4" name="initrd-oemboot-suse-leap-42.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/oemboot/suse-tumbleweed/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-tumbleweed/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-oemboot-suse-tumbleweed">
+<image schemaversion="6.4" name="initrd-oemboot-suse-tumbleweed">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/x86_64/oemboot/ubuntu-xenial/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/ubuntu-xenial/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-oemboot-ubuntu-xenial">
+<image schemaversion="6.4" name="initrd-oemboot-ubuntu-xenial">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/vmxboot/rhel-07.0/config.xml
+++ b/kiwi/boot/arch/x86_64/vmxboot/rhel-07.0/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-vmxboot-rhel-07.0">
+<image schemaversion="6.4" name="initrd-vmxboot-rhel-07.0">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/x86_64/vmxboot/suse-13.2/config.xml
+++ b/kiwi/boot/arch/x86_64/vmxboot/suse-13.2/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-vmxboot-suse-13.2">
+<image schemaversion="6.4" name="initrd-vmxboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/x86_64/vmxboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/x86_64/vmxboot/suse-SLES12/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-vmxboot-suse-SLES12">
+<image schemaversion="6.4" name="initrd-vmxboot-suse-SLES12">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/x86_64/vmxboot/suse-leap42.1/config.xml
+++ b/kiwi/boot/arch/x86_64/vmxboot/suse-leap42.1/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-vmxboot-suse-leap-42.1">
+<image schemaversion="6.4" name="initrd-vmxboot-suse-leap-42.1">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/vmxboot/suse-leap42.2/config.xml
+++ b/kiwi/boot/arch/x86_64/vmxboot/suse-leap42.2/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-vmxboot-suse-leap-42.2">
+<image schemaversion="6.4" name="initrd-vmxboot-suse-leap-42.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/vmxboot/suse-tumbleweed/config.xml
+++ b/kiwi/boot/arch/x86_64/vmxboot/suse-tumbleweed/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-vmxboot-suse-tumbleweed">
+<image schemaversion="6.4" name="initrd-vmxboot-suse-tumbleweed">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/x86_64/vmxboot/ubuntu-xenial/config.xml
+++ b/kiwi/boot/arch/x86_64/vmxboot/ubuntu-xenial/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-vmxboot-ubuntu-xenial">
+<image schemaversion="6.4" name="initrd-vmxboot-ubuntu-xenial">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/config/strip.xml
+++ b/kiwi/config/strip.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-strip-metadata">
+<image schemaversion="6.4" name="initrd-strip-metadata">
     <description type="boot">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -37,6 +37,8 @@ mac-address-type = xsd:token {pattern = "([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}"}
 size-type = xsd:token {pattern = "\d*|image"}
 volume-size-type = xsd:token {pattern = "\d+|\d+M|\d+G|all"}
 vhd-tag-type = xsd:token {pattern = "[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}"}
+group-name = xsd:token {pattern = "[a-zA-Z0-9_\-\.]+"}
+secgroups-list = xsd:token {pattern = "[a-zA-Z0-9_\-\.]+(,?[a-zA-Z0-9_\-\.]+)*"}
 
 #==========================================
 # start with image description
@@ -1954,6 +1956,12 @@ div {
     k.user.id.attribute = 
         ## The user ID for this user
         attribute id { xsd:nonNegativeInteger }
+    k.user.group.attribute =
+        ## The primary group for this user
+        attribute group { group-name }
+    k.user.secgroups.attribute =
+        ## The secondary groups for this user
+        attribute secgroups { secgroups-list }
     k.user.realname.attribute =
         ## The name of an user
         attribute realname { text }
@@ -1968,6 +1976,8 @@ div {
         ## The shell for this user
         attribute shell { text }
     k.user.attlist =
+        k.user.group.attribute &
+        k.user.secgroups.attribute? &
         k.user.home.attribute &
         k.user.id.attribute? &
         k.user.name.attribute &
@@ -2834,16 +2844,8 @@ div {
 # main block: <users>
 #
 div {
-    k.users.group.attribute =
-        ## Contains the group to which the user belongs
-        attribute group { text }
-    k.users.id.attribute =
-        ## Contains the group ID to which the user belongs
-        attribute id { xsd:nonNegativeInteger }
     k.users.profiles.attribute = k.profiles.attribute
     k.users.attlist =
-        k.users.group.attribute &
-        k.users.id.attribute? &
         k.users.profiles.attribute?
     k.users = 
         ## A List of Users

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -37,8 +37,7 @@ mac-address-type = xsd:token {pattern = "([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}"}
 size-type = xsd:token {pattern = "\d*|image"}
 volume-size-type = xsd:token {pattern = "\d+|\d+M|\d+G|all"}
 vhd-tag-type = xsd:token {pattern = "[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}"}
-group-name = xsd:token {pattern = "[a-zA-Z0-9_\-\.]+"}
-secgroups-list = xsd:token {pattern = "[a-zA-Z0-9_\-\.]+(,?[a-zA-Z0-9_\-\.]+)*"}
+groups-list = xsd:token {pattern = "[a-zA-Z0-9_\-\.]+(,[a-zA-Z0-9_\-\.]+)*"}
 
 #==========================================
 # start with image description
@@ -1956,12 +1955,12 @@ div {
     k.user.id.attribute = 
         ## The user ID for this user
         attribute id { xsd:nonNegativeInteger }
-    k.user.group.attribute =
-        ## The primary group for this user
-        attribute group { group-name }
-    k.user.secgroups.attribute =
-        ## The secondary groups for this user
-        attribute secgroups { secgroups-list }
+    k.user.groups.attribute =
+        ## The list of groups that he user belongs to. The
+        ## frist item in the list is used as the login group.
+        ## If 'groups' is not present a default group is assigned
+        ## to the user according to he specifing toolchain behaviour.
+        attribute groups { groups-list }
     k.user.realname.attribute =
         ## The name of an user
         attribute realname { text }
@@ -1976,8 +1975,7 @@ div {
         ## The shell for this user
         attribute shell { text }
     k.user.attlist =
-        k.user.group.attribute &
-        k.user.secgroups.attribute? &
+        k.user.groups.attribute? &
         k.user.home.attribute &
         k.user.id.attribute? &
         k.user.name.attribute &

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -26,7 +26,7 @@ db:info [
     db:releaseinfo [
         "$Id: $"
     ]
-    db:releaseinfo [ "RNC Schema Version 6.3" ]
+    db:releaseinfo [ "RNC Schema Version 6.4" ]
     db:pubdate [ "START" ]
     db:pubdate [ "2016-03-18" ]
 ]
@@ -62,7 +62,7 @@ div {
         attribute xsi:schemaLocation { xsd:anyURI }
     k.image.schemaversion.attribute =
         ## The allowed Schema version (fixed value)
-        attribute schemaversion { "6.3" }
+        attribute schemaversion { "6.4" }
     k.image.kiwirevision.attribute =
         ## A kiwi git revision number which is known to build
         ## a working image from this description. If the kiwi git

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -57,6 +57,16 @@
       <param name="pattern">[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}</param>
     </data>
   </define>
+  <define name="group-name">
+    <data type="token">
+      <param name="pattern">[a-zA-Z0-9_\-\.]+</param>
+    </data>
+  </define>
+  <define name="secgroups-list">
+    <data type="token">
+      <param name="pattern">[a-zA-Z0-9_\-\.]+(,?[a-zA-Z0-9_\-\.]+)*</param>
+    </data>
+  </define>
   <!--
     ==========================================
     start with image description
@@ -2757,6 +2767,18 @@ compressed filesystem.</db:para>
         <data type="nonNegativeInteger"/>
       </attribute>
     </define>
+    <define name="k.user.group.attribute">
+      <attribute name="group">
+        <a:documentation>The primary group for this user</a:documentation>
+        <ref name="group-name"/>
+      </attribute>
+    </define>
+    <define name="k.user.secgroups.attribute">
+      <attribute name="secgroups">
+        <a:documentation>The secondary groups for this user</a:documentation>
+        <ref name="secgroups-list"/>
+      </attribute>
+    </define>
     <define name="k.user.realname.attribute">
       <attribute name="realname">
         <a:documentation>The name of an user</a:documentation>
@@ -2786,6 +2808,10 @@ compressed filesystem.</db:para>
     </define>
     <define name="k.user.attlist">
       <interleave>
+        <ref name="k.user.group.attribute"/>
+        <optional>
+          <ref name="k.user.secgroups.attribute"/>
+        </optional>
         <ref name="k.user.home.attribute"/>
         <optional>
           <ref name="k.user.id.attribute"/>
@@ -4117,30 +4143,13 @@ drivers can bind itself to one of the listed namespaces.</db:para>
     
   -->
   <div>
-    <define name="k.users.group.attribute">
-      <attribute name="group">
-        <a:documentation>Contains the group to which the user belongs</a:documentation>
-      </attribute>
-    </define>
-    <define name="k.users.id.attribute">
-      <attribute name="id">
-        <a:documentation>Contains the group ID to which the user belongs</a:documentation>
-        <data type="nonNegativeInteger"/>
-      </attribute>
-    </define>
     <define name="k.users.profiles.attribute">
       <ref name="k.profiles.attribute"/>
     </define>
     <define name="k.users.attlist">
-      <interleave>
-        <ref name="k.users.group.attribute"/>
-        <optional>
-          <ref name="k.users.id.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.users.profiles.attribute"/>
-        </optional>
-      </interleave>
+      <optional>
+        <ref name="k.users.profiles.attribute"/>
+      </optional>
     </define>
     <define name="k.users">
       <element name="users">

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -23,7 +23,7 @@
 <grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:db="http://docbook.org/ns/docbook" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
   <db:info>
     <db:releaseinfo>$Id: $</db:releaseinfo>
-    <db:releaseinfo>RNC Schema Version 6.3</db:releaseinfo>
+    <db:releaseinfo>RNC Schema Version 6.4</db:releaseinfo>
     <db:pubdate>START</db:pubdate>
     <db:pubdate>2016-03-18</db:pubdate>
   </db:info>
@@ -101,7 +101,7 @@ second the location of the XSD Schema
     <define name="k.image.schemaversion.attribute">
       <attribute name="schemaversion">
         <a:documentation>The allowed Schema version (fixed value)</a:documentation>
-        <value>6.3</value>
+        <value>6.4</value>
       </attribute>
     </define>
     <define name="k.image.kiwirevision.attribute">

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -57,14 +57,9 @@
       <param name="pattern">[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}</param>
     </data>
   </define>
-  <define name="group-name">
+  <define name="groups-list">
     <data type="token">
-      <param name="pattern">[a-zA-Z0-9_\-\.]+</param>
-    </data>
-  </define>
-  <define name="secgroups-list">
-    <data type="token">
-      <param name="pattern">[a-zA-Z0-9_\-\.]+(,?[a-zA-Z0-9_\-\.]+)*</param>
+      <param name="pattern">[a-zA-Z0-9_\-\.]+(,[a-zA-Z0-9_\-\.]+)*</param>
     </data>
   </define>
   <!--
@@ -2767,16 +2762,13 @@ compressed filesystem.</db:para>
         <data type="nonNegativeInteger"/>
       </attribute>
     </define>
-    <define name="k.user.group.attribute">
-      <attribute name="group">
-        <a:documentation>The primary group for this user</a:documentation>
-        <ref name="group-name"/>
-      </attribute>
-    </define>
-    <define name="k.user.secgroups.attribute">
-      <attribute name="secgroups">
-        <a:documentation>The secondary groups for this user</a:documentation>
-        <ref name="secgroups-list"/>
+    <define name="k.user.groups.attribute">
+      <attribute name="groups">
+        <a:documentation>The list of groups that he user belongs to. The
+frist item in the list is used as the login group.
+If 'groups' is not present a default group is assigned
+to the user according to he specifing toolchain behaviour.</a:documentation>
+        <ref name="groups-list"/>
       </attribute>
     </define>
     <define name="k.user.realname.attribute">
@@ -2808,9 +2800,8 @@ compressed filesystem.</db:para>
     </define>
     <define name="k.user.attlist">
       <interleave>
-        <ref name="k.user.group.attribute"/>
         <optional>
-          <ref name="k.user.secgroups.attribute"/>
+          <ref name="k.user.groups.attribute"/>
         </optional>
         <ref name="k.user.home.attribute"/>
         <optional>

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -279,9 +279,9 @@ class SystemSetup(object):
                 if user.get_group() and not system_users.group_exists(user.get_group()):
                     log.info('Adding group %s', user.get_group())
                     system_users.group_add(user.get_group(), [])
-                if not user.get_sec_groups():
+                if not user.get_secgroups():
                     continue
-                for group in user.get_sec_groups():
+                for group in user.get_secgroups().split(','):
                     if not system_users.group_exists(group):
                         log.info('Adding group %s', group)
                         system_users.group_add(group, [])
@@ -302,7 +302,7 @@ class SystemSetup(object):
                 user_id = user.get_id()
                 user_realname = user.get_realname()
                 user_shell = user.get_shell()
-                user_sec_groups = user.get_sec_groups()
+                user_secgroups = user.get_secgroups()
                 user_group = user.get_group()
 
                 user_exists = system_users.user_exists(user_name)
@@ -319,9 +319,9 @@ class SystemSetup(object):
                 if user_group:
                     options.append('-g')
                     options.append(user_group)
-                if user_sec_groups and len(user_sec_groups) > 0:
+                if user_secgroups:
                     options.append('-G')
-                    options.append(','.join(user_sec_groups))
+                    options.append(user_secgroups)
                 if user_id:
                     options.append('-u')
                     options.append(user_id)

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -274,14 +274,11 @@ class SystemSetup(object):
         """
         system_users = Users(self.root_dir)
 
-        for users_set in self.xml_state.get_users():
-            for user in users_set:
-                if user.get_groups():
-                    user_groups = user.get_groups().split(',')
-                    for group in user_groups:
-                        if not system_users.group_exists(group):
-                            log.info('Adding group %s', group)
-                            system_users.group_add(group, [])
+        for user in self.xml_state.get_users():
+            for group in self.xml_state.get_user_groups(user.get_name()):
+                if not system_users.group_exists(group):
+                    log.info('Adding group %s', group)
+                    system_users.group_add(group, [])
 
     def setup_users(self):
         """
@@ -289,73 +286,69 @@ class SystemSetup(object):
         """
         system_users = Users(self.root_dir)
 
-        for users_set in self.xml_state.get_users():
-            for user in users_set:
-                log.info('Setting up user %s', user.get_name())
-                password = user.get_password()
-                password_format = user.get_pwdformat()
-                home_path = user.get_home()
-                user_name = user.get_name()
-                user_id = user.get_id()
-                user_realname = user.get_realname()
-                user_shell = user.get_shell()
-                if user.get_groups():
-                    user_groups = user.get_groups().split(',')
-                else:
-                    user_groups = None
+        for user in self.xml_state.get_users():
+            log.info('Setting up user %s', user.get_name())
+            password = user.get_password()
+            password_format = user.get_pwdformat()
+            home_path = user.get_home()
+            user_name = user.get_name()
+            user_id = user.get_id()
+            user_realname = user.get_realname()
+            user_shell = user.get_shell()
+            user_groups = self.xml_state.get_user_groups(user.get_name())
 
-                user_exists = system_users.user_exists(user_name)
+            user_exists = system_users.user_exists(user_name)
 
-                options = []
-                if password_format == 'plain':
-                    password = self._create_passwd_hash(password)
-                if password:
-                    options.append('-p')
-                    options.append(password)
-                if user_shell:
-                    options.append('-s')
-                    options.append(user_shell)
-                if user_groups:
-                    options.append('-g')
-                    options.append(user_groups[0])
-                    if len(user_groups) > 1:
-                        options.append('-G')
-                        options.append(','.join(user_groups[1:]))
-                if user_id:
-                    options.append('-u')
-                    options.append(user_id)
-                if user_realname:
-                    options.append('-c')
-                    options.append(user_realname)
-                if not user_exists and home_path:
-                    options.append('-m')
-                    options.append('-d')
-                    options.append(home_path)
+            options = []
+            if password_format == 'plain':
+                password = self._create_passwd_hash(password)
+            if password:
+                options.append('-p')
+                options.append(password)
+            if user_shell:
+                options.append('-s')
+                options.append(user_shell)
+            if len(user_groups):
+                options.append('-g')
+                options.append(user_groups[0])
+                if len(user_groups) > 1:
+                    options.append('-G')
+                    options.append(','.join(user_groups[1:]))
+            if user_id:
+                options.append('-u')
+                options.append(user_id)
+            if user_realname:
+                options.append('-c')
+                options.append(user_realname)
+            if not user_exists and home_path:
+                options.append('-m')
+                options.append('-d')
+                options.append(home_path)
 
-                if user_exists:
+            if user_exists:
+                log.info(
+                    '--> Modifying user: %s [%s]',
+                    user_name,
+                    user_groups[0] if len(user_groups) else ''
+                )
+                system_users.user_modify(user_name, options)
+            else:
+                log.info(
+                    '--> Adding user: %s [%s]',
+                    user_name,
+                    user_groups[0] if len(user_groups) else ''
+                )
+                system_users.user_add(user_name, options)
+                if home_path:
                     log.info(
-                        '--> Modifying user: %s [%s]',
-                        user_name,
-                        user_groups[0] if user_groups else ''
+                        '--> Setting permissions for %s', home_path
                     )
-                    system_users.user_modify(user_name, options)
-                else:
-                    log.info(
-                        '--> Adding user: %s [%s]',
+                    # Emtpy group string assumes the login or default group
+                    system_users.setup_home_for_user(
                         user_name,
-                        user_groups[0] if user_groups else ''
+                        user_groups[0] if len(user_groups) else '',
+                        home_path
                     )
-                    system_users.user_add(user_name, options)
-                    if home_path:
-                        log.info(
-                            '--> Setting permissions for %s', home_path
-                        )
-                        # Emtpy group string assumes the login or default group
-                        system_users.setup_home_for_user(
-                            user_name,
-                            user_groups[0] if user_groups else '',
-                            home_path
-                        )
 
     def import_image_identifier(self):
         """

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Mon Jun 20 17:54:01 2016 by generateDS.py version 2.19b.
+# Generated Tue Jul 26 17:38:33 2016 by generateDS.py version 2.22a.
 #
 # Command line options:
 #   ('-f', '')
@@ -13,7 +13,7 @@
 #   kiwi/schema/kiwi.xsd
 #
 # Command line:
-#   /usr/bin/generateDS.py -f --external-encoding="utf-8" -o "kiwi/xml_parse.py" kiwi/schema/kiwi.xsd
+#   /home/david/workspaces/kiwi/.env2.7/bin/generateDS.py -f --external-encoding="utf-8" -o "kiwi/xml_parse.py" kiwi/schema/kiwi.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -757,6 +757,13 @@ class image(GeneratedsSuper):
     def set_noNamespaceSchemaLocation(self, noNamespaceSchemaLocation): self.noNamespaceSchemaLocation = noNamespaceSchemaLocation
     def get_schemaLocation(self): return self.schemaLocation
     def set_schemaLocation(self, schemaLocation): self.schemaLocation = schemaLocation
+    def validate_image_name(self, value):
+        # Validate type image-name, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_image_name_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_image_name_patterns_, ))
+    validate_image_name_patterns_ = [['^[a-zA-Z0-9_\\-\\.]+$']]
     def hasContent_(self):
         if (
             self.description or
@@ -847,6 +854,8 @@ class image(GeneratedsSuper):
         if value is not None and 'name' not in already_processed:
             already_processed.add('name')
             self.name = value
+            self.name = ' '.join(self.name.split())
+            self.validate_image_name(self.name)    # validate type image-name
         value = find_attr_value_('displayname', node)
         if value is not None and 'displayname' not in already_processed:
             already_processed.add('displayname')
@@ -1803,6 +1812,13 @@ class partition(GeneratedsSuper):
     def set_mountpoint(self, mountpoint): self.mountpoint = mountpoint
     def get_target(self): return self.target
     def set_target(self, target): self.target = target
+    def validate_size_type(self, value):
+        # Validate type size-type, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_size_type_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_size_type_patterns_, ))
+    validate_size_type_patterns_ = [['^\\d*|image$']]
     def hasContent_(self):
         if (
 
@@ -1865,6 +1881,8 @@ class partition(GeneratedsSuper):
         if value is not None and 'size' not in already_processed:
             already_processed.add('size')
             self.size = value
+            self.size = ' '.join(self.size.split())
+            self.validate_size_type(self.size)    # validate type size-type
         value = find_attr_value_('mountpoint', node)
         if value is not None and 'mountpoint' not in already_processed:
             already_processed.add('mountpoint')
@@ -2763,6 +2781,13 @@ class type_(GeneratedsSuper):
     def set_volid(self, volid): self.volid = volid
     def get_wwid_wait_timeout(self): return self.wwid_wait_timeout
     def set_wwid_wait_timeout(self, wwid_wait_timeout): self.wwid_wait_timeout = wwid_wait_timeout
+    def validate_vhd_tag_type(self, value):
+        # Validate type vhd-tag-type, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_vhd_tag_type_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_vhd_tag_type_patterns_, ))
+    validate_vhd_tag_type_patterns_ = [['^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$']]
     def hasContent_(self):
         if (
             self.machine or
@@ -3271,6 +3296,8 @@ class type_(GeneratedsSuper):
         if value is not None and 'vhdfixedtag' not in already_processed:
             already_processed.add('vhdfixedtag')
             self.vhdfixedtag = value
+            self.vhdfixedtag = ' '.join(self.vhdfixedtag.split())
+            self.validate_vhd_tag_type(self.vhdfixedtag)    # validate type vhd-tag-type
         value = find_attr_value_('volid', node)
         if value is not None and 'volid' not in already_processed:
             already_processed.add('volid')
@@ -3410,8 +3437,10 @@ class user(GeneratedsSuper):
     """A User with Name, Password, Path to Its Home And Shell"""
     subclass = None
     superclass = None
-    def __init__(self, home=None, id=None, name=None, password=None, pwdformat=None, realname=None, shell=None):
+    def __init__(self, group=None, secgroups=None, home=None, id=None, name=None, password=None, pwdformat=None, realname=None, shell=None):
         self.original_tagname_ = None
+        self.group = _cast(None, group)
+        self.secgroups = _cast(None, secgroups)
         self.home = _cast(None, home)
         self.id = _cast(int, id)
         self.name = _cast(None, name)
@@ -3430,6 +3459,10 @@ class user(GeneratedsSuper):
         else:
             return user(*args_, **kwargs_)
     factory = staticmethod(factory)
+    def get_group(self): return self.group
+    def set_group(self, group): self.group = group
+    def get_secgroups(self): return self.secgroups
+    def set_secgroups(self, secgroups): self.secgroups = secgroups
     def get_home(self): return self.home
     def set_home(self, home): self.home = home
     def get_id(self): return self.id
@@ -3444,6 +3477,20 @@ class user(GeneratedsSuper):
     def set_realname(self, realname): self.realname = realname
     def get_shell(self): return self.shell
     def set_shell(self, shell): self.shell = shell
+    def validate_group_name(self, value):
+        # Validate type group-name, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_group_name_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_group_name_patterns_, ))
+    validate_group_name_patterns_ = [['^[a-zA-Z0-9_\\-\\.]+$']]
+    def validate_secgroups_list(self, value):
+        # Validate type secgroups-list, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_secgroups_list_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_secgroups_list_patterns_, ))
+    validate_secgroups_list_patterns_ = [['^[a-zA-Z0-9_\\-\\.]+(,?[a-zA-Z0-9_\\-\\.]+)*$']]
     def hasContent_(self):
         if (
 
@@ -3469,6 +3516,12 @@ class user(GeneratedsSuper):
         else:
             outfile.write('/>%s' % (eol_, ))
     def exportAttributes(self, outfile, level, already_processed, namespace_='', name_='user'):
+        if self.group is not None and 'group' not in already_processed:
+            already_processed.add('group')
+            outfile.write(' group=%s' % (quote_attrib(self.group), ))
+        if self.secgroups is not None and 'secgroups' not in already_processed:
+            already_processed.add('secgroups')
+            outfile.write(' secgroups=%s' % (quote_attrib(self.secgroups), ))
         if self.home is not None and 'home' not in already_processed:
             already_processed.add('home')
             outfile.write(' home=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.home), input_name='home')), ))
@@ -3500,6 +3553,18 @@ class user(GeneratedsSuper):
             self.buildChildren(child, node, nodeName_)
         return self
     def buildAttributes(self, node, attrs, already_processed):
+        value = find_attr_value_('group', node)
+        if value is not None and 'group' not in already_processed:
+            already_processed.add('group')
+            self.group = value
+            self.group = ' '.join(self.group.split())
+            self.validate_group_name(self.group)    # validate type group-name
+        value = find_attr_value_('secgroups', node)
+        if value is not None and 'secgroups' not in already_processed:
+            already_processed.add('secgroups')
+            self.secgroups = value
+            self.secgroups = ' '.join(self.secgroups.split())
+            self.validate_secgroups_list(self.secgroups)    # validate type secgroups-list
         value = find_attr_value_('home', node)
         if value is not None and 'home' not in already_processed:
             already_processed.add('home')
@@ -3766,6 +3831,13 @@ class vmnic(GeneratedsSuper):
     def set_mode(self, mode): self.mode = mode
     def get_mac(self): return self.mac
     def set_mac(self, mac): self.mac = mac
+    def validate_mac_address_type(self, value):
+        # Validate type mac-address-type, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_mac_address_type_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_mac_address_type_patterns_, ))
+    validate_mac_address_type_patterns_ = [['^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$']]
     def hasContent_(self):
         if (
 
@@ -3829,6 +3901,8 @@ class vmnic(GeneratedsSuper):
         if value is not None and 'mac' not in already_processed:
             already_processed.add('mac')
             self.mac = value
+            self.mac = ' '.join(self.mac.split())
+            self.validate_mac_address_type(self.mac)    # validate type mac-address-type
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         pass
 # end class vmnic
@@ -3863,6 +3937,13 @@ class volume(GeneratedsSuper):
     def set_name(self, name): self.name = name
     def get_size(self): return self.size
     def set_size(self, size): self.size = size
+    def validate_volume_size_type(self, value):
+        # Validate type volume-size-type, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_volume_size_type_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_volume_size_type_patterns_, ))
+    validate_volume_size_type_patterns_ = [['^\\d+|\\d+M|\\d+G|all$']]
     def hasContent_(self):
         if (
 
@@ -3914,6 +3995,8 @@ class volume(GeneratedsSuper):
         if value is not None and 'freespace' not in already_processed:
             already_processed.add('freespace')
             self.freespace = value
+            self.freespace = ' '.join(self.freespace.split())
+            self.validate_volume_size_type(self.freespace)    # validate type volume-size-type
         value = find_attr_value_('mountpoint', node)
         if value is not None and 'mountpoint' not in already_processed:
             already_processed.add('mountpoint')
@@ -3926,6 +4009,8 @@ class volume(GeneratedsSuper):
         if value is not None and 'size' not in already_processed:
             already_processed.add('size')
             self.size = value
+            self.size = ' '.join(self.size.split())
+            self.validate_volume_size_type(self.size)    # validate type volume-size-type
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         pass
 # end class volume
@@ -6111,40 +6196,40 @@ class oemconfig(GeneratedsSuper):
             eol_ = ''
         for oem_ataraid_scan_ in self.oem_ataraid_scan:
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%soem-ataraid-scan>%s</%soem-ataraid-scan>%s' % (namespace_, self.gds_encode(self.gds_format_string(quote_xml(oem_ataraid_scan_), input_name='oem-ataraid-scan')), namespace_, eol_))
+            outfile.write('<%soem-ataraid-scan>%s</%soem-ataraid-scan>%s' % (namespace_, self.gds_format_boolean(oem_ataraid_scan_, input_name='oem-ataraid-scan'), namespace_, eol_))
         for oem_boot_title_ in self.oem_boot_title:
             showIndent(outfile, level, pretty_print)
             outfile.write('<%soem-boot-title>%s</%soem-boot-title>%s' % (namespace_, self.gds_encode(self.gds_format_string(quote_xml(oem_boot_title_), input_name='oem-boot-title')), namespace_, eol_))
         for oem_bootwait_ in self.oem_bootwait:
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%soem-bootwait>%s</%soem-bootwait>%s' % (namespace_, self.gds_encode(self.gds_format_string(quote_xml(oem_bootwait_), input_name='oem-bootwait')), namespace_, eol_))
+            outfile.write('<%soem-bootwait>%s</%soem-bootwait>%s' % (namespace_, self.gds_format_boolean(oem_bootwait_, input_name='oem-bootwait'), namespace_, eol_))
         for oem_device_filter_ in self.oem_device_filter:
             showIndent(outfile, level, pretty_print)
             outfile.write('<%soem-device-filter>%s</%soem-device-filter>%s' % (namespace_, self.gds_encode(self.gds_format_string(quote_xml(oem_device_filter_), input_name='oem-device-filter')), namespace_, eol_))
         for oem_inplace_recovery_ in self.oem_inplace_recovery:
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%soem-inplace-recovery>%s</%soem-inplace-recovery>%s' % (namespace_, self.gds_encode(self.gds_format_string(quote_xml(oem_inplace_recovery_), input_name='oem-inplace-recovery')), namespace_, eol_))
+            outfile.write('<%soem-inplace-recovery>%s</%soem-inplace-recovery>%s' % (namespace_, self.gds_format_boolean(oem_inplace_recovery_, input_name='oem-inplace-recovery'), namespace_, eol_))
         for oem_kiwi_initrd_ in self.oem_kiwi_initrd:
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%soem-kiwi-initrd>%s</%soem-kiwi-initrd>%s' % (namespace_, self.gds_encode(self.gds_format_string(quote_xml(oem_kiwi_initrd_), input_name='oem-kiwi-initrd')), namespace_, eol_))
+            outfile.write('<%soem-kiwi-initrd>%s</%soem-kiwi-initrd>%s' % (namespace_, self.gds_format_boolean(oem_kiwi_initrd_, input_name='oem-kiwi-initrd'), namespace_, eol_))
         for oem_multipath_scan_ in self.oem_multipath_scan:
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%soem-multipath-scan>%s</%soem-multipath-scan>%s' % (namespace_, self.gds_encode(self.gds_format_string(quote_xml(oem_multipath_scan_), input_name='oem-multipath-scan')), namespace_, eol_))
+            outfile.write('<%soem-multipath-scan>%s</%soem-multipath-scan>%s' % (namespace_, self.gds_format_boolean(oem_multipath_scan_, input_name='oem-multipath-scan'), namespace_, eol_))
         for oem_vmcp_parmfile_ in self.oem_vmcp_parmfile:
             showIndent(outfile, level, pretty_print)
             outfile.write('<%soem-vmcp-parmfile>%s</%soem-vmcp-parmfile>%s' % (namespace_, self.gds_encode(self.gds_format_string(quote_xml(oem_vmcp_parmfile_), input_name='oem-vmcp-parmfile')), namespace_, eol_))
         for oem_partition_install_ in self.oem_partition_install:
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%soem-partition-install>%s</%soem-partition-install>%s' % (namespace_, self.gds_encode(self.gds_format_string(quote_xml(oem_partition_install_), input_name='oem-partition-install')), namespace_, eol_))
+            outfile.write('<%soem-partition-install>%s</%soem-partition-install>%s' % (namespace_, self.gds_format_boolean(oem_partition_install_, input_name='oem-partition-install'), namespace_, eol_))
         for oem_reboot_ in self.oem_reboot:
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%soem-reboot>%s</%soem-reboot>%s' % (namespace_, self.gds_encode(self.gds_format_string(quote_xml(oem_reboot_), input_name='oem-reboot')), namespace_, eol_))
+            outfile.write('<%soem-reboot>%s</%soem-reboot>%s' % (namespace_, self.gds_format_boolean(oem_reboot_, input_name='oem-reboot'), namespace_, eol_))
         for oem_reboot_interactive_ in self.oem_reboot_interactive:
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%soem-reboot-interactive>%s</%soem-reboot-interactive>%s' % (namespace_, self.gds_encode(self.gds_format_string(quote_xml(oem_reboot_interactive_), input_name='oem-reboot-interactive')), namespace_, eol_))
+            outfile.write('<%soem-reboot-interactive>%s</%soem-reboot-interactive>%s' % (namespace_, self.gds_format_boolean(oem_reboot_interactive_, input_name='oem-reboot-interactive'), namespace_, eol_))
         for oem_recovery_ in self.oem_recovery:
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%soem-recovery>%s</%soem-recovery>%s' % (namespace_, self.gds_encode(self.gds_format_string(quote_xml(oem_recovery_), input_name='oem-recovery')), namespace_, eol_))
+            outfile.write('<%soem-recovery>%s</%soem-recovery>%s' % (namespace_, self.gds_format_boolean(oem_recovery_, input_name='oem-recovery'), namespace_, eol_))
         for oem_recoveryID_ in self.oem_recoveryID:
             showIndent(outfile, level, pretty_print)
             outfile.write('<%soem-recoveryID>%s</%soem-recoveryID>%s' % (namespace_, self.gds_format_integer(oem_recoveryID_, input_name='oem-recoveryID'), namespace_, eol_))
@@ -6153,25 +6238,25 @@ class oemconfig(GeneratedsSuper):
             outfile.write('<%soem-recovery-part-size>%s</%soem-recovery-part-size>%s' % (namespace_, self.gds_format_integer(oem_recovery_part_size_, input_name='oem-recovery-part-size'), namespace_, eol_))
         for oem_shutdown_ in self.oem_shutdown:
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%soem-shutdown>%s</%soem-shutdown>%s' % (namespace_, self.gds_encode(self.gds_format_string(quote_xml(oem_shutdown_), input_name='oem-shutdown')), namespace_, eol_))
+            outfile.write('<%soem-shutdown>%s</%soem-shutdown>%s' % (namespace_, self.gds_format_boolean(oem_shutdown_, input_name='oem-shutdown'), namespace_, eol_))
         for oem_shutdown_interactive_ in self.oem_shutdown_interactive:
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%soem-shutdown-interactive>%s</%soem-shutdown-interactive>%s' % (namespace_, self.gds_encode(self.gds_format_string(quote_xml(oem_shutdown_interactive_), input_name='oem-shutdown-interactive')), namespace_, eol_))
+            outfile.write('<%soem-shutdown-interactive>%s</%soem-shutdown-interactive>%s' % (namespace_, self.gds_format_boolean(oem_shutdown_interactive_, input_name='oem-shutdown-interactive'), namespace_, eol_))
         for oem_silent_boot_ in self.oem_silent_boot:
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%soem-silent-boot>%s</%soem-silent-boot>%s' % (namespace_, self.gds_encode(self.gds_format_string(quote_xml(oem_silent_boot_), input_name='oem-silent-boot')), namespace_, eol_))
+            outfile.write('<%soem-silent-boot>%s</%soem-silent-boot>%s' % (namespace_, self.gds_format_boolean(oem_silent_boot_, input_name='oem-silent-boot'), namespace_, eol_))
         for oem_silent_install_ in self.oem_silent_install:
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%soem-silent-install>%s</%soem-silent-install>%s' % (namespace_, self.gds_encode(self.gds_format_string(quote_xml(oem_silent_install_), input_name='oem-silent-install')), namespace_, eol_))
+            outfile.write('<%soem-silent-install>%s</%soem-silent-install>%s' % (namespace_, self.gds_format_boolean(oem_silent_install_, input_name='oem-silent-install'), namespace_, eol_))
         for oem_silent_verify_ in self.oem_silent_verify:
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%soem-silent-verify>%s</%soem-silent-verify>%s' % (namespace_, self.gds_encode(self.gds_format_string(quote_xml(oem_silent_verify_), input_name='oem-silent-verify')), namespace_, eol_))
+            outfile.write('<%soem-silent-verify>%s</%soem-silent-verify>%s' % (namespace_, self.gds_format_boolean(oem_silent_verify_, input_name='oem-silent-verify'), namespace_, eol_))
         for oem_skip_verify_ in self.oem_skip_verify:
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%soem-skip-verify>%s</%soem-skip-verify>%s' % (namespace_, self.gds_encode(self.gds_format_string(quote_xml(oem_skip_verify_), input_name='oem-skip-verify')), namespace_, eol_))
+            outfile.write('<%soem-skip-verify>%s</%soem-skip-verify>%s' % (namespace_, self.gds_format_boolean(oem_skip_verify_, input_name='oem-skip-verify'), namespace_, eol_))
         for oem_swap_ in self.oem_swap:
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%soem-swap>%s</%soem-swap>%s' % (namespace_, self.gds_encode(self.gds_format_string(quote_xml(oem_swap_), input_name='oem-swap')), namespace_, eol_))
+            outfile.write('<%soem-swap>%s</%soem-swap>%s' % (namespace_, self.gds_format_boolean(oem_swap_, input_name='oem-swap'), namespace_, eol_))
         for oem_swapsize_ in self.oem_swapsize:
             showIndent(outfile, level, pretty_print)
             outfile.write('<%soem-swapsize>%s</%soem-swapsize>%s' % (namespace_, self.gds_format_integer(oem_swapsize_, input_name='oem-swapsize'), namespace_, eol_))
@@ -6180,7 +6265,7 @@ class oemconfig(GeneratedsSuper):
             outfile.write('<%soem-systemsize>%s</%soem-systemsize>%s' % (namespace_, self.gds_format_integer(oem_systemsize_, input_name='oem-systemsize'), namespace_, eol_))
         for oem_unattended_ in self.oem_unattended:
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%soem-unattended>%s</%soem-unattended>%s' % (namespace_, self.gds_encode(self.gds_format_string(quote_xml(oem_unattended_), input_name='oem-unattended')), namespace_, eol_))
+            outfile.write('<%soem-unattended>%s</%soem-unattended>%s' % (namespace_, self.gds_format_boolean(oem_unattended_, input_name='oem-unattended'), namespace_, eol_))
         for oem_unattended_id_ in self.oem_unattended_id:
             showIndent(outfile, level, pretty_print)
             outfile.write('<%soem-unattended-id>%s</%soem-unattended-id>%s' % (namespace_, self.gds_encode(self.gds_format_string(quote_xml(oem_unattended_id_), input_name='oem-unattended-id')), namespace_, eol_))
@@ -6195,53 +6280,107 @@ class oemconfig(GeneratedsSuper):
         pass
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         if nodeName_ == 'oem-ataraid-scan':
-            oem_ataraid_scan_ = child_.text
-            oem_ataraid_scan_ = self.gds_validate_string(oem_ataraid_scan_, node, 'oem_ataraid_scan')
-            self.oem_ataraid_scan.append(oem_ataraid_scan_)
+            sval_ = child_.text
+            if sval_ in ('true', '1'):
+                ival_ = True
+            elif sval_ in ('false', '0'):
+                ival_ = False
+            else:
+                raise_parse_error(child_, 'requires boolean')
+            ival_ = self.gds_validate_boolean(ival_, node, 'oem_ataraid_scan')
+            self.oem_ataraid_scan.append(ival_)
         elif nodeName_ == 'oem-boot-title':
             oem_boot_title_ = child_.text
             oem_boot_title_ = self.gds_validate_string(oem_boot_title_, node, 'oem_boot_title')
             self.oem_boot_title.append(oem_boot_title_)
         elif nodeName_ == 'oem-bootwait':
-            oem_bootwait_ = child_.text
-            oem_bootwait_ = self.gds_validate_string(oem_bootwait_, node, 'oem_bootwait')
-            self.oem_bootwait.append(oem_bootwait_)
+            sval_ = child_.text
+            if sval_ in ('true', '1'):
+                ival_ = True
+            elif sval_ in ('false', '0'):
+                ival_ = False
+            else:
+                raise_parse_error(child_, 'requires boolean')
+            ival_ = self.gds_validate_boolean(ival_, node, 'oem_bootwait')
+            self.oem_bootwait.append(ival_)
         elif nodeName_ == 'oem-device-filter':
             oem_device_filter_ = child_.text
             oem_device_filter_ = self.gds_validate_string(oem_device_filter_, node, 'oem_device_filter')
             self.oem_device_filter.append(oem_device_filter_)
         elif nodeName_ == 'oem-inplace-recovery':
-            oem_inplace_recovery_ = child_.text
-            oem_inplace_recovery_ = self.gds_validate_string(oem_inplace_recovery_, node, 'oem_inplace_recovery')
-            self.oem_inplace_recovery.append(oem_inplace_recovery_)
+            sval_ = child_.text
+            if sval_ in ('true', '1'):
+                ival_ = True
+            elif sval_ in ('false', '0'):
+                ival_ = False
+            else:
+                raise_parse_error(child_, 'requires boolean')
+            ival_ = self.gds_validate_boolean(ival_, node, 'oem_inplace_recovery')
+            self.oem_inplace_recovery.append(ival_)
         elif nodeName_ == 'oem-kiwi-initrd':
-            oem_kiwi_initrd_ = child_.text
-            oem_kiwi_initrd_ = self.gds_validate_string(oem_kiwi_initrd_, node, 'oem_kiwi_initrd')
-            self.oem_kiwi_initrd.append(oem_kiwi_initrd_)
+            sval_ = child_.text
+            if sval_ in ('true', '1'):
+                ival_ = True
+            elif sval_ in ('false', '0'):
+                ival_ = False
+            else:
+                raise_parse_error(child_, 'requires boolean')
+            ival_ = self.gds_validate_boolean(ival_, node, 'oem_kiwi_initrd')
+            self.oem_kiwi_initrd.append(ival_)
         elif nodeName_ == 'oem-multipath-scan':
-            oem_multipath_scan_ = child_.text
-            oem_multipath_scan_ = self.gds_validate_string(oem_multipath_scan_, node, 'oem_multipath_scan')
-            self.oem_multipath_scan.append(oem_multipath_scan_)
+            sval_ = child_.text
+            if sval_ in ('true', '1'):
+                ival_ = True
+            elif sval_ in ('false', '0'):
+                ival_ = False
+            else:
+                raise_parse_error(child_, 'requires boolean')
+            ival_ = self.gds_validate_boolean(ival_, node, 'oem_multipath_scan')
+            self.oem_multipath_scan.append(ival_)
         elif nodeName_ == 'oem-vmcp-parmfile':
             oem_vmcp_parmfile_ = child_.text
             oem_vmcp_parmfile_ = self.gds_validate_string(oem_vmcp_parmfile_, node, 'oem_vmcp_parmfile')
             self.oem_vmcp_parmfile.append(oem_vmcp_parmfile_)
         elif nodeName_ == 'oem-partition-install':
-            oem_partition_install_ = child_.text
-            oem_partition_install_ = self.gds_validate_string(oem_partition_install_, node, 'oem_partition_install')
-            self.oem_partition_install.append(oem_partition_install_)
+            sval_ = child_.text
+            if sval_ in ('true', '1'):
+                ival_ = True
+            elif sval_ in ('false', '0'):
+                ival_ = False
+            else:
+                raise_parse_error(child_, 'requires boolean')
+            ival_ = self.gds_validate_boolean(ival_, node, 'oem_partition_install')
+            self.oem_partition_install.append(ival_)
         elif nodeName_ == 'oem-reboot':
-            oem_reboot_ = child_.text
-            oem_reboot_ = self.gds_validate_string(oem_reboot_, node, 'oem_reboot')
-            self.oem_reboot.append(oem_reboot_)
+            sval_ = child_.text
+            if sval_ in ('true', '1'):
+                ival_ = True
+            elif sval_ in ('false', '0'):
+                ival_ = False
+            else:
+                raise_parse_error(child_, 'requires boolean')
+            ival_ = self.gds_validate_boolean(ival_, node, 'oem_reboot')
+            self.oem_reboot.append(ival_)
         elif nodeName_ == 'oem-reboot-interactive':
-            oem_reboot_interactive_ = child_.text
-            oem_reboot_interactive_ = self.gds_validate_string(oem_reboot_interactive_, node, 'oem_reboot_interactive')
-            self.oem_reboot_interactive.append(oem_reboot_interactive_)
+            sval_ = child_.text
+            if sval_ in ('true', '1'):
+                ival_ = True
+            elif sval_ in ('false', '0'):
+                ival_ = False
+            else:
+                raise_parse_error(child_, 'requires boolean')
+            ival_ = self.gds_validate_boolean(ival_, node, 'oem_reboot_interactive')
+            self.oem_reboot_interactive.append(ival_)
         elif nodeName_ == 'oem-recovery':
-            oem_recovery_ = child_.text
-            oem_recovery_ = self.gds_validate_string(oem_recovery_, node, 'oem_recovery')
-            self.oem_recovery.append(oem_recovery_)
+            sval_ = child_.text
+            if sval_ in ('true', '1'):
+                ival_ = True
+            elif sval_ in ('false', '0'):
+                ival_ = False
+            else:
+                raise_parse_error(child_, 'requires boolean')
+            ival_ = self.gds_validate_boolean(ival_, node, 'oem_recovery')
+            self.oem_recovery.append(ival_)
         elif nodeName_ == 'oem-recoveryID':
             sval_ = child_.text
             try:
@@ -6263,33 +6402,75 @@ class oemconfig(GeneratedsSuper):
             ival_ = self.gds_validate_integer(ival_, node, 'oem_recovery_part_size')
             self.oem_recovery_part_size.append(ival_)
         elif nodeName_ == 'oem-shutdown':
-            oem_shutdown_ = child_.text
-            oem_shutdown_ = self.gds_validate_string(oem_shutdown_, node, 'oem_shutdown')
-            self.oem_shutdown.append(oem_shutdown_)
+            sval_ = child_.text
+            if sval_ in ('true', '1'):
+                ival_ = True
+            elif sval_ in ('false', '0'):
+                ival_ = False
+            else:
+                raise_parse_error(child_, 'requires boolean')
+            ival_ = self.gds_validate_boolean(ival_, node, 'oem_shutdown')
+            self.oem_shutdown.append(ival_)
         elif nodeName_ == 'oem-shutdown-interactive':
-            oem_shutdown_interactive_ = child_.text
-            oem_shutdown_interactive_ = self.gds_validate_string(oem_shutdown_interactive_, node, 'oem_shutdown_interactive')
-            self.oem_shutdown_interactive.append(oem_shutdown_interactive_)
+            sval_ = child_.text
+            if sval_ in ('true', '1'):
+                ival_ = True
+            elif sval_ in ('false', '0'):
+                ival_ = False
+            else:
+                raise_parse_error(child_, 'requires boolean')
+            ival_ = self.gds_validate_boolean(ival_, node, 'oem_shutdown_interactive')
+            self.oem_shutdown_interactive.append(ival_)
         elif nodeName_ == 'oem-silent-boot':
-            oem_silent_boot_ = child_.text
-            oem_silent_boot_ = self.gds_validate_string(oem_silent_boot_, node, 'oem_silent_boot')
-            self.oem_silent_boot.append(oem_silent_boot_)
+            sval_ = child_.text
+            if sval_ in ('true', '1'):
+                ival_ = True
+            elif sval_ in ('false', '0'):
+                ival_ = False
+            else:
+                raise_parse_error(child_, 'requires boolean')
+            ival_ = self.gds_validate_boolean(ival_, node, 'oem_silent_boot')
+            self.oem_silent_boot.append(ival_)
         elif nodeName_ == 'oem-silent-install':
-            oem_silent_install_ = child_.text
-            oem_silent_install_ = self.gds_validate_string(oem_silent_install_, node, 'oem_silent_install')
-            self.oem_silent_install.append(oem_silent_install_)
+            sval_ = child_.text
+            if sval_ in ('true', '1'):
+                ival_ = True
+            elif sval_ in ('false', '0'):
+                ival_ = False
+            else:
+                raise_parse_error(child_, 'requires boolean')
+            ival_ = self.gds_validate_boolean(ival_, node, 'oem_silent_install')
+            self.oem_silent_install.append(ival_)
         elif nodeName_ == 'oem-silent-verify':
-            oem_silent_verify_ = child_.text
-            oem_silent_verify_ = self.gds_validate_string(oem_silent_verify_, node, 'oem_silent_verify')
-            self.oem_silent_verify.append(oem_silent_verify_)
+            sval_ = child_.text
+            if sval_ in ('true', '1'):
+                ival_ = True
+            elif sval_ in ('false', '0'):
+                ival_ = False
+            else:
+                raise_parse_error(child_, 'requires boolean')
+            ival_ = self.gds_validate_boolean(ival_, node, 'oem_silent_verify')
+            self.oem_silent_verify.append(ival_)
         elif nodeName_ == 'oem-skip-verify':
-            oem_skip_verify_ = child_.text
-            oem_skip_verify_ = self.gds_validate_string(oem_skip_verify_, node, 'oem_skip_verify')
-            self.oem_skip_verify.append(oem_skip_verify_)
+            sval_ = child_.text
+            if sval_ in ('true', '1'):
+                ival_ = True
+            elif sval_ in ('false', '0'):
+                ival_ = False
+            else:
+                raise_parse_error(child_, 'requires boolean')
+            ival_ = self.gds_validate_boolean(ival_, node, 'oem_skip_verify')
+            self.oem_skip_verify.append(ival_)
         elif nodeName_ == 'oem-swap':
-            oem_swap_ = child_.text
-            oem_swap_ = self.gds_validate_string(oem_swap_, node, 'oem_swap')
-            self.oem_swap.append(oem_swap_)
+            sval_ = child_.text
+            if sval_ in ('true', '1'):
+                ival_ = True
+            elif sval_ in ('false', '0'):
+                ival_ = False
+            else:
+                raise_parse_error(child_, 'requires boolean')
+            ival_ = self.gds_validate_boolean(ival_, node, 'oem_swap')
+            self.oem_swap.append(ival_)
         elif nodeName_ == 'oem-swapsize':
             sval_ = child_.text
             try:
@@ -6311,9 +6492,15 @@ class oemconfig(GeneratedsSuper):
             ival_ = self.gds_validate_integer(ival_, node, 'oem_systemsize')
             self.oem_systemsize.append(ival_)
         elif nodeName_ == 'oem-unattended':
-            oem_unattended_ = child_.text
-            oem_unattended_ = self.gds_validate_string(oem_unattended_, node, 'oem_unattended')
-            self.oem_unattended.append(oem_unattended_)
+            sval_ = child_.text
+            if sval_ in ('true', '1'):
+                ival_ = True
+            elif sval_ in ('false', '0'):
+                ival_ = False
+            else:
+                raise_parse_error(child_, 'requires boolean')
+            ival_ = self.gds_validate_boolean(ival_, node, 'oem_unattended')
+            self.oem_unattended.append(ival_)
         elif nodeName_ == 'oem-unattended-id':
             oem_unattended_id_ = child_.text
             oem_unattended_id_ = self.gds_validate_string(oem_unattended_id_, node, 'oem_unattended_id')
@@ -7118,13 +7305,13 @@ class preferences(GeneratedsSuper):
             outfile.write('<%spartitioner>%s</%spartitioner>%s' % (namespace_, self.gds_encode(self.gds_format_string(quote_xml(partitioner_), input_name='partitioner')), namespace_, eol_))
         for rpm_check_signatures_ in self.rpm_check_signatures:
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%srpm-check-signatures>%s</%srpm-check-signatures>%s' % (namespace_, self.gds_encode(self.gds_format_string(quote_xml(rpm_check_signatures_), input_name='rpm-check-signatures')), namespace_, eol_))
+            outfile.write('<%srpm-check-signatures>%s</%srpm-check-signatures>%s' % (namespace_, self.gds_format_boolean(rpm_check_signatures_, input_name='rpm-check-signatures'), namespace_, eol_))
         for rpm_excludedocs_ in self.rpm_excludedocs:
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%srpm-excludedocs>%s</%srpm-excludedocs>%s' % (namespace_, self.gds_encode(self.gds_format_string(quote_xml(rpm_excludedocs_), input_name='rpm-excludedocs')), namespace_, eol_))
+            outfile.write('<%srpm-excludedocs>%s</%srpm-excludedocs>%s' % (namespace_, self.gds_format_boolean(rpm_excludedocs_, input_name='rpm-excludedocs'), namespace_, eol_))
         for rpm_force_ in self.rpm_force:
             showIndent(outfile, level, pretty_print)
-            outfile.write('<%srpm-force>%s</%srpm-force>%s' % (namespace_, self.gds_encode(self.gds_format_string(quote_xml(rpm_force_), input_name='rpm-force')), namespace_, eol_))
+            outfile.write('<%srpm-force>%s</%srpm-force>%s' % (namespace_, self.gds_format_boolean(rpm_force_, input_name='rpm-force'), namespace_, eol_))
         for showlicense_ in self.showlicense:
             showIndent(outfile, level, pretty_print)
             outfile.write('<%sshowlicense>%s</%sshowlicense>%s' % (namespace_, self.gds_encode(self.gds_format_string(quote_xml(showlicense_), input_name='showlicense')), namespace_, eol_))
@@ -7171,6 +7358,7 @@ class preferences(GeneratedsSuper):
             self.defaultroot.append(defaultroot_)
         elif nodeName_ == 'hwclock':
             hwclock_ = child_.text
+            hwclock_ = re_.sub(String_cleanup_pat_, " ", hwclock_).strip()
             hwclock_ = self.gds_validate_string(hwclock_, node, 'hwclock')
             self.hwclock.append(hwclock_)
         elif nodeName_ == 'keytable':
@@ -7179,28 +7367,49 @@ class preferences(GeneratedsSuper):
             self.keytable.append(keytable_)
         elif nodeName_ == 'locale':
             locale_ = child_.text
+            locale_ = re_.sub(String_cleanup_pat_, " ", locale_).strip()
             locale_ = self.gds_validate_string(locale_, node, 'locale')
             self.locale.append(locale_)
         elif nodeName_ == 'packagemanager':
             packagemanager_ = child_.text
+            packagemanager_ = re_.sub(String_cleanup_pat_, " ", packagemanager_).strip()
             packagemanager_ = self.gds_validate_string(packagemanager_, node, 'packagemanager')
             self.packagemanager.append(packagemanager_)
         elif nodeName_ == 'partitioner':
             partitioner_ = child_.text
+            partitioner_ = re_.sub(String_cleanup_pat_, " ", partitioner_).strip()
             partitioner_ = self.gds_validate_string(partitioner_, node, 'partitioner')
             self.partitioner.append(partitioner_)
         elif nodeName_ == 'rpm-check-signatures':
-            rpm_check_signatures_ = child_.text
-            rpm_check_signatures_ = self.gds_validate_string(rpm_check_signatures_, node, 'rpm_check_signatures')
-            self.rpm_check_signatures.append(rpm_check_signatures_)
+            sval_ = child_.text
+            if sval_ in ('true', '1'):
+                ival_ = True
+            elif sval_ in ('false', '0'):
+                ival_ = False
+            else:
+                raise_parse_error(child_, 'requires boolean')
+            ival_ = self.gds_validate_boolean(ival_, node, 'rpm_check_signatures')
+            self.rpm_check_signatures.append(ival_)
         elif nodeName_ == 'rpm-excludedocs':
-            rpm_excludedocs_ = child_.text
-            rpm_excludedocs_ = self.gds_validate_string(rpm_excludedocs_, node, 'rpm_excludedocs')
-            self.rpm_excludedocs.append(rpm_excludedocs_)
+            sval_ = child_.text
+            if sval_ in ('true', '1'):
+                ival_ = True
+            elif sval_ in ('false', '0'):
+                ival_ = False
+            else:
+                raise_parse_error(child_, 'requires boolean')
+            ival_ = self.gds_validate_boolean(ival_, node, 'rpm_excludedocs')
+            self.rpm_excludedocs.append(ival_)
         elif nodeName_ == 'rpm-force':
-            rpm_force_ = child_.text
-            rpm_force_ = self.gds_validate_string(rpm_force_, node, 'rpm_force')
-            self.rpm_force.append(rpm_force_)
+            sval_ = child_.text
+            if sval_ in ('true', '1'):
+                ival_ = True
+            elif sval_ in ('false', '0'):
+                ival_ = False
+            else:
+                raise_parse_error(child_, 'requires boolean')
+            ival_ = self.gds_validate_boolean(ival_, node, 'rpm_force')
+            self.rpm_force.append(ival_)
         elif nodeName_ == 'showlicense':
             showlicense_ = child_.text
             showlicense_ = self.gds_validate_string(showlicense_, node, 'showlicense')
@@ -7303,10 +7512,8 @@ class users(GeneratedsSuper):
     """A List of Users"""
     subclass = None
     superclass = None
-    def __init__(self, group=None, id=None, profiles=None, user=None):
+    def __init__(self, profiles=None, user=None):
         self.original_tagname_ = None
-        self.group = _cast(None, group)
-        self.id = _cast(int, id)
         self.profiles = _cast(None, profiles)
         if user is None:
             self.user = []
@@ -7328,10 +7535,6 @@ class users(GeneratedsSuper):
     def add_user(self, value): self.user.append(value)
     def insert_user_at(self, index, value): self.user.insert(index, value)
     def replace_user_at(self, index, value): self.user[index] = value
-    def get_group(self): return self.group
-    def set_group(self, group): self.group = group
-    def get_id(self): return self.id
-    def set_id(self, id): self.id = id
     def get_profiles(self): return self.profiles
     def set_profiles(self, profiles): self.profiles = profiles
     def hasContent_(self):
@@ -7360,12 +7563,6 @@ class users(GeneratedsSuper):
         else:
             outfile.write('/>%s' % (eol_, ))
     def exportAttributes(self, outfile, level, already_processed, namespace_='', name_='users'):
-        if self.group is not None and 'group' not in already_processed:
-            already_processed.add('group')
-            outfile.write(' group=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.group), input_name='group')), ))
-        if self.id is not None and 'id' not in already_processed:
-            already_processed.add('id')
-            outfile.write(' id="%s"' % self.gds_format_integer(self.id, input_name='id'))
         if self.profiles is not None and 'profiles' not in already_processed:
             already_processed.add('profiles')
             outfile.write(' profiles=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.profiles), input_name='profiles')), ))
@@ -7384,19 +7581,6 @@ class users(GeneratedsSuper):
             self.buildChildren(child, node, nodeName_)
         return self
     def buildAttributes(self, node, attrs, already_processed):
-        value = find_attr_value_('group', node)
-        if value is not None and 'group' not in already_processed:
-            already_processed.add('group')
-            self.group = value
-        value = find_attr_value_('id', node)
-        if value is not None and 'id' not in already_processed:
-            already_processed.add('id')
-            try:
-                self.id = int(value)
-            except ValueError as exp:
-                raise_parse_error(node, 'Bad integer attribute: %s' % exp)
-            if self.id < 0:
-                raise_parse_error(node, 'Invalid NonNegativeInteger')
         value = find_attr_value_('profiles', node)
         if value is not None and 'profiles' not in already_processed:
             already_processed.add('profiles')

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Wed Jul 27 10:58:30 2016 by generateDS.py version 2.22a.
+# Generated Mon Aug  1 11:15:39 2016 by generateDS.py version 2.22a.
 #
 # Command line options:
 #   ('-f', '')
@@ -13,7 +13,7 @@
 #   kiwi/schema/kiwi.xsd
 #
 # Command line:
-#   /home/david/workspaces/kiwi/.env2.7/bin/generateDS.py -f --external-encoding="utf-8" -o "kiwi/xml_parse.py" kiwi/schema/kiwi.xsd
+#   /home/ms/Project/kiwi/.tox/2.7/bin/generateDS.py -f --external-encoding="utf-8" -o "kiwi/xml_parse.py" kiwi/schema/kiwi.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Tue Jul 26 17:38:33 2016 by generateDS.py version 2.22a.
+# Generated Wed Jul 27 10:58:30 2016 by generateDS.py version 2.22a.
 #
 # Command line options:
 #   ('-f', '')
@@ -3437,10 +3437,9 @@ class user(GeneratedsSuper):
     """A User with Name, Password, Path to Its Home And Shell"""
     subclass = None
     superclass = None
-    def __init__(self, group=None, secgroups=None, home=None, id=None, name=None, password=None, pwdformat=None, realname=None, shell=None):
+    def __init__(self, groups=None, home=None, id=None, name=None, password=None, pwdformat=None, realname=None, shell=None):
         self.original_tagname_ = None
-        self.group = _cast(None, group)
-        self.secgroups = _cast(None, secgroups)
+        self.groups = _cast(None, groups)
         self.home = _cast(None, home)
         self.id = _cast(int, id)
         self.name = _cast(None, name)
@@ -3459,10 +3458,8 @@ class user(GeneratedsSuper):
         else:
             return user(*args_, **kwargs_)
     factory = staticmethod(factory)
-    def get_group(self): return self.group
-    def set_group(self, group): self.group = group
-    def get_secgroups(self): return self.secgroups
-    def set_secgroups(self, secgroups): self.secgroups = secgroups
+    def get_groups(self): return self.groups
+    def set_groups(self, groups): self.groups = groups
     def get_home(self): return self.home
     def set_home(self, home): self.home = home
     def get_id(self): return self.id
@@ -3477,20 +3474,13 @@ class user(GeneratedsSuper):
     def set_realname(self, realname): self.realname = realname
     def get_shell(self): return self.shell
     def set_shell(self, shell): self.shell = shell
-    def validate_group_name(self, value):
-        # Validate type group-name, a restriction on xs:token.
+    def validate_groups_list(self, value):
+        # Validate type groups-list, a restriction on xs:token.
         if value is not None and Validate_simpletypes_:
             if not self.gds_validate_simple_patterns(
-                    self.validate_group_name_patterns_, value):
-                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_group_name_patterns_, ))
-    validate_group_name_patterns_ = [['^[a-zA-Z0-9_\\-\\.]+$']]
-    def validate_secgroups_list(self, value):
-        # Validate type secgroups-list, a restriction on xs:token.
-        if value is not None and Validate_simpletypes_:
-            if not self.gds_validate_simple_patterns(
-                    self.validate_secgroups_list_patterns_, value):
-                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_secgroups_list_patterns_, ))
-    validate_secgroups_list_patterns_ = [['^[a-zA-Z0-9_\\-\\.]+(,?[a-zA-Z0-9_\\-\\.]+)*$']]
+                    self.validate_groups_list_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_groups_list_patterns_, ))
+    validate_groups_list_patterns_ = [['^[a-zA-Z0-9_\\-\\.]+(,[a-zA-Z0-9_\\-\\.]+)*$']]
     def hasContent_(self):
         if (
 
@@ -3516,12 +3506,9 @@ class user(GeneratedsSuper):
         else:
             outfile.write('/>%s' % (eol_, ))
     def exportAttributes(self, outfile, level, already_processed, namespace_='', name_='user'):
-        if self.group is not None and 'group' not in already_processed:
-            already_processed.add('group')
-            outfile.write(' group=%s' % (quote_attrib(self.group), ))
-        if self.secgroups is not None and 'secgroups' not in already_processed:
-            already_processed.add('secgroups')
-            outfile.write(' secgroups=%s' % (quote_attrib(self.secgroups), ))
+        if self.groups is not None and 'groups' not in already_processed:
+            already_processed.add('groups')
+            outfile.write(' groups=%s' % (quote_attrib(self.groups), ))
         if self.home is not None and 'home' not in already_processed:
             already_processed.add('home')
             outfile.write(' home=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.home), input_name='home')), ))
@@ -3553,18 +3540,12 @@ class user(GeneratedsSuper):
             self.buildChildren(child, node, nodeName_)
         return self
     def buildAttributes(self, node, attrs, already_processed):
-        value = find_attr_value_('group', node)
-        if value is not None and 'group' not in already_processed:
-            already_processed.add('group')
-            self.group = value
-            self.group = ' '.join(self.group.split())
-            self.validate_group_name(self.group)    # validate type group-name
-        value = find_attr_value_('secgroups', node)
-        if value is not None and 'secgroups' not in already_processed:
-            already_processed.add('secgroups')
-            self.secgroups = value
-            self.secgroups = ' '.join(self.secgroups.split())
-            self.validate_secgroups_list(self.secgroups)    # validate type secgroups-list
+        value = find_attr_value_('groups', node)
+        if value is not None and 'groups' not in already_processed:
+            already_processed.add('groups')
+            self.groups = value
+            self.groups = ' '.join(self.groups.split())
+            self.validate_groups_list(self.groups)    # validate type groups-list
         value = find_attr_value_('home', node)
         if value is not None and 'home' not in already_processed:
             already_processed.add('home')

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -522,33 +522,22 @@ class XMLState(object):
         """
         List of configured users.
 
-        Each entry in the list is a tuple with the following information
-
-        * group_name, name of the group
-        * group_id, id of the group
-        * user_sections, list of xml_parse::users instances which belong
-          to the group name and id of this tuple
+        Each entry in the list is another nested list where each item in
+        the child list is a single xml_parse::user instance, and each
+        item in the parent list represents all the users under a single
+        <users> section in the description XML file.
 
         :return: user data
         :rtype: list
         """
-        users_by_group_type = namedtuple(
-            'users_by_group_type', ['group_name', 'group_id', 'user_sections']
-        )
-        users_by_group = []
+        users_list = []
         users_sections = self.get_users_sections()
         if users_sections:
             for users in users_sections:
                 user_sections = users.get_user()
                 if user_sections:
-                    users_by_group.append(
-                        users_by_group_type(
-                            group_name=users.get_group(),
-                            group_id=users.get_id(),
-                            user_sections=user_sections
-                        )
-                    )
-        return users_by_group
+                    users_list.append(user_sections)
+        return users_list
 
     def get_volumes(self):
         """

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -522,22 +522,39 @@ class XMLState(object):
         """
         List of configured users.
 
-        Each entry in the list is another nested list where each item in
-        the child list is a single xml_parse::user instance, and each
-        item in the parent list represents all the users under a single
-        <users> section in the description XML file.
+        Each entry in the list is a single xml_parse::user instance.
 
         :return: user data
         :rtype: list
         """
         users_list = []
         users_sections = self.get_users_sections()
-        if users_sections:
-            for users in users_sections:
-                user_sections = users.get_user()
-                if user_sections:
-                    users_list.append(user_sections)
+        if len(users_sections):
+            for users_section in users_sections:
+                for user in users_section.get_user():
+                    if not any(u.get_name() == user.get_name() for u in users_list):
+                        users_list.append(user)
+
         return users_list
+
+    def get_user_groups(self, user_name):
+        """
+        List of configured users.
+
+        Each entry in the list is the name of a group that the specified
+        user belongs to. The first item in the list is the login or primary
+        group. The list will be empty if no groups are specified in the
+        description file.
+
+        :return: groups data for the given user
+        :rtype: list
+        """
+        groups_list = []
+        for user in self.get_users():
+            if user.get_name() == user_name and user.get_groups():
+                groups_list.extend(user.get_groups().split(','))
+
+        return groups_list
 
     def get_volumes(self):
         """

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -532,7 +532,15 @@ class XMLState(object):
         if len(users_sections):
             for users_section in users_sections:
                 for user in users_section.get_user():
-                    if not any(u.get_name() == user.get_name() for u in users_list):
+                    match = [i for i, u in enumerate(users_list) if u.get_name() == user.get_name()]
+                    for idx in match:
+                        if users_list[idx].get_groups() and user.get_groups():
+                            users_list[idx].set_groups(
+                                ','.join([users_list[idx].get_groups(), user.get_groups()])
+                            )
+                        elif not users_list[idx].get_groups() and user.get_groups():
+                            users_list[idx].set_groups(user.get_groups())
+                    if not len(match):
                         users_list.append(user)
 
         return users_list
@@ -552,7 +560,12 @@ class XMLState(object):
         groups_list = []
         for user in self.get_users():
             if user.get_name() == user_name and user.get_groups():
-                groups_list.extend(user.get_groups().split(','))
+                seen = set()
+                groups_list = [
+                    grp for grp in user.get_groups().split(',')
+                    if not (grp in seen or seen.add(grp))
+                ]
+                break
 
         return groups_list
 

--- a/kiwi/xsl/convert62to63.xsl
+++ b/kiwi/xsl/convert62to63.xsl
@@ -35,31 +35,11 @@
 </xsl:template>
 
 <para xmlns="http://docbook.org/ns/docbook">
-    Remove obsolete fsreadonly attribute from types
+    Remove obsolete fsreadonly, fsreadwrite and zfsoptions attributes from types
 </para>
 <xsl:template match="type" mode="conv62to63">
     <type>
-        <xsl:copy-of select="@*[not(local-name(.) = 'fsreadonly')]"/>
-        <xsl:apply-templates mode="conv62to63"/>
-    </type>
-</xsl:template>
-
-<para xmlns="http://docbook.org/ns/docbook">
-    Remove obsolete fsreadwrite attribute from types
-</para>
-<xsl:template match="type" mode="conv62to63">
-    <type>
-        <xsl:copy-of select="@*[not(local-name(.) = 'fsreadwrite')]"/>
-        <xsl:apply-templates mode="conv62to63"/>
-    </type>
-</xsl:template>
-
-<para xmlns="http://docbook.org/ns/docbook">
-    Remove obsolete zfsoptions attribute from types
-</para>
-<xsl:template match="type" mode="conv62to63">
-    <type>
-        <xsl:copy-of select="@*[not(local-name(.) = 'zfsoptions')]"/>
+        <xsl:copy-of select="@*[not(local-name(.) = 'fsreadonly') and not(local-name(.) = 'fsreadwrite') and not(local-name(.) = 'zfsoptions')]"/>
         <xsl:apply-templates mode="conv62to63"/>
     </type>
 </xsl:template>

--- a/kiwi/xsl/convert63to64.xsl
+++ b/kiwi/xsl/convert63to64.xsl
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*|processing-instruction()|comment()" mode="conv63to64">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv63to64"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<!-- remove inherit attribute from image -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>6.3</literal> to <literal>6.4</literal>.
+</para>
+<xsl:template match="image" mode="conv63to64">
+    <xsl:choose>
+        <!-- nothing to do if already at 6.4 -->
+        <xsl:when test="@schemaversion > 6.3">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="6.4">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion' and local-name() != 'inherit']"/>
+                <xsl:apply-templates  mode="conv63to64"/>  
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<para xmlns="http://docbook.org/ns/docbook">
+    Remove obsolete group and id attribute from users
+</para>
+<xsl:template match="users" mode="conv63to64">
+    <users>
+        <xsl:copy-of select="@*[not(local-name(.) = 'group') and not(local-name(.) = 'id')]"/>
+        <xsl:apply-templates mode="conv63to64"/>
+    </users>
+</xsl:template>
+
+<para xmlns="http://docbook.org/ns/docbook">
+    Move global group attribute as groups to user section(s)
+</para>
+<xsl:template match="user" mode="conv63to64">
+    <user>
+        <xsl:variable name="group_name" select="../@group"/>
+        <xsl:copy-of select="@*"/>
+        <xsl:if test="$group_name">
+            <xsl:attribute name="groups">
+                <xsl:value-of select="$group_name"/>
+            </xsl:attribute>
+        </xsl:if>
+        <xsl:apply-templates mode="conv63to64"/>
+    </user>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/kiwi/xsl/master.xsl
+++ b/kiwi/xsl/master.xsl
@@ -34,6 +34,7 @@
 <xsl:import href="convert60to61.xsl"/>
 <xsl:import href="convert61to62.xsl"/>
 <xsl:import href="convert62to63.xsl"/>
+<xsl:import href="convert63to64.xsl"/>
 <xsl:import href="pretty.xsl"/>
 
 
@@ -156,8 +157,12 @@
         <xsl:apply-templates select="exslt:node-set($v62)" mode="conv62to63"/>
     </xsl:variable>
 
+    <xsl:variable name="v64">
+        <xsl:apply-templates select="exslt:node-set($v63)" mode="conv63to64"/>
+    </xsl:variable>
+
     <xsl:apply-templates
-        select="exslt:node-set($v63)" mode="pretty"
+        select="exslt:node-set($v64)" mode="pretty"
     />
 </xsl:template>
 

--- a/test/data/example_arm_disk_size_config.xml
+++ b/test/data/example_arm_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_btrfs_config.xml
+++ b/test/data/example_btrfs_config.xml
@@ -31,8 +31,8 @@
             </machine>
         </type>
     </preferences>
-    <users group="root">
-        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+    <users>
+        <user group='root' password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
     </users>
     <repository type="yast2">
         <source path="obs://13.2/repo/oss"/>

--- a/test/data/example_btrfs_config.xml
+++ b/test/data/example_btrfs_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_btrfs_config.xml
+++ b/test/data/example_btrfs_config.xml
@@ -32,7 +32,7 @@
         </type>
     </preferences>
     <users>
-        <user group='root' password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+        <user groups="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
     </users>
     <repository type="yast2">
         <source path="obs://13.2/repo/oss"/>

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="6.4" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
     <drivers>
         <file name="crypto/*"/>
         <file name="drivers/acpi/*"/>

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -98,9 +98,9 @@
         </type>
     </preferences>
     <users>
-        <user group="root" pwdformat="plain" password="mypwd" shell="/bin/bash" id="815" realname="Bob" home="/root" name="root"/>
-        <user group="users" secgroups="admin" pwdformat="plain" password="mypwd" home="/home/tux" name="tux"/>
-        <user group="kiwi" secgroups="users,admin" pwdformat="plain" password="mypwd" home="/home/kiwi" name="kiwi"/>
+        <user pwdformat="plain" password="mypwd" shell="/bin/bash" id="815" realname="Bob" home="/root" name="root"/>
+        <user groups="users" pwdformat="plain" password="mypwd" home="/home/tux" name="tux"/>
+        <user groups="kiwi,admin,users" pwdformat="plain" password="mypwd" home="/home/kiwi" name="kiwi"/>
     </users>
     <repository type="yast2" priority="42">
         <source path="iso:///image/CDs/dvd.iso"/>

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -97,8 +97,10 @@
             </machine>
         </type>
     </preferences>
-    <users group="root" id="42">
-        <user pwdformat="plain" password="mypwd" shell="/bin/bash" id="815" realname="Bob" home="/root" name="root"/>
+    <users>
+        <user group="root" pwdformat="plain" password="mypwd" shell="/bin/bash" id="815" realname="Bob" home="/root" name="root"/>
+        <user group="users" secgroups="admin" pwdformat="plain" password="mypwd" home="/home/tux" name="tux"/>
+        <user group="kiwi" secgroups="users,admin" pwdformat="plain" password="mypwd" home="/home/kiwi" name="kiwi"/>
     </users>
     <repository type="yast2" priority="42">
         <source path="iso:///image/CDs/dvd.iso"/>

--- a/test/data/example_disk_config.xml
+++ b/test/data/example_disk_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_config.xml
+++ b/test/data/example_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_empty_vol_config.xml
+++ b/test/data/example_disk_size_empty_vol_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_vol_root_config.xml
+++ b/test/data/example_disk_size_vol_root_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_volume_config.xml
+++ b/test/data/example_disk_size_volume_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_dot_profile_config.xml
+++ b/test/data/example_dot_profile_config.xml
@@ -39,8 +39,8 @@
             </machine>
         </type>
     </preferences>
-    <users group="root">
-        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+    <users>
+        <user group="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
     </users>
     <repository type="yast2">
         <source path="obs://13.2/repo/oss"/>

--- a/test/data/example_dot_profile_config.xml
+++ b/test/data/example_dot_profile_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_dot_profile_config.xml
+++ b/test/data/example_dot_profile_config.xml
@@ -40,7 +40,7 @@
         </type>
     </preferences>
     <users>
-        <user group="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+        <user groups="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
     </users>
     <repository type="yast2">
         <source path="obs://13.2/repo/oss"/>

--- a/test/data/example_lvm_default_config.xml
+++ b/test/data/example_lvm_default_config.xml
@@ -36,8 +36,8 @@
             </machine>
         </type>
     </preferences>
-    <users group="root">
-        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+    <users>
+        <user group="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
     </users>
     <repository type="yast2">
         <source path="obs://13.2/repo/oss"/>

--- a/test/data/example_lvm_default_config.xml
+++ b/test/data/example_lvm_default_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_default_config.xml
+++ b/test/data/example_lvm_default_config.xml
@@ -37,7 +37,7 @@
         </type>
     </preferences>
     <users>
-        <user group="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+        <user groups="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
     </users>
     <repository type="yast2">
         <source path="obs://13.2/repo/oss"/>

--- a/test/data/example_lvm_no_root_config.xml
+++ b/test/data/example_lvm_no_root_config.xml
@@ -32,7 +32,7 @@
         </type>
     </preferences>
     <users>
-        <user group="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+        <user groups="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
     </users>
     <repository type="yast2">
         <source path="obs://13.2/repo/oss"/>

--- a/test/data/example_lvm_no_root_config.xml
+++ b/test/data/example_lvm_no_root_config.xml
@@ -31,8 +31,8 @@
             </machine>
         </type>
     </preferences>
-    <users group="root">
-        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+    <users>
+        <user group="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
     </users>
     <repository type="yast2">
         <source path="obs://13.2/repo/oss"/>

--- a/test/data/example_lvm_no_root_config.xml
+++ b/test/data/example_lvm_no_root_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_no_root_full_usr_config.xml
+++ b/test/data/example_lvm_no_root_full_usr_config.xml
@@ -34,7 +34,7 @@
         </type>
     </preferences>
     <users>
-        <user group='root' password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+        <user groups="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
     </users>
     <repository type="yast2">
         <source path="obs://13.2/repo/oss"/>

--- a/test/data/example_lvm_no_root_full_usr_config.xml
+++ b/test/data/example_lvm_no_root_full_usr_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_no_root_full_usr_config.xml
+++ b/test/data/example_lvm_no_root_full_usr_config.xml
@@ -33,8 +33,8 @@
             </machine>
         </type>
     </preferences>
-    <users group="root">
-        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+    <users>
+        <user group='root' password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
     </users>
     <repository type="yast2">
         <source path="obs://13.2/repo/oss"/>

--- a/test/data/example_lvm_preferred_config.xml
+++ b/test/data/example_lvm_preferred_config.xml
@@ -32,7 +32,7 @@
         </type>
     </preferences>
     <users>
-        <user group="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+        <user groups="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
     </users>
     <repository type="yast2">
         <source path="obs://13.2/repo/oss"/>

--- a/test/data/example_lvm_preferred_config.xml
+++ b/test/data/example_lvm_preferred_config.xml
@@ -31,8 +31,8 @@
             </machine>
         </type>
     </preferences>
-    <users group="root">
-        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+    <users>
+        <user group="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
     </users>
     <repository type="yast2">
         <source path="obs://13.2/repo/oss"/>

--- a/test/data/example_lvm_preferred_config.xml
+++ b/test/data/example_lvm_preferred_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_multiple_users_config.xml
+++ b/test/data/example_multiple_users_config.xml
@@ -1,23 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.4" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
-    <drivers>
-        <file name="crypto/*"/>
-        <file name="drivers/acpi/*"/>
-        <file name="bar"/>
-    </drivers>
-    <strip type="delete">
-        <file name="del-a"/>
-        <file name="del-b"/>
-    </strip>
-    <strip type="tools">
-        <file name="tool-a"/>
-        <file name="tool-b"/>
-    </strip>
-    <strip type="libs">
-        <file name="lib-a"/>
-        <file name="lib-b"/>
-    </strip>
+<image schemaversion="6.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -31,23 +14,6 @@
         <profile name="vmxFlavour" description="VMX with default kernel" import="true"/>
     </profiles>
     <preferences>
-        <locale>de_DE</locale>
-    </preferences>
-    <preferences>
-        <type bootloader="grub2" image="oem" primary="true" boot="oemboot/example-distribution" flags="overlay" hybrid="true" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async">
-            <size unit="G" additive="true">1</size>
-            <systemdisk name="mydisk"/>
-            <machine memory="512" domain="domU">
-                <vmdisk id="0" device="/dev/xvda" controller="ide"/>
-                <vmnic interface=""/>
-                <vmdvd id="0" controller="scsi"/>
-            </machine>
-            <oemconfig>
-                <oem-systemsize>2048</oem-systemsize>
-                <oem-swap>true</oem-swap>
-                <oem-recovery>false</oem-recovery>
-            </oemconfig>
-        </type>
         <version>1.13.2</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_US</locale>
@@ -55,46 +21,10 @@
         <timezone>Europe/Berlin</timezone>
         <hwclock>utc</hwclock>
         <rpm-excludedocs>true</rpm-excludedocs>
+        <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-    </preferences>
-    <preferences profiles="ec2Flavour">
-        <type image="vmx" filesystem="ext3" boot="vmxboot/example-distribution" bootprofile="ec2" bootkernel="ec2k" bootloader="grub2" kernelcmdline="xencons=xvc0 console=xvc0 multipath=off splash" firmware="ec2"/>
-    </preferences>
-    <preferences profiles="xenFlavour">
-        <type image="vmx" filesystem="ext3" boot="vmxboot/example-distribution" bootprofile="xen" bootkernel="xenk" bootloader="grub2" kernelcmdline="splash">
-            <machine memory="512" domain="domU">
-                <vmdisk id="0" device="/dev/xvda" controller="ide"/>
-                <vmnic interface=""/>
-            </machine>
-        </type>
-        <type image="oem" filesystem="ext3" boot="oemboot/example-distribution" bootprofile="xen" bootkernel="xenk" installiso="true" bootloader="grub2" kernelcmdline="splash">
-            <oemconfig>
-                <oem-systemsize>2048</oem-systemsize>
-                <oem-swap>true</oem-swap>
-            </oemconfig>
-            <machine domain="dom0">
-                <vmdisk id="0" controller="ide"/>
-            </machine>
-        </type>
-    </preferences>
-    <preferences profiles="vmxFlavour">
-        <type image="vmx" filesystem="ext3" boot="vmxboot/example-distribution" format="vmdk" bootloader="grub2" kernelcmdline="splash" bootpartition="false">
-            <systemdisk name="systemVG"/>
-            <machine memory="512" guestOS="suse" HWversion="4">
-                <vmdisk id="0" controller="ide"/>
-                <vmnic driver="e1000" interface="0" mode="bridged"/>
-            </machine>
-        </type>
-        <type image="oem" filesystem="ext3" boot="oemboot/example-distribution" installiso="true" bootloader="grub2" kernelcmdline="splash">
-            <oemconfig>
-                <oem-systemsize>2048</oem-systemsize>
-                <oem-swap>true</oem-swap>
-            </oemconfig>
-            <machine memory="512" guestOS="suse" HWversion="4">
-                <vmdisk id="0" controller="ide"/>
-                <vmnic driver="e1000" interface="0" mode="bridged"/>
-            </machine>
+        <type image="vmx" filesystem="btrfs" boot="oemboot/suse-13.2" installiso="true" bootloader="grub2" kernelcmdline="splash" firmware="efi">
         </type>
     </preferences>
     <users>
@@ -106,55 +36,15 @@
         <user groups="users" pwdformat="plain" password="mypwd" home="/home/tux" name="tux"/>
         <user groups="kiwi,admin" pwdformat="plain" password="mypwd" home="/home/kiwi" name="kiwi"/>
     </users>
-    <repository type="yast2" priority="42">
-        <source path="iso:///image/CDs/dvd.iso"/>
+    <repository type="yast2">
+        <source path="obs://13.2/repo/oss"/>
     </repository>
-    <repository type="rpm-md" imageinclude="true">
-        <source path="obs://Devel:PubCloud:AmazonEC2/SLE_12_GA"/>
-    </repository>
-    <packages type="image" patternType="plusRecommended">
-        <namedCollection name="base"/>
-        <product name="openSUSE"/>
-        <package name="plymouth-branding-openSUSE" bootinclude="true"/>
-        <package name="grub2-branding-openSUSE" bootinclude="true"/>
-        <package name="ifplugd"/>
-        <package name="iputils"/>
-        <package name="vim" bootdelete="true"/>
-        <package name="openssh"/>
-        <archive name="/absolute/path/to/image.tgz" bootinclude="true"/>
-        <package name="foo" arch="some-arch"/>
-    </packages>
-    <packages type="iso">
-        <package name="gfxboot-branding-openSUSE" bootinclude="true" bootdelete="true"/>
-    </packages>
-    <packages type="oem">
-        <package name="gfxboot-branding-openSUSE" bootinclude="true" bootdelete="true"/>
-    </packages>
-    <packages type="image" profiles="ec2Flavour">
-        <package name="kernel-ec2" replaces="kernel-default"/>
-        <package name="kernel-ec2" replaces="kernel-xen"/>
-        <package name="xen-tools" arch="x86_64" replaces=""/>
-        <package name="xen" arch="x86_64" replaces=""/>
-    </packages>
-    <packages type="image" profiles="xenFlavour">
-        <package name="kernel-xen" replaces="kernel-default"/>
-        <package name="kernel-xen" replaces="kernel-ec2"/>
-        <package name="xen-tools" arch="x86_64" replaces=""/>
-        <package name="xen" arch="x86_64" replaces=""/>
-    </packages>
-    <packages type="image" profiles="vmxFlavour">
-        <package name="kernel-default" replaces="kernel-xen"/>
-        <package name="kernel-default" replaces="kernel-ec2"/>
-        <package name="kernel-default" replaces="xen-tools"/>
-        <package name="kernel-default" replaces="xen"/>
+    <packages type="image">
+        <package name="patterns-openSUSE-base"/>
     </packages>
     <packages type="bootstrap">
+        <package name="udev"/>
         <package name="filesystem"/>
-        <namedCollection name="bootstrap-collection"/>
-        <product name="kiwi"/>
-        <archive name="bootstrap.tgz"/>
-    </packages>
-    <packages type="delete">
-        <package name="kernel-debug"/>
+        <package name="glibc-locale"/>
     </packages>
 </image>

--- a/test/data/example_multiple_users_config.xml
+++ b/test/data/example_multiple_users_config.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="6.4" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+    <drivers>
+        <file name="crypto/*"/>
+        <file name="drivers/acpi/*"/>
+        <file name="bar"/>
+    </drivers>
+    <strip type="delete">
+        <file name="del-a"/>
+        <file name="del-b"/>
+    </strip>
+    <strip type="tools">
+        <file name="tool-a"/>
+        <file name="tool-b"/>
+    </strip>
+    <strip type="libs">
+        <file name="lib-a"/>
+        <file name="lib-b"/>
+    </strip>
+    <description type="system">
+        <author>Marcus Schäfer</author>
+        <contact>ms@suse.com</contact>
+        <specification>
+            openSUSE 13.2 JeOS, is a small text based image
+        </specification>
+    </description>
+    <profiles>
+        <profile name="xenFlavour" description="VMX with Xen kernel"/>
+        <profile name="ec2Flavour" description="VMX with EC2/Xen kernel"/>
+        <profile name="vmxFlavour" description="VMX with default kernel" import="true"/>
+    </profiles>
+    <preferences>
+        <locale>de_DE</locale>
+    </preferences>
+    <preferences>
+        <type bootloader="grub2" image="oem" primary="true" boot="oemboot/example-distribution" flags="overlay" hybrid="true" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async">
+            <size unit="G" additive="true">1</size>
+            <systemdisk name="mydisk"/>
+            <machine memory="512" domain="domU">
+                <vmdisk id="0" device="/dev/xvda" controller="ide"/>
+                <vmnic interface=""/>
+                <vmdvd id="0" controller="scsi"/>
+            </machine>
+            <oemconfig>
+                <oem-systemsize>2048</oem-systemsize>
+                <oem-swap>true</oem-swap>
+                <oem-recovery>false</oem-recovery>
+            </oemconfig>
+        </type>
+        <version>1.13.2</version>
+        <packagemanager>zypper</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us.map.gz</keytable>
+        <timezone>Europe/Berlin</timezone>
+        <hwclock>utc</hwclock>
+        <rpm-excludedocs>true</rpm-excludedocs>
+        <bootsplash-theme>openSUSE</bootsplash-theme>
+        <bootloader-theme>openSUSE</bootloader-theme>
+    </preferences>
+    <preferences profiles="ec2Flavour">
+        <type image="vmx" filesystem="ext3" boot="vmxboot/example-distribution" bootprofile="ec2" bootkernel="ec2k" bootloader="grub2" kernelcmdline="xencons=xvc0 console=xvc0 multipath=off splash" firmware="ec2"/>
+    </preferences>
+    <preferences profiles="xenFlavour">
+        <type image="vmx" filesystem="ext3" boot="vmxboot/example-distribution" bootprofile="xen" bootkernel="xenk" bootloader="grub2" kernelcmdline="splash">
+            <machine memory="512" domain="domU">
+                <vmdisk id="0" device="/dev/xvda" controller="ide"/>
+                <vmnic interface=""/>
+            </machine>
+        </type>
+        <type image="oem" filesystem="ext3" boot="oemboot/example-distribution" bootprofile="xen" bootkernel="xenk" installiso="true" bootloader="grub2" kernelcmdline="splash">
+            <oemconfig>
+                <oem-systemsize>2048</oem-systemsize>
+                <oem-swap>true</oem-swap>
+            </oemconfig>
+            <machine domain="dom0">
+                <vmdisk id="0" controller="ide"/>
+            </machine>
+        </type>
+    </preferences>
+    <preferences profiles="vmxFlavour">
+        <type image="vmx" filesystem="ext3" boot="vmxboot/example-distribution" format="vmdk" bootloader="grub2" kernelcmdline="splash" bootpartition="false">
+            <systemdisk name="systemVG"/>
+            <machine memory="512" guestOS="suse" HWversion="4">
+                <vmdisk id="0" controller="ide"/>
+                <vmnic driver="e1000" interface="0" mode="bridged"/>
+            </machine>
+        </type>
+        <type image="oem" filesystem="ext3" boot="oemboot/example-distribution" installiso="true" bootloader="grub2" kernelcmdline="splash">
+            <oemconfig>
+                <oem-systemsize>2048</oem-systemsize>
+                <oem-swap>true</oem-swap>
+            </oemconfig>
+            <machine memory="512" guestOS="suse" HWversion="4">
+                <vmdisk id="0" controller="ide"/>
+                <vmnic driver="e1000" interface="0" mode="bridged"/>
+            </machine>
+        </type>
+    </preferences>
+    <users>
+        <user pwdformat="plain" password="mypwd" shell="/bin/bash" id="815" realname="Bob" home="/root" name="root"/>
+        <user pwdformat="plain" password="mypwd" home="/home/tux" name="tux"/>
+        <user groups="kiwi,users" pwdformat="plain" password="mypwd" home="/home/kiwi" name="kiwi"/>
+    </users>
+    <users>
+        <user groups="users" pwdformat="plain" password="mypwd" home="/home/tux" name="tux"/>
+        <user groups="kiwi,admin" pwdformat="plain" password="mypwd" home="/home/kiwi" name="kiwi"/>
+    </users>
+    <repository type="yast2" priority="42">
+        <source path="iso:///image/CDs/dvd.iso"/>
+    </repository>
+    <repository type="rpm-md" imageinclude="true">
+        <source path="obs://Devel:PubCloud:AmazonEC2/SLE_12_GA"/>
+    </repository>
+    <packages type="image" patternType="plusRecommended">
+        <namedCollection name="base"/>
+        <product name="openSUSE"/>
+        <package name="plymouth-branding-openSUSE" bootinclude="true"/>
+        <package name="grub2-branding-openSUSE" bootinclude="true"/>
+        <package name="ifplugd"/>
+        <package name="iputils"/>
+        <package name="vim" bootdelete="true"/>
+        <package name="openssh"/>
+        <archive name="/absolute/path/to/image.tgz" bootinclude="true"/>
+        <package name="foo" arch="some-arch"/>
+    </packages>
+    <packages type="iso">
+        <package name="gfxboot-branding-openSUSE" bootinclude="true" bootdelete="true"/>
+    </packages>
+    <packages type="oem">
+        <package name="gfxboot-branding-openSUSE" bootinclude="true" bootdelete="true"/>
+    </packages>
+    <packages type="image" profiles="ec2Flavour">
+        <package name="kernel-ec2" replaces="kernel-default"/>
+        <package name="kernel-ec2" replaces="kernel-xen"/>
+        <package name="xen-tools" arch="x86_64" replaces=""/>
+        <package name="xen" arch="x86_64" replaces=""/>
+    </packages>
+    <packages type="image" profiles="xenFlavour">
+        <package name="kernel-xen" replaces="kernel-default"/>
+        <package name="kernel-xen" replaces="kernel-ec2"/>
+        <package name="xen-tools" arch="x86_64" replaces=""/>
+        <package name="xen" arch="x86_64" replaces=""/>
+    </packages>
+    <packages type="image" profiles="vmxFlavour">
+        <package name="kernel-default" replaces="kernel-xen"/>
+        <package name="kernel-default" replaces="kernel-ec2"/>
+        <package name="kernel-default" replaces="xen-tools"/>
+        <package name="kernel-default" replaces="xen"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="filesystem"/>
+        <namedCollection name="bootstrap-collection"/>
+        <product name="kiwi"/>
+        <archive name="bootstrap.tgz"/>
+    </packages>
+    <packages type="delete">
+        <package name="kernel-debug"/>
+    </packages>
+</image>

--- a/test/data/example_ppc_disk_size_config.xml
+++ b/test/data/example_ppc_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_pxe_config.xml
+++ b/test/data/example_pxe_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.4" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_runtime_checker_config.xml
+++ b/test/data/example_runtime_checker_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="6.4" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
     <drivers>
         <file name="crypto/*"/>
         <file name="drivers/acpi/*"/>

--- a/test/data/example_runtime_checker_config.xml
+++ b/test/data/example_runtime_checker_config.xml
@@ -96,8 +96,8 @@
             </machine>
         </type>
     </preferences>
-    <users group="root" id="42">
-        <user pwdformat="plain" password="mypwd" shell="/bin/bash" id="815" realname="Bob" home="/root" name="root"/>
+    <users>
+        <user group="root" pwdformat="plain" password="mypwd" shell="/bin/bash" id="815" realname="Bob" home="/root" name="root"/>
     </users>
     <repository type="yast2" priority="42" imageinclude="true">
         <source path="iso:///image/CDs/dvd.iso"/>

--- a/test/data/example_runtime_checker_config.xml
+++ b/test/data/example_runtime_checker_config.xml
@@ -97,7 +97,7 @@
         </type>
     </preferences>
     <users>
-        <user group="root" pwdformat="plain" password="mypwd" shell="/bin/bash" id="815" realname="Bob" home="/root" name="root"/>
+        <user groups="root" pwdformat="plain" password="mypwd" shell="/bin/bash" id="815" realname="Bob" home="/root" name="root"/>
     </users>
     <repository type="yast2" priority="42" imageinclude="true">
         <source path="iso:///image/CDs/dvd.iso"/>

--- a/test/data/isoboot/example-distribution-no-delete-section/config.xml
+++ b/test/data/isoboot/example-distribution-no-delete-section/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-isoboot-suse-13.2">
+<image schemaversion="6.4" name="initrd-isoboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/data/isoboot/example-distribution/config.xml
+++ b/test/data/isoboot/example-distribution/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-isoboot-suse-13.2">
+<image schemaversion="6.4" name="initrd-isoboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/data/oemboot/example-distribution/config.xml
+++ b/test/data/oemboot/example-distribution/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.3" name="initrd-oemboot-suse-13.2">
+<image schemaversion="6.4" name="initrd-oemboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/unit/system_setup_test.py
+++ b/test/unit/system_setup_test.py
@@ -302,15 +302,15 @@ class TestSystemSetup(object):
         self.setup_with_real_xml.setup_groups()
 
         calls = [
-            call('root'),
             call('users'),
+            call('kiwi'),
             call('admin') 
         ] 
         users.group_exists.assert_has_calls(calls)
 
         calls = [
-            call('root', []),
             call('users', []),
+            call('kiwi', []),
             call('admin', []) 
         ] 
         users.group_add.assert_has_calls(calls)
@@ -330,6 +330,7 @@ class TestSystemSetup(object):
         calls = [
             call('root'),
             call('tux'),
+            call('kiwi')
         ] 
         users.user_exists.assert_has_calls(calls)
 
@@ -337,7 +338,7 @@ class TestSystemSetup(object):
             call(
                 'root', [
                     '-p', 'password-hash',
-                    '-s', '/bin/bash', '-g', 'root',
+                    '-s', '/bin/bash',
                     '-u', 815, '-c', 'Bob',
                     '-m', '-d', '/root'
                 ]
@@ -345,8 +346,15 @@ class TestSystemSetup(object):
             call(
                 'tux', [
                     '-p', 'password-hash',
-                    '-g', 'users', '-G', 'admin',
+                    '-g', 'users', 
                     '-m', '-d', '/home/tux'
+                ]
+            ),
+            call(
+                'kiwi', [
+                    '-p', 'password-hash',
+                    '-g', 'kiwi', '-G', 'admin,users',
+                    '-m', '-d', '/home/kiwi'
                 ]
             )
         ]
@@ -371,6 +379,7 @@ class TestSystemSetup(object):
         calls = [
             call('root'),
             call('tux'),
+            call('kiwi')
         ] 
         users.user_exists.assert_has_calls(calls)
 
@@ -378,15 +387,21 @@ class TestSystemSetup(object):
             call(
                 'root', [
                     '-p', 'password-hash',
-                    '-s', '/bin/bash', '-g', 'root', '-u', 815, '-c', 'Bob'
+                    '-s', '/bin/bash', '-u', 815, '-c', 'Bob'
                 ]
             ),
             call(
                 'tux', [
                     '-p', 'password-hash',
-                    '-g', 'users', '-G', 'admin',
+                    '-g', 'users'
                 ]
-            ) 
+            ),
+            call(
+                'kiwi', [
+                    '-p', 'password-hash',
+                    '-g', 'kiwi', '-G', 'admin,users'
+                ]
+            )
         ]
         users.user_modify.assert_has_calls(calls)
 

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -305,8 +305,27 @@ class TestXMLState(object):
             'root'
 
     def test_get_users(self):
-        assert self.state.get_users()[0].get_name() == \
-            'root'
+        description = XMLDescription('../data/example_multiple_users_config.xml')
+        xml_data = description.load()
+        state = XMLState(xml_data)
+        users = state.get_users()
+        assert len(users) == 3
+        assert any(u.get_name() == 'root' for u in users)
+        assert any(u.get_name() == 'tux' for u in users)
+        assert any(u.get_name() == 'kiwi' for u in users) 
+
+    def test_get_user_groups(self):
+        description = XMLDescription('../data/example_multiple_users_config.xml')
+        xml_data = description.load()
+        state = XMLState(xml_data)
+        
+        assert len(state.get_user_groups('root')) == 0
+        assert len(state.get_user_groups('tux')) == 1
+        assert any(grp == 'users' for grp in state.get_user_groups('tux'))
+        assert len(state.get_user_groups('kiwi')) == 3
+        assert any(grp == 'users' for grp in state.get_user_groups('kiwi'))
+        assert any(grp == 'kiwi' for grp in state.get_user_groups('kiwi'))
+        assert any(grp == 'admin' for grp in state.get_user_groups('kiwi'))
 
     def test_copy_displayname(self):
         self.state.copy_displayname(self.boot_state)

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -305,7 +305,7 @@ class TestXMLState(object):
             'root'
 
     def test_get_users(self):
-        assert self.state.get_users()[0][0].get_name() == \
+        assert self.state.get_users()[0].get_name() == \
             'root'
 
     def test_copy_displayname(self):

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -305,7 +305,7 @@ class TestXMLState(object):
             'root'
 
     def test_get_users(self):
-        assert self.state.get_users()[0].user_sections[0].get_name() == \
+        assert self.state.get_users()[0][0].get_name() == \
             'root'
 
     def test_copy_displayname(self):


### PR DESCRIPTION
__Changed user and group schema layout__


The user schema layout has been changed in order to make groups management easier and more flexible. The current schema is like the one below:

```
<users>
    <user group="root" secgroups="testgrp,anothergrp" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
    <user group="tux" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/home/tux" name="tux"/>
    <user group="users" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/home/custom_dir" name="oracle"/>
</users>
```

The **group** attribute is mandatory and it is the primary group of the user. The **secgroups** attribute is optional and it is a comma separated value list of different secondary groups, if not present the user is no included in any secondary group.

In order to ensure the comma separated normalization for the secondary groups list, a pattern has been included in schema to restrict the naming possibilities of groups. Now any group name must be format according to the _POSIX portable filename character set_. Finally, due to this new schema layout the feature of setting the group ID has been dropped.

This pull request will require updating the the descriptions in [kiwi-descriptions](https://github.com/SUSE/kiwi-descriptions).
