### PR TITLE
No more hard links in result bundle

### DIFF
--- a/kiwi/tasks/result_bundle.py
+++ b/kiwi/tasks/result_bundle.py
@@ -116,7 +116,7 @@ class ResultBundleTask(CliTask):
                 )
                 Command.run(
                     [
-                        'cp', '-l', result_file.filename, bundle_file
+                        'cp', result_file.filename, bundle_file
                     ]
                 )
                 if result_file.compress:

--- a/test/unit/tasks_result_bundle_test.py
+++ b/test/unit/tasks_result_bundle_test.py
@@ -90,7 +90,7 @@ class TestResultBundleTask(object):
         mock_path.assert_called_once_with('bundle_dir')
         mock_command.assert_called_once_with(
             [
-                'cp', '-l', 'filename-1.2.3',
+                'cp', 'filename-1.2.3',
                 'bundle_dir/filename-1.2.3-Build_42'
             ]
         )


### PR DESCRIPTION
This PR changes the copy command of the result bundle task. Now
instead of creating hard-links a regular copy is performed. This way
we ensure that the bundled files will not be modified by
overwriting a linked file.

This PR Fixes #199