### PR TITLE
Create info.xml file for btrfs snapshot

### DIFF
--- a/kiwi/volume_manager/btrfs.py
+++ b/kiwi/volume_manager/btrfs.py
@@ -17,6 +17,9 @@
 #
 import re
 import os
+import datetime
+from xml.etree import ElementTree
+from xml.dom import minidom
 
 # project
 from ..command import Command
@@ -267,6 +270,9 @@ class VolumeManagerBtrfs(VolumeManagerBase):
             sync_target = self.mountpoint + '/@'
             if self.custom_args['root_is_snapshot']:
                 sync_target = self.mountpoint + '/@/.snapshots/1/snapshot'
+                self._create_snapshot_info(
+                    self.mountpoint + '/@/.snapshots/1/info.xml'
+                )
             data = DataSync(self.root_dir, sync_target)
             data.sync_data(
                 options=['-a', '-H', '-X', '-A', '--one-file-system'],
@@ -305,6 +311,32 @@ class VolumeManagerBtrfs(VolumeManagerBase):
         raise KiwiVolumeRootIDError(
             'Failed to find btrfs volume: %s' % default_volume
         )
+
+    def _xml_pretty(self, toplevel_element):
+        xml_data_unformatted = ElementTree.tostring(
+            toplevel_element, 'utf-8'
+        )
+        xml_data_domtree = minidom.parseString(xml_data_unformatted)
+        return xml_data_domtree.toprettyxml(indent="    ")
+
+    def _create_snapshot_info(self, filename):
+        date_info = datetime.datetime.now()
+        snapshot = ElementTree.Element('snapshot')
+
+        snapshot_type = ElementTree.SubElement(snapshot, 'type')
+        snapshot_type.text = 'single'
+
+        snapshot_number = ElementTree.SubElement(snapshot, 'num')
+        snapshot_number.text = '1'
+
+        snapshot_description = ElementTree.SubElement(snapshot, 'description')
+        snapshot_description.text = 'first root filesystem'
+
+        snapshot_date = ElementTree.SubElement(snapshot, 'date')
+        snapshot_date.text = date_info.strftime("%Y-%m-%d %H:%M:%S")
+
+        with open(filename, 'w') as snapshot_info_file:
+            snapshot_info_file.write(self._xml_pretty(snapshot))
 
     def _get_subvol_name_from_mountpoint(self, volume_mount):
         subvol_name = '/'.join(volume_mount.mountpoint.split('/')[3:])

--- a/kiwi/volume_manager/btrfs.py
+++ b/kiwi/volume_manager/btrfs.py
@@ -271,7 +271,7 @@ class VolumeManagerBtrfs(VolumeManagerBase):
             if self.custom_args['root_is_snapshot']:
                 sync_target = self.mountpoint + '/@/.snapshots/1/snapshot'
                 self._create_snapshot_info(
-                    self.mountpoint + '/@/.snapshots/1/info.xml'
+                    ''.join([self.mountpoint, '/@/.snapshots/1/info.xml'])
                 )
             data = DataSync(self.root_dir, sync_target)
             data.sync_data(

--- a/test/data/info.xml
+++ b/test/data/info.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+<snapshot>
+    <type>single</type>
+    <num>1</num>
+    <description>first root filesystem</description>
+    <date>2016-01-01 00:00:00</date>
+</snapshot>

--- a/test/unit/volume_manager_btrfs_test.py
+++ b/test/unit/volume_manager_btrfs_test.py
@@ -3,7 +3,6 @@ from mock import call
 import mock
 import os
 
-from textwrap import dedent
 import datetime
 
 from .test_helper import (

--- a/test/unit/volume_manager_btrfs_test.py
+++ b/test/unit/volume_manager_btrfs_test.py
@@ -6,7 +6,10 @@ import os
 from textwrap import dedent
 import datetime
 
-from .test_helper import *
+from .test_helper import (
+    raises, patch_open
+)
+
 from collections import namedtuple
 
 from kiwi.exceptions import *

--- a/test/unit/volume_manager_btrfs_test.py
+++ b/test/unit/volume_manager_btrfs_test.py
@@ -26,15 +26,6 @@ class TestVolumeManagerBtrfs(object):
         self.enter_mock.return_value = self.file_mock
         setattr(self.context_manager_mock, '__enter__', self.enter_mock)
         setattr(self.context_manager_mock, '__exit__', self.exit_mock)
-        self.xml_info = dedent('''
-        <?xml version="1.0" ?>
-        <snapshot>
-            <type>single</type>
-            <num>1</num>
-            <description>first root filesystem</description>
-            <date>2016-01-01 00:00:00</date>
-        </snapshot>
-        ''').strip() + os.linesep
         self.volume_type = namedtuple(
             'volume_type', [
                 'name',
@@ -318,7 +309,10 @@ class TestVolumeManagerBtrfs(object):
         mock_open.assert_called_once_with(
             'tmpdir/@/.snapshots/1/info.xml', 'w'
         )
-        self.file_mock.write.assert_called_once_with(self.xml_info)
+        with open('../data/info.xml') as xml_info:
+            self.file_mock.write.assert_called_once_with(
+                xml_info.read()
+            )
 
     @patch('kiwi.volume_manager.btrfs.Command.run')
     def test_set_property_readonly_root(self, mock_command):

--- a/test/unit/volume_manager_btrfs_test.py
+++ b/test/unit/volume_manager_btrfs_test.py
@@ -5,9 +5,7 @@ import os
 
 import datetime
 
-from .test_helper import (
-    raises, patch_open
-)
+from .test_helper import raises, patch_open
 
 from collections import namedtuple
 


### PR DESCRIPTION
If the system is installed into a btrfs snapshot a metadata file called info.xml is created which is used by tools like snapper. Fixes bnc#1000117