### PR TITLE
Solver

### DIFF
--- a/doc/source/api/kiwi.solver.rst
+++ b/doc/source/api/kiwi.solver.rst
@@ -8,6 +8,17 @@ Subpackages
 
     kiwi.solver.repository
 
+Submodules
+----------
+
+`kiwi.solver.solver` Module
+-----------------------------
+
+.. automodule:: kiwi.solver.sat
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Module Contents
 ---------------
 

--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -570,6 +570,29 @@ class KiwiRuntimeError(KiwiError):
     """
 
 
+class KiwiSatSolverJobError(KiwiError):
+    """
+    Exception raised if a sat solver job can not be done, e.g because
+    the requested package or collection does not exist in the registered
+    repository metadata
+    """
+
+
+class KiwiSatSolverJobProblems(KiwiError):
+    """
+    Exception raised if the sat solver operations returned with solver
+    problems e.g package conflicts
+    """
+
+
+class KiwiSatSolverPluginError(KiwiError):
+    """
+    Exception raised if the python solv module failed to load.
+    The solv module is provided by SUSE's rpm package python-solv
+    and provides a python binding to the libsolv C library
+    """
+
+
 class KiwiSchemaImportError(KiwiError):
     """
     Exception raised if the schema file could not be read

--- a/kiwi/solver/sat.py
+++ b/kiwi/solver/sat.py
@@ -1,0 +1,211 @@
+# Copyright (c) 2015 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+import importlib
+from collections import namedtuple
+from xml.etree import ElementTree
+from xml.dom import minidom
+
+# project
+from ..logger import log
+
+from ..exceptions import (
+    KiwiSatSolverPluginError,
+    KiwiSatSolverJobError,
+    KiwiSatSolverJobProblems
+)
+
+
+class Sat(object):
+    """
+    Sat Solver class to run package solver operations
+
+    The class uses SUSE's libsolv sat plugin
+    """
+    def __init__(self):
+        """
+        An instance of Sat auto loads the python solv plugin which is a
+        python binding to the libsolv C library. An exception is raised
+        if the module failed to load. On success a new solver pool is
+        initialized for this instance
+        """
+        try:
+            self.solv = importlib.import_module('solv')
+            self.Pool = getattr(
+                importlib.import_module('solv', 'Pool'), 'Pool'
+            )
+            self.Selection = getattr(
+                importlib.import_module('solv', 'Selection'), 'Selection'
+            )
+        except Exception as e:
+            raise KiwiSatSolverPluginError(
+                '{0}: {1}'.format(type(e).__name__, format(e))
+            )
+
+        self.pool = self.Pool()
+        self.pool.setarch()
+
+    def add_repository(self, solver_repository):
+        """
+        Add a repository solvable to the pool. This basically add the
+        required repository metadata which is needed to run a solver
+        operation later.
+
+        :param object solver_repository: Instance of SolverRepository
+        """
+        solvable = solver_repository.create_repository_solvable()
+        pool_repository = self.pool.add_repo(solver_repository.uri.uri)
+        pool_repository.add_solv(solvable)
+        self.pool.addfileprovides()
+        self.pool.createwhatprovides()
+
+    def solve(self, job_names, skip_missing=False):
+        """
+        Solve dependencies for the given job list. The list is allowd
+        to contain element names of the following format:
+
+        * name
+          describes a package name
+
+        * pattern:name
+          describes a package collection name whose metadata type
+          is called 'pattern' and stored as such in the repository
+          metadata. Usually SUSE repos uses that
+
+        * group:name
+          describes a package collection name whose metadata type
+          is called 'group' and stored as such in the repository
+          metadata. Usually RHEL/CentOS/Fedora repos uses that
+
+        :param list job_names: list of strings
+        :param bool skip_missing: skip job if not found
+
+        :rtype: dict
+        :return: Transaction result information
+        """
+        solver = self.pool.Solver()
+        solver_problems = solver.solve(
+            self._setup_jobs(job_names, skip_missing)
+        )
+        solver_problem_info = self._evaluate_solver_problems(
+            solver_problems
+        )
+        if solver_problem_info:
+            raise KiwiSatSolverJobProblems(solver_problem_info)
+
+        solver_transaction = solver.transaction()
+        return self._evaluate_solver_result(
+            solver_transaction
+        )
+
+    def _evaluate_solver_problems(self, solver_problems):
+        """
+        Iterate over solver problems and their solutions
+
+        The method creates a pretty print XML information
+        and returns that as a UTF-8 encoded string
+
+        :param object solver_problems: result of Pool::Solver::solve()
+
+        :rtype: string
+        :return: solver problem info and solutions
+        """
+        if solver_problems:
+            problems = ElementTree.Element('problems')
+            for problem in solver_problems:
+                problem_detail = ElementTree.SubElement(
+                    problems, 'problem', id=format(problem.id),
+                    message=problem.findproblemrule().info().problemstr()
+                )
+                for solution in problem.solutions():
+                    solution_detail = ElementTree.SubElement(
+                        problem_detail, 'solution', id=format(solution.id)
+                    )
+                    for option in solution.elements(1):
+                        solution_option = ElementTree.SubElement(
+                            solution_detail, 'option'
+                        )
+                        solution_option.text = option.str()
+
+            xml_data_unformatted = ElementTree.tostring(
+                problems, 'utf-8'
+            )
+            xml_data_domtree = minidom.parseString(xml_data_unformatted)
+            return xml_data_domtree.toprettyxml(indent="    ")
+
+    def _evaluate_solver_result(self, solver_transaction):
+        """
+        Iterate over solver result and return a data dictionary
+
+        :param object solver_transaction: result of Pool::Solver::transaction()
+
+        :rtype: dict
+        :return: dict of packages and their details
+        """
+        result_type = namedtuple(
+            'result_type', [
+                'uri', 'installsize_bytes', 'arch', 'version', 'checksum'
+            ]
+        )
+        result = {}
+        for solvable in solver_transaction.newpackages():
+            name = solvable.lookup_str(self.solv.SOLVABLE_NAME)
+            result[name] = result_type(
+                uri=solvable.repo.name,
+                installsize_bytes=solvable.lookup_num(
+                    self.solv.SOLVABLE_INSTALLSIZE
+                ),
+                arch=solvable.lookup_str(
+                    self.solv.SOLVABLE_ARCH
+                ),
+                version=solvable.lookup_str(
+                    self.solv.SOLVABLE_EVR
+                ),
+                checksum=solvable.lookup_checksum(
+                    self.solv.SOLVABLE_CHECKSUM
+                )
+            )
+        return result
+
+    def _setup_jobs(self, job_names, skip_missing):
+        """
+        Create a solver job list from given list of job names
+
+        :param list job_names: list of package,pattern,group names
+        :param bool skip_missing: continue or raise if job selection failed
+
+        :rtype: list
+        :return: list of Pool.selection() objects
+        """
+        jobs = []
+        for job_name in job_names:
+            selection = self.pool.select(
+                job_name, self.Selection.SELECTION_NAME
+            )
+            if selection.isempty():
+                if skip_missing:
+                    log.info(
+                        '--> Package {0} not found: skipped'.format(job_name)
+                    )
+                else:
+                    raise KiwiSatSolverJobError(
+                        'Package {0} not found'.format(job_name)
+                    )
+            else:
+                jobs += selection.jobs(self.solv.Job.SOLVER_INSTALL)
+
+        return jobs

--- a/test/unit/solver_sat_test.py
+++ b/test/unit/solver_sat_test.py
@@ -1,0 +1,128 @@
+from mock import patch, call
+import mock
+
+from .test_helper import raises
+
+from kiwi.solver.sat import Sat
+from kiwi.exceptions import (
+    KiwiSatSolverPluginError,
+    KiwiSatSolverJobProblems,
+    KiwiSatSolverJobError
+)
+
+
+class TestSat(object):
+    @patch('importlib.import_module')
+    def setup(self, mock_import_module):
+        self.sat = Sat()
+        self.solver = mock.MagicMock()
+        self.transaction = mock.Mock()
+        self.transaction.newpackages = mock.Mock(
+            return_value=[mock.Mock()]
+        )
+        self.selection = mock.Mock()
+        self.solver.transaction = mock.Mock(
+            return_value=self.transaction
+        )
+        self.sat.pool.Solver = mock.Mock(
+            return_value=self.solver
+        )
+        self.sat.pool.select = mock.Mock(
+            return_value=self.selection
+        )
+        assert mock_import_module.call_args_list == [
+            call('solv'), call('solv', 'Pool'), call('solv', 'Selection')
+        ]
+
+    @patch('importlib.import_module')
+    @raises(KiwiSatSolverPluginError)
+    def test_setup_no_sat_plugin(self, mock_import_module):
+        mock_import_module.side_effect = Exception
+        Sat()
+
+    def test_add_repository(self):
+        solver_repository = mock.Mock()
+        solver_repository.uri.uri = 'some-uri'
+        solvable = mock.Mock()
+        solver_repository.create_repository_solvable.return_value = solvable
+        pool_repository = mock.Mock()
+        self.sat.pool.add_repo.return_value = pool_repository
+
+        self.sat.add_repository(solver_repository)
+
+        solver_repository.create_repository_solvable.assert_called_once_with()
+        self.sat.pool.add_repo.assert_called_once_with('some-uri')
+        pool_repository.add_solv.assert_called_once_with(solvable)
+        self.sat.pool.addfileprovides.assert_called_once_with()
+        self.sat.pool.createwhatprovides.assert_called_once_with()
+
+    @raises(KiwiSatSolverJobProblems)
+    @patch.object(Sat, '_setup_jobs')
+    def test_solve_has_problems(self, mock_setup_jobs):
+        packages = ['vim']
+        problem = mock.Mock()
+        problem.id = 42
+        info = mock.Mock()
+        info.problemstr = mock.Mock(
+            return_value='some-problem'
+        )
+        findproblemrule = mock.Mock()
+        findproblemrule.info = mock.Mock(
+            return_value=info
+        )
+        problem.findproblemrule.return_value = findproblemrule
+
+        option = mock.Mock()
+        option.str = mock.Mock(
+            return_value='some-option'
+        )
+        solution = mock.Mock()
+        solution.id = 42
+        solution.elements = mock.Mock(
+            return_value=[option]
+        )
+        problem.solutions.return_value = [solution]
+        self.solver.solve = mock.Mock(
+            return_value=[problem]
+        )
+        self.sat.solve(packages)
+
+    @patch('kiwi.logger.log.info')
+    def test_solve_package_not_found_and_skipped(self, mock_log_info):
+        packages = ['vim']
+        self.solver.solve = mock.Mock(
+            return_value=None
+        )
+        self.selection.isempty = mock.Mock(
+            return_value=True
+        )
+        self.sat.solve(packages, skip_missing=True)
+        mock_log_info.assert_called_once_with(
+            '--> Package vim not found: skipped'
+        )
+
+    @raises(KiwiSatSolverJobError)
+    def test_solve_package_not_found_raises(self):
+        packages = ['vim']
+        self.solver.solve = mock.Mock(
+            return_value=None
+        )
+        self.selection.isempty = mock.Mock(
+            return_value=True
+        )
+        self.sat.solve(packages)
+
+    def test_solve(self):
+        packages = ['vim']
+        self.solver.solve = mock.Mock(
+            return_value=None
+        )
+        self.selection.isempty = mock.Mock(
+            return_value=False
+        )
+        self.selection.jobs = mock.Mock(
+            return_value=packages
+        )
+        self.sat.solve(packages)
+        self.solver.solve.assert_called_once_with(['vim'])
+        self.solver.transaction.assert_called_once_with()


### PR DESCRIPTION
The Sat solver class - an example
    
The Sat solver class can be used to run a solver operation over a list of packages and/or patterns in order to receive  a dependency solved list of all required packages according  to the request. In order to do that a set of repositories  is required which provides the package metadata and their requirements. The following is an example how to use the Sat class in your application:

```python
    
from kiwi.solver.sat import Sat
from kiwi.system.uri import Uri
from kiwi.solver.repository import SolverRepository

solver = Sat()
solver.add_repository(
    SolverRepository(Uri('obs://leap/42.2/repo/oss', 'yast2'))
)
print(solver.solve(['vim']))
```
