### PR TITLE
Added support for mkisofs

### DIFF
--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -243,6 +243,7 @@ class LiveImageBuilder(object):
             log.info('ISO exceeds 4G size, using UDF filesystem')
             custom_iso_args['create_options'].append('-iso-level')
             custom_iso_args['create_options'].append('3')
+            custom_iso_args['create_options'].append('-udf')
 
         # create iso filesystem from media_dir
         log.info('Creating live ISO image')

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -241,8 +241,8 @@ class LiveImageBuilder(object):
         # calculate size and decide if we need UDF
         if rootsize.accumulate_mbyte_file_sizes() > 4096:
             log.info('ISO exceeds 4G size, using UDF filesystem')
-            custom_iso_args['create_options'].append('-allow-limited-size')
-            custom_iso_args['create_options'].append('-udf')
+            custom_iso_args['create_options'].append('-iso-level')
+            custom_iso_args['create_options'].append('3')
 
         # create iso filesystem from media_dir
         log.info('Creating live ISO image')

--- a/kiwi/iso.py
+++ b/kiwi/iso.py
@@ -350,18 +350,17 @@ class Iso(object):
         listing_result = {}
         for line in listing.output.split('\n'):
             iso_entry = re.search(
-                '^(.).*\s\[\s*(\d+)(\s+\d+)?\]\s+(.*?)\s*$', line
+                '.*(-[-rwx]{9}).*\s\[\s*(\d+)(\s+\d+)?\]\s+(.*?)\s*$', line
             )
             if iso_entry:
                 entry_type = iso_entry.group(1)
                 entry_name = iso_entry.group(4)
                 entry_addr = int(iso_entry.group(2))
-                if entry_type == '-':
-                    listing_result[entry_addr] = listing_type(
-                        name=entry_name,
-                        filetype=entry_type,
-                        start=entry_addr
-                    )
+                listing_result[entry_addr] = listing_type(
+                    name=entry_name,
+                    filetype=entry_type,
+                    start=entry_addr
+                )
         return collections.OrderedDict(
             sorted(listing_result.items())
         )

--- a/test/unit/builder_live_test.py
+++ b/test/unit/builder_live_test.py
@@ -208,7 +208,7 @@ class TestLiveImageBuilder(object):
                     '-p', '"KIWI - http://suse.github.com/kiwi"',
                     '-publisher', '"SUSE LINUX GmbH"',
                     '-V', '"volid"',
-                    '-iso-level', '3'
+                    '-iso-level', '3', '-udf'
                 ]
             }, device_provider=None, root_dir='temp_media_dir'
         )

--- a/test/unit/builder_live_test.py
+++ b/test/unit/builder_live_test.py
@@ -208,7 +208,7 @@ class TestLiveImageBuilder(object):
                     '-p', '"KIWI - http://suse.github.com/kiwi"',
                     '-publisher', '"SUSE LINUX GmbH"',
                     '-V', '"volid"',
-                    '-allow-limited-size', '-udf'
+                    '-iso-level', '3'
                 ]
             }, device_provider=None, root_dir='temp_media_dir'
         )


### PR DESCRIPTION
Support for mkisofs tool (instead of genisoimage) was not properly implemented, since these tools do not support exactly the same flags. It can be solved by making sure we use only common flags, this way is transparent to kiwi which is the underlying tool installed in the platform.