### PR TITLE
Fixed a rounding error in partedMBToCylinder method

### DIFF
--- a/kiwi/boot/functions.sh
+++ b/kiwi/boot/functions.sh
@@ -7620,7 +7620,9 @@ function partedMBToCylinder {
     # ----
     local IFS=$IFS_ORIG
     local sizeBytes=$(($1 * 1048576))
-    local cylreq=$(echo "scale=0; $sizeBytes / ($partedCylKSize * 1000)" | bc)
+    # bc truncates to zero decimal places, which results in a partition that
+    # is slightly smaller than the requested size. Add one cylinder to compensate.
+    local cylreq=$(echo "scale=0; $sizeBytes / ($partedCylKSize * 1000) + 1" | bc)
     echo $cylreq
 }
 #======================================


### PR DESCRIPTION
bc truncates number of cylinders to zero decimal places, which results
in a partition that is slightly smaller than the requested size. Add one
cylinder to compensate.

This is a port form the patch proposed in former kiwi versions here: openSUSE/kiwi#605