### PR TITLE
Delete obsolete <except> section

### DIFF
--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -312,21 +312,6 @@ div {
 }
 
 #==========================================
-# common element <except>
-#
-div {
-    k.except.name.attribute = k.name.attribute
-    k.except.attlist =
-        k.except.name.attribute
-    k.except =
-        ## A Pointer to a File which should be excluded
-        element except {
-            k.except.attlist,
-            empty
-        }
-}
-
-#==========================================
 # common element <file>
 #
 div {

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -474,26 +474,6 @@ the directory is not specified on the command line</a:documentation>
   </div>
   <!--
     ==========================================
-    common element <except>
-    
-  -->
-  <div>
-    <define name="k.except.name.attribute">
-      <ref name="k.name.attribute"/>
-    </define>
-    <define name="k.except.attlist">
-      <ref name="k.except.name.attribute"/>
-    </define>
-    <define name="k.except">
-      <element name="except">
-        <a:documentation>A Pointer to a File which should be excluded</a:documentation>
-        <ref name="k.except.attlist"/>
-        <empty/>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
     common element <file>
     
   -->

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Mon Aug  1 11:15:39 2016 by generateDS.py version 2.22a.
+# Generated Thu Aug 11 10:55:32 2016 by generateDS.py version 2.22a.
 #
 # Command line options:
 #   ('-f', '')
@@ -1097,73 +1097,6 @@ class configuration(GeneratedsSuper):
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         pass
 # end class configuration
-
-
-class except_(GeneratedsSuper):
-    """A Pointer to a File which should be excluded"""
-    subclass = None
-    superclass = None
-    def __init__(self, name=None):
-        self.original_tagname_ = None
-        self.name = _cast(None, name)
-    def factory(*args_, **kwargs_):
-        if CurrentSubclassModule_ is not None:
-            subclass = getSubclassFromModule_(
-                CurrentSubclassModule_, except_)
-            if subclass is not None:
-                return subclass(*args_, **kwargs_)
-        if except_.subclass:
-            return except_.subclass(*args_, **kwargs_)
-        else:
-            return except_(*args_, **kwargs_)
-    factory = staticmethod(factory)
-    def get_name(self): return self.name
-    def set_name(self, name): self.name = name
-    def hasContent_(self):
-        if (
-
-        ):
-            return True
-        else:
-            return False
-    def export(self, outfile, level, namespace_='', name_='except', namespacedef_='', pretty_print=True):
-        if pretty_print:
-            eol_ = '\n'
-        else:
-            eol_ = ''
-        if self.original_tagname_ is not None:
-            name_ = self.original_tagname_
-        showIndent(outfile, level, pretty_print)
-        outfile.write('<%s%s%s' % (namespace_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
-        already_processed = set()
-        self.exportAttributes(outfile, level, already_processed, namespace_, name_='except')
-        if self.hasContent_():
-            outfile.write('>%s' % (eol_, ))
-            self.exportChildren(outfile, level + 1, namespace_='', name_='except', pretty_print=pretty_print)
-            outfile.write('</%s%s>%s' % (namespace_, name_, eol_))
-        else:
-            outfile.write('/>%s' % (eol_, ))
-    def exportAttributes(self, outfile, level, already_processed, namespace_='', name_='except'):
-        if self.name is not None and 'name' not in already_processed:
-            already_processed.add('name')
-            outfile.write(' name=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.name), input_name='name')), ))
-    def exportChildren(self, outfile, level, namespace_='', name_='except', fromsubclass_=False, pretty_print=True):
-        pass
-    def build(self, node):
-        already_processed = set()
-        self.buildAttributes(node, node.attrib, already_processed)
-        for child in node:
-            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
-            self.buildChildren(child, node, nodeName_)
-        return self
-    def buildAttributes(self, node, attrs, already_processed):
-        value = find_attr_value_('name', node)
-        if value is not None and 'name' not in already_processed:
-            already_processed.add('name')
-            self.name = value
-    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
-        pass
-# end class except_
 
 
 class file(GeneratedsSuper):
@@ -8010,7 +7943,6 @@ __all__ = [
     "description",
     "drivers",
     "driverupdate",
-    "except_",
     "file",
     "ignore",
     "image",


### PR DESCRIPTION
The <except> section was formerly used as part of the <split>
section. kiwi no longer supports static split images in favour
of overlay systems based on e.g overlayfs. Fixes #120