### PR TITLE
Fixup netboot code for multipath boot device

### DIFF
--- a/kiwi/boot/arch/ppc/netboot/linuxrc
+++ b/kiwi/boot/arch/ppc/netboot/linuxrc
@@ -274,22 +274,23 @@ selectLanguage
 # 12) Check for diskful station
 #--------------------------------------
 if [ $LOCAL_BOOT = "no" ];then
-    checkDevice=$DISK
-    if [ -z "$checkDevice" ];then
-        checkDevice=$(echo $IMAGE | cut -f1 -d\;)
+    biosBootDevice=$DISK
+    if [ -z "$biosBootDevice" ];then
+        biosBootDevice=$(echo $IMAGE | cut -f1 -d\;)
     fi
-    if [ ! -z "$checkDevice" ];then
-        if ! waitForStorageDevice $checkDevice;then
+    setupBootDeviceIfMultipath
+    if [ ! -z "$biosBootDevice" ];then
+        if ! waitForStorageDevice $biosBootDevice;then
             systemException \
-                "Block device $checkDevice doesn't appear... fatal !" \
+                "Block device $biosBootDevice doesn't appear... fatal !" \
             "reboot"
         fi
-        if echo $checkDevice | grep -q dev\/ram;then
+        if echo $biosBootDevice | grep -q dev\/ram;then
             export haveRamDisk=1
             systemIntegrity="clean"
         else
             export haveDisk=1
-            export imageDiskDevice=$checkDevice
+            export imageDiskDevice=$biosBootDevice
         fi
     fi
 fi

--- a/kiwi/boot/arch/s390/netboot/linuxrc
+++ b/kiwi/boot/arch/s390/netboot/linuxrc
@@ -289,22 +289,23 @@ selectLanguage
 #--------------------------------------
 searchBusIDBootDevice
 if [ $LOCAL_BOOT = "no" ];then
-    checkDevice=$DISK
-    if [ -z "$checkDevice" ];then
-        checkDevice=$(echo $IMAGE | cut -f1 -d\;)
+    biosBootDevice=$DISK
+    if [ -z "$biosBootDevice" ];then
+        biosBootDevice=$(echo $IMAGE | cut -f1 -d\;)
     fi
-    if [ ! -z "$checkDevice" ];then
-        if ! waitForStorageDevice $checkDevice;then
+    setupBootDeviceIfMultipath
+    if [ ! -z "$biosBootDevice" ];then
+        if ! waitForStorageDevice $biosBootDevice;then
             systemException \
-                "Block device $checkDevice doesn't appear... fatal !" \
+                "Block device $biosBootDevice doesn't appear... fatal !" \
             "reboot"
         fi
-        if echo $checkDevice | grep -q dev\/ram;then
+        if echo $biosBootDevice | grep -q dev\/ram;then
             export haveRamDisk=1
             systemIntegrity="clean"
         else
             export haveDisk=1
-            export imageDiskDevice=$checkDevice
+            export imageDiskDevice=$biosBootDevice
         fi
     fi
 fi

--- a/kiwi/boot/arch/x86_64/netboot/linuxrc
+++ b/kiwi/boot/arch/x86_64/netboot/linuxrc
@@ -274,22 +274,23 @@ selectLanguage
 # 12) Check for diskful station
 #--------------------------------------
 if [ $LOCAL_BOOT = "no" ];then
-    checkDevice=$DISK
-    if [ -z "$checkDevice" ];then
-        checkDevice=$(echo $IMAGE | cut -f1 -d\;)
+    biosBootDevice=$DISK
+    if [ -z "$biosBootDevice" ];then
+        biosBootDevice=$(echo $IMAGE | cut -f1 -d\;)
     fi
-    if [ ! -z "$checkDevice" ];then
-        if ! waitForStorageDevice $checkDevice;then
+    if [ ! -z "$biosBootDevice" ];then
+        setupBootDeviceIfMultipath
+        if ! waitForStorageDevice $biosBootDevice;then
             systemException \
-                "Block device $checkDevice doesn't appear... fatal !" \
+                "Block device $biosBootDevice doesn't appear... fatal !" \
             "reboot"
         fi
-        if echo $checkDevice | grep -q dev\/ram;then
+        if echo $biosBootDevice | grep -q dev\/ram;then
             export haveRamDisk=1
             systemIntegrity="clean"
         else
             export haveDisk=1
-            export imageDiskDevice=$checkDevice
+            export imageDiskDevice=$biosBootDevice
         fi
     fi
 fi

--- a/kiwi/boot/functions.sh
+++ b/kiwi/boot/functions.sh
@@ -6354,6 +6354,7 @@ function activateImage {
             systemException "Failed to copy: pidof" "reboot"
         fi
     fi
+    stopMultipathd
 }
 #======================================
 # cleanImage


### PR DESCRIPTION
If the root disk in a netboot deployment is a multipath device
we have to make sure the multipathd is started and the boot
device is mapped to the wwn