### PR TITLE
Cache location configurable

### DIFF
--- a/doc/source/manual/kiwi.rst
+++ b/doc/source/manual/kiwi.rst
@@ -46,29 +46,45 @@ architectures are supported.
 GLOBAL OPTIONS
 --------------
 
---profile=<name>
+--color-output
 
-  Select profile to use. The specified profile must be part of the
-  XML description. The option can be specified multiple times to
-  allow using a combination of profiles
+  Use Escape Sequences to print different types of information
+  in colored output. The underlaying terminal has to understand
+  those escape characters. Error messages appear red, warning
+  messages yellow and debugging information will be printed light
+  grey.
 
---type=<build_type>
+--compat
 
-  Select image build type. The specified build type must be configured
-  as part of the XML description.
+  Support legacy kiwi commandline, see COMPATIBILITY section for details.
+
+--debug
+
+  Print debug information on the commandline.
 
 --logfile=<filename>
 
   Specify log file. the logfile contains detailed information about
   the process.
 
---compat
+--profile=<name>
 
-  Support legacy kiwi commandline, see COMPATIBILITY section for details
+  Select profile to use. The specified profile must be part of the
+  XML description. The option can be specified multiple times to
+  allow using a combination of profiles
 
---debug
+--shared-cache-dir=<directory>
 
-  Print debug information on the commandline
+  Specify an alternative shared cache directory. The directory
+  is shared via bind mount between the build host and image
+  root system and contains information about package repositories
+  and their cache and meta data. The default location is set
+  to /var/cache/kiwi
+
+--type=<build_type>
+
+  Select image build type. The specified build type must be configured
+  as part of the XML description.
 
 --version
 

--- a/kiwi/cli.py
+++ b/kiwi/cli.py
@@ -27,6 +27,7 @@ usage: kiwi -h | --help
             [--color-output]
            result <command> [<args>...]
        kiwi [--profile=<name>...]
+            [--shared-cache-dir=<directory>]
             [--type=<build_type>]
             [--logfile=<filename>]
             [--debug]
@@ -57,6 +58,12 @@ global options for services: image, system
     --profile=<name>
         profile name, multiple profiles can be selected by passing
         this option multiple times
+    --shared-cache-dir=<directory>
+        specify an alternative shared cache directory. The directory
+        is shared via bind mount between the build host and image
+        root system and contains information about package repositories
+        and their cache and meta data. The default location is set
+        to /var/cache/kiwi
     --type=<build_type>
         image build type. If not set the default XML specified
         build type will be used

--- a/kiwi/cli.py
+++ b/kiwi/cli.py
@@ -62,8 +62,7 @@ global options for services: image, system
         specify an alternative shared cache directory. The directory
         is shared via bind mount between the build host and image
         root system and contains information about package repositories
-        and their cache and meta data. The default location is set
-        to /var/cache/kiwi
+        and their cache and meta data. [default: /var/cache/kiwi]
     --type=<build_type>
         image build type. If not set the default XML specified
         build type will be used

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -65,13 +65,15 @@ class Defaults(object):
         """
         The shared location is a directory which shares data from
         the image buildsystem host with the image root system.
+        The location is returned as an absolute path stripped off
+        by the leading '/'. This is because the path is transparently
+        used on the host /<cache-dir> and inside of the image
+        imageroot/<cache-dir>
         """
         from .cli import Cli
-        global_args = Cli().get_global_args()
-        if global_args['--shared-cache-dir']:
-            return global_args['--shared-cache-dir']
-        else:
-            return 'var/cache/kiwi'
+        return os.path.abspath(os.path.normpath(
+            Cli().get_global_args().get('--shared-cache-dir')
+        )).lstrip(os.sep)
 
     @classmethod
     def get_failsafe_kernel_options(self):

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -66,7 +66,12 @@ class Defaults(object):
         The shared location is a directory which shares data from
         the image buildsystem host with the image root system.
         """
-        return 'var/cache/kiwi'
+        from .cli import Cli
+        global_args = Cli().get_global_args()
+        if global_args['--shared-cache-dir']:
+            return global_args['--shared-cache-dir']
+        else:
+            return 'var/cache/kiwi'
 
     @classmethod
     def get_failsafe_kernel_options(self):

--- a/kiwi/system/root_init.py
+++ b/kiwi/system/root_init.py
@@ -134,7 +134,8 @@ class RootInit(object):
             'proc',
             'etc/sysconfig',
             'run',
-            'sys'
+            'sys',
+            'var'
         )
         root_uid = getpwnam('root').pw_uid
         root_gid = getpwnam('root').pw_gid

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -314,7 +314,7 @@ class TestDiskBuilder(object):
                 'image', '.profile', '.kconfig', 'var/cache/kiwi',
                 'boot/*', 'boot/.*', 'boot/efi/*', 'boot/efi/.*'
             ])
-        assert mock_open.call_args_list == [
+        assert mock_open.call_args_list[0:3] == [
             call('boot_dir/config.partids', 'w'),
             call('root_dir/boot/mbrid', 'w'),
             call('/dev/some-loop', 'wb')

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -24,6 +24,7 @@ class TestCli(object):
             '--debug': False,
             'result': False,
             '--profile': [],
+            '--shared-cache-dir': None,
             '--help': False
         }
         self.command_args = {
@@ -42,14 +43,11 @@ class TestCli(object):
             'prepare': True,
             'system': True
         }
-        sys.argv = [
-            sys.argv[0],
-            'system', 'prepare',
-            '--description', 'description',
-            '--root', 'directory'
-        ]
         self.cli = Cli()
         self.loaded_command = self.cli.load_command()
+
+    def teardown(self):
+        sys.argv = argv_kiwi_tests
 
     @raises(SystemExit)
     @patch('kiwi.cli.Help.show')
@@ -59,12 +57,6 @@ class TestCli(object):
         help_show.assert_called_once_with('kiwi')
 
     def test_get_servicename_system(self):
-        sys.argv = [
-            sys.argv[0],
-            'system', 'prepare',
-            '--description', 'description',
-            '--root', 'directory'
-        ]
         cli = Cli()
         assert cli.get_servicename() == 'system'
 

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -24,7 +24,7 @@ class TestCli(object):
             '--debug': False,
             'result': False,
             '--profile': [],
-            '--shared-cache-dir': None,
+            '--shared-cache-dir': '/var/cache/kiwi',
             '--help': False
         }
         self.command_args = {

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -1,9 +1,9 @@
-
+import sys
 from mock import patch
 
 import mock
 
-from .test_helper import *
+from .test_helper import argv_kiwi_tests
 
 from kiwi.defaults import Defaults
 
@@ -11,6 +11,9 @@ from kiwi.defaults import Defaults
 class TestDefaults(object):
     def setup(self):
         self.defaults = Defaults()
+
+    def teardown(self):
+        sys.argv = argv_kiwi_tests
 
     def test_get(self):
         assert self.defaults.get('kiwi_align') == 1048576
@@ -36,3 +39,15 @@ class TestDefaults(object):
 
     def test_get_publisher(self):
         assert Defaults.get_publisher() == 'SUSE LINUX GmbH'
+
+    def test_get_default_shared_cache_location(self):
+        assert Defaults.get_shared_cache_location() == 'var/cache/kiwi'
+
+    def test_get_custom_shared_cache_location(self):
+        sys.argv = [
+            sys.argv[0],
+            '--shared-cache-dir', 'cachedir',
+            'system', 'prepare',
+            '--description', 'description', '--root', 'directory'
+        ]
+        assert Defaults.get_shared_cache_location() == 'cachedir'

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -46,8 +46,8 @@ class TestDefaults(object):
     def test_get_custom_shared_cache_location(self):
         sys.argv = [
             sys.argv[0],
-            '--shared-cache-dir', 'cachedir',
+            '--shared-cache-dir', '/my/cachedir',
             'system', 'prepare',
             '--description', 'description', '--root', 'directory'
         ]
-        assert Defaults.get_shared_cache_location() == 'cachedir'
+        assert Defaults.get_shared_cache_location() == 'my/cachedir'

--- a/test/unit/system_root_init_test.py
+++ b/test/unit/system_root_init_test.py
@@ -66,7 +66,8 @@ class TestRootInit(object):
             call('tmpdir/proc'),
             call('tmpdir/etc/sysconfig'),
             call('tmpdir/run'),
-            call('tmpdir/sys')
+            call('tmpdir/sys'),
+            call('tmpdir/var')
         ]
         assert mock_chwon.call_args_list == [
             call('tmpdir/var/cache/kiwi', 0, 0),
@@ -74,7 +75,8 @@ class TestRootInit(object):
             call('tmpdir/proc', 0, 0),
             call('tmpdir/etc/sysconfig', 0, 0),
             call('tmpdir/run', 0, 0),
-            call('tmpdir/sys', 0, 0)
+            call('tmpdir/sys', 0, 0),
+            call('tmpdir/var', 0, 0)
         ]
         assert mock_mknod.call_args_list == [
             call('tmpdir/dev/null', 8630, 'makedev'),

--- a/test/unit/tasks_base_test.py
+++ b/test/unit/tasks_base_test.py
@@ -1,43 +1,49 @@
-import sys
 import mock
 
 from mock import patch
 
 import logging
-from .test_helper import *
-import inspect
+from .test_helper import raises, argv_kiwi_tests
 
 from kiwi.tasks.base import CliTask
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiConfigFileNotFound
 
 import kiwi.xml_parse
 
 
 class TestCliTask(object):
-    @patch('os.path.isfile')
-    @patch('configparser.ConfigParser.has_section')
     @patch('kiwi.logger.log.setLogLevel')
     @patch('kiwi.logger.log.set_logfile')
     @patch('kiwi.logger.log.set_color_format')
     @patch('kiwi.cli.Cli.show_and_exit_on_help_request')
+    @patch('kiwi.cli.Cli.load_command')
+    @patch('kiwi.cli.Cli.get_command_args')
+    @patch('kiwi.cli.Cli.get_global_args')
     def setup(
-        self, mock_help, mock_color, mock_setlog, mock_setlevel,
-        mock_section, mock_isfile
+        self, mock_global_args, mock_command_args,
+        mock_load_command, mock_help_check, mock_color,
+        mock_setlog, mock_setlevel
     ):
-        sys.argv = [
-            sys.argv[0],
-            '--debug',
-            '--logfile', 'log',
-            '--color-output',
-            '--profile', 'vmxFlavour',
-            'system',
-            'prepare',
-            '--description', 'description',
-            '--root', 'directory'
-        ]
+        mock_global_args.return_value = {
+            '--debug': True,
+            '--logfile': 'log',
+            '--color-output': True,
+            '--profile': ['vmxFlavour'],
+            '--type': None
+        }
+        mock_command_args.return_value = {
+            'system': True,
+            'prepare': True,
+            '--description': 'description',
+            '--root': 'directory'
+        }
+
         self.task = CliTask()
 
-        mock_help.assert_called_once_with()
+        mock_help_check.assert_called_once_with()
+        mock_load_command.assert_called_once_with()
+        mock_command_args.assert_called_once_with()
+        mock_global_args.assert_called_once_with()
         mock_setlevel.assert_called_once_with(logging.DEBUG)
         mock_setlog.assert_called_once_with('log')
         mock_color.assert_called_once_with()

--- a/test/unit/tasks_image_resize_test.py
+++ b/test/unit/tasks_image_resize_test.py
@@ -4,7 +4,7 @@ from mock import call
 
 import kiwi
 
-from .test_helper import raises, patch
+from .test_helper import raises, patch, argv_kiwi_tests
 
 from kiwi.exceptions import KiwiImageResizeError, KiwiConfigFileNotFound
 
@@ -30,6 +30,9 @@ class TestImageResizeTask(object):
         )
 
         self.task = ImageResizeTask()
+
+    def teardown(self):
+        sys.argv = argv_kiwi_tests
 
     def _init_command_args(self):
         self.task.command_args = {}

--- a/test/unit/tasks_result_bundle_test.py
+++ b/test/unit/tasks_result_bundle_test.py
@@ -5,7 +5,7 @@ from mock import patch
 from mock import call
 import kiwi
 
-from .test_helper import *
+from .test_helper import patch, raises, argv_kiwi_tests, patch_open
 from kiwi.exceptions import *
 from kiwi.tasks.result_bundle import ResultBundleTask
 from kiwi.system.result import Result
@@ -42,6 +42,9 @@ class TestResultBundleTask(object):
             return_value=mock.Mock()
         )
         self.task = ResultBundleTask()
+
+    def teardown(self):
+        sys.argv = argv_kiwi_tests
 
     def _init_command_args(self):
         self.task.command_args = {}

--- a/test/unit/tasks_result_list_test.py
+++ b/test/unit/tasks_result_list_test.py
@@ -5,7 +5,7 @@ from mock import patch
 
 import kiwi
 
-from .test_helper import *
+from .test_helper import patch, argv_kiwi_tests
 from kiwi.exceptions import *
 from kiwi.tasks.result_list import ResultListTask
 
@@ -20,6 +20,9 @@ class TestResultListTask(object):
             return_value=mock.Mock()
         )
         self.task = ResultListTask()
+
+    def teardown(self):
+        sys.argv = argv_kiwi_tests
 
     def _init_command_args(self):
         self.task.command_args = {}

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -5,7 +5,7 @@ from mock import patch
 
 import kiwi
 
-from .test_helper import *
+from .test_helper import patch, argv_kiwi_tests
 
 from kiwi.tasks.system_build import SystemBuildTask
 from kiwi.exceptions import *
@@ -60,6 +60,9 @@ class TestSystemBuildTask(object):
         )
 
         self.task = SystemBuildTask()
+
+    def teardown(self):
+        sys.argv = argv_kiwi_tests
 
     def _init_command_args(self):
         self.task.command_args = {}

--- a/test/unit/tasks_system_create_test.py
+++ b/test/unit/tasks_system_create_test.py
@@ -5,7 +5,7 @@ from mock import patch
 
 import kiwi
 
-from .test_helper import *
+from .test_helper import patch, argv_kiwi_tests
 
 from kiwi.tasks.system_create import SystemCreateTask
 from kiwi.exceptions import *
@@ -44,6 +44,9 @@ class TestSystemCreateTask(object):
         )
 
         self.task = SystemCreateTask()
+
+    def teardown(self):
+        sys.argv = argv_kiwi_tests
 
     def _init_command_args(self):
         self.task.command_args = {}

--- a/test/unit/tasks_system_prepare_test.py
+++ b/test/unit/tasks_system_prepare_test.py
@@ -5,7 +5,7 @@ from mock import patch
 
 import kiwi
 
-from .test_helper import *
+from .test_helper import patch, argv_kiwi_tests
 
 from kiwi.tasks.system_prepare import SystemPrepareTask
 
@@ -48,6 +48,9 @@ class TestSystemPrepareTask(object):
             return_value=mock.Mock()
         )
         self.task = SystemPrepareTask()
+
+    def teardown(self):
+        sys.argv = argv_kiwi_tests
 
     def _init_command_args(self):
         self.task.command_args = {}

--- a/test/unit/tasks_system_update_test.py
+++ b/test/unit/tasks_system_update_test.py
@@ -5,7 +5,7 @@ from mock import patch
 
 import kiwi
 
-from .test_helper import *
+from .test_helper import patch, argv_kiwi_tests
 
 from kiwi.tasks.system_update import SystemUpdateTask
 
@@ -29,6 +29,9 @@ class TestSystemUpdateTask(object):
             return_value=mock.Mock()
         )
         self.task = SystemUpdateTask()
+
+    def teardown(self):
+        sys.argv = argv_kiwi_tests
 
     def _init_command_args(self):
         self.task.command_args = {}

--- a/test/unit/test_helper.py
+++ b/test/unit/test_helper.py
@@ -6,7 +6,20 @@ import logging
 from io import BytesIO
 from mock import MagicMock, patch
 
+# default log level, overwrite when needed
 kiwi.logger.log.setLevel(logging.WARN)
+
+# default commandline used for any test, overwrite when needed
+sys.argv = [
+    sys.argv[0], 'system', 'prepare',
+    '--description', 'description', '--root', 'directory'
+]
+argv_kiwi_tests = sys.argv
+
+# mock open calls
+patch_open = patch("{0}.open".format(
+    sys.version_info.major < 3 and "__builtin__" or "builtins")
+)
 
 
 class raises(object):
@@ -32,10 +45,6 @@ class raises(object):
                 raise AssertionError(message)
         newfunc = wraps(func)(newfunc)
         return newfunc
-
-
-patch_open = patch("{0}.open".format(sys.version_info.major < 3 and
-                                     "__builtin__" or "builtins"))
 
 def mock_open(data=None):
     '''


### PR DESCRIPTION
Added global option --shared-cache-dir
    
The option allows to specify an alternative shared host_to_image cache directory. The default location is /var/cache/kiwi. Fixes #92