### PR TITLE
Move to tar.gz as sdist target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ build: clean po tox
 	# cleanup setup.py variant used for rpm build
 	rm -f setup.build.py
 	# provide rpm source tarball
-	mv dist/kiwi-${version}.tar.bz2 dist/python3-kiwi.tar.bz2
+	mv dist/kiwi-${version}.tar.gz dist/python3-kiwi.tar.gz
 	# provide rpm changelog from git changelog
 	git log | helper/changelog_generator |\
 		helper/changelog_descending > dist/python3-kiwi.changes

--- a/package/python3-kiwi-spec-template
+++ b/package/python3-kiwi-spec-template
@@ -24,7 +24,7 @@ Url:            https://github.com/SUSE/kiwi
 Summary:        KIWI - Appliance Builder Next Generation
 License:        GPL-3.0+
 Group:          Development/Languages/Python
-Source:         %{name}.tar.bz2
+Source:         %{name}.tar.gz
 Source1:        %{name}-boot-packages
 Source2:        %{name}-rpmlintrc
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ universal = 1
 
 [sdist]
 # Used by setup.py sdist
-formats=bztar
+formats=gztar
 
 [nosetests]
 where = test/unit


### PR DESCRIPTION
PyPI is planning to support only .tar.gz in the near future.
See https://www.python.org/dev/peps/pep-0527. This Fixes #132