### PR TITLE
No need to mock Path.which

### DIFF
--- a/test/unit/iso_test.py
+++ b/test/unit/iso_test.py
@@ -200,9 +200,7 @@ class TestIso(object):
         assert result[2158].name == 'header_end'
 
 
-    @patch('kiwi.path.Path.which')
-    def test_create_header_end_block(self, mock_which):
-        mock_which.return_value = 'isoinfo'
+    def test_create_header_end_block(self):
         temp_file = NamedTemporaryFile()
         self.iso.header_end_file = temp_file.name
         assert self.iso.create_header_end_block(
@@ -210,9 +208,7 @@ class TestIso(object):
         ) == 96
 
     @raises(KiwiIsoLoaderError)
-    @patch('kiwi.path.Path.which')
-    def test_create_header_end_block_raises(self, mock_which):
-        mock_which.return_value = 'isoinfo'
+    def test_create_header_end_block_raises(self):
         temp_file = NamedTemporaryFile()
         self.iso.header_end_file = temp_file.name
         self.iso.create_header_end_block(


### PR DESCRIPTION
This PR makes sure the iso unit tests can run in a platform where `isoinfo` is not present in PATH. Concretely, this is the case in an openSUSE platform that has no installation of `mkisofs` or `cdrkit-cdrtools-compat` packages. Note that none of those packages are KIWI requirements.