### PR TITLE
SystemPrepare instance delete before runnig SystemSetup

### DIFF
--- a/kiwi/boot/image/kiwi.py
+++ b/kiwi/boot/image/kiwi.py
@@ -78,6 +78,8 @@ class BootImageKiwi(BootImageBase):
         system.pinch_system(
             manager=manager, force=True
         )
+        # make sure system instance is cleaned up before setting up
+        del system
 
         self.setup.call_image_script()
         self.setup.create_init_link_from_linuxrc()


### PR DESCRIPTION
This PR fixes #175. Now the SystemPrepare instance is cleaned before any other change over the build root is performed by a SystemSetup instance.