### PR TITLE
Fixed kernel name lookup

### DIFF
--- a/kiwi/boot/image/dracut.py
+++ b/kiwi/boot/image/dracut.py
@@ -46,9 +46,7 @@ class BootImageDracut(BootImageBase):
         if self.is_prepared():
             log.info('Creating generic dracut initrd archive')
             kernel_info = Kernel(self.boot_root_directory)
-            kernel_details = kernel_info.get_kernel(
-                raise_on_not_found=True
-            )
+            kernel_details = kernel_info.get_kernel(raise_on_not_found=True)
             Command.run(
                 [
                     'chroot', self.boot_root_directory,

--- a/kiwi/boot/image/dracut.py
+++ b/kiwi/boot/image/dracut.py
@@ -46,7 +46,9 @@ class BootImageDracut(BootImageBase):
         if self.is_prepared():
             log.info('Creating generic dracut initrd archive')
             kernel_info = Kernel(self.boot_root_directory)
-            kernel_version = kernel_info.get_kernel().version
+            kernel_details = kernel_info.get_kernel(
+                raise_on_not_found=True
+            )
             Command.run(
                 [
                     'chroot', self.boot_root_directory,
@@ -55,7 +57,7 @@ class BootImageDracut(BootImageBase):
                     '--no-hostonly-cmdline',
                     '--no-compress',
                     os.path.basename(self.initrd_file_name),
-                    kernel_version
+                    kernel_details.version
                 ]
             )
             Command.run(

--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -373,6 +373,12 @@ class KiwiIsoToolError(KiwiError):
     """
 
 
+class KiwiKernelLookupError(KiwiError):
+    """
+    Exception raised if the search for the kernel image file failed
+    """
+
+
 class KiwiLiveBootImageError(KiwiError):
     """
     Exception raised if an attempt was made to use an

--- a/kiwi/system/kernel.py
+++ b/kiwi/system/kernel.py
@@ -139,20 +139,24 @@ class Kernel(object):
         :rtype: list
         :return: list of kernel image names
         """
-        for kernel_dir in os.listdir(''.join([self.root_dir, '/lib/modules'])):
-            return [
-                # lookup the link names first, or the result from
-                # functions.sh::suseStripKernel() if a kiwi initrd
-                # is used
-                'vmlinux', 'vmlinuz', 'zImage',
-
-                # not found, then lookup the real kernel image names
-                # depending on the arch and os they are different
-                ''.join(['uImage-', kernel_dir]),
-                ''.join(['Image-', kernel_dir]),
-                ''.join(['zImage-', kernel_dir]),
-                ''.join(['vmlinuz-', kernel_dir, '.gz']),
-                ''.join(['vmlinux-', kernel_dir]),
-                ''.join(['image-', kernel_dir]),
-                ''.join(['vmlinuz-', kernel_dir])
+        kernel_names = [
+            # lookup for the symlink or functions.sh::suseStripKernel()
+            # generated names first
+            'vmlinux', 'vmlinuz', 'zImage'
+        ]
+        kernel_dir = os.listdir(''.join([self.root_dir, '/lib/modules']))
+        if kernel_dir:
+            # append lookup for the real kernel image names
+            # depending on the arch and os they are different
+            # in their prefix
+            kernel_prefixes = [
+                'uImage', 'Image', 'zImage', 'vmlinuz', 'vmlinux', 'image'
             ]
+            kernel_name_pattern = '{prefix}-{name}'
+            for kernel_prefix in kernel_prefixes:
+                kernel_names.append(
+                    kernel_name_pattern.format(
+                        prefix=kernel_prefix, name=kernel_dir[0]
+                    )
+                )
+        return kernel_names

--- a/test/unit/boot_image_dracut_test.py
+++ b/test/unit/boot_image_dracut_test.py
@@ -33,15 +33,17 @@ class TestBootImageKiwi(object):
         self.boot_image.prepare()
 
     @patch('kiwi.boot.image.dracut.Compress')
-    @patch('kiwi.boot.image.dracut.Kernel.get_kernel')
+    @patch('kiwi.boot.image.dracut.Kernel')
     @patch('kiwi.boot.image.dracut.Command.run')
     @patch('kiwi.boot.image.base.BootImageBase.is_prepared')
     def test_create_initrd(
-        self, mock_prepared, mock_command, mock_get_kernel, mock_compress
+        self, mock_prepared, mock_command, mock_kernel, mock_compress
     ):
         kernel = mock.Mock()
-        kernel.version = '1.2.3'
-        mock_get_kernel.return_value = kernel
+        kernel_details = mock.Mock()
+        kernel_details.version = '1.2.3'
+        kernel.get_kernel = mock.Mock(return_value=kernel_details)
+        mock_kernel.return_value = kernel
         compress = mock.Mock()
         mock_compress.return_value = compress
         self.boot_image.create_initrd()

--- a/test/unit/system_kernel_test.py
+++ b/test/unit/system_kernel_test.py
@@ -16,6 +16,17 @@ class TestKernel(object):
     def setup(self, mock_listdir):
         mock_listdir.return_value = ['1.2.3-default']
         self.kernel = Kernel('root-dir')
+        assert self.kernel.kernel_names == [
+            'vmlinux',
+            'vmlinuz',
+            'zImage',
+            'uImage-1.2.3-default',
+            'Image-1.2.3-default',
+            'zImage-1.2.3-default',
+            'vmlinuz-1.2.3-default',
+            'vmlinux-1.2.3-default',
+            'image-1.2.3-default'
+        ]
 
     @raises(KiwiKernelLookupError)
     def test_get_kernel_raises_if_no_kernel_found(self):

--- a/test/unit/system_kernel_test.py
+++ b/test/unit/system_kernel_test.py
@@ -3,17 +3,24 @@ from mock import patch
 
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
 from collections import namedtuple
 
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiKernelLookupError
 from kiwi.system.kernel import Kernel
 
 
 class TestKernel(object):
-    def setup(self):
+    @patch('os.listdir')
+    def setup(self, mock_listdir):
+        mock_listdir.return_value = ['1.2.3-default']
         self.kernel = Kernel('root-dir')
+
+    @raises(KiwiKernelLookupError)
+    def test_get_kernel_raises_if_no_kernel_found(self):
+        self.kernel.kernel_names = []
+        self.kernel.get_kernel(raise_on_not_found=True)
 
     @patch('os.path.exists')
     @patch('kiwi.command.Command.run')


### PR DESCRIPTION
Complete the list of kernel names for the lookup. Normally
the kernel package provides a symlink to the actual kernel
image file. However if the link does not exist we extend the
search to a collection of names for possible kernel images.
The new list now also covers kernel names as used for arm

Along with the change this patch also provides an option to
raise an exception if the kernel lookup did not find any
kernel, which is used for the get_kernel() request in the
dracut initrd system setup where it is mandatory to find
a kernel image.

This fixes bnc#1010874