### PR TITLE
Insufficient disk size for xfs

### DIFF
--- a/kiwi/system/size.py
+++ b/kiwi/system/size.py
@@ -58,7 +58,7 @@ class SystemSize(object):
         elif requested_filesystem == 'btrfs':
             size *= 1.5
         elif requested_filesystem == 'xfs':
-            size *= 1.2
+            size *= 1.5
 
         return int(size)
 

--- a/test/unit/system_size_test.py
+++ b/test/unit/system_size_test.py
@@ -23,7 +23,7 @@ class TestSystemSize(object):
         assert self.size.customize(42, 'btrfs') == 63
 
     def test_customize_xfs(self):
-        assert self.size.customize(42, 'xfs') == 50
+        assert self.size.customize(42, 'xfs') == 63
 
     @patch('kiwi.system.size.Command.run')
     def test_accumulate_mbyte_file_sizes(self, mock_command):


### PR DESCRIPTION
When no size is specified in type section the resulting image size is calculated using the size of the whole build-root increased by an empiric factor. Some tests revealed that this factor was not enough for XFS filesystems. The empiric factor has been increased.

This pull request fixes #186