### PR TITLE
Adding newline separator in vmconfig entries

### DIFF
--- a/kiwi/storage/subformat/vmdk.py
+++ b/kiwi/storage/subformat/vmdk.py
@@ -188,7 +188,7 @@ class DiskFormatVmdk(DiskFormatBase):
             with open(settings_file, 'w') as config:
                 config.write(settings_template.substitute(template_record))
                 for custom_entry in custom_entries:
-                    config.write(custom_entry + '\n')
+                    config.write(custom_entry + os.linesep)
         except Exception as e:
             raise KiwiTemplateError(
                 '%s: %s' % (type(e).__name__, format(e))

--- a/test/unit/storage_subformat_vmdk_test.py
+++ b/test/unit/storage_subformat_vmdk_test.py
@@ -2,6 +2,7 @@
 from mock import patch
 from mock import call
 import mock
+import os
 
 from .test_helper import *
 
@@ -308,10 +309,10 @@ class TestDiskFormatVmdk(object):
             self.vmdk_settings
         )
         assert self.file_mock.write.call_args_list[2] == call(
-            'custom entry 1\n'
+            'custom entry 1' + os.linesep
         )
         assert self.file_mock.write.call_args_list[3] == call(
-            'custom entry 2\n'
+            'custom entry 2' + os.linesep
         )
         assert self.file_mock.seek.call_args_list == [
             call(512, 0), call(0, 2)


### PR DESCRIPTION
Fixes #130

This commit fixes #130, vmconfig custom entries were not separated
by newline character, so '\n' appended in each custom entry string.