### PR TITLE
Efi setup for removable devices

### DIFF
--- a/doc/source/schema.rst
+++ b/doc/source/schema.rst
@@ -321,7 +321,7 @@ List of attributes for ``type``:
 * ``ramonly`` `[?]`_: for use with overlay filesystems only: will force any COW action to happen in RAM
 * ``rootfs_label`` `[?]`_: label to set for the root filesystem. By default ROOT is used
 * ``target_blocksize`` `[?]`_: Specifies the image blocksize in bytes which has to match the logical (SSZ) blocksize of the target storage device. By default 512 byte is used which works on many disks However 4096 byte disks are coming. You can check the desired target by calling: blockdev --report device
-* ``target_removable`` `[?]`_: Indicate if the target disk for oem images is deployed to a removable device e.g a USB stick or not. This only affects the EFI setup if requested and in the end avoids the creation of a custom boot menu entry in the firmware of the target machine. By default the target disk is expected to be solid
+* ``target_removable`` `[?]`_: Indicate if the target disk for oem images is deployed to a removable device e.g a USB stick or not. This only affects the EFI setup if requested and in the end avoids the creation of a custom boot menu entry in the firmware of the target machine. By default the target disk is expected to be non-removable
 * ``vbootsize`` `[?]`_: For images with a an extra virtual boot space specifies the size in MB. If not set the min vboot size is set to 10 MB
 * ``vga`` `[?]`_: Specifies the kernel framebuffer mode. More information about the possible values can be found by calling hwinfo --framebuffer or in /usr/src/linux/Documentation/fb/vesafb.txt
 * ``vhdfixedtag`` `[?]`_: Specifies the GUID in a fixed format VHD

--- a/doc/source/schema.rst
+++ b/doc/source/schema.rst
@@ -321,6 +321,7 @@ List of attributes for ``type``:
 * ``ramonly`` `[?]`_: for use with overlay filesystems only: will force any COW action to happen in RAM
 * ``rootfs_label`` `[?]`_: label to set for the root filesystem. By default ROOT is used
 * ``target_blocksize`` `[?]`_: Specifies the image blocksize in bytes which has to match the logical (SSZ) blocksize of the target storage device. By default 512 byte is used which works on many disks However 4096 byte disks are coming. You can check the desired target by calling: blockdev --report device
+* ``target_removable`` `[?]`_: Indicate if the target disk for oem images is deployed to a removable device e.g a USB stick or not. This only affects the EFI setup if requested and in the end avoids the creation of a custom boot menu entry in the firmware of the target machine. By default the target disk is expected to be solid
 * ``vbootsize`` `[?]`_: For images with a an extra virtual boot space specifies the size in MB. If not set the min vboot size is set to 10 MB
 * ``vga`` `[?]`_: Specifies the kernel framebuffer mode. More information about the possible values can be found by calling hwinfo --framebuffer or in /usr/src/linux/Documentation/fb/vesafb.txt
 * ``vhdfixedtag`` `[?]`_: Specifies the GUID in a fixed format VHD

--- a/kiwi/boot/functions.sh
+++ b/kiwi/boot/functions.sh
@@ -1104,6 +1104,10 @@ function installBootLoaderS390Grub {
     local confFile_grub=/boot/grub2/grub.cfg
     local active_devs=/boot/zipl/active_devices.txt
     local deviceID=$(cat /sys/firmware/ipl/device)
+    local instTooOptions
+    if [ "$kiwi_target_removable" = "true" ];then
+        instTooOptions="--removable"
+    fi
     #======================================
     # mount zipl EFI partition
     #--------------------------------------
@@ -1143,7 +1147,7 @@ function installBootLoaderS390Grub {
         Echo "Can't install bootloader"
         return 1
     fi
-    if ! $instTool;then
+    if ! $instTool $instTooOptions;then
         Echo "Failed to install bootloader"
         return 1
     fi
@@ -1194,6 +1198,10 @@ function installBootLoaderGrub2 {
     local product=/etc/products.d/baseproduct
     local grub_efi=/boot/efi/EFI/BOOT/grub.efi
     local isEFI=0
+    local instTooOptions
+    if [ "$kiwi_target_removable" = "true" ];then
+        instTooOptions="--removable"
+    fi
     #======================================
     # check for EFI and mount EFI partition
     #--------------------------------------
@@ -1235,21 +1243,21 @@ function installBootLoaderGrub2 {
     if [ ! -z "$kiwi_PrepPart" ];then
         local prepdev=$(ddn $imageDiskDevice $kiwi_PrepPart)
         # install powerpc grub2
-        $instTool $prepdev 1>&2
+        $instTool $instTooOptions $prepdev 1>&2
         if [ ! $? = 0 ];then
             Echo "Failed to install boot loader"
             return 1
         fi
     elif [ $isEFI -eq 0 ];then
         # use plain grub2-install in standard bios mode
-        $instTool $imageDiskDevice 1>&2
+        $instTool $instTooOptions $imageDiskDevice 1>&2
         if [ ! $? = 0 ];then
             Echo "Failed to install boot loader"
             return 1
         fi
     elif [ ! -z "$kiwi_BiosGrub" ] && [ -d $bios_grub ];then
         # force install of bios grub2 in efi legacy mode
-        $instTool --force --target i386-pc $imageDiskDevice 1>&2
+        $instTool $instTooOptions --force --target i386-pc $imageDiskDevice 1>&2
         if [ ! $? = 0 ];then
             Echo "Failed to install legacy boot loader"
             return 1

--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -242,6 +242,7 @@ class BootImageBase(object):
             'installprovidefailsafe',
             'kernelcmdline',
             'ramonly',
+            'target_removable',
             'vga',
             'wwid_wait_timeout'
         ]

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -199,6 +199,7 @@ class DiskBuilder(object):
             xml_state.build_type.get_bootfilesystem()
         self.bootloader = xml_state.build_type.get_bootloader()
         self.initrd_system = xml_state.build_type.get_initrd_system()
+        self.target_removable = xml_state.build_type.get_target_removable()
         self.disk_setup = DiskSetup(
             xml_state, root_dir
         )
@@ -867,7 +868,8 @@ class DiskBuilder(object):
         custom_install_arguments = {
             'boot_device': boot_device.get_device(),
             'root_device': root_device.get_device(),
-            'firmware': self.firmware
+            'firmware': self.firmware,
+            'target_removable': self.target_removable
         }
 
         if 'efi' in device_map:

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1614,7 +1614,7 @@ div {
         ## affects the EFI setup if requested and in the end avoids
         ## the creation of a custom boot menu entry in the firmware
         ## of the target machine. By default the target disk is
-        ## expected to be solid
+        ## expected to be non-removable
         attribute target_removable { xsd:boolean }
     k.type.zipl_targettype.attribute =
        ## The device type of the disk zipl should boot. On zFCP

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1608,6 +1608,14 @@ div {
         ## However 4096 byte disks are coming. You can check the
         ## desired target by calling: blockdev --report device
         attribute target_blocksize { xsd:nonNegativeInteger }
+    k.type.target_removable =
+        ## Indicate if the target disk for oem images is deployed
+        ## to a removable device e.g a USB stick or not. This only
+        ## affects the EFI setup if requested and in the end avoids
+        ## the creation of a custom boot menu entry in the firmware
+        ## of the target machine. By default the target disk is
+        ## expected to be solid
+        attribute target_removable { xsd:boolean }
     k.type.zipl_targettype.attribute =
        ## The device type of the disk zipl should boot. On zFCP
        ## devices use SCSI, on DASD devices use CDL or LDL on
@@ -1890,6 +1898,7 @@ div {
         k.type.ramonly.attribute? &
         k.type.rootfs_label.attribute? &
         k.type.target_blocksize? &
+        k.type.target_removable? &
         k.type.vbootsize.attribute? &
         k.type.vga.attribute? &
         k.type.vhdfixedtag.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -20,7 +20,7 @@
   STATUS        : Development
   ****************
 -->
-<grammar xmlns:db="http://docbook.org/ns/docbook" xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+<grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:db="http://docbook.org/ns/docbook" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
   <db:info>
     <db:releaseinfo>$Id: $</db:releaseinfo>
     <db:releaseinfo>RNC Schema Version 6.4</db:releaseinfo>
@@ -2111,6 +2111,17 @@ desired target by calling: blockdev --report device</a:documentation>
         <data type="nonNegativeInteger"/>
       </attribute>
     </define>
+    <define name="k.type.target_removable">
+      <attribute name="target_removable">
+        <a:documentation>Indicate if the target disk for oem images is deployed
+to a removable device e.g a USB stick or not. This only
+affects the EFI setup if requested and in the end avoids
+the creation of a custom boot menu entry in the firmware
+of the target machine. By default the target disk is
+expected to be solid</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+    </define>
     <define name="k.type.zipl_targettype.attribute">
       <attribute name="zipl_targettype">
         <a:documentation>The device type of the disk zipl should boot. On zFCP
@@ -2655,6 +2666,9 @@ are available on the host. Default timeout is 3 seconds</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.target_blocksize"/>
+        </optional>
+        <optional>
+          <ref name="k.type.target_removable"/>
         </optional>
         <optional>
           <ref name="k.type.vbootsize.attribute"/>

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2118,7 +2118,7 @@ to a removable device e.g a USB stick or not. This only
 affects the EFI setup if requested and in the end avoids
 the creation of a custom boot menu entry in the firmware
 of the target machine. By default the target disk is
-expected to be solid</a:documentation>
+expected to be non-removable</a:documentation>
         <data type="boolean"/>
       </attribute>
     </define>

--- a/kiwi/system/profile.py
+++ b/kiwi/system/profile.py
@@ -259,6 +259,7 @@ class Profile(object):
         # kiwi_initrd_system
         # kiwi_ramonly
         # kiwi_target_blocksize
+        # kiwi_target_removable
         # kiwi_cmdline
         # kiwi_firmware
         # kiwi_bootloader
@@ -291,6 +292,8 @@ class Profile(object):
             type_section.get_ramonly()
         self.dot_profile['kiwi_target_blocksize'] = \
             type_section.get_target_blocksize()
+        self.dot_profile['kiwi_target_removable'] = \
+            type_section.get_target_removable()
         self.dot_profile['kiwi_cmdline'] = \
             type_section.get_kernelcmdline()
         self.dot_profile['kiwi_firmware'] = \

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Wed Oct  5 13:14:58 2016 by generateDS.py version 2.23a.
+# Generated Thu Oct 13 15:08:25 2016 by generateDS.py version 2.23a.
 #
 # Command line options:
 #   ('-f', '')
@@ -13,7 +13,7 @@
 #   kiwi/schema/kiwi.xsd
 #
 # Command line:
-#   /home/ms/Project/kiwi/.env2/bin/generateDS.py -f --external-encoding="utf-8" -o "kiwi/xml_parse.py" kiwi/schema/kiwi.xsd
+#   /home/ms/Project/kiwi/.tox/2.7/bin/generateDS.py -f --external-encoding="utf-8" -o "kiwi/xml_parse.py" kiwi/schema/kiwi.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -2504,7 +2504,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, checkprebuilt=None, compressed=None, container=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsnocheck=None, fsmountoptions=None, gcelicense=None, hybrid=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, target_blocksize=None, vbootsize=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, checkprebuilt=None, compressed=None, container=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsnocheck=None, fsmountoptions=None, gcelicense=None, hybrid=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, target_blocksize=None, target_removable=None, vbootsize=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2552,6 +2552,7 @@ class type_(GeneratedsSuper):
         self.ramonly = _cast(bool, ramonly)
         self.rootfs_label = _cast(None, rootfs_label)
         self.target_blocksize = _cast(int, target_blocksize)
+        self.target_removable = _cast(bool, target_removable)
         self.vbootsize = _cast(int, vbootsize)
         self.vga = _cast(None, vga)
         self.vhdfixedtag = _cast(None, vhdfixedtag)
@@ -2714,6 +2715,8 @@ class type_(GeneratedsSuper):
     def set_rootfs_label(self, rootfs_label): self.rootfs_label = rootfs_label
     def get_target_blocksize(self): return self.target_blocksize
     def set_target_blocksize(self, target_blocksize): self.target_blocksize = target_blocksize
+    def get_target_removable(self): return self.target_removable
+    def set_target_removable(self, target_removable): self.target_removable = target_removable
     def get_vbootsize(self): return self.vbootsize
     def set_vbootsize(self, vbootsize): self.vbootsize = vbootsize
     def get_vga(self): return self.vga
@@ -2900,6 +2903,9 @@ class type_(GeneratedsSuper):
         if self.target_blocksize is not None and 'target_blocksize' not in already_processed:
             already_processed.add('target_blocksize')
             outfile.write(' target_blocksize="%s"' % self.gds_format_integer(self.target_blocksize, input_name='target_blocksize'))
+        if self.target_removable is not None and 'target_removable' not in already_processed:
+            already_processed.add('target_removable')
+            outfile.write(' target_removable="%s"' % self.gds_format_boolean(self.target_removable, input_name='target_removable'))
         if self.vbootsize is not None and 'vbootsize' not in already_processed:
             already_processed.add('vbootsize')
             outfile.write(' vbootsize="%s"' % self.gds_format_integer(self.vbootsize, input_name='vbootsize'))
@@ -3234,6 +3240,15 @@ class type_(GeneratedsSuper):
                 raise_parse_error(node, 'Bad integer attribute: %s' % exp)
             if self.target_blocksize < 0:
                 raise_parse_error(node, 'Invalid NonNegativeInteger')
+        value = find_attr_value_('target_removable', node)
+        if value is not None and 'target_removable' not in already_processed:
+            already_processed.add('target_removable')
+            if value in ('true', '1'):
+                self.target_removable = True
+            elif value in ('false', '0'):
+                self.target_removable = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
         value = find_attr_value_('vbootsize', node)
         if value is not None and 'vbootsize' not in already_processed:
             already_processed.add('vbootsize')

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Thu Oct 13 15:08:25 2016 by generateDS.py version 2.23a.
+# Generated Mon Oct 17 09:10:25 2016 by generateDS.py version 2.23a.
 #
 # Command line options:
 #   ('-f', '')

--- a/test/unit/bootloader_install_grub2_test.py
+++ b/test/unit/bootloader_install_grub2_test.py
@@ -27,7 +27,8 @@ class TestBootLoaderInstallGrub2(object):
             'efi_device': '/dev/mapper/loop0p3',
             'prep_device': '/dev/mapper/loop0p2',
             'system_volumes': {'boot/grub2': 'subvol=@/boot/grub2'},
-            'firmware': self.firmware
+            'firmware': self.firmware,
+            'target_removable': None
         }
 
         self.root_mount = mock.Mock()
@@ -204,6 +205,7 @@ class TestBootLoaderInstallGrub2(object):
             return self.mount_managers.pop()
 
         mock_mount_manager.side_effect = side_effect
+        self.bootloader.target_removable = True
 
         self.bootloader.install()
         self.root_mount.mount.assert_called_once_with()
@@ -212,7 +214,8 @@ class TestBootLoaderInstallGrub2(object):
         )
         mock_command.assert_called_once_with(
             [
-                'chroot', 'tmp_root', 'grub2-install', '--skip-fs-probe',
+                'chroot', 'tmp_root', 'grub2-install',
+                '--removable', '--skip-fs-probe',
                 '--directory', '/usr/lib/grub2/i386-pc',
                 '--boot-directory', '/boot',
                 '--target', 'i386-pc',

--- a/test/unit/system_profile_test.py
+++ b/test/unit/system_profile_test.py
@@ -41,6 +41,7 @@ class TestProfile(object):
             'kiwi_bootkernel': None,
             'kiwi_bootloader': 'grub2',
             'kiwi_bootprofile': None,
+            'kiwi_target_removable': None,
             'kiwi_boot_timeout': None,
             'kiwi_cmdline': 'splash',
             'kiwi_compressed': None,


### PR DESCRIPTION
Added target_removable attribute
    
Indicate if the target disk for oem images is deployed to a removable device e.g a USB stick or not. This only affects the EFI setup if requested and in the end avoids the creation of a custom boot menu entry in the firmware of the target machine on first boot. This is related to bnc#993130