### PR TITLE
Load the default unicode font in grub2

### DIFF
--- a/kiwi/bootloader/template/grub2.py
+++ b/kiwi/bootloader/template/grub2.py
@@ -73,6 +73,9 @@ class BootLoaderTemplateGrub2(object):
         ''').strip() + os.linesep
 
         self.header_theme = self.fonts + dedent('''
+            if [ -f $${font} ];then
+                loadfont $${font}
+            fi
             if [ -f ($$root)${bootpath}/$${ascii_font} ];then
                 loadfont ($$root)${bootpath}/$${ascii_font}
             fi
@@ -91,6 +94,9 @@ class BootLoaderTemplateGrub2(object):
         ''').strip() + os.linesep
 
         self.header_theme_iso = self.fonts + dedent('''
+            if [ -f $${font} ];then
+                loadfont $${font}
+            fi
             if [ -f ($$root)/boot/$${ascii_font} ];then
                 loadfont ($$root)/boot/$${ascii_font}
             fi


### PR DESCRIPTION
This commit fixes #179. The default font was never loaded,
the loadfont call for the default unicode font was missing.