### PR TITLE
Ip up status check

### DIFF
--- a/kiwi/boot/arch/arm/oemboot/suse-leap42.1/config.xml
+++ b/kiwi/boot/arch/arm/oemboot/suse-leap42.1/config.xml
@@ -139,6 +139,7 @@
         <package name="sysvinit-tools"/>
         <package name="xz"/>
         <package name="gawk"/>
+        <package name="ifplugd"/>
     </packages>
     <packages type="delete">
         <package name="cracklib-dict-full"/>

--- a/kiwi/boot/arch/arm/oemboot/suse-leap42.2/config.xml
+++ b/kiwi/boot/arch/arm/oemboot/suse-leap42.2/config.xml
@@ -139,6 +139,7 @@
         <package name="sysvinit-tools"/>
         <package name="xz"/>
         <package name="gawk"/>
+        <package name="ifplugd"/>
     </packages>
     <packages type="delete">
         <package name="cracklib-dict-full"/>

--- a/kiwi/boot/arch/arm/oemboot/suse-tumbleweed/config.xml
+++ b/kiwi/boot/arch/arm/oemboot/suse-tumbleweed/config.xml
@@ -141,6 +141,7 @@
         <package name="sysvinit-tools"/>
         <package name="xz"/>
         <package name="gawk"/>
+        <package name="ifplugd"/>
     </packages>
     <packages type="delete">
         <package name="cracklib-dict-full"/>

--- a/kiwi/boot/arch/x86_64/netboot/suse-leap42.1/config.xml
+++ b/kiwi/boot/arch/x86_64/netboot/suse-leap42.1/config.xml
@@ -199,6 +199,7 @@
         <package name="psmisc"/>
         <package name="sysvinit-tools"/>
         <package name="e2fsprogs"/>
+        <package name="ifplugd"/>
     </packages>
     <packages type="delete" profiles="default,diskless,xen">
         <package name="dracut"/>

--- a/kiwi/boot/arch/x86_64/netboot/suse-leap42.2/config.xml
+++ b/kiwi/boot/arch/x86_64/netboot/suse-leap42.2/config.xml
@@ -199,6 +199,7 @@
         <package name="psmisc"/>
         <package name="sysvinit-tools"/>
         <package name="e2fsprogs"/>
+        <package name="ifplugd"/>
     </packages>
     <packages type="delete" profiles="default,diskless,xen">
         <package name="dracut"/>

--- a/kiwi/boot/arch/x86_64/netboot/suse-tumbleweed/config.xml
+++ b/kiwi/boot/arch/x86_64/netboot/suse-tumbleweed/config.xml
@@ -199,6 +199,7 @@
         <package name="psmisc"/>
         <package name="sysvinit-tools"/>
         <package name="e2fsprogs"/>
+        <package name="ifplugd"/>
     </packages>
     <packages type="delete" profiles="default,diskless,xen">
         <package name="dracut"/>

--- a/kiwi/boot/arch/x86_64/oemboot/suse-leap42.1/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-leap42.1/config.xml
@@ -184,6 +184,7 @@
         <package name="sysvinit-tools"/>
         <package name="xz"/>
         <package name="gawk"/>
+        <package name="ifplugd"/>
     </packages>
     <packages type="delete">
         <package name="cracklib-dict-full"/>

--- a/kiwi/boot/arch/x86_64/oemboot/suse-leap42.2/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-leap42.2/config.xml
@@ -184,6 +184,7 @@
         <package name="sysvinit-tools"/>
         <package name="xz"/>
         <package name="gawk"/>
+        <package name="ifplugd"/>
     </packages>
     <packages type="delete">
         <package name="cracklib-dict-full"/>

--- a/kiwi/boot/arch/x86_64/oemboot/suse-tumbleweed/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-tumbleweed/config.xml
@@ -184,6 +184,7 @@
         <package name="sysvinit-tools"/>
         <package name="xz"/>
         <package name="gawk"/>
+        <package name="ifplugd"/>
     </packages>
     <packages type="delete">
         <package name="cracklib-dict-full"/>

--- a/kiwi/boot/functions.sh
+++ b/kiwi/boot/functions.sh
@@ -5554,8 +5554,17 @@ function waitForLinkUp {
     local IFS=$IFS_ORIG
     local dev=$1
     local check=0
+    local linkstatus
+    local linkgrep
     while true;do
-        ip link ls $dev | grep -qi "state UP"
+        if lookup ifplugstatus &>/dev/null;then
+            linkstatus=ifplugstatus
+￼           linkgrep="link beat detected"
+￼       else
+￼           linkstatus="ip link ls"
+￼           linkgrep="state UP"
+￼       fi
+        $linkstatus $dev | grep -qi "$linkgrep"
         if [ $? = 0 ];then
             sleep 1; return 0
         fi

--- a/kiwi/config/strip.xml
+++ b/kiwi/config/strip.xml
@@ -158,6 +158,7 @@
         <file name="init"/>
         <file name="insmod"/>
         <file name="id"/>
+        <file name="ifplugstatus"/>
         <file name="iucv_configure"/>
         <file name="kexec"/>
         <file name="kill"/>


### PR DESCRIPTION
On some clients 'ip link ls' shows 'state UNKNOWN' using ifplugstatus seems to be more reliable so prefer that if it is available, ifplugd which provides ifplugstatus command is only added to leap and tumbleweed config.xml at the moment