### PR TITLE
Exclude docs yum

### DIFF
--- a/kiwi/repository/apt.py
+++ b/kiwi/repository/apt.py
@@ -55,8 +55,14 @@ class RepositoryApt(RepositoryBase):
         :param list custom_args: apt-get arguments
         """
         self.custom_args = custom_args
+        self.exclude_docs = False
         if not custom_args:
             self.custom_args = []
+
+        # extract custom arguments used for apt config only
+        if 'exclude_docs' in self.custom_args:
+            self.custom_args.remove('exclude_docs')
+            self.exclude_docs = True
 
         self.distribution = None
         self.distribution_path = None
@@ -189,10 +195,10 @@ class RepositoryApt(RepositoryBase):
             parameters = {
                 'apt_shared_base': self.manager_base
             }
-            template = self.apt_conf.get_host_template()
+            template = self.apt_conf.get_host_template(self.exclude_docs)
             apt_conf_data = template.substitute(parameters)
         else:
-            template = self.apt_conf.get_image_template()
+            template = self.apt_conf.get_image_template(self.exclude_docs)
             apt_conf_data = template.substitute()
 
         with open(self.runtime_apt_get_config_file.name, 'w') as config:

--- a/kiwi/repository/template/apt.py
+++ b/kiwi/repository/template/apt.py
@@ -52,30 +52,46 @@ class PackageManagerTemplateAptGet(object):
         ''').strip() + os.linesep
 
         self.dpkg = dedent('''
-            DPkg
-            {
-                Options {"--force-all";}
+            DPkg::Options {
+                "--force-all";
             };
         ''').strip() + os.linesep
 
-    def get_host_template(self):
+        self.dpkg_exclude_docs = dedent('''
+            DPkg::Options {
+                "--path-exclude=/usr/share/man/*";
+                "--path-exclude=/usr/share/doc/*";
+                "--path-include=/usr/share/doc/*/copyright";
+                "--force-all";
+            };
+        ''').strip() + os.linesep
+
+    def get_host_template(self, exclude_docs=False):
         """
         apt-get package manager template for apt-get called
         outside of the image, not chrooted
 
         :rtype: Template
         """
-        return Template(
-            ''.join([self.host_header, self.apt, self.dpkg])
-        )
+        template_data = self.host_header + self.apt
+        if exclude_docs:
+            template_data += self.dpkg_exclude_docs
+        else:
+            template_data += self.dpkg
 
-    def get_image_template(self):
+        return Template(template_data)
+
+    def get_image_template(self, exclude_docs=False):
         """
         apt-get package manager template for apt-get called
         inside of the image, chrooted
 
         :rtype: Template
         """
-        return Template(
-            ''.join([self.image_header, self.apt, self.dpkg])
-        )
+        template_data = self.image_header + self.apt
+        if exclude_docs:
+            template_data += self.dpkg_exclude_docs
+        else:
+            template_data += self.dpkg
+
+        return Template(template_data)

--- a/kiwi/repository/yum.py
+++ b/kiwi/repository/yum.py
@@ -20,6 +20,7 @@ from six.moves.configparser import ConfigParser
 from tempfile import NamedTemporaryFile
 
 # project
+from ..logger import log
 from .base import RepositoryBase
 from ..path import Path
 
@@ -54,6 +55,11 @@ class RepositoryYum(RepositoryBase):
         self.custom_args = custom_args
         if not custom_args:
             self.custom_args = []
+
+        # extract custom arguments not used in yum call
+        if 'exclude_docs' in self.custom_args:
+            self.custom_args.remove('exclude_docs')
+            log.warning('rpm-excludedocs not supported for yum: ignoring')
 
         self.repo_names = []
 

--- a/test/unit/repository_apt_test.py
+++ b/test/unit/repository_apt_test.py
@@ -40,19 +40,30 @@ class TestRepositoryApt(object):
         root_bind.root_dir = '../data'
         root_bind.shared_location = '/shared-dir'
 
-        self.repo = RepositoryApt(root_bind)
+        self.repo = RepositoryApt(root_bind, ['exclude_docs'])
 
-        self.apt_conf.get_host_template.assert_called_once_with()
+        self.exclude_docs = True
+        self.apt_conf.get_host_template.assert_called_once_with(
+            self.exclude_docs
+        )
         template.substitute.assert_called_once_with(
             {'apt_shared_base': '/shared-dir/apt-get'}
         )
-        
+
+    @patch('kiwi.repository.apt.NamedTemporaryFile')
+    @patch('kiwi.repository.apt.Path.create')
+    def test_post_init_no_custom_args(self, mock_path, mock_temp):
+        self.repo.post_init()
+        assert self.repo.custom_args == []
+
     @patch_open
     def test_use_default_location(self, mock_open):
         template = mock.Mock()
         self.apt_conf.get_image_template.return_value = template
         self.repo.use_default_location()
-        self.apt_conf.get_image_template.assert_called_once_with()
+        self.apt_conf.get_image_template.assert_called_once_with(
+            self.exclude_docs
+        )
         template.substitute.assert_called_once_with()
 
     def test_runtime_config(self):

--- a/test/unit/repository_template_apt_test.py
+++ b/test/unit/repository_template_apt_test.py
@@ -19,3 +19,11 @@ class TestPackageManagerTemplateAptGet(object):
 
     def test_get_image_template(self):
         assert self.apt.get_image_template().substitute()
+
+    def test_get_host_template_with_exclude_docs(self):
+        assert self.apt.get_host_template(exclude_docs=True).substitute(
+            apt_shared_base='/var/cache/kiwi/apt-get'
+        )
+
+    def test_get_image_template_with_exclude_docs(self):
+        assert self.apt.get_image_template(exclude_docs=True).substitute()

--- a/test/unit/repository_yum_test.py
+++ b/test/unit/repository_yum_test.py
@@ -15,7 +15,8 @@ class TestRepositoryYum(object):
     @patch_open
     @patch('kiwi.repository.yum.ConfigParser')
     @patch('kiwi.repository.yum.Path.create')
-    def setup(self, mock_path, mock_config, mock_open, mock_temp):
+    @patch('kiwi.logger.log.warning')
+    def setup(self, mock_warn, mock_path, mock_config, mock_open, mock_temp):
         runtime_yum_config = mock.Mock()
         mock_config.return_value = runtime_yum_config
         tmpfile = mock.Mock()
@@ -27,7 +28,7 @@ class TestRepositoryYum(object):
         )
         root_bind.root_dir = '../data'
         root_bind.shared_location = '/shared-dir'
-        self.repo = RepositoryYum(root_bind)
+        self.repo = RepositoryYum(root_bind, ['exclude_docs'])
 
         assert runtime_yum_config.set.call_args_list == [
             call('main', 'cachedir', '/shared-dir/yum/cache'),
@@ -42,6 +43,9 @@ class TestRepositoryYum(object):
             call('main', 'metadata_expire', '1800'),
             call('main', 'group_command', 'compat')
         ]
+        mock_warn.assert_called_once_with(
+            'rpm-excludedocs not supported for yum: ignoring'
+        )
 
     @patch_open
     @patch('kiwi.repository.yum.ConfigParser')


### PR DESCRIPTION
Added rpm_excludedocs handling for yum
    
rpm supports the --excludepath option. However, yum can not be configured to pass along options to rpm or the python interface  it uses. Thus only a warning about excludedocs not being  supported by kiwi for yum is issued. Fixes #133