### PR TITLE
Added rpm_excludedocs handling for yum

### DIFF
--- a/kiwi/repository/yum.py
+++ b/kiwi/repository/yum.py
@@ -20,6 +20,7 @@ from six.moves.configparser import ConfigParser
 from tempfile import NamedTemporaryFile
 
 # project
+from ..logger import log
 from .base import RepositoryBase
 from ..path import Path
 
@@ -54,6 +55,11 @@ class RepositoryYum(RepositoryBase):
         self.custom_args = custom_args
         if not custom_args:
             self.custom_args = []
+
+        # extract custom arguments not used in yum call
+        if 'exclude_docs' in self.custom_args:
+            self.custom_args.remove('exclude_docs')
+            log.warning('rpm-excludedocs not supported for yum: ignoring')
 
         self.repo_names = []
 

--- a/test/unit/repository_yum_test.py
+++ b/test/unit/repository_yum_test.py
@@ -15,7 +15,8 @@ class TestRepositoryYum(object):
     @patch_open
     @patch('kiwi.repository.yum.ConfigParser')
     @patch('kiwi.repository.yum.Path.create')
-    def setup(self, mock_path, mock_config, mock_open, mock_temp):
+    @patch('kiwi.logger.log.warning')
+    def setup(self, mock_warn, mock_path, mock_config, mock_open, mock_temp):
         runtime_yum_config = mock.Mock()
         mock_config.return_value = runtime_yum_config
         tmpfile = mock.Mock()
@@ -27,7 +28,7 @@ class TestRepositoryYum(object):
         )
         root_bind.root_dir = '../data'
         root_bind.shared_location = '/shared-dir'
-        self.repo = RepositoryYum(root_bind)
+        self.repo = RepositoryYum(root_bind, ['exclude_docs'])
 
         assert runtime_yum_config.set.call_args_list == [
             call('main', 'cachedir', '/shared-dir/yum/cache'),
@@ -42,6 +43,16 @@ class TestRepositoryYum(object):
             call('main', 'metadata_expire', '1800'),
             call('main', 'group_command', 'compat')
         ]
+        mock_warn.assert_called_once_with(
+            'rpm-excludedocs not supported for yum: ignoring'
+        )
+
+    @patch_open
+    @patch('kiwi.repository.yum.NamedTemporaryFile')
+    @patch('kiwi.repository.yum.Path.create')
+    def test_post_init_no_custom_args(self, mock_path, mock_temp, mock_open):
+        self.repo.post_init()
+        assert self.repo.custom_args == []
 
     @patch_open
     @patch('kiwi.repository.yum.ConfigParser')


### PR DESCRIPTION
rpm supports the --excludepath option. However, yum can not be configured to pass along options to rpm or the python interface it uses. Thus only a warning about excludedocs not being supported by kiwi for yum is issued. Fixes #133