### PR TITLE
Fixed secure boot setup for iso media

### DIFF
--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -17,6 +17,7 @@
 #
 from tempfile import mkdtemp
 import platform
+import shutil
 
 # project
 from ..bootloader.config import BootLoaderConfig
@@ -233,6 +234,13 @@ class LiveImageBuilder(object):
                 mbrid=self.mbrid
             )
             bootloader_config_grub.write()
+            if self.firmware.efi_mode() == 'uefi':
+                # write bootloader config to EFI directory in order to allow
+                # grub loaded by shim to find the config file
+                shutil.copy(
+                    self.media_dir + '/boot/grub2/grub.cfg',
+                    self.media_dir + '/EFI/BOOT'
+                )
 
         # create initrd for live image
         log.info('Creating live ISO boot image')

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -272,6 +272,14 @@ class Defaults(object):
         return 'SUSE LINUX GmbH'
 
     @classmethod
+    def get_shim_name(self):
+        return 'shim.efi'
+
+    @classmethod
+    def get_signed_grub_name(self):
+        return 'grub.efi'
+
+    @classmethod
     def get_default_volume_group_name(self):
         """
         Implements default LVM volume group name

--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -100,6 +100,13 @@ class KiwiBootLoaderGrubPlatformError(KiwiError):
     """
 
 
+class KiwiBootLoaderGrubSecureBootError(KiwiError):
+    """
+    Exception raised if the Microsoft signed shim loader or
+    grub2 loader could not be found in the image root system
+    """
+
+
 class KiwiBootLoaderInstallSetupError(KiwiError):
     """
     Exception raised if an installation for an unsupported


### PR DESCRIPTION
Provide the shim loader and the shim signed grub loader in the required boot path. Normally this task is done by the shim-install tool. However, shim-install does not exist on all distributions and the script does not operate well in CD environments from which we generate live and/or install media. Thus shim-install is used if possible at install time of the bootloader because it requires access to the target block device. In any other case the kiwi fallback code applies