### PR TITLE
Support for btrfs read-only root snapshot

### DIFF
--- a/doc/source/schema.rst
+++ b/doc/source/schema.rst
@@ -287,6 +287,7 @@ List of attributes for ``type``:
 * ``bootprofile`` `[?]`_: Specifies the boot profile defined in the boot image description. When kiwi builds the boot image the information is passed as add-profile option
 * ``boottimeout`` `[?]`_: Specifies the boot timeout in seconds prior to launching the default boot option. the unit for the timeout value is seconds if GRUB is used as the boot loader and 1/10 seconds if syslinux is used
 * ``btrfs_root_is_snapshot`` `[?]`_: Tell kiwi to install the system into a btrfs snapshot The snapshot layout is compatible with the snapper management toolkit. By default no snapshots are used
+* ``btrfs_root_is_readonly_snapshot`` `[?]`_: Tell kiwi to set the btrfs root filesystem snapshot read-only Once all data has been placed to the root filesystem snapshot it will be turned into read-only mode if this option is set to true. The option is only effective if btrfs_root_is_snapshot is also set to true. By default the root filesystem snapshot is writable
 * ``checkprebuilt`` `[?]`_: Activates whether KIWI should search for a prebuild boot image or not
 * ``compressed`` `[?]`_: Specifies whether the image output file should be compressed or not. This makes only sense for filesystem only images respectively for the pxe or cpio type
 * ``container`` `[?]`_: Specifies a name for the container

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1593,6 +1593,14 @@ div {
         ## The snapshot layout is compatible with the snapper management
         ## toolkit. By default no snapshots are used
         attribute btrfs_root_is_snapshot { xsd:boolean }
+    k.type.btrfs_root_is_readonly_snapshot =
+        ## Tell kiwi to set the btrfs root filesystem snapshot read-only
+        ## Once all data has been placed to the root filesystem snapshot
+        ## it will be turned into read-only mode if this option is set to
+        ## true. The option is only effective if btrfs_root_is_snapshot
+        ## is also set to true. By default the root filesystem snapshot
+        ## is writable
+        attribute btrfs_root_is_readonly_snapshot { xsd:boolean }
     k.type.target_blocksize =
         ## Specifies the image blocksize in bytes which has to match
         ## the logical (SSZ) blocksize of the target storage device.
@@ -1848,6 +1856,7 @@ div {
         k.type.bootprofile.attribute? &
         k.type.boottimeout.attribute? &
         k.type.btrfs_root_is_snapshot? &
+        k.type.btrfs_root_is_readonly_snapshot? &
         k.type.checkprebuilt.attribute? &
         k.type.compressed.attribute? &
         k.type.container.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -20,7 +20,7 @@
   STATUS        : Development
   ****************
 -->
-<grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:db="http://docbook.org/ns/docbook" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+<grammar xmlns:db="http://docbook.org/ns/docbook" xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
   <db:info>
     <db:releaseinfo>$Id: $</db:releaseinfo>
     <db:releaseinfo>RNC Schema Version 6.4</db:releaseinfo>
@@ -2090,6 +2090,17 @@ toolkit. By default no snapshots are used</a:documentation>
         <data type="boolean"/>
       </attribute>
     </define>
+    <define name="k.type.btrfs_root_is_readonly_snapshot">
+      <attribute name="btrfs_root_is_readonly_snapshot">
+        <a:documentation>Tell kiwi to set the btrfs root filesystem snapshot read-only
+Once all data has been placed to the root filesystem snapshot
+it will be turned into read-only mode if this option is set to
+true. The option is only effective if btrfs_root_is_snapshot
+is also set to true. By default the root filesystem snapshot
+is writable</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+    </define>
     <define name="k.type.target_blocksize">
       <attribute name="target_blocksize">
         <a:documentation>Specifies the image blocksize in bytes which has to match
@@ -2544,6 +2555,9 @@ are available on the host. Default timeout is 3 seconds</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.btrfs_root_is_snapshot"/>
+        </optional>
+        <optional>
+          <ref name="k.type.btrfs_root_is_readonly_snapshot"/>
         </optional>
         <optional>
           <ref name="k.type.checkprebuilt.attribute"/>

--- a/kiwi/volume_manager/base.py
+++ b/kiwi/volume_manager/base.py
@@ -314,6 +314,14 @@ class VolumeManagerBase(DeviceProvider):
             )
             self.umount_volumes()
 
+    def set_property_readonly_root(self):
+        """
+        Implements setup of read-only root property
+        """
+        raise KiwiVolumeManagerSetupError(
+            'read only property not supported'
+        )
+
     def setup_mountpoint(self):
         """
         Implements creation of a master directory holding

--- a/kiwi/volume_manager/btrfs.py
+++ b/kiwi/volume_manager/btrfs.py
@@ -62,6 +62,8 @@ class VolumeManagerBtrfs(VolumeManagerBase):
             self.custom_args['root_label'] = 'ROOT'
         if 'root_is_snapshot' not in self.custom_args:
             self.custom_args['root_is_snapshot'] = False
+        if 'root_is_readonly_snapshot' not in self.custom_args:
+            self.custom_args['root_is_readonly_snapshot'] = False
 
         self.subvol_mount_list = []
         self.toplevel_mount = None
@@ -269,6 +271,17 @@ class VolumeManagerBtrfs(VolumeManagerBase):
             data.sync_data(
                 options=['-a', '-H', '-X', '-A', '--one-file-system'],
                 exclude=exclude
+            )
+
+    def set_property_readonly_root(self):
+        root_is_snapshot = \
+            self.custom_args['root_is_snapshot']
+        root_is_readonly_snapshot = \
+            self.custom_args['root_is_readonly_snapshot']
+        if root_is_snapshot and root_is_readonly_snapshot:
+            sync_target = self.mountpoint + '/@/.snapshots/1/snapshot'
+            Command.run(
+                ['btrfs', 'property', 'set', sync_target, 'ro', 'true']
             )
 
     def _set_default_volume(self, default_volume):

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Mon Sep 26 18:28:11 2016 by generateDS.py version 2.23a.
+# Generated Wed Oct  5 13:14:58 2016 by generateDS.py version 2.23a.
 #
 # Command line options:
 #   ('-f', '')
@@ -13,7 +13,7 @@
 #   kiwi/schema/kiwi.xsd
 #
 # Command line:
-#   /home/ms/Project/kiwi/.tox/2.7/bin/generateDS.py -f --external-encoding="utf-8" -o "kiwi/xml_parse.py" kiwi/schema/kiwi.xsd
+#   /home/ms/Project/kiwi/.env2/bin/generateDS.py -f --external-encoding="utf-8" -o "kiwi/xml_parse.py" kiwi/schema/kiwi.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -2504,7 +2504,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, checkprebuilt=None, compressed=None, container=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsnocheck=None, fsmountoptions=None, gcelicense=None, hybrid=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, target_blocksize=None, vbootsize=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, checkprebuilt=None, compressed=None, container=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsnocheck=None, fsmountoptions=None, gcelicense=None, hybrid=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, target_blocksize=None, vbootsize=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2518,6 +2518,7 @@ class type_(GeneratedsSuper):
         self.bootprofile = _cast(None, bootprofile)
         self.boottimeout = _cast(int, boottimeout)
         self.btrfs_root_is_snapshot = _cast(bool, btrfs_root_is_snapshot)
+        self.btrfs_root_is_readonly_snapshot = _cast(bool, btrfs_root_is_readonly_snapshot)
         self.checkprebuilt = _cast(bool, checkprebuilt)
         self.compressed = _cast(bool, compressed)
         self.container = _cast(None, container)
@@ -2645,6 +2646,8 @@ class type_(GeneratedsSuper):
     def set_boottimeout(self, boottimeout): self.boottimeout = boottimeout
     def get_btrfs_root_is_snapshot(self): return self.btrfs_root_is_snapshot
     def set_btrfs_root_is_snapshot(self, btrfs_root_is_snapshot): self.btrfs_root_is_snapshot = btrfs_root_is_snapshot
+    def get_btrfs_root_is_readonly_snapshot(self): return self.btrfs_root_is_readonly_snapshot
+    def set_btrfs_root_is_readonly_snapshot(self, btrfs_root_is_readonly_snapshot): self.btrfs_root_is_readonly_snapshot = btrfs_root_is_readonly_snapshot
     def get_checkprebuilt(self): return self.checkprebuilt
     def set_checkprebuilt(self, checkprebuilt): self.checkprebuilt = checkprebuilt
     def get_compressed(self): return self.compressed
@@ -2795,6 +2798,9 @@ class type_(GeneratedsSuper):
         if self.btrfs_root_is_snapshot is not None and 'btrfs_root_is_snapshot' not in already_processed:
             already_processed.add('btrfs_root_is_snapshot')
             outfile.write(' btrfs_root_is_snapshot="%s"' % self.gds_format_boolean(self.btrfs_root_is_snapshot, input_name='btrfs_root_is_snapshot'))
+        if self.btrfs_root_is_readonly_snapshot is not None and 'btrfs_root_is_readonly_snapshot' not in already_processed:
+            already_processed.add('btrfs_root_is_readonly_snapshot')
+            outfile.write(' btrfs_root_is_readonly_snapshot="%s"' % self.gds_format_boolean(self.btrfs_root_is_readonly_snapshot, input_name='btrfs_root_is_readonly_snapshot'))
         if self.checkprebuilt is not None and 'checkprebuilt' not in already_processed:
             already_processed.add('checkprebuilt')
             outfile.write(' checkprebuilt="%s"' % self.gds_format_boolean(self.checkprebuilt, input_name='checkprebuilt'))
@@ -3005,6 +3011,15 @@ class type_(GeneratedsSuper):
                 self.btrfs_root_is_snapshot = True
             elif value in ('false', '0'):
                 self.btrfs_root_is_snapshot = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
+        value = find_attr_value_('btrfs_root_is_readonly_snapshot', node)
+        if value is not None and 'btrfs_root_is_readonly_snapshot' not in already_processed:
+            already_processed.add('btrfs_root_is_readonly_snapshot')
+            if value in ('true', '1'):
+                self.btrfs_root_is_readonly_snapshot = True
+            elif value in ('false', '0'):
+                self.btrfs_root_is_readonly_snapshot = False
             else:
                 raise_parse_error(node, 'Bad boolean attribute')
         value = find_attr_value_('checkprebuilt', node)

--- a/test/data/example_disk_config.xml
+++ b/test/data/example_disk_config.xml
@@ -19,7 +19,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="vmx" filesystem="btrfs" boot="oemboot/suse-13.2" installiso="true" bootloader="grub2" kernelcmdline="splash" firmware="efi"/>
+        <type image="vmx" filesystem="btrfs" boot="oemboot/suse-13.2" installiso="true" bootloader="grub2" kernelcmdline="splash" firmware="efi" btrfs_root_is_snapshot="true" btrfs_root_is_readonly_snapshot="true"/>
     </preferences>
     <repository type="yast2">
         <source path="obs://13.2/repo/oss"/>

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -532,17 +532,17 @@ class TestDiskBuilder(object):
         )
         volume_manager.setup.assert_called_once_with('systemVG')
         volume_manager.create_volumes.assert_called_once_with('btrfs')
-        volume_manager.mount_volumes.assert_called_once_with()
+        volume_manager.mount_volumes.call_args_list[0].assert_called_once_with()
         volume_manager.get_fstab.assert_called_once_with(None, 'btrfs')
         volume_manager.sync_data.assert_called_once_with([
             'image', '.profile', '.kconfig', 'var/cache/kiwi',
             'boot/*', 'boot/.*', 'boot/efi/*', 'boot/efi/.*'
         ])
-        volume_manager.umount_volumes.assert_called_once_with()
+        volume_manager.umount_volumes.call_args_list[0].assert_called_once_with()
         self.setup.create_fstab.assert_called_once_with(
             [
                 'fstab_volume_entries',
-                'UUID=blkid_result / filesystem defaults 1 1',
+                'UUID=blkid_result / filesystem ro 0 0',
                 'UUID=blkid_result /boot filesystem defaults 0 0',
                 'UUID=blkid_result /boot/efi filesystem defaults 0 0'
             ]
@@ -550,7 +550,7 @@ class TestDiskBuilder(object):
         self.boot_image_task.setup.create_fstab.assert_called_once_with(
             [
                 'fstab_volume_entries',
-                'UUID=blkid_result / filesystem defaults 1 1',
+                'UUID=blkid_result / filesystem ro 0 0',
                 'UUID=blkid_result /boot filesystem defaults 0 0',
                 'UUID=blkid_result /boot/efi filesystem defaults 0 0'
             ]

--- a/test/unit/volume_manager_base_test.py
+++ b/test/unit/volume_manager_base_test.py
@@ -167,6 +167,10 @@ class TestVolumeManagerBase(object):
         self.volume_manager.setup_mountpoint()
         assert self.volume_manager.mountpoint == 'tmpdir'
 
+    @raises(KiwiVolumeManagerSetupError)
+    def test_set_property_readonly_root(self):
+        self.volume_manager.set_property_readonly_root()
+
     def test_destructor(self):
         # does nothing by default, just pass
         self.volume_manager.__del__()

--- a/test/unit/volume_manager_btrfs_test.py
+++ b/test/unit/volume_manager_btrfs_test.py
@@ -290,6 +290,19 @@ class TestVolumeManagerBtrfs(object):
             options=['-a', '-H', '-X', '-A', '--one-file-system']
         )
 
+    @patch('kiwi.volume_manager.btrfs.Command.run')
+    def test_set_property_readonly_root(self, mock_command):
+        self.volume_manager.mountpoint = 'tmpdir'
+        self.volume_manager.custom_args['root_is_snapshot'] = True
+        self.volume_manager.custom_args['root_is_readonly_snapshot'] = True
+        self.volume_manager.set_property_readonly_root()
+        mock_command.assert_called_once_with(
+            [
+                'btrfs', 'property', 'set',
+                'tmpdir/@/.snapshots/1/snapshot', 'ro', 'true'
+            ]
+        )
+
     @patch('kiwi.volume_manager.btrfs.VolumeManagerBtrfs.umount_volumes')
     @patch('kiwi.volume_manager.btrfs.Path.wipe')
     def test_destructor(self, mock_wipe, mock_umount_volumes):


### PR DESCRIPTION
Added btrfs_root_is_readonly_snapshot attribute
    
The attribute allows to specify if the root filesystem should be set to read-only if it is created as a btrfs snapshot. The option only has an effect if a btrfs snapshot is used as root filesystem. Fixes bnc#1000080