### PR TITLE
Persistent fstab entries

### DIFF
--- a/kiwi/boot/functions.sh
+++ b/kiwi/boot/functions.sh
@@ -2156,35 +2156,6 @@ function updateRootDeviceFstab {
     else
         echo "/dev/root / auto defaults 1 1" >> $nfstab
     fi
-    #======================================
-    # check for LVM volume setup
-    #--------------------------------------
-    if [ "$haveLVM" = "yes" ];then
-        local volume_name
-        local mount_device
-        local mount_point
-        for i in $(readVolumeSetup "/.profile");do
-            volume_name=$(getVolumeName $i)
-            if [ $volume_name = "LVRoot" ]; then
-                continue
-            fi
-            mount_point=$(getVolumeMountPoint $i)
-            mount_device="/dev/$kiwi_lvmgroup/$volume_name"
-            echo "$mount_device /$mount_point $fstype $opts 1 2" >> $nfstab
-        done
-    elif [ "$fstype" = "btrfs" ];then
-        if [ "$kiwi_btrfs_root_is_snapshot" = "true" ];then
-            if [ $devicepersistency = "by-label" ];then
-                local device="LABEL=$(blkid $rdev -s LABEL -o value)"
-            else
-                local device="UUID=$(blkid $rdev -s UUID -o value)"
-            fi
-            for subvol in $(getBtrfsSubVolumes "$prefix"); do
-                syspath=$(echo $subvol | tr -d @)
-                echo "$device $syspath btrfs subvol=$subvol 0 0" >> $nfstab
-            done
-        fi
-    fi
 }
 #======================================
 # updateSwapDeviceFstab

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -492,6 +492,15 @@ class SystemSetup(object):
             'edit_boot_install.sh', [diskname, boot_device_node]
         )
 
+    def create_fstab(self, entries):
+        """
+        Create etc/fstab from given list of entries
+        """
+        fstab_file = self.root_dir + '/etc/fstab'
+        with open(fstab_file, 'w') as fstab:
+            for entry in entries:
+                fstab.write(entry + os.linesep)
+
     def create_init_link_from_linuxrc(self):
         """
         kiwi boot images provides the linuxrc script, however the kernel

--- a/kiwi/volume_manager/base.py
+++ b/kiwi/volume_manager/base.py
@@ -142,6 +142,18 @@ class VolumeManagerBase(DeviceProvider):
         """
         raise NotImplementedError
 
+    def get_fstab(self, persistency_type, filesystem_name):
+        """
+        Implements setup of the fstab entries. The method should
+        return a list of fstab compatible entries
+
+        :param string persistency_type: unused
+        :param string filesystem_name: unused
+
+        :rtype: list
+        """
+        raise NotImplementedError
+
     def mount_volumes(self):
         """
         Implements mounting of all volumes below one master directory

--- a/kiwi/volume_manager/btrfs.py
+++ b/kiwi/volume_manager/btrfs.py
@@ -172,10 +172,12 @@ class VolumeManagerBtrfs(VolumeManagerBase):
         for volume_mount in self.subvol_mount_list:
             if not os.path.exists(volume_mount.mountpoint):
                 Path.create(volume_mount.mountpoint)
-            subvol_name = os.path.basename(volume_mount.mountpoint)
+            subvol_name = '/'.join(volume_mount.mountpoint.split('/')[3:])
+            if self.custom_args['root_is_snapshot']:
+                subvol_name = subvol_name.replace('.snapshots/1/snapshot/', '')
             subvol_options = ','.join(
                 [
-                    'subvol=' + os.path.normpath('@/' + subvol_name)
+                    'subvol=' + os.path.normpath(subvol_name)
                 ] + self.custom_filesystem_args['mount_options']
             )
             volume_mount.mount(

--- a/kiwi/volume_manager/lvm.py
+++ b/kiwi/volume_manager/lvm.py
@@ -155,6 +155,34 @@ class VolumeManagerLVM(VolumeManagerBase):
                 full_size_volume.name, full_size_volume.realpath
             )
 
+    def get_fstab(self, filesystem_name, persistency_type=None):
+        """
+        Implements creation of the fstab entries. The method
+        returns a list of fstab compatible entries
+
+        :param string persistency_type: unused
+        :param string filesystem_name: volumes filesystem name
+
+        :rtype: list
+        """
+        fstab_entries = []
+        for volume_mount in self.mount_list:
+            if 'LVRoot' not in volume_mount.device:
+                fstab_entry = ' '.join(
+                    [
+                        volume_mount.device,
+                        '/' + '/'.join(volume_mount.mountpoint.split('/')[3:]),
+                        filesystem_name,
+                        ''.join(
+                            self.custom_filesystem_args['mount_options']
+                        ) or 'defaults',
+                        '1 2'
+                    ]
+                )
+                fstab_entries.append(fstab_entry)
+
+        return fstab_entries
+
     def mount_volumes(self):
         """
         Mount lvm volumes

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -480,6 +480,9 @@ class TestDiskBuilder(object):
                 'root': MappedDevice('/dev/systemVG/LVRoot', mock.Mock())
             }
         )
+        volume_manager.get_fstab = mock.Mock(
+            return_value=['fstab_entry']
+        )
         mock_volume_manager.return_value = volume_manager
         filesystem = mock.Mock()
         mock_fs.return_value = filesystem
@@ -491,10 +494,14 @@ class TestDiskBuilder(object):
         volume_manager.setup.assert_called_once_with('systemVG')
         volume_manager.create_volumes.assert_called_once_with('btrfs')
         volume_manager.mount_volumes.assert_called_once_with()
+        volume_manager.get_fstab.assert_called_once_with(None, 'btrfs')
         volume_manager.sync_data.assert_called_once_with([
             'image', '.profile', '.kconfig', 'var/cache/kiwi',
             'boot/*', 'boot/.*', 'boot/efi/*', 'boot/efi/.*'
         ])
+        self.setup.create_fstab.assert_called_once_with(
+            ['fstab_entry']
+        )
 
     @patch('kiwi.builder.disk.FileSystem')
     @patch_open

--- a/test/unit/system_setup_test.py
+++ b/test/unit/system_setup_test.py
@@ -540,6 +540,22 @@ class TestSystemSetup(object):
             ['bash', '-c', 'rm -f root_dir/recovery.*']
         )
 
+    @patch_open
+    def test_create_fstab(self, mock_open):
+        context_manager_mock = mock.Mock()
+        mock_open.return_value = context_manager_mock
+        file_mock = mock.Mock()
+        enter_mock = mock.Mock()
+        exit_mock = mock.Mock()
+        enter_mock.return_value = file_mock
+        setattr(context_manager_mock, '__enter__', enter_mock)
+        setattr(context_manager_mock, '__exit__', exit_mock)
+        self.setup.create_fstab(['fstab_entry'])
+        mock_open.assert_called_once_with(
+            'root_dir/etc/fstab', 'w'
+        )
+        file_mock.write.assert_called_once_with('fstab_entry\n')
+
     @patch('kiwi.command.Command.run')
     @patch('kiwi.system.setup.NamedTemporaryFile')
     @patch('kiwi.system.setup.ArchiveTar')

--- a/test/unit/volume_manager_base_test.py
+++ b/test/unit/volume_manager_base_test.py
@@ -73,6 +73,10 @@ class TestVolumeManagerBase(object):
     def test_create_volumes(self):
         self.volume_manager.create_volumes('ext3')
 
+    @raises(NotImplementedError)
+    def test_get_fstab(self):
+        self.volume_manager.get_fstab('by-label', 'ext3')
+
     @patch('kiwi.volume_manager.base.Path.create')
     @patch('os.path.exists')
     def test_create_volume_paths_in_root_dir(self, mock_os_path, mock_path):

--- a/test/unit/volume_manager_btrfs_test.py
+++ b/test/unit/volume_manager_btrfs_test.py
@@ -191,14 +191,16 @@ class TestVolumeManagerBtrfs(object):
     def test_mount_volumes(self, mock_path, mock_os_exists):
         mock_os_exists.return_value = False
         volume_mount = mock.Mock()
-        volume_mount.mountpoint = 'tmpdir/@/.snapshots/1/snapshot/subvol'
+        volume_mount.mountpoint = \
+            '/tmp/kiwi_volumes.xx/@/.snapshots/1/snapshot/var/tmp'
+        self.volume_manager.custom_args['root_is_snapshot'] = True
         self.volume_manager.subvol_mount_list = [volume_mount]
 
         self.volume_manager.mount_volumes()
 
         mock_path.assert_called_once_with(volume_mount.mountpoint)
         volume_mount.mount.assert_called_once_with(
-            options=['subvol=@/subvol']
+            options=['subvol=@/var/tmp']
         )
 
     def test_umount_volumes(self):

--- a/test/unit/volume_manager_btrfs_test.py
+++ b/test/unit/volume_manager_btrfs_test.py
@@ -186,6 +186,22 @@ class TestVolumeManagerBtrfs(object):
             )
         ]
 
+    @patch('kiwi.volume_manager.btrfs.Command.run')
+    def test_get_fstab(self, mock_command):
+        blkid_result = mock.Mock()
+        blkid_result.output = 'id'
+        mock_command.return_value = blkid_result
+        volume_mount = mock.Mock()
+        volume_mount.mountpoint = \
+            '/tmp/kiwi_volumes.xx/@/.snapshots/1/snapshot/var/tmp'
+        volume_mount.device = 'device'
+        self.volume_manager.subvol_mount_list = [volume_mount]
+        self.volume_manager.custom_args['root_is_snapshot'] = True
+        assert self.volume_manager.get_fstab() == [
+            'LABEL=id /.snapshots btrfs subvol=@/.snapshots defaults 0 0',
+            'LABEL=id /var/tmp btrfs subvol=@/var/tmp defaults 0 0'
+        ]
+
     @patch('os.path.exists')
     @patch('kiwi.volume_manager.btrfs.Path.create')
     def test_mount_volumes(self, mock_path, mock_os_exists):

--- a/test/unit/volume_manager_lvm_test.py
+++ b/test/unit/volume_manager_lvm_test.py
@@ -194,6 +194,15 @@ class TestVolumeManagerLVM(object):
         assert self.volume_manager.umount_volumes() is True
         volume_mount.umount.assert_called_once_with()
 
+    def test_get_fstab(self):
+        volume_mount = mock.Mock()
+        volume_mount.mountpoint = '/tmp/kiwi_volumes.f2qx_d3y/var/tmp'
+        volume_mount.device = 'device'
+        self.volume_manager.mount_list = [volume_mount]
+        assert self.volume_manager.get_fstab('ext3') == [
+            'device /var/tmp ext3 defaults 1 2'
+        ]
+
     @patch('kiwi.volume_manager.lvm.Path.wipe')
     @patch('kiwi.volume_manager.lvm.Command.run')
     def test_destructor_busy_volumes(self, mock_command, mock_wipe):


### PR DESCRIPTION
Delete fstab setup for volumes from kiwi boot code
    
For persistent devices like LVM volumes or btrfs sub volumes
the fstab setup can be done at build time. Fixes #142
