### PR TITLE
updateOtherDeviceFstab did not get the fstab location parameter

### DIFF
--- a/kiwi/boot/functions.sh
+++ b/kiwi/boot/functions.sh
@@ -2233,7 +2233,6 @@ function updateOtherDeviceFstab {
     # ----
     local IFS=$IFS_ORIG
     local prefix=$1
-    local prefix=$2
     local nfstab=$prefix/etc/fstab
     local index=0
     local field=0


### PR DESCRIPTION
With this PR the fstab file gets updated as it should in netboot deployments that had defined one or more non root or swap partitions.

This is port from the kiwi v7 code base openSUSE/kiwi#610