### PR TITLE
vhdfixed images compression

### DIFF
--- a/kiwi/storage/subformat/vhdfixed.py
+++ b/kiwi/storage/subformat/vhdfixed.py
@@ -81,6 +81,24 @@ class DiskFormatVhdFixed(DiskFormatBase):
         if self.tag:
             self._write_vhd_tag(self.tag)
 
+    def store_to_result(self, result):
+        """
+        Store result file of the vhdfixed format conversion into the
+        provided result instance. In this case compressing the result
+        is preferred as vhdfixed is not a compressed or dynamic format.
+
+        :param object result: Instance of Result
+        """
+        result.add(
+            key='disk_format_image',
+            filename=self.get_target_name_for_format(
+                self.image_format
+            ),
+            use_for_bundle=True,
+            compress=True,
+            shasum=True
+        )
+
     def _pack_net_guid_tag(self, tag):
         """
         Pack tag format into 16 byte binary representation. String format

--- a/test/unit/storage_subformat_vhdfixed_test.py
+++ b/test/unit/storage_subformat_vhdfixed_test.py
@@ -85,3 +85,14 @@ class TestDiskFormatVhdFixed(object):
             call(65536, 0), call(0, 2),
             call(65536, 0), call(0, 2)
         ]
+
+    def test_store_to_result(self):
+        result = mock.Mock()
+        self.disk_format.store_to_result(result)
+        result.add.assert_called_once_with(
+            compress=True,
+            filename='target_dir/some-disk-image.x86_64-1.2.3.vhdfixed',
+            key='disk_format_image',
+            shasum=True,
+            use_for_bundle=True
+        )


### PR DESCRIPTION
This pull request is related to #184 and #187. With these
changes the bundle procedure for vhdfixed images produces
compressed files, as it used to do in previous kiwi versions. 
This way the current kiwi version is still compatible with other
related services.