### PR TITLE
grub hotfixes

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -544,7 +544,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 module_path + '/', boot_module_path
             )
             data.sync_data(
-                options=['-z', '-a']
+                options=['-z', '-a'], exclude=['*.module']
             )
         except Exception as e:
             raise KiwiBootLoaderGrubModulesError(

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -858,6 +858,11 @@ class DiskBuilder(object):
                 {'prep_device': prep_device.get_device()}
             )
 
+        if self.volume_manager_name:
+            custom_install_arguments.update(
+                {'boot_volumes': self.system.get_boot_volumes()}
+            )
+
         log.debug(
             "custom arguments for bootloader installation %s",
             custom_install_arguments

--- a/kiwi/volume_manager/base.py
+++ b/kiwi/volume_manager/base.py
@@ -154,6 +154,14 @@ class VolumeManagerBase(DeviceProvider):
         """
         raise NotImplementedError
 
+    def get_boot_volumes(self):
+        """
+        Implements return of dict of volumes relevant for booting
+
+        :rtype: dict
+        """
+        raise NotImplementedError
+
     def mount_volumes(self):
         """
         Implements mounting of all volumes below one master directory

--- a/kiwi/volume_manager/btrfs.py
+++ b/kiwi/volume_manager/btrfs.py
@@ -203,6 +203,24 @@ class VolumeManagerBtrfs(VolumeManagerBase):
             fstab_entries.append(fstab_entry)
         return fstab_entries
 
+    def get_boot_volumes(self):
+        """
+        Return dict of volumes relevant for booting
+
+        :rtype: dict
+        """
+        boot_volumes = {}
+        for volume_mount in self.subvol_mount_list:
+            subvol_name = self._get_subvol_name_from_mountpoint(volume_mount)
+            if 'boot/' in subvol_name:
+                subvol_options = ','.join(
+                    [
+                        'subvol=' + subvol_name
+                    ] + self.custom_filesystem_args['mount_options']
+                )
+                boot_volumes[subvol_name.replace('@', '')] = subvol_options
+        return boot_volumes
+
     def mount_volumes(self):
         """
         Mount btrfs subvolumes

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -391,7 +391,7 @@ class TestBootLoaderConfigGrub2(object):
             'root_dir/boot/grub2/x86_64-efi'
         )
         data.sync_data.assert_called_once_with(
-            options=['-z', '-a']
+            exclude=['*.module'], options=['-z', '-a']
         )
 
     @patch('kiwi.bootloader.config.grub2.Command.run')
@@ -445,7 +445,8 @@ class TestBootLoaderConfigGrub2(object):
         self.bootloader.setup_disk_boot_images('uuid')
         assert mock_command.call_args_list == [
             call([
-                'rsync', '-z', '-a', 'root_dir/usr/lib/grub2/x86_64-efi/',
+                'rsync', '-z', '-a', '--exclude', '/*.module',
+                'root_dir/usr/lib/grub2/x86_64-efi/',
                 'root_dir/boot/grub2/x86_64-efi'
             ])
         ]
@@ -522,7 +523,7 @@ class TestBootLoaderConfigGrub2(object):
             'root_dir/boot/grub2/x86_64-efi'
         )
         data.sync_data.assert_called_once_with(
-            options=['-z', '-a']
+            exclude=['*.module'], options=['-z', '-a']
         )
 
     @patch('kiwi.bootloader.config.grub2.Command.run')
@@ -544,7 +545,8 @@ class TestBootLoaderConfigGrub2(object):
         self.bootloader.setup_install_boot_images(self.mbrid)
         assert mock_command.call_args_list == [
             call([
-                'rsync', '-z', '-a', 'root_dir/usr/lib/grub2/x86_64-efi/',
+                'rsync', '-z', '-a', '--exclude', '/*.module',
+                'root_dir/usr/lib/grub2/x86_64-efi/',
                 'root_dir/boot/grub2/x86_64-efi'
             ]),
             call([
@@ -587,7 +589,9 @@ class TestBootLoaderConfigGrub2(object):
             'root_dir/usr/share/grub2/themes/some-theme',
             'root_dir/boot/grub2/themes'
         )
-        assert data.sync_data.call_args_list[0] == call(options=['-z', '-a'])
+        assert data.sync_data.call_args_list[0] == call(
+            options=['-z', '-a']
+        )
 
     @patch('kiwi.bootloader.config.grub2.Path.wipe')
     @patch('kiwi.bootloader.config.grub2.Command.run')

--- a/test/unit/volume_manager_base_test.py
+++ b/test/unit/volume_manager_base_test.py
@@ -135,6 +135,10 @@ class TestVolumeManagerBase(object):
     def test_umount_volumes(self):
         self.volume_manager.umount_volumes()
 
+    @raises(NotImplementedError)
+    def test_get_boot_volumes(self):
+        self.volume_manager.get_boot_volumes()
+
     @patch('kiwi.volume_manager.base.DataSync')
     @patch('kiwi.volume_manager.base.MountManager.is_mounted')
     @patch('kiwi.volume_manager.base.VolumeManagerBase.mount_volumes')

--- a/test/unit/volume_manager_btrfs_test.py
+++ b/test/unit/volume_manager_btrfs_test.py
@@ -38,7 +38,7 @@ class TestVolumeManagerBtrfs(object):
             self.volume_type(
                 name='LVhome', size=None, realpath='/home',
                 mountpoint='/home', fullsize=True
-            ),
+            )
         ]
         mock_path.return_value = True
         self.device_provider = mock.Mock()
@@ -185,6 +185,17 @@ class TestVolumeManagerBtrfs(object):
                 mountpoint='tmpdir/@/.snapshots/1/snapshot/home'
             )
         ]
+
+    def test_get_boot_volumes(self):
+        volume_mount = mock.Mock()
+        volume_mount.mountpoint = \
+            '/tmp/kiwi_volumes.xx/@/.snapshots/1/snapshot/boot/grub2'
+        volume_mount.device = 'device'
+        self.volume_manager.subvol_mount_list = [volume_mount]
+        self.volume_manager.custom_args['root_is_snapshot'] = True
+        assert self.volume_manager.get_boot_volumes() == {
+            '/boot/grub2': 'subvol=@/boot/grub2'
+        }
 
     @patch('kiwi.volume_manager.btrfs.Command.run')
     def test_get_fstab(self, mock_command):


### PR DESCRIPTION
* Only sync .mod grub2 module files
* Mount boot volumes on grub install
    
    If there are volumes below /boot they need to be mounted before
    grub2-install / shim-install is called in order to make sure all
    data is available in the volume