### PR TITLE
Activate partition using parted instead of sfdisk

### DIFF
--- a/kiwi/boot/functions.sh
+++ b/kiwi/boot/functions.sh
@@ -9322,7 +9322,7 @@ function activateBootPartition {
     fi
     local bootID=$(nd $device)
     local diskID=$(dn $device)
-    sfdisk $diskID --force -A $bootID
+    parted $diskID set $bootID boot on
 }
 #======================================
 # relocateGPTAtEndOfDisk

--- a/kiwi/partitioner/msdos.py
+++ b/kiwi/partitioner/msdos.py
@@ -107,8 +107,8 @@ class PartitionerMsDos(PartitionerBase):
             if flag_name == 'f.active':
                 Command.run(
                     [
-                        'sfdisk', '--activate=' + format(partition_id),
-                        self.disk_device
+                        'parted', self.disk_device,
+                        'set', format(partition_id), 'boot', 'on'
                     ]
                 )
             else:

--- a/test/unit/partitioner_msdos_test.py
+++ b/test/unit/partitioner_msdos_test.py
@@ -98,7 +98,7 @@ class TestPartitionerMsDos(object):
     def test_set_active(self, mock_command):
         self.partitioner.set_flag(1, 'f.active')
         mock_command.assert_called_once_with(
-            ['sfdisk', '--activate=1', '/dev/loop0']
+            ['parted', '/dev/loop0', 'set', '1', 'boot', 'on']
         )
 
     @patch('kiwi.logger.log.warning')


### PR DESCRIPTION
sfdisk changes their caller semantics incompatible. Therefore
we move to a tool which is still stable in the caller options
Fixes #129