### PR TITLE
Don't prefix bootpath with snapshot path

### DIFF
--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -300,9 +300,7 @@ class BootLoaderConfigBase(object):
                     # setup and no extra boot partition we have to care for
                     # the layout of the system which places all volumes below
                     # a topleve volume or snapshot
-                    if not boot_is_on_volume and root_is_snapshot:
-                        bootpath = '/@/.snapshots/1/snapshot' + bootpath
-                    else:
+                    if not boot_is_on_volume and not root_is_snapshot:
                         bootpath = '/@' + bootpath
 
         return bootpath


### PR DESCRIPTION
We call set-default to make the snapshot subvolume the
default root. In this case, grub2 and the kernel will
always use the correct snapshot. Prefixing it with the
snapshot path will only work, if /.snapshots is accessible
and as long as you don't do a rollback. In rollback case,
only the filesystem default is adjusted, but not grub.cfg.
So grub2 would try to load a kernel from an outdated
snapshot and in worst case, the snapshot is already
deleted and no kernel found anymore.