### PR TITLE
Do not allow imageinclude for images build in obs

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -61,6 +61,12 @@ class Defaults(object):
         ]
 
     @classmethod
+    def is_obs_worker(self):
+        # the presence of /.buildenv on the build host indicates
+        # we are building inside of the open buildservice
+        return os.path.exists('/.buildenv')
+
+    @classmethod
     def get_shared_cache_location(self):
         """
         The shared location is a directory which shares data from

--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -71,7 +71,7 @@ class RuntimeChecker(object):
                 repo_source = xml_repo.get_source().get_path()
                 repo_type = xml_repo.get_type()
                 uri = Uri(repo_source, repo_type)
-                if not uri.is_remote():
+                if not uri.is_remote() or Defaults.is_obs_worker():
                     raise KiwiRuntimeError(message % repo_source)
 
     def check_target_directory_not_in_shared_cache(self, target_dir):

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -55,8 +55,6 @@ options:
     --target-dir=<directory>
         the target directory to store the system image file(s)
 """
-import os
-
 # project
 from .base import CliTask
 from ..help import Help
@@ -128,7 +126,7 @@ class SystemBuildTask(CliTask):
 
         self.runtime_checker.check_repositories_configured()
 
-        if os.path.exists('/.buildenv'):
+        if Defaults.is_obs_worker():
             # This build runs inside of a buildservice worker. Therefore
             # the repo defintions is adapted accordingly
             self.xml_state.translate_obs_to_suse_repositories()

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -59,8 +59,6 @@ options:
         overwrite the repo source, type, alias or priority for the first
         repository in the XML description
 """
-import os
-
 # project
 from .base import CliTask
 from ..help import Help
@@ -119,7 +117,7 @@ class SystemPrepareTask(CliTask):
 
         self.runtime_checker.check_repositories_configured()
 
-        if os.path.exists('/.buildenv'):
+        if Defaults.is_obs_worker():
             # This build runs inside of a buildservice worker. Therefore
             # the repo defintions is adapted accordingly
             self.xml_state.translate_obs_to_suse_repositories()


### PR DESCRIPTION
When building in the buildservice the repos are moved into a local source path which only exists on that worker. Using the imageinclude attribute to setup that repo as a repo in the image doesn't make sense and should result in a runtime exception