### PR TITLE
Bundler setup changes

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -494,7 +494,7 @@ class DiskBuilder(object):
         self.result.add(
             key='disk_image',
             filename=self.diskname,
-            use_for_bundle=True,
+            use_for_bundle=True if not self.image_format else False,
             compress=True,
             shasum=True
         )

--- a/kiwi/storage/subformat/base.py
+++ b/kiwi/storage/subformat/base.py
@@ -148,7 +148,7 @@ class DiskFormatBase(object):
                 self.image_format
             ),
             use_for_bundle=True,
-            compress=True,
+            compress=False,
             shasum=True
         )
 

--- a/kiwi/storage/subformat/vmdk.py
+++ b/kiwi/storage/subformat/vmdk.py
@@ -85,7 +85,7 @@ class DiskFormatVmdk(DiskFormatBase):
                 self.image_format
             ),
             use_for_bundle=True,
-            compress=True,
+            compress=False,
             shasum=True
         )
         result.add(

--- a/test/unit/storage_subformat_base_test.py
+++ b/test/unit/storage_subformat_base_test.py
@@ -56,7 +56,7 @@ class TestDiskFormatBase(object):
         self.disk_format.image_format = 'qcow2'
         self.disk_format.store_to_result(result)
         result.add.assert_called_once_with(
-            compress=True,
+            compress=False,
             filename='target_dir/some-disk-image.x86_64-1.2.3.qcow2',
             key='disk_format_image',
             shasum=True,

--- a/test/unit/storage_subformat_vmdk_test.py
+++ b/test/unit/storage_subformat_vmdk_test.py
@@ -159,7 +159,7 @@ class TestDiskFormatVmdk(object):
         self.disk_format.store_to_result(result)
         assert result.add.call_args_list == [
             call(
-                compress=True,
+                compress=False,
                 filename='target_dir/some-disk-image.x86_64-1.2.3.vmdk',
                 key='disk_format_image',
                 shasum=True,


### PR DESCRIPTION
Fixes #159 

Do not bundle the raw disk if a format is setup
    
* Only bundle the compressed version of the .raw disk image if no disk format like qcow2, vmdk, etc... is specified.

Do not compress disk formats
    
* Stay compatible with the former version of kiwi and do not compress disk formats like qcow2, vmdk, etc... It also does not make much sense since the disk formats itself are using a compression algorithm.