### PR TITLE
SAT solvable interface for package repository types

### DIFF
--- a/doc/source/api/kiwi.rst
+++ b/doc/source/api/kiwi.rst
@@ -19,6 +19,7 @@ Subpackages
     kiwi.repository
     kiwi.storage
     kiwi.system
+    kiwi.solver
     kiwi.tasks
     kiwi.utils
     kiwi.volume_manager

--- a/doc/source/api/kiwi.solver.repository.rst
+++ b/doc/source/api/kiwi.solver.repository.rst
@@ -1,0 +1,40 @@
+kiwi.solver.repository Package
+==============================
+
+Submodules
+----------
+
+`kiwi.solver.repository.base` Module
+------------------------------------
+
+.. automodule:: kiwi.solver.repository.base
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+.. automodule:: kiwi.solver.repository.rpm_md
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+.. automodule:: kiwi.solver.repository.rpm_dir
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+.. automodule:: kiwi.solver.repository.suse
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module Contents
+---------------
+
+.. automodule:: kiwi.solver.repository
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/api/kiwi.solver.rst
+++ b/doc/source/api/kiwi.solver.rst
@@ -1,0 +1,17 @@
+kiwi.solver Package
+===================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    kiwi.solver.repository
+
+Module Contents
+---------------
+
+.. automodule:: kiwi.solver
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -67,6 +67,15 @@ class Defaults(object):
         return os.path.exists('/.buildenv')
 
     @classmethod
+    def get_solvable_location(self):
+        """
+        The directory to store SAT solvables for repositories.
+        The solvable files are used to perform package
+        dependency and metadata resolution
+        """
+        return '/var/tmp/kiwi/satsolver'
+
+    @classmethod
     def get_shared_cache_location(self):
         """
         The shared location is a directory which shares data from

--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -558,6 +558,12 @@ class KiwiRpmDatabaseReloadError(KiwiError):
     """
 
 
+class KiwiRpmDirNotRemoteError(KiwiError):
+    """
+    Exception raised if the provided rpm-dir repository is not local
+    """
+
+
 class KiwiRuntimeError(KiwiError):
     """
     Exception raised if a runtime check has failed.

--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -640,6 +640,12 @@ class KiwiUnknownServiceName(KiwiError):
     """
 
 
+class KiwiUriOpenError(KiwiError):
+    """
+    Exception raised if the urllib urlopen request has failed
+    """
+
+
 class KiwiUriStyleUnknown(KiwiError):
     """
     Exception raised if an unsupported URI style was used in the

--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -585,6 +585,13 @@ class KiwiSetupIntermediateConfigError(KiwiError):
     """
 
 
+class KiwiSolverRepositorySetupError(KiwiError):
+    """
+    Exception raised if the repository type is not supported for
+    the creation of a SAT solvable
+    """
+
+
 class KiwiSystemDeletePackagesFailed(KiwiError):
     """
     Exception raised if the deletion of a package has failed in

--- a/kiwi/solver/repository/__init__.py
+++ b/kiwi/solver/repository/__init__.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2015 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+# project
+from .suse import SolverRepositorySUSE
+from .rpm_md import SolverRepositoryRpmMd
+from .rpm_dir import SolverRepositoryRpmDir
+
+from ...exceptions import KiwiSolverRepositorySetupError
+
+
+class SolverRepository(object):
+    """
+    Repository factory for creation of SAT solvables
+
+    Attributes
+
+    * :attr:`repository_type`
+        Repository type name
+
+    * :attr:`uri`
+        Instance of Uri
+    """
+    def __new__(self, repository_type, uri):
+        if repository_type == 'yast2':
+            return SolverRepositorySUSE(uri)
+        elif repository_type == 'rpm-md':
+            return SolverRepositoryRpmMd(uri)
+        elif repository_type == 'rpm-dir':
+            return SolverRepositoryRpmDir(uri)
+        else:
+            raise KiwiSolverRepositorySetupError(
+                'Support for %s solver repository type not implemented' %
+                repository_type
+            )

--- a/kiwi/solver/repository/__init__.py
+++ b/kiwi/solver/repository/__init__.py
@@ -29,21 +29,18 @@ class SolverRepository(object):
 
     Attributes
 
-    * :attr:`repository_type`
-        Repository type name
-
     * :attr:`uri`
         Instance of Uri
     """
-    def __new__(self, repository_type, uri):
-        if repository_type == 'yast2':
+    def __new__(self, uri):
+        if uri.repo_type == 'yast2':
             return SolverRepositorySUSE(uri)
-        elif repository_type == 'rpm-md':
+        elif uri.repo_type == 'rpm-md':
             return SolverRepositoryRpmMd(uri)
-        elif repository_type == 'rpm-dir':
+        elif uri.repo_type == 'rpm-dir':
             return SolverRepositoryRpmDir(uri)
         else:
             raise KiwiSolverRepositorySetupError(
                 'Support for %s solver repository type not implemented' %
-                repository_type
+                uri.repo_type
             )

--- a/kiwi/solver/repository/base.py
+++ b/kiwi/solver/repository/base.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2015 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+
+
+class SolverRepositoryBase(object):
+    pass

--- a/kiwi/solver/repository/rpm_dir.py
+++ b/kiwi/solver/repository/rpm_dir.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2015 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+# project
+from .base import SolverRepositoryBase
+
+
+class SolverRepositoryRpmDir(SolverRepositoryBase):
+    pass

--- a/kiwi/solver/repository/rpm_md.py
+++ b/kiwi/solver/repository/rpm_md.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2015 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+# project
+from .base import SolverRepositoryBase
+
+
+class SolverRepositoryRpmMd(SolverRepositoryBase):
+    pass

--- a/kiwi/solver/repository/rpm_md.py
+++ b/kiwi/solver/repository/rpm_md.py
@@ -15,9 +15,91 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+import os
+from collections import namedtuple
+
 # project
 from .base import SolverRepositoryBase
 
 
 class SolverRepositoryRpmMd(SolverRepositoryBase):
-    pass
+    def _setup_repository_metadata(self):
+        """
+        Download repo metadata for rpm-md specific repositories
+        and create SAT solvables from all solver relevant files
+        """
+        # Download rpm-md metadata for the rpmmd2solv solvable
+        # creation. This includes the files marked as primary
+        # and pattern in the repo definition
+        rpm_md_dir = self._create_temporary_metadata_dir()
+        rpm_md_data = self._find_repomd_files(
+            ['primary', 'patterns'], 'rpmmd2solv'
+        )
+        for rpm_md_file in rpm_md_data.metadata_files:
+            self.download_from_repository(
+                rpm_md_file,
+                os.sep.join([rpm_md_dir, os.path.basename(rpm_md_file)])
+            )
+        self._create_solvables(
+            rpm_md_dir, rpm_md_data.solv_tool
+        )
+
+        # Download rpm-md metadata for the comps2solv solvable
+        # creation. This includes the files marked as group_gz
+        # This component information is like the SUSE pattern
+        # information but for RHEL. In order to allow resolving
+        # yum group id names this information needs to be present
+        rpm_comps_dir = self._create_temporary_metadata_dir()
+        rpm_comps_data = self._find_repomd_files(
+            ['group_gz'], 'comps2solv'
+        )
+        for rpm_comps_file in rpm_comps_data.metadata_files:
+            self.download_from_repository(
+                rpm_comps_file,
+                os.sep.join([rpm_comps_dir, os.path.basename(rpm_comps_file)])
+            )
+        self._create_solvables(
+            rpm_comps_dir, rpm_comps_data.solv_tool
+        )
+
+    def timestamp(self):
+        """
+        Get timestamp from the first primary metadata
+
+        :rtype: time value as text
+        """
+        return self._get_repomd_xpath(
+            self._get_repomd_xml(),
+            'repo:data[@type="primary"]/repo:timestamp'
+        )[0].text
+
+    def _find_repomd_files(self, type_list, tool):
+        """
+        Lookup repodata/repomd.xml and the metadata files for the
+        specified type list. Assign the found entries to the given
+        tool
+
+        * :attr:`type_list`
+            Value of type attribute in the repomd.xml definition
+
+        * :attr:`tool`
+            Tool to create a solvable from this data
+
+        :return: string:solv_tool, list:metadata_files
+        :rtype: tuple
+        """
+        result_type = namedtuple(
+            'result_type', ['solv_tool', 'metadata_files']
+        )
+        metadata_files = []
+        for metadata_type in type_list:
+            metadata_locations = self._get_repomd_xpath(
+                self._get_repomd_xml(),
+                'repo:data[@type="{0}"]/repo:location'.format(metadata_type)
+            )
+            for location in metadata_locations:
+                metadata_files.append(location.get('href'))
+
+        return result_type(
+            solv_tool=tool, metadata_files=metadata_files
+        )

--- a/kiwi/solver/repository/suse.py
+++ b/kiwi/solver/repository/suse.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2015 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+# project
+from .base import SolverRepositoryBase
+
+
+class SolverRepositorySUSE(SolverRepositoryBase):
+    pass

--- a/kiwi/system/uri.py
+++ b/kiwi/system/uri.py
@@ -43,6 +43,9 @@ class Uri(object):
     * :attr:`uri`
         URI, repository location, file
 
+    * :attr:`repo_type`
+        repository type name, rpm-dir, rpm-md, yast2
+
     * :attr:`mount_stack`
         list of mounted locations
 
@@ -55,6 +58,7 @@ class Uri(object):
     def __init__(self, uri, repo_type):
         self.repo_type = repo_type
         self.uri = uri
+        self.repo_type = repo_type
         self.mount_stack = []
 
         self.remote_uri_types = {

--- a/test/data/repomd.xml
+++ b/test/data/repomd.xml
@@ -28,4 +28,12 @@ xmlns:rpm="http://linux.duke.edu/metadata/rpm">
     <open-size>71277866</open-size>
     <open-checksum type="sha256">b64f1faece62f5d6d07f52b15b4c419c6644957142f526a76eff6b8289764f88</open-checksum>
   </data>
+  <data type="group_gz">
+    <location href="repodata/0815-other.xml.gz"/>
+    <checksum type="sha256">d62ed932df26f29968f17d3ed780a617ce116e651d4b0042495bbec4182671ac</checksum>
+    <timestamp>1478352191</timestamp>
+    <size>88624493</size>
+    <open-size>434990650</open-size>
+    <open-checksum type="sha256">80a8f395483b70b68b5a9fd95b8752c46fb557eae77b0ade087aabdd39d988c0</open-checksum>
+  </data>
 </repomd>

--- a/test/data/repomd.xml
+++ b/test/data/repomd.xml
@@ -1,0 +1,31 @@
+<repomd xmlns="http://linux.duke.edu/metadata/repo"
+xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+  <revision>1478351022</revision>
+  <tags>
+    <repo>obsproduct://build.opensuse.org/openSUSE:Leap:42.2/openSUSE/42.2/ftp/x86_64</repo>
+  </tags>
+  <data type="filelists">
+    <location href="repodata/15b3d98843efb0bd51d59917018bf8228a728f56274305d35b3b763047e34858-filelists.xml.gz"/>
+    <checksum type="sha256">15b3d98843efb0bd51d59917018bf8228a728f56274305d35b3b763047e34858</checksum>
+    <timestamp>1478352191</timestamp>
+    <size>19330267</size>
+    <open-size>269260530</open-size>
+    <open-checksum type="sha256">3fa65cebc5f58c1f92eb369180dac3a396e0f76a76957e5a1208aa4f09c6ee43</open-checksum>
+  </data>
+  <data type="other">
+    <location href="repodata/d62ed932df26f29968f17d3ed780a617ce116e651d4b0042495bbec4182671ac-other.xml.gz"/>
+    <checksum type="sha256">d62ed932df26f29968f17d3ed780a617ce116e651d4b0042495bbec4182671ac</checksum>
+    <timestamp>1478352191</timestamp>
+    <size>88624493</size>
+    <open-size>434990650</open-size>
+    <open-checksum type="sha256">80a8f395483b70b68b5a9fd95b8752c46fb557eae77b0ade087aabdd39d988c0</open-checksum>
+  </data>
+  <data type="primary">
+    <location href="repodata/55f95a93-primary.xml.gz"/>
+    <checksum type="sha256">55f95a93</checksum>
+    <timestamp>1478352191</timestamp>
+    <size>9476542</size>
+    <open-size>71277866</open-size>
+    <open-checksum type="sha256">b64f1faece62f5d6d07f52b15b4c419c6644957142f526a76eff6b8289764f88</open-checksum>
+  </data>
+</repomd>

--- a/test/unit/solver_repository_base_test.py
+++ b/test/unit/solver_repository_base_test.py
@@ -1,0 +1,220 @@
+from mock import patch, call
+import os
+import mock
+
+from lxml import etree
+
+from .test_helper import raises, patch_open
+
+from kiwi.solver.repository.base import SolverRepositoryBase
+from kiwi.exceptions import KiwiUriOpenError
+
+
+class TestSolverRepositoryBase(object):
+    def setup(self):
+        self.context_manager_mock = mock.Mock()
+        self.file_mock = mock.Mock()
+        self.enter_mock = mock.Mock()
+        self.exit_mock = mock.Mock()
+        self.enter_mock.return_value = self.file_mock
+        setattr(self.context_manager_mock, '__enter__', self.enter_mock)
+        setattr(self.context_manager_mock, '__exit__', self.exit_mock)
+
+        self.uri = mock.Mock()
+
+        self.solver = SolverRepositoryBase(self.uri)
+
+    @raises(NotImplementedError)
+    def test__setup_repository_metadata(self):
+        self.solver._setup_repository_metadata()
+
+    def test__get_repomd_xpath(self):
+        xml_data = etree.parse('../data/repomd.xml')
+        assert self.solver._get_repomd_xpath(
+            xml_data, 'repo:data[@type="primary"]/repo:location'
+        )[0].get('href') == 'repodata/55f95a93-primary.xml.gz'
+
+    @patch('kiwi.solver.repository.base.NamedTemporaryFile')
+    @patch.object(SolverRepositoryBase, 'download_from_repository')
+    @patch('lxml.etree.parse')
+    def test__get_repomd_xml(self, mock_parse, mock_download, mock_tmpfile):
+        tmpfile = mock.Mock()
+        tmpfile.name = 'tmpfile'
+        xml_data = mock.Mock()
+        mock_parse.return_value = xml_data
+        mock_tmpfile.return_value = tmpfile
+        assert self.solver._get_repomd_xml() == xml_data
+        mock_download.assert_called_once_with(
+            'repodata/repomd.xml', 'tmpfile'
+        )
+        mock_parse.assert_called_once_with('tmpfile')
+
+    @patch('kiwi.solver.repository.base.mkdtemp')
+    def test__create_temporary_metadata_dir(self, mock_mkdtemp):
+        mock_mkdtemp.return_value = 'tmpdir'
+        self.solver._create_temporary_metadata_dir()
+        assert self.solver.repository_metadata_dirs == ['tmpdir']
+        mock_mkdtemp.assert_called_once_with(prefix='metadata_dir.')
+
+    @patch_open
+    @patch('os.path.exists')
+    def test_is_uptodate_static_time(self, mock_exists, mock_open):
+        mock_exists.return_value = True
+        mock_open.return_value = self.context_manager_mock
+        self.file_mock.read.return_value = 'static'
+        self.uri.alias.return_value = 'repo-alias'
+        assert self.solver.is_uptodate() is False
+        mock_open.assert_called_once_with(
+            '/var/tmp/kiwi/satsolver/repo-alias.timestamp'
+        )
+
+    @patch_open
+    @patch('os.path.exists')
+    @patch('kiwi.solver.repository.base.SolverRepositoryBase.timestamp')
+    def test_is_uptodate_some_time(
+        self, mock_timestamp, mock_exists, mock_open
+    ):
+        mock_exists.return_value = True
+        mock_open.return_value = self.context_manager_mock
+        self.file_mock.read.return_value = 'some-time'
+        mock_timestamp.return_value = 'some-time'
+        self.uri.alias.return_value = 'repo-alias'
+        assert self.solver.is_uptodate() is True
+        mock_open.assert_called_once_with(
+            '/var/tmp/kiwi/satsolver/repo-alias.timestamp'
+        )
+
+    def test_timestamp(self):
+        assert self.solver.timestamp() == 'static'
+
+    @patch('kiwi.solver.repository.base.urlopen')
+    @patch_open
+    def test_download_from_repository_remote(self, mock_open, mock_urlopen):
+        location = mock.Mock()
+        location.read.return_value = 'data-from-network'
+        mock_urlopen.return_value = location
+        mock_open.return_value = self.context_manager_mock
+        self.uri.is_remote.return_value = True
+        self.uri.translate.return_value = 'http://myrepo/file'
+        self.solver.download_from_repository('repodata/file', 'target-file')
+        mock_urlopen.assert_called_once_with(
+            'http://myrepo/file/repodata/file'
+        )
+        mock_open.assert_called_once_with(
+            'target-file', 'wb'
+        )
+        self.file_mock.write.assert_called_once_with(
+            'data-from-network'
+        )
+
+    @patch('kiwi.solver.repository.base.urlopen')
+    @patch_open
+    def test_download_from_repository_local(self, mock_open, mock_urlopen):
+        location = mock.Mock()
+        location.read.return_value = 'data'
+        mock_urlopen.return_value = location
+        mock_open.return_value = self.context_manager_mock
+        self.uri.is_remote.return_value = False
+        self.uri.translate.return_value = '/my_local_repo/file'
+        self.solver.download_from_repository('repodata/file', 'target-file')
+        mock_urlopen.assert_called_once_with(
+            'file:///my_local_repo/file/repodata/file'
+        )
+        mock_open.assert_called_once_with(
+            'target-file', 'wb'
+        )
+        self.file_mock.write.assert_called_once_with(
+            'data'
+        )
+
+    @patch('kiwi.solver.repository.base.urlopen')
+    @raises(KiwiUriOpenError)
+    def test_download_from_repository_raises(self, mock_urlopen):
+        self.uri.is_remote.return_value = False
+        self.uri.translate.return_value = '/my_local_repo/file'
+        mock_urlopen.side_effect = Exception
+        self.solver.download_from_repository('repodata/file', 'target-file')
+
+    @patch('kiwi.solver.repository.base.mkdtemp')
+    @patch('kiwi.solver.repository.base.random.randrange')
+    @patch('kiwi.solver.repository.base.Command.run')
+    def test__create_solvables_rpms2_solv(
+        self, mock_command, mock_rand, mock_mkdtemp
+    ):
+        mock_rand.return_value = 0xfe
+        self.solver.repository_metadata_dirs = ['metadata_dir.XXXX']
+        mock_mkdtemp.return_value = 'solv_dir.XX'
+        self.solver._create_solvables('meta_dir.XX', 'rpms2solv')
+        mock_command.assert_called_once_with(
+            [
+                'bash', '-c',
+                'rpms2solv meta_dir.XX/*.rpm > solv_dir.XX/solvable-fefefefe'
+            ]
+        )
+
+    @patch('kiwi.solver.repository.base.mkdtemp')
+    @patch('kiwi.solver.repository.base.random.randrange')
+    @patch('kiwi.solver.repository.base.Command.run')
+    @patch('kiwi.solver.repository.base.glob.iglob')
+    def test__create_solvables_rpmmd2_solv(
+        self, mock_glob, mock_command, mock_rand, mock_mkdtemp
+    ):
+        mock_glob.return_value = ['some-solv-data-file']
+        mock_rand.return_value = 0xfe
+        self.solver.repository_metadata_dirs = ['metadata_dir.XXXX']
+        mock_mkdtemp.return_value = 'solv_dir.XX'
+        self.solver._create_solvables('meta_dir.XX', 'rpmmd2solv')
+        mock_glob.assert_called_once_with('meta_dir.XX/*')
+        mock_command.assert_called_once_with(
+            [
+                'bash', '-c',
+                ' '.join([
+                    'gzip -cd --force some-solv-data-file',
+                    '|',
+                    'rpmmd2solv > solv_dir.XX/solvable-fefefefe'
+                ])
+            ]
+        )
+
+    @patch('kiwi.solver.repository.base.Command.run')
+    @patch('kiwi.solver.repository.base.Path.wipe')
+    @patch('kiwi.solver.repository.base.Path.create')
+    @patch('kiwi.solver.repository.base.SolverRepositoryBase.is_uptodate')
+    @patch.object(SolverRepositoryBase, '_setup_repository_metadata')
+    @patch_open
+    def test_create_repository_solvable(
+        self, mock_open, mock_setup_repository_metadata, mock_is_uptodate,
+        mock_path_create, mock_path_wipe, mock_command
+    ):
+        mock_is_uptodate.return_value = False
+        mock_open.return_value = self.context_manager_mock
+        self.solver.repository_solvable_dir = 'solvable_dir.XX'
+        self.uri.alias.return_value = 'repo-alias'
+        self.uri.uri = 'repo-uri'
+        assert self.solver.create_repository_solvable('target_dir') == \
+            'target_dir/repo-alias'
+        mock_is_uptodate.assert_called_once_with('target_dir')
+        mock_setup_repository_metadata.assert_called_once_with()
+        mock_command.assert_called_once_with(
+            [
+                'bash', '-c',
+                'mergesolv solvable_dir.XX/* > target_dir/repo-alias'
+            ]
+        )
+        assert mock_open.call_args_list == [
+            call('target_dir/repo-alias.info', 'w'),
+            call('target_dir/repo-alias.timestamp', 'w')
+        ]
+        assert self.file_mock.write.call_args_list == [
+            call(''.join(['repo-uri', os.linesep])),
+            call('static')
+        ]
+
+    @patch('kiwi.solver.repository.base.Path.wipe')
+    def test_destructor(self, mock_wipe):
+        self.solver.repository_metadata_dirs = ['meta_dir.XX']
+        self.solver.repository_solvable_dir = 'solv_dir.XX'
+        self.solver.__del__()
+        assert mock_wipe.call_args_list == [
+            call('meta_dir.XX'), call('solv_dir.XX')
+        ]

--- a/test/unit/solver_repository_rpm_dir_test.py
+++ b/test/unit/solver_repository_rpm_dir_test.py
@@ -1,0 +1,39 @@
+from mock import patch, call
+
+import mock
+
+from .test_helper import raises
+
+from kiwi.solver.repository.rpm_dir import SolverRepositoryRpmDir
+from kiwi.solver.repository.base import SolverRepositoryBase
+from kiwi.exceptions import KiwiRpmDirNotRemoteError
+
+
+class TestSolverRepositoryRpmDir(object):
+    def setup(self):
+        self.uri = mock.Mock()
+        self.solver = SolverRepositoryRpmDir(self.uri)
+
+    @raises(KiwiRpmDirNotRemoteError)
+    def test__setup_repository_metadata_raises(self):
+        self.solver._setup_repository_metadata()
+
+    @patch.object(SolverRepositoryBase, 'download_from_repository')
+    @patch.object(SolverRepositoryBase, '_create_solvables')
+    @patch.object(SolverRepositoryBase, '_create_temporary_metadata_dir')
+    @patch('kiwi.solver.repository.rpm_dir.glob.iglob')
+    def test__setup_repository_metadata(
+        self, mock_iglob, mock_mkdtemp, mock_create_solvables,
+        mock_download_from_repository
+    ):
+        self.uri.is_remote.return_value = False
+        self.uri.translate.return_value = '/some/local/repo'
+        mock_iglob.return_value = ['some-package.rpm']
+        mock_mkdtemp.return_value = 'metadata_dir.XX'
+        self.solver._setup_repository_metadata()
+        mock_download_from_repository.assert_called_once_with(
+            'some-package.rpm', 'metadata_dir.XX/some-package.rpm'
+        )
+        mock_create_solvables.assert_called_once_with(
+            'metadata_dir.XX', 'rpms2solv'
+        )

--- a/test/unit/solver_repository_rpm_md_test.py
+++ b/test/unit/solver_repository_rpm_md_test.py
@@ -1,0 +1,49 @@
+from mock import patch, call
+
+import mock
+
+from lxml import etree
+
+from .test_helper import raises
+
+from kiwi.solver.repository.rpm_md import SolverRepositoryRpmMd
+from kiwi.solver.repository.base import SolverRepositoryBase
+
+
+class TestSolverRepositoryRpmMd(object):
+    def setup(self):
+        self.xml_data = etree.parse('../data/repomd.xml')
+        self.uri = mock.Mock()
+        self.solver = SolverRepositoryRpmMd(self.uri)
+
+    @patch.object(SolverRepositoryBase, 'download_from_repository')
+    @patch.object(SolverRepositoryBase, '_create_solvables')
+    @patch.object(SolverRepositoryBase, '_create_temporary_metadata_dir')
+    @patch.object(SolverRepositoryBase, '_get_repomd_xml')
+    def test__setup_repository_metadata(
+        self, mock_xml, mock_mkdtemp, mock_create_solvables,
+        mock_download_from_repository
+    ):
+        mock_mkdtemp.return_value = 'metadata_dir.XX'
+        mock_xml.return_value = self.xml_data
+        self.solver._setup_repository_metadata()
+
+        assert mock_download_from_repository.call_args_list == [
+            call(
+                'repodata/55f95a93-primary.xml.gz',
+                'metadata_dir.XX/55f95a93-primary.xml.gz'
+            ),
+            call(
+                'repodata/0815-other.xml.gz',
+                'metadata_dir.XX/0815-other.xml.gz'
+            )
+        ]
+        assert mock_create_solvables.call_args_list == [
+            call('metadata_dir.XX', 'rpmmd2solv'),
+            call('metadata_dir.XX', 'comps2solv')
+        ]
+
+    @patch.object(SolverRepositoryBase, '_get_repomd_xml')
+    def test_timestamp(self, mock_xml):
+        mock_xml.return_value = self.xml_data
+        assert self.solver.timestamp() == '1478352191'

--- a/test/unit/solver_repository_suse_test.py
+++ b/test/unit/solver_repository_suse_test.py
@@ -1,0 +1,54 @@
+from mock import patch, call
+
+import mock
+
+from lxml import etree
+
+from .test_helper import raises
+
+from kiwi.solver.repository.suse import SolverRepositorySUSE
+from kiwi.solver.repository.base import SolverRepositoryBase
+
+
+class TestSolverRepositorySUSE(object):
+    def setup(self):
+        self.xml_data = etree.parse('../data/repomd.xml')
+        self.uri = mock.Mock()
+        self.solver = SolverRepositorySUSE(self.uri)
+
+    @patch.object(SolverRepositoryBase, 'download_from_repository')
+    @patch.object(SolverRepositoryBase, '_create_solvables')
+    @patch.object(SolverRepositoryBase, '_create_temporary_metadata_dir')
+    @patch.object(SolverRepositoryBase, '_get_repomd_xml')
+    def test__setup_repository_metadata_online(
+        self, mock_xml, mock_mkdtemp, mock_create_solvables,
+        mock_download_from_repository
+    ):
+        mock_mkdtemp.return_value = 'metadata_dir.XX'
+        mock_xml.return_value = self.xml_data
+        self.solver._setup_repository_metadata()
+        mock_download_from_repository.assert_called_once_with(
+            'suse/repodata/55f95a93-primary.xml.gz',
+            'metadata_dir.XX/55f95a93-primary.xml.gz'
+        )
+        mock_create_solvables.assert_called_once_with(
+            'metadata_dir.XX', 'rpmmd2solv'
+        )
+
+    @patch.object(SolverRepositoryBase, 'download_from_repository')
+    @patch.object(SolverRepositoryBase, '_create_solvables')
+    @patch.object(SolverRepositoryBase, '_get_repomd_xml')
+    @patch.object(SolverRepositoryBase, '_create_temporary_metadata_dir')
+    def test__setup_repository_metadata_media(
+        self, mock_mkdtemp, mock_xml, mock_create_solvables,
+        mock_download_from_repository
+    ):
+        mock_xml.side_effect = Exception
+        mock_mkdtemp.return_value = 'metadata_dir.XX'
+        self.solver._setup_repository_metadata()
+        mock_download_from_repository.assert_called_once_with(
+            'suse/setup/descr/packages.gz', 'metadata_dir.XX/packages.gz'
+        )
+        mock_create_solvables.assert_called_once_with(
+            'metadata_dir.XX', 'susetags2solv'
+        )

--- a/test/unit/solver_repository_test.py
+++ b/test/unit/solver_repository_test.py
@@ -1,0 +1,32 @@
+from mock import patch
+
+import mock
+
+from .test_helper import raises
+
+from kiwi.solver.repository import SolverRepository
+from kiwi.exceptions import KiwiSolverRepositorySetupError
+
+
+class TestSolverRepository(object):
+    @raises(KiwiSolverRepositorySetupError)
+    def test_solver_repository_type_not_implemented(self):
+        SolverRepository('some-unknown-type', mock.Mock())
+
+    @patch('kiwi.solver.repository.SolverRepositorySUSE')
+    def test_solver_repository_suse(self, mock_suse):
+        uri = mock.Mock()
+        SolverRepository('yast2', uri)
+        mock_suse.assert_called_once_with(uri)
+
+    @patch('kiwi.solver.repository.SolverRepositoryRpmMd')
+    def test_solver_repository_rpm_md(self, mock_rpm_md):
+        uri = mock.Mock()
+        SolverRepository('rpm-md', uri)
+        mock_rpm_md.assert_called_once_with(uri)
+
+    @patch('kiwi.solver.repository.SolverRepositoryRpmDir')
+    def test_solver_repository_rpm_dir(self, mock_rpm_dir):
+        uri = mock.Mock()
+        SolverRepository('rpm-dir', uri)
+        mock_rpm_dir.assert_called_once_with(uri)

--- a/test/unit/solver_repository_test.py
+++ b/test/unit/solver_repository_test.py
@@ -9,24 +9,28 @@ from kiwi.exceptions import KiwiSolverRepositorySetupError
 
 
 class TestSolverRepository(object):
+    def setup(self):
+        self.uri = mock.Mock()
+        self.uri.repo_type = 'some-unknown-type'
+
     @raises(KiwiSolverRepositorySetupError)
     def test_solver_repository_type_not_implemented(self):
-        SolverRepository('some-unknown-type', mock.Mock())
+        SolverRepository(self.uri)
 
     @patch('kiwi.solver.repository.SolverRepositorySUSE')
     def test_solver_repository_suse(self, mock_suse):
-        uri = mock.Mock()
-        SolverRepository('yast2', uri)
-        mock_suse.assert_called_once_with(uri)
+        self.uri.repo_type = 'yast2'
+        SolverRepository(self.uri)
+        mock_suse.assert_called_once_with(self.uri)
 
     @patch('kiwi.solver.repository.SolverRepositoryRpmMd')
     def test_solver_repository_rpm_md(self, mock_rpm_md):
-        uri = mock.Mock()
-        SolverRepository('rpm-md', uri)
-        mock_rpm_md.assert_called_once_with(uri)
+        self.uri.repo_type = 'rpm-md'
+        SolverRepository(self.uri)
+        mock_rpm_md.assert_called_once_with(self.uri)
 
     @patch('kiwi.solver.repository.SolverRepositoryRpmDir')
     def test_solver_repository_rpm_dir(self, mock_rpm_dir):
-        uri = mock.Mock()
-        SolverRepository('rpm-dir', uri)
-        mock_rpm_dir.assert_called_once_with(uri)
+        self.uri.repo_type = 'rpm-dir'
+        SolverRepository(self.uri)
+        mock_rpm_dir.assert_called_once_with(self.uri)


### PR DESCRIPTION
With regards to:

* https://trello.com/c/Rn124uyP/198-support-package-solver-via-python-solv

This is an implementation of classes to create SAT repository solvables which are needed to
run solver tasks based on python-solv. The module provides an interface to the libsolv library
which I'd like to support as custom SUSE plugin in the next round of commits once the repository
setup introduced here is merged

So far the following repo types will be supported:

* local and remote yast2 types
* local and remote rpm-md types
* local rpm-dir types

The interface allows for adding more if needed, e.g apt, but that's for later