### PR TITLE
Fixes #124

### DIFF
--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -316,7 +316,7 @@ class SystemSetup(object):
                     options.append(','.join(user_groups[1:]))
             if user_id:
                 options.append('-u')
-                options.append(user_id)
+                options.append(str(user_id))
             if user_realname:
                 options.append('-c')
                 options.append(user_realname)

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -316,7 +316,7 @@ class SystemSetup(object):
                     options.append(','.join(user_groups[1:]))
             if user_id:
                 options.append('-u')
-                options.append(str(user_id))
+                options.append('{0}'.format(user_id))
             if user_realname:
                 options.append('-c')
                 options.append(user_realname)

--- a/test/unit/system_setup_test.py
+++ b/test/unit/system_setup_test.py
@@ -339,7 +339,7 @@ class TestSystemSetup(object):
                 'root', [
                     '-p', 'password-hash',
                     '-s', '/bin/bash',
-                    '-u', 815, '-c', 'Bob',
+                    '-u', '815', '-c', 'Bob',
                     '-m', '-d', '/root'
                 ]
             ),
@@ -375,19 +375,18 @@ class TestSystemSetup(object):
         mock_command.return_value = self.run_result
 
         self.setup_with_real_xml.setup_users()
-        
         calls = [
             call('root'),
             call('tux'),
             call('kiwi')
-        ] 
+        ]
         users.user_exists.assert_has_calls(calls)
 
         calls = [
             call(
                 'root', [
                     '-p', 'password-hash',
-                    '-s', '/bin/bash', '-u', 815, '-c', 'Bob'
+                    '-s', '/bin/bash', '-u', '815', '-c', 'Bob'
                 ]
             ),
             call(


### PR DESCRIPTION
Fixes #124

user.get_id() returns int type and string type is required in the options list the finally is handled by Command.

