### PR TITLE
Initialize the systemd machine ID on first boot

### DIFF
--- a/kiwi/boot/arch/arm/oemboot/preinit
+++ b/kiwi/boot/arch/arm/oemboot/preinit
@@ -139,12 +139,17 @@ fi
 setupConsole
 
 #======================================
-# 10) Run user script
+# 10) setup machine id
+#--------------------------------------
+setupMachineID
+
+#======================================
+# 11) Run user script
 #--------------------------------------
 runHook preCallInit
 
 #======================================
-# 11) kill udev
+# 12) kill udev
 #--------------------------------------
 udevSystemStop
 umountSystemFilesystems

--- a/kiwi/boot/arch/arm/vmxboot/preinit
+++ b/kiwi/boot/arch/arm/vmxboot/preinit
@@ -76,12 +76,17 @@ fi
 setupConsole
 
 #======================================
-# 9) Run user script
+# 9) setup machine id
+#--------------------------------------
+setupMachineID
+
+#======================================
+# 10) Run user script
 #--------------------------------------
 runHook preCallInit
 
 #======================================
-# 10) kill udev
+# 11) kill udev
 #--------------------------------------
 udevSystemStop
 umountSystemFilesystems

--- a/kiwi/boot/arch/ppc/netboot/preinit
+++ b/kiwi/boot/arch/ppc/netboot/preinit
@@ -117,6 +117,7 @@ fi
 #--------------------------------------
 if [ "$systemIntegrity" = "clean" ];then
     setupConsole
+    setupMachineID
 fi
 
 #======================================

--- a/kiwi/boot/arch/ppc/oemboot/preinit
+++ b/kiwi/boot/arch/ppc/oemboot/preinit
@@ -139,12 +139,17 @@ fi
 setupConsole
 
 #======================================
-# 10) Run user script
+# 10) setup machine id
+#--------------------------------------
+setupMachineID
+
+#======================================
+# 11) Run user script
 #--------------------------------------
 runHook preCallInit
 
 #======================================
-# 11) kill udev
+# 12) kill udev
 #--------------------------------------
 udevSystemStop
 umountSystemFilesystems

--- a/kiwi/boot/arch/ppc/vmxboot/preinit
+++ b/kiwi/boot/arch/ppc/vmxboot/preinit
@@ -76,12 +76,17 @@ fi
 setupConsole
 
 #======================================
-# 9) Run user script
+# 9) setup machine id
+#--------------------------------------
+setupMachineID
+
+#======================================
+# 10) Run user script
 #--------------------------------------
 runHook preCallInit
 
 #======================================
-# 10) kill udev
+# 11) kill udev
 #--------------------------------------
 udevSystemStop
 umountSystemFilesystems

--- a/kiwi/boot/arch/s390/netboot/preinit
+++ b/kiwi/boot/arch/s390/netboot/preinit
@@ -123,6 +123,7 @@ fi
 #--------------------------------------
 if [ "$systemIntegrity" = "clean" ];then
     setupConsole
+    setupMachineID
 fi
 
 #======================================

--- a/kiwi/boot/arch/s390/oemboot/preinit
+++ b/kiwi/boot/arch/s390/oemboot/preinit
@@ -152,11 +152,16 @@ fi
 setupConsole
 
 #======================================
-# 11) load network module
+# 11) setup machine id
+#--------------------------------------
+setupMachineID
+
+#======================================
+# 12) load network module
 #--------------------------------------
 if loadNetworkCardS390 "0.0.0191";then
     #======================================
-    # 11.2) Setup network interface and DNS
+    # 12.2) Setup network interface and DNS
     #--------------------------------------
     setupNetworkInterfaceS390
     udevPending
@@ -165,12 +170,12 @@ if loadNetworkCardS390 "0.0.0191";then
 fi
 
 #======================================
-# 12) Run user script
+# 13) Run user script
 #--------------------------------------
 runHook preCallInit
 
 #======================================
-# 13) kill udev
+# 14) kill udev
 #--------------------------------------
 udevSystemStop
 umountSystemFilesystems

--- a/kiwi/boot/arch/s390/vmxboot/preinit
+++ b/kiwi/boot/arch/s390/vmxboot/preinit
@@ -89,11 +89,16 @@ fi
 setupConsole
 
 #======================================
-# 10) load network module
+# 10) setup machine id
+#--------------------------------------
+setupMachineID
+
+#======================================
+# 11) load network module
 #--------------------------------------
 if loadNetworkCardS390 "0.0.0191";then
     #======================================
-    # 10.2) Setup network interface and DNS
+    # 11.2) Setup network interface and DNS
     #--------------------------------------
     setupNetworkInterfaceS390
     udevPending
@@ -102,12 +107,12 @@ if loadNetworkCardS390 "0.0.0191";then
 fi
 
 #======================================
-# 11) Run user script
+# 12) Run user script
 #--------------------------------------
 runHook preCallInit
 
 #======================================
-# 12) kill udev
+# 13) kill udev
 #--------------------------------------
 udevSystemStop
 umountSystemFilesystems

--- a/kiwi/boot/arch/x86_64/isoboot/preinit
+++ b/kiwi/boot/arch/x86_64/isoboot/preinit
@@ -36,11 +36,16 @@ updateMTAB
 setupConsole
 
 #======================================
-# 4) create framebuffer devices
+# 4) setup machine id
+#--------------------------------------
+setupMachineID
+
+#======================================
+# 5) create framebuffer devices
 #--------------------------------------
 createFramebufferDevices
 
 #======================================
-# 5) clean mount
+# 6) clean mount
 #--------------------------------------
 umountSystemFilesystems

--- a/kiwi/boot/arch/x86_64/netboot/preinit
+++ b/kiwi/boot/arch/x86_64/netboot/preinit
@@ -117,6 +117,7 @@ fi
 #--------------------------------------
 if [ "$systemIntegrity" = "clean" ];then
     setupConsole
+    setupMachineID
 fi
 
 #======================================

--- a/kiwi/boot/arch/x86_64/oemboot/preinit
+++ b/kiwi/boot/arch/x86_64/oemboot/preinit
@@ -139,12 +139,17 @@ fi
 setupConsole
 
 #======================================
-# 10) Run user script
+# 10) setup machine id
+#--------------------------------------
+setupMachineID
+
+#======================================
+# 11) Run user script
 #--------------------------------------
 runHook preCallInit
 
 #======================================
-# 11) kill udev
+# 12) kill udev
 #--------------------------------------
 udevSystemStop
 umountSystemFilesystems

--- a/kiwi/boot/arch/x86_64/vmxboot/preinit
+++ b/kiwi/boot/arch/x86_64/vmxboot/preinit
@@ -76,12 +76,17 @@ fi
 setupConsole
 
 #======================================
-# 9) Run user script
+# 9) setup machine id
+#--------------------------------------
+setupMachineID
+
+#======================================
+# 10) Run user script
 #--------------------------------------
 runHook preCallInit
 
 #======================================
-# 10) kill udev
+# 11) kill udev
 #--------------------------------------
 udevSystemStop
 umountSystemFilesystems

--- a/kiwi/boot/functions.sh
+++ b/kiwi/boot/functions.sh
@@ -6163,6 +6163,18 @@ function setupConfigFiles {
     rm -rf /config
 }
 #======================================
+# setupMachineID
+#--------------------------------------
+function setupMachineID {
+    # /.../
+    # systemd-machine-id-setup. Initialize the machine ID
+    # in /etc/machine-id. The machine ID is defined to be a
+    # unique information. Thus it is required to initialize
+    # it on first boot of the image
+    # ----
+    systemd-machine-id-setup
+}
+#======================================
 # activateImage
 #--------------------------------------
 function activateImage {


### PR DESCRIPTION
The systemd machine id is considered to be a unique information
Thus it is required to initialize it on first boot of the image.
If the image uses the kiwi boot code (initrd) this action is
performed and and Fixes #169