### PR TITLE
Call dracut in system root tree

### DIFF
--- a/kiwi/boot/image/__init__.py
+++ b/kiwi/boot/image/__init__.py
@@ -33,7 +33,7 @@ class BootImage(object):
         if not initrd_system:
             initrd_system = 'kiwi'
         if initrd_system == 'kiwi':
-            return BootImageKiwi(xml_state, target_dir, root_dir)
+            return BootImageKiwi(xml_state, target_dir)
         elif initrd_system == 'dracut':
             return BootImageDracut(xml_state, target_dir, root_dir)
         else:

--- a/kiwi/boot/image/dracut.py
+++ b/kiwi/boot/image/dracut.py
@@ -18,11 +18,7 @@
 import os
 
 # project
-from ...defaults import Defaults
-from ...system.prepare import SystemPrepare
-from ...system.profile import Profile
 from ...utils.compress import Compress
-from ...system.setup import SystemSetup
 from ...logger import log
 from ...command import Command
 from ...system.kernel import Kernel
@@ -31,47 +27,15 @@ from .base import BootImageBase
 
 class BootImageDracut(BootImageBase):
     """
-    Implements preparation and creation of kiwi boot(initrd) images
-    The kiwi initrd is a customized first boot initrd which allows
-    to control the first boot an appliance. The kiwi initrd replaces
-    itself after first boot by the result of dracut.
+    Implements creation of dracut boot(initrd) images.
     """
     def prepare(self):
         """
-        Prepare new root system suitable to run dracut as chrooted
-        operation to create the initrd
+        For dracut no further preparation steps are required.
+        dracut is called as chroot operation in the system tree.
+        No extra caller environment will be created in this case
         """
-        self.load_boot_xml_description()
-        boot_image_name = self.boot_xml_state.xml_data.get_name()
-
-        self.import_system_description_elements()
-
-        log.info('Preparing boot image')
-        system = SystemPrepare(
-            xml_state=self.boot_xml_state,
-            root_dir=self.boot_root_directory,
-            allow_existing=True
-        )
-        manager = system.setup_repositories()
-        system.install_bootstrap(
-            manager
-        )
-        system.install_system(
-            manager
-        )
-
-        profile = Profile(self.boot_xml_state)
-        profile.add('kiwi_initrdname', boot_image_name)
-
-        defaults = Defaults()
-        defaults.to_profile(profile)
-
-        self.setup = SystemSetup(
-            self.boot_xml_state, self.boot_root_directory
-        )
-        self.setup.import_shell_environment(profile)
-        self.setup.import_description()
-        self.setup.call_image_script()
+        pass
 
     def create_initrd(self, mbrid=None):
         """

--- a/test/unit/boot_image_dracut_test.py
+++ b/test/unit/boot_image_dracut_test.py
@@ -15,61 +15,21 @@ from kiwi.exceptions import *
 
 
 class TestBootImageKiwi(object):
-    @patch('kiwi.boot.image.base.mkdtemp')
     @patch('kiwi.boot.image.base.os.path.exists')
     @patch('platform.machine')
-    def setup(self, mock_machine, mock_exists, mock_mkdtemp):
+    def setup(self, mock_machine, mock_exists):
         mock_machine.return_value = 'x86_64'
         mock_exists.return_value = True
         description = XMLDescription('../data/example_config.xml')
         self.xml_state = XMLState(
             description.load()
         )
-        self.setup = mock.Mock()
-        self.profile = mock.Mock()
-        self.manager = mock.Mock()
-        self.system_prepare = mock.Mock()
-        self.system_prepare.setup_repositories = mock.Mock(
-            return_value=self.manager
-        )
-        kiwi.boot.image.dracut.SystemPrepare = mock.Mock(
-            return_value=self.system_prepare
-        )
-        kiwi.boot.image.dracut.SystemSetup = mock.Mock(
-            return_value=self.setup
-        )
-        kiwi.boot.image.dracut.Profile = mock.Mock(
-            return_value=self.profile
-        )
-        mock_mkdtemp.return_value = 'boot-directory'
         self.boot_image = BootImageDracut(
-            self.xml_state, 'some-target-dir'
+            self.xml_state, 'some-target-dir', 'system-directory'
         )
 
-    @patch('kiwi.defaults.Defaults.get_boot_image_description_path')
-    def test_prepare(self, mock_boot_path):
-        mock_boot_path.return_value = '../data'
-        self.boot_image.prepare()
-        self.system_prepare.setup_repositories.assert_called_once_with()
-        self.system_prepare.install_bootstrap.assert_called_once_with(
-            self.manager
-        )
-        self.system_prepare.install_system.assert_called_once_with(
-            self.manager
-        )
-        assert self.profile.add.call_args_list[0] == call(
-            'kiwi_initrdname', 'initrd-oemboot-suse-13.2'
-        )
-        self.setup.import_shell_environment.assert_called_once_with(
-            self.profile
-        )
-        self.setup.import_description.assert_called_once_with()
-        self.setup.call_image_script.assert_called_once_with()
-
-    @raises(KiwiConfigFileNotFound)
-    @patch('os.path.exists')
-    def test_prepare_no_boot_description_found(self, mock_os_path):
-        mock_os_path.return_value = False
+    def test_prepare(self):
+        # just pass, there is nothing we need to do for dracut here
         self.boot_image.prepare()
 
     @patch('kiwi.boot.image.dracut.Compress')
@@ -87,14 +47,14 @@ class TestBootImageKiwi(object):
         self.boot_image.create_initrd()
         assert mock_command.call_args_list == [
             call([
-                'chroot', 'boot-directory',
+                'chroot', 'system-directory',
                 'dracut', '--force', '--no-hostonly',
                 '--no-hostonly-cmdline', '--no-compress',
                 'LimeJeOS-openSUSE-13.2.x86_64-1.13.2.initrd', '1.2.3'
             ]),
             call([
                 'mv',
-                'boot-directory/LimeJeOS-openSUSE-13.2.x86_64-1.13.2.initrd',
+                'system-directory/LimeJeOS-openSUSE-13.2.x86_64-1.13.2.initrd',
                 'some-target-dir/LimeJeOS-openSUSE-13.2.x86_64-1.13.2.initrd'
             ])
         ]

--- a/test/unit/boot_image_test.py
+++ b/test/unit/boot_image_test.py
@@ -24,7 +24,7 @@ class TestBootImage(object):
         self.xml_state.build_type.get_initrd_system.return_value = None
         BootImage(self.xml_state, 'target_dir')
         mock_kiwi.assert_called_once_with(
-            self.xml_state, 'target_dir', None
+            self.xml_state, 'target_dir'
         )
 
     @patch('kiwi.boot.image.BootImageKiwi')
@@ -32,7 +32,7 @@ class TestBootImage(object):
         self.xml_state.build_type.get_initrd_system.return_value = 'kiwi'
         BootImage(self.xml_state, 'target_dir')
         mock_kiwi.assert_called_once_with(
-            self.xml_state, 'target_dir', None
+            self.xml_state, 'target_dir'
         )
 
     @patch('kiwi.boot.image.BootImageDracut')

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -332,15 +332,8 @@ class TestDiskBuilder(object):
         ]
         assert mock_command.call_args_list == [
             call(['cp', 'root_dir/recovery.partition.size', 'boot_dir']),
-            call(['mv', 'initrd', 'root_dir/boot/initrd-1.2.3']),
             call(['cp', 'root_dir/recovery.partition.size', 'boot_dir_kiwi'])
         ]
-        self.kernel.copy_kernel.assert_called_once_with(
-            'root_dir', '/boot/vmlinuz-1.2.3'
-        )
-        self.kernel.copy_xen_hypervisor.assert_called_once_with(
-            'root_dir', '/boot/xen.gz'
-        )
         self.setup.export_rpm_package_list.assert_called_once_with(
             'target_dir'
         )


### PR DESCRIPTION
Change BootImageDracut class to call dracut in the specified system root directory and not in a self prepared new root environment. dracut reads scripts and dracut module configurations from the
installed system components, e.g kdump. Therefore calling it from an isolated runtime environment creates an initrd which is not matching the system components. Fixes bnc#1005246