### PR TITLE
Hanlde rpm excludedocs entry

### DIFF
--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -180,6 +180,7 @@ class BootImageBase(object):
             'locale',
             'packagemanager',
             'rpm_check_signatures',
+            'rpm_excludedocs',
             'showlicense'
         ]
         self.xml_state.copy_preferences_subsections(

--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -63,8 +63,14 @@ class RepositoryZypper(RepositoryBase):
         :param list custom_args: zypper arguments
         """
         self.custom_args = custom_args
+        self.exclude_docs = False
         if not custom_args:
             self.custom_args = []
+
+        # extract custom arguments used for zypp config only
+        if 'exclude_docs' in self.custom_args:
+            self.custom_args.remove('exclude_docs')
+            self.exclude_docs = True
 
         self.repo_names = []
 
@@ -110,18 +116,10 @@ class RepositoryZypper(RepositoryBase):
         # config file parameters for libzypp library
         self.runtime_zypp_config = ConfigParser()
         self.runtime_zypp_config.add_section('main')
-        self.runtime_zypp_config.set(
-            'main', 'cachedir', self.shared_zypper_dir['cache-dir']
-        )
-        self.runtime_zypp_config.set(
-            'main', 'metadatadir', self.shared_zypper_dir['raw-cache-dir']
-        )
-        self.runtime_zypp_config.set(
-            'main', 'solvfilesdir', self.shared_zypper_dir['solv-cache-dir']
-        )
-        self.runtime_zypp_config.set(
-            'main', 'packagesdir', self.shared_zypper_dir['pkg-cache-dir']
-        )
+        if self.exclude_docs:
+            self.runtime_zypp_config.set(
+                'main', 'rpm.install.excludedocs', 'yes'
+            )
 
         self._write_runtime_config()
 

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -91,10 +91,13 @@ class SystemPrepare(object):
         :return: Instance of PackageManager
         :rtype: PackageManager
         """
+        repository_options = []
         repository_sections = self.xml_state.get_repository_sections()
         package_manager = self.xml_state.get_package_manager()
+        if self.xml_state.get_rpm_excludedocs():
+            repository_options.append('exclude_docs')
         repo = Repository(
-            self.root_bind, package_manager
+            self.root_bind, package_manager, repository_options
         )
         for xml_repo in repository_sections:
             repo_type = xml_repo.get_type()

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -106,6 +106,20 @@ class XMLState(object):
             if version:
                 return version[0]
 
+    def get_rpm_excludedocs(self):
+        """
+        Gets the rpm-excludedocs configuration flag. Returns
+        False if not present.
+
+        :return: excludedocs flag
+        :rtype: bool
+        """
+        for preferences in self.get_preferences_sections():
+            exclude_docs = preferences.get_rpm_excludedocs()
+            if exclude_docs:
+                return exclude_docs[0]
+        return False
+
     def get_package_manager(self):
         """
         Configured package manager

--- a/test/unit/repository_zypper_test.py
+++ b/test/unit/repository_zypper_test.py
@@ -29,7 +29,14 @@ class TestRepositoryZypper(object):
         )
         root_bind.root_dir = '../data'
         root_bind.shared_location = '/shared-dir'
-        self.repo = RepositoryZypper(root_bind)
+        self.repo = RepositoryZypper(root_bind, ['exclude_docs'])
+
+    @patch('kiwi.command.Command.run')
+    @patch('kiwi.repository.zypper.NamedTemporaryFile')
+    @patch_open
+    def test_custom_args_init(self, mock_open, mock_temp, mock_command):
+        self.repo = RepositoryZypper(mock.MagicMock())
+        assert self.repo.custom_args == []
 
     @raises(KiwiRepoTypeUnknown)
     @patch('kiwi.command.Command.run')

--- a/test/unit/system_prepare_test.py
+++ b/test/unit/system_prepare_test.py
@@ -139,7 +139,7 @@ class TestSystemPrepare(object):
         self.system.setup_repositories()
 
         mock_repo.assert_called_once_with(
-            self.system.root_bind, 'package-manager-name'
+            self.system.root_bind, 'package-manager-name', ['exclude_docs']
         )
         # mock local repos will be translated and bind mounted
         assert uri.translate.call_args_list == [

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -37,6 +37,14 @@ class TestXMLState(object):
         )
         assert self.state.get_build_type_name() == 'oem'
 
+    @patch('kiwi.xml_state.XMLState.get_preferences_sections')
+    def test_get_rpm_excludedocs_without_entry(self, mock_preferences):
+        mock_preferences.return_value = []
+        assert self.state.get_rpm_excludedocs() == False
+
+    def test_get_rpm_excludedocs(self):
+        assert self.state.get_rpm_excludedocs() == True
+
     def test_get_package_manager(self):
         assert self.state.get_package_manager() == 'zypper'
 


### PR DESCRIPTION
Fixes #133

This pull request only handles the rpm-excludedocs for zypper.

Changes proposed in this pull request:
* Added get_rpm_excludedocs method in xml_state to get the value from parsed data.
* Added exclude_docs flag in RepositoryBase.
* Updated RepositoryZypper to make use of the exclude_docs flag and include `rpm.install.excludedocs` parameter accordingly in the libzypp configuration file. 
* Removed paths in the libzypp configuration files, as they are already provided in the command line as parameters and later on the are inconsistent in chrooted operations.
* Updated PackageMangerZypper to export a correct ZYPP_CONF environment variable in chrooted operations.
* Updated RootBind to provide a move_path_to_root method that works for a single path and makes sure it only replaces the first ocurrence of root_dir.
