### PR TITLE
Add evaluation of machine's vmconfig_entry

### DIFF
--- a/kiwi/storage/subformat/vmdk.py
+++ b/kiwi/storage/subformat/vmdk.py
@@ -168,6 +168,9 @@ class DiskFormatVmdk(DiskFormatBase):
             if disk_id:
                 template_record['disk_id'] = disk_id
 
+        # Addition custom entries
+        custom_entries = self.xml_state.get_build_type_vmconfig_entries()
+
         # Build settings template and write settings file
         settings_template = VmwareSettingsTemplate().get_template(
             memory_setup,
@@ -184,6 +187,8 @@ class DiskFormatVmdk(DiskFormatBase):
             settings_file = self.get_target_name_for_format('vmx')
             with open(settings_file, 'w') as config:
                 config.write(settings_template.substitute(template_record))
+                for custom_entry in custom_entries:
+                    config.write(custom_entry)
         except Exception as e:
             raise KiwiTemplateError(
                 '%s: %s' % (type(e).__name__, format(e))

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -470,6 +470,18 @@ class XMLState(object):
             if vmdvd_sections:
                 return vmdvd_sections[0]
 
+    def get_build_type_vmconfig_entries(self):
+        """
+        List of vmconfig-entry section values from the first
+        machine section in the build type section
+
+        :return: vmconfig_entry values
+        :rtype: list
+        """
+        machine_section = self.get_build_type_machine_section()
+        if machine_section:
+            return machine_section.get_vmconfig_entry()
+
     def get_build_type_oemconfig_section(self):
         """
         First oemconfig section from the build type section

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -480,7 +480,11 @@ class XMLState(object):
         """
         machine_section = self.get_build_type_machine_section()
         if machine_section:
-            return machine_section.get_vmconfig_entry()
+            vmconfig_entries = machine_section.get_vmconfig_entry()
+            if vmconfig_entries:
+                return vmconfig_entries
+
+        return []
 
     def get_build_type_oemconfig_section(self):
         """

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -84,6 +84,8 @@
             <machine memory="512" guestOS="suse" HWversion="4">
                 <vmdisk id="0" controller="ide"/>
                 <vmnic driver="e1000" interface="0" mode="bridged"/>
+                <vmconfig-entry>numvcpus = "4"</vmconfig-entry>
+                <vmconfig-entry>cpuid.coresPerSocket = "2"</vmconfig-entry>
             </machine>
         </type>
         <type image="oem" filesystem="ext3" boot="oemboot/example-distribution" installiso="true" bootloader="grub2" kernelcmdline="splash">

--- a/test/unit/storage_subformat_vmdk_test.py
+++ b/test/unit/storage_subformat_vmdk_test.py
@@ -37,6 +37,10 @@ class TestDiskFormatVmdk(object):
             return_value='1.2.3'
         )
 
+        self.xml_state.get_build_type_vmconfig_entries = mock.Mock(
+            return_value=['custom entry 1', 'custom entry 2']
+        )
+
         self.machine_setup = mock.Mock()
         self.xml_state.get_build_type_machine_section = mock.Mock(
             return_value=self.machine_setup
@@ -302,6 +306,12 @@ class TestDiskFormatVmdk(object):
         )
         assert self.file_mock.write.call_args_list[1] == call(
             self.vmdk_settings
+        )
+        assert self.file_mock.write.call_args_list[2] == call(
+            'custom entry 1'
+        )
+        assert self.file_mock.write.call_args_list[3] == call(
+            'custom entry 2'
         )
         assert self.file_mock.seek.call_args_list == [
             call(512, 0), call(0, 2)

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -437,3 +437,14 @@ class TestXMLState(object):
     def test_delete_repository_sections(self):
         self.state.delete_repository_sections()
         assert self.state.get_repository_sections() == []
+
+    def test_get_build_type_vmconfig_entries(self):
+        assert self.state.get_build_type_vmconfig_entries() == []
+
+    def test_get_build_type_vmconfig_entries_for_vmx_type(self):
+        description = XMLDescription('../data/example_config.xml')
+        xml_data = description.load()
+        state = XMLState(xml_data, ['vmxFlavour'], 'vmx')
+        assert state.get_build_type_vmconfig_entries() == [
+            'numvcpus = "4"', 'cpuid.coresPerSocket = "2"'
+        ]

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -448,3 +448,9 @@ class TestXMLState(object):
         assert state.get_build_type_vmconfig_entries() == [
             'numvcpus = "4"', 'cpuid.coresPerSocket = "2"'
         ]
+
+    def test_get_build_type_vmconfig_entries_no_machine_section(self):
+        description = XMLDescription('../data/example_disk_config.xml')
+        xml_data = description.load()
+        state = XMLState(xml_data)
+        assert state.get_build_type_vmconfig_entries() == []


### PR DESCRIPTION
As part of the machine section it is possible to setup a custom
entry which is stored in the machine configuration file. The
evaluation of such an entry for the vmdk (.vmx) config file
was still missing. This Fixes #122