### PR TITLE
Move source of grub-snapshot.cfg to the right position

### DIFF
--- a/kiwi/bootloader/template/grub2.py
+++ b/kiwi/bootloader/template/grub2.py
@@ -32,7 +32,7 @@ class BootLoaderTemplateGrub2(object):
             search ${search_params}
             set default=${default_boot}
             set timeout=${boot_timeout}
-	    if [ -n "$$extra_cmdline" ]; then
+            if [ -n "$$extra_cmdline" ]; then
               submenu "Bootable snapshot $$snapshot_num" {
                 menuentry "If OK, run 'snapper rollback' and reboot." { true; }
               }

--- a/kiwi/bootloader/template/grub2.py
+++ b/kiwi/bootloader/template/grub2.py
@@ -30,9 +30,6 @@ class BootLoaderTemplateGrub2(object):
             search ${search_params}
             set default=${default_boot}
             set timeout=${boot_timeout}
-            if [ -f "/.snapshots/grub-snapshot.cfg" ]; then
-                source "/.snapshots/grub-snapshot.cfg"
-            fi
         ''').strip() + os.linesep
 
         self.header_hybrid = dedent('''
@@ -116,6 +113,13 @@ class BootLoaderTemplateGrub2(object):
                 set theme=($$root)/boot/grub2/themes/${theme}/theme.txt
             fi
         ''').strip() + os.linesep
+
+        self.menu_entry_boot_snapshots = dedent('''
+            if [ -f "/.snapshots/grub-snapshot.cfg" ]; then
+                source "/.snapshots/grub-snapshot.cfg"
+            fi
+        ''').strip() + os.linesep
+
 
         self.menu_entry_console_switch = dedent('''
             if [ "$${grub_platform}" = "efi" ]; then
@@ -291,6 +295,7 @@ class BootLoaderTemplateGrub2(object):
             template_data += self.menu_entry
             if failsafe:
                 template_data += self.menu_entry_failsafe
+        template_data += self.menu_entry_boot_snapshots
         if terminal == 'gfxterm':
             template_data += self.menu_entry_console_switch
         return Template(template_data)
@@ -318,6 +323,7 @@ class BootLoaderTemplateGrub2(object):
         template_data += self.menu_entry_multiboot
         if failsafe:
             template_data += self.menu_entry_failsafe_multiboot
+        template_data += self.menu_entry_boot_snapshots
         if terminal == 'gfxterm':
             template_data += self.menu_entry_console_switch
         return Template(template_data)
@@ -353,6 +359,7 @@ class BootLoaderTemplateGrub2(object):
             if failsafe:
                 template_data += self.menu_entry_failsafe
         template_data += self.menu_iso_harddisk_entry
+        template_data += self.menu_entry_boot_snapshots
         if terminal == 'gfxterm':
             template_data += self.menu_entry_console_switch
         return Template(template_data)
@@ -381,6 +388,7 @@ class BootLoaderTemplateGrub2(object):
         if failsafe:
             template_data += self.menu_entry_failsafe_multiboot
         template_data += self.menu_iso_harddisk_entry
+        template_data += self.menu_entry_boot_snapshots
         if terminal == 'gfxterm':
             template_data += self.menu_entry_console_switch
         return Template(template_data)
@@ -416,6 +424,7 @@ class BootLoaderTemplateGrub2(object):
             template_data += self.menu_install_entry
             if failsafe:
                 template_data += self.menu_install_entry_failsafe
+        template_data += self.menu_entry_boot_snapshots
         if terminal == 'gfxterm':
             template_data += self.menu_entry_console_switch
         return Template(template_data)
@@ -444,6 +453,7 @@ class BootLoaderTemplateGrub2(object):
         template_data += self.menu_install_entry_multiboot
         if failsafe:
             template_data += self.menu_install_entry_failsafe_multiboot
+        template_data += self.menu_entry_boot_snapshots
         if terminal == 'gfxterm':
             template_data += self.menu_entry_console_switch
         return Template(template_data)

--- a/kiwi/bootloader/template/grub2.py
+++ b/kiwi/bootloader/template/grub2.py
@@ -27,9 +27,16 @@ class BootLoaderTemplateGrub2(object):
     def __init__(self):
         self.header = dedent('''
             # kiwi generated one time grub2 config file
+            set btrfs_relative_path="y"
+            export btrfs_relative_path
             search ${search_params}
             set default=${default_boot}
             set timeout=${boot_timeout}
+	    if [ -n "$$extra_cmdline" ]; then
+              submenu "Bootable snapshot $$snapshot_num" {
+                menuentry "If OK, run 'snapper rollback' and reboot." { true; }
+              }
+            fi
         ''').strip() + os.linesep
 
         self.header_hybrid = dedent('''
@@ -90,6 +97,7 @@ class BootLoaderTemplateGrub2(object):
             fi
             if [ -f ($$root)${bootpath}/grub2/themes/${theme}/theme.txt ];then
                 set theme=($$root)${bootpath}/grub2/themes/${theme}/theme.txt
+                export theme
             fi
         ''').strip() + os.linesep
 
@@ -134,7 +142,7 @@ class BootLoaderTemplateGrub2(object):
             menuentry "${title}" --class os --unrestricted {
                 set gfxpayload=keep
                 echo Loading kernel...
-                $$linux ($$root)${bootpath}/${kernel_file} ${boot_options}
+                $$linux ($$root)${bootpath}/${kernel_file} $${extra_cmdline} ${boot_options}
                 echo Loading initrd...
                 $$initrd ($$root)${bootpath}/${initrd_file}
             }
@@ -156,7 +164,7 @@ class BootLoaderTemplateGrub2(object):
             menuentry "${title}" --class os --unrestricted {
                 set gfxpayload=keep
                 echo Loading kernel...
-                linux ($$root)${bootpath}/${kernel_file} ${boot_options}
+                linux ($$root)${bootpath}/${kernel_file} $${extra_cmdline} ${boot_options}
                 echo Loading initrd...
                 initrd ($$root)${bootpath}/${initrd_file}
             }
@@ -166,7 +174,7 @@ class BootLoaderTemplateGrub2(object):
             menuentry "Failsafe -- ${title}" --class os --unrestricted {
                 set gfxpayload=keep
                 echo Loading kernel...
-                $$linux ($$root)${bootpath}/${kernel_file} ${failsafe_boot_options}
+                $$linux ($$root)${bootpath}/${kernel_file} $${extra_cmdline} ${failsafe_boot_options}
                 echo Loading initrd...
                 $$initrd ($$root)${bootpath}/${initrd_file}
             }
@@ -188,7 +196,7 @@ class BootLoaderTemplateGrub2(object):
             menuentry "Failsafe -- ${title}" --class os --unrestricted {
                 set gfxpayload=keep
                 echo Loading kernel...
-                linux ($$root)${bootpath}/${kernel_file} ${failsafe_boot_options}
+                linux ($$root)${bootpath}/${kernel_file} $${extra_cmdline} ${failsafe_boot_options}
                 echo Loading initrd...
                 initrd ($$root)${bootpath}/${initrd_file}
             }

--- a/kiwi/bootloader/template/grub2.py
+++ b/kiwi/bootloader/template/grub2.py
@@ -128,7 +128,6 @@ class BootLoaderTemplateGrub2(object):
             fi
         ''').strip() + os.linesep
 
-
         self.menu_entry_console_switch = dedent('''
             if [ "$${grub_platform}" = "efi" ]; then
                 hiddenentry "Text mode" --hotkey "t" {


### PR DESCRIPTION
grub-snapshot.cfg should not be sourced at the beginning, but
at the end of grub.cfg. Else with creating the first snapshot
this entry is getting the default boot target and the system
does not boot automatically anymore.