### PR TITLE
Btrfs grub setup fix

### DIFF
--- a/kiwi/bootloader/template/grub2.py
+++ b/kiwi/bootloader/template/grub2.py
@@ -30,6 +30,9 @@ class BootLoaderTemplateGrub2(object):
             search ${search_params}
             set default=${default_boot}
             set timeout=${boot_timeout}
+            if [ -f "/.snapshots/grub-snapshot.cfg" ]; then
+                source "/.snapshots/grub-snapshot.cfg"
+            fi
         ''').strip() + os.linesep
 
         self.header_hybrid = dedent('''

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -34,7 +34,7 @@
         <locale>de_DE</locale>
     </preferences>
     <preferences>
-        <type bootloader="grub2" image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async">
+        <type bootloader="grub2" image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async" btrfs_root_is_snapshot="true">
             <size unit="G" additive="true">1</size>
             <systemdisk name="mydisk"/>
             <machine memory="512" domain="domU">


### PR DESCRIPTION
grub2 fixes in combination with btrfs rootfs

* Don't prefix the bootpath with the snapshot path if the btrfs root is placed in a snapshot. Instead the file etc/default/grub must be written/updated with the SUSE_BTRFS_SNAPSHOT_BOOTING variable set to true. Once this is done the bootpath is consistently set to /boot no matter which snapshot is active

* Add a lookup for /.snapshots/grub-snapshot.cfg to the generated grub.cfg. The file is shell sourced if it  exists
