### PR TITLE
Parse arch attribute as a comma separated list

### DIFF
--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -151,6 +151,23 @@ class XMLState(object):
                 result.append(packages)
         return result
 
+    def package_matches_host_architecture(self, package):
+        """
+        Tests if the given package is applicable for the current host
+        architecture. If no architecture is specified within the package
+        it is considered as a match.
+
+        :param package: <package>
+        :return: True if there is a match or if the package has no architecture.
+        :rtype: bool
+        """
+
+        architectures = package.get_arch()
+        if architectures:
+            if self.host_architecture not in architectures.split(','):
+                return False
+        return True
+
     def get_package_sections(self, packages_sections):
         """
         List of package sections from the given packages sections.
@@ -174,16 +191,7 @@ class XMLState(object):
                 package_list = packages_section.get_package()
                 if package_list:
                     for package in package_list:
-                        package_architecture = package.get_arch()
-                        if package_architecture:
-                            if package_architecture == self.host_architecture:
-                                result.append(
-                                    package_type(
-                                        packages_section=packages_section,
-                                        package_section=package
-                                    )
-                                )
-                        else:
+                        if self.package_matches_host_architecture(package):
                             result.append(
                                 package_type(
                                     packages_section=packages_section,

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -120,7 +120,7 @@
         <package name="vim" bootdelete="true"/>
         <package name="openssh"/>
         <archive name="/absolute/path/to/image.tgz" bootinclude="true"/>
-        <package name="foo" arch="some-arch"/>
+        <package name="foo" arch="some-arch,some-other-arch"/>
     </packages>
     <packages type="iso">
         <package name="gfxboot-branding-openSUSE" bootinclude="true" bootdelete="true"/>

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -68,6 +68,27 @@ class TestXMLState(object):
             'vim'
         ]
 
+    @patch('platform.machine')
+    def test_get_system_packages_some_arch(self, mock_machine):
+        mock_machine.return_value = 'some-arch'
+        description = XMLDescription(
+            '../data/example_config.xml'
+        )
+        state = XMLState(
+            description.load()
+        )
+        assert state.get_system_packages() == [
+            'foo',
+            'gfxboot-branding-openSUSE',
+            'grub2-branding-openSUSE',
+            'ifplugd',
+            'iputils',
+            'kernel-default',
+            'openssh',
+            'plymouth-branding-openSUSE',
+            'vim'
+        ]
+
     def test_get_system_collections(self):
         assert self.state.get_system_collections() == [
             'base'


### PR DESCRIPTION
This commit ensure that the arch attribute of each package section
is parsed as a comma separated list. This way, as in previous kiwi
versions, each package might be suitable for one or more specified
architectures.

Fixes #202