### PR TITLE
Fixed hybrid setup for large ISO images

### DIFF
--- a/kiwi/iso.py
+++ b/kiwi/iso.py
@@ -421,16 +421,20 @@ class Iso(object):
             sortfile.write('%s 3\n' % catalog_file)
             sortfile.write('%s 2\n' % loader_file)
 
-            for basedir, dirnames, filenames in os.walk(self.source_dir):
+            boot_files = list(os.walk(self.source_dir + '/' + self.boot_path))
+            boot_files += list(os.walk(self.source_dir + '/EFI'))
+            for basedir, dirnames, filenames in boot_files:
                 for filename in filenames:
                     if filename == 'efi':
                         sortfile.write('%s/%s 1000001\n' % (basedir, filename))
-                    elif filename == self.header_end_name:
-                        sortfile.write('%s/%s 1000000\n' % (basedir, filename))
                     else:
                         sortfile.write('%s/%s 1\n' % (basedir, filename))
                 for dirname in dirnames:
                     sortfile.write('%s/%s 1\n' % (basedir, dirname))
+
+            sortfile.write(
+                '%s/%s 1000000\n' % (self.source_dir, self.header_end_name)
+            )
 
     @staticmethod
     def _read_iso_metadata(isofile):


### PR DESCRIPTION
The isohybrid tool uses fseek() to locate the bootloader files. That's unfortunately not 64-bit safe. In case of an ISO image bigger than 4G this leads to 32-bit offset issues. kiwi can workaround this problem by putting the bootloader files near the top of the iso image, which is done by a change in the
sortfile of this commit