### PR TITLE
Kernel name fix

### DIFF
--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -68,7 +68,7 @@ class BootLoaderConfigBase(object):
         raise NotImplementedError
 
     def setup_disk_image_config(
-        self, uuid, hypervisor, kernel, initrd
+        self, boot_uuid, root_uuid, hypervisor, kernel, initrd
     ):
         """
         Create boot config file to boot from disk.

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -199,7 +199,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             [cmdline, Defaults.get_failsafe_kernel_options()]
         )
         parameters = {
-            'search_params': '--fs-uuid --set=root ' + boot_uuid,
+            'search_params': ' '.join(['--fs-uuid', '--set=root', boot_uuid]),
             'default_boot': '0',
             'kernel_file': kernel,
             'initrd_file': initrd,

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -180,24 +180,26 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                             grub_default.write(config_entry + os.linesep)
 
     def setup_disk_image_config(
-        self, uuid, hypervisor='xen.gz', kernel='linux.vmx', initrd='initrd.vmx'
+        self, boot_uuid, root_uuid, hypervisor='xen.gz', kernel='linux.vmx',
+        initrd='initrd.vmx'
     ):
         """
         Create the grub.cfg in memory from a template suitable to boot
         from a disk image
 
-        :param string uuid: boot device UUID
+        :param string boot_uuid: boot device UUID
+        :param string root_uuid: root device UUID
         :param string hypervisor: hypervisor name
         :param string kernel: kernel name
         :param string initrd: initrd name
         """
         log.info('Creating grub config file from template')
-        cmdline = self.get_boot_cmdline(uuid)
+        cmdline = self.get_boot_cmdline(root_uuid)
         cmdline_failsafe = ' '.join(
             [cmdline, Defaults.get_failsafe_kernel_options()]
         )
         parameters = {
-            'search_params': '--fs-uuid --set=root ' + uuid,
+            'search_params': '--fs-uuid --set=root ' + boot_uuid,
             'default_boot': '0',
             'kernel_file': kernel,
             'initrd_file': initrd,

--- a/kiwi/bootloader/config/zipl.py
+++ b/kiwi/bootloader/config/zipl.py
@@ -140,14 +140,15 @@ class BootLoaderConfigZipl(BootLoaderConfigBase):
             )
 
     def setup_disk_image_config(
-        self, uuid=None, hypervisor=None,
+        self, boot_uuid=None, root_uuid=None, hypervisor=None,
         kernel='linux.vmx', initrd='initrd.vmx'
     ):
         """
         Create the zipl config in memory from a template suitable to
         boot from a disk image.
 
-        :param string uuid: unused
+        :param string boot_uuid: unused
+        :param string root_uuid: unused
         :param string hypervisor: unused
         :param string kernel: kernel name
         :param string initrd: initrd name

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -974,11 +974,8 @@ class DiskBuilder(object):
                 self.boot_image.boot_root_directory
             )
         if self.initrd_system and self.initrd_system == 'dracut':
-            kernel_name_prefix = 'vmlinuz-'
-            if self.arch == 'aarch64' or self.arch.startswith('arm'):
-                kernel_name_prefix = 'zImage-'
             return boot_names_type(
-                kernel_name=kernel_name_prefix + kernel_info.version,
+                kernel_name=kernel_info.name,
                 initrd_name='initrd-' + kernel_info.version
             )
         else:

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -851,12 +851,16 @@ class DiskBuilder(object):
         if 'kiwi_BootPart' in partition_id_map:
             boot_partition_id = partition_id_map['kiwi_BootPart']
 
+        root_uuid = self.disk.get_uuid(
+            device_map['root'].get_device()
+        )
         boot_uuid = self.disk.get_uuid(
             boot_device.get_device()
         )
         self.bootloader_config.setup_disk_boot_images(boot_uuid)
         self.bootloader_config.setup_disk_image_config(
-            uuid=boot_uuid,
+            boot_uuid=boot_uuid,
+            root_uuid=root_uuid,
             kernel=boot_names.kernel_name,
             initrd=boot_names.initrd_name
         )

--- a/kiwi/system/kernel.py
+++ b/kiwi/system/kernel.py
@@ -47,7 +47,7 @@ class Kernel(object):
         """
         Lookup kernel files and provide filename and version
 
-        :return: tuple with filename and version
+        :return: tuple with filename, kernelname and version
         :rtype: namedtuple
         """
         for kernel_name in self.kernel_names:
@@ -60,9 +60,10 @@ class Kernel(object):
                     version = 'no-version-found'
                 version = version.rstrip('\n')
                 kernel = namedtuple(
-                    'kernel', ['filename', 'version']
+                    'kernel', ['name', 'filename', 'version']
                 )
                 return kernel(
+                    name=os.path.basename(os.path.realpath(kernel_file)),
                     filename=kernel_file,
                     version=version
                 )

--- a/test/unit/bootloader_config_base_test.py
+++ b/test/unit/bootloader_config_base_test.py
@@ -29,7 +29,7 @@ class TestBootLoaderConfigBase(object):
     @raises(NotImplementedError)
     def test_setup_disk_image_config(self):
         self.bootloader.setup_disk_image_config(
-            'uuid', 'hypervisor', 'kernel', 'initrd'
+            'boot_uuid', 'root_uuid', 'hypervisor', 'kernel', 'initrd'
         )
 
     @raises(NotImplementedError)

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -247,7 +247,7 @@ class TestBootLoaderConfigGrub2(object):
 
     def test_setup_disk_image_config_multiboot(self):
         self.bootloader.multiboot = True
-        self.bootloader.setup_disk_image_config('uuid')
+        self.bootloader.setup_disk_image_config('boot_uuid', 'root_uuid')
         self.grub2.get_multiboot_disk_template.assert_called_once_with(
             True, 'gfxterm'
         )
@@ -261,7 +261,7 @@ class TestBootLoaderConfigGrub2(object):
 
     def test_setup_disk_image_config_standard(self):
         self.bootloader.multiboot = False
-        self.bootloader.setup_disk_image_config('uuid')
+        self.bootloader.setup_disk_image_config('boot_uuid', 'root_uuid')
         self.grub2.get_disk_template.assert_called_once_with(
             True, True, 'gfxterm'
         )
@@ -293,7 +293,7 @@ class TestBootLoaderConfigGrub2(object):
         self.grub2.get_multiboot_disk_template = mock.Mock(
             return_value=template
         )
-        self.bootloader.setup_disk_image_config('uuid')
+        self.bootloader.setup_disk_image_config('boot_uuid', 'root_uuid')
 
     @raises(KiwiTemplateError)
     def test_setup_install_image_config_substitute_error(self):

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -73,6 +73,7 @@ class TestDiskBuilder(object):
         )
         kernel_info = mock.Mock()
         kernel_info.version = '1.2.3'
+        kernel_info.name = 'vmlinuz-1.2.3-default'
         self.kernel = mock.Mock()
         self.kernel.get_kernel = mock.Mock(
             return_value=kernel_info
@@ -400,7 +401,7 @@ class TestDiskBuilder(object):
             '0815'
         )
         self.bootloader_config.setup_disk_image_config.assert_called_once_with(
-            initrd='initrd-1.2.3', kernel='vmlinuz-1.2.3', uuid='0815'
+            initrd='initrd-1.2.3', kernel='vmlinuz-1.2.3-default', uuid='0815'
         )
         self.setup.call_edit_boot_config_script.assert_called_once_with(
             'btrfs', 1
@@ -468,10 +469,11 @@ class TestDiskBuilder(object):
         self.disk_builder.initrd_system = 'dracut'
         kernel = mock.Mock()
         kernel.version = '1.2.3'
+        kernel.name = 'vmlinuz-1.2.3'
         self.kernel.get_kernel.return_value = kernel
         self.disk_builder.create_disk()
         self.bootloader_config.setup_disk_image_config.assert_called_once_with(
-            uuid='0815', initrd='initrd-1.2.3', kernel='vmlinuz-1.2.3'
+            uuid='0815', initrd='initrd-1.2.3', kernel=kernel.name
         )
 
     @patch('kiwi.builder.disk.FileSystem')
@@ -520,10 +522,11 @@ class TestDiskBuilder(object):
         self.disk_builder.arch = 'aarch64'
         kernel = mock.Mock()
         kernel.version = '1.2.3'
+        kernel.name = 'Image-1.2.3-default'
         self.kernel.get_kernel.return_value = kernel
         self.disk_builder.create_disk()
         self.bootloader_config.setup_disk_image_config.assert_called_once_with(
-            uuid='0815', initrd='initrd-1.2.3', kernel='zImage-1.2.3'
+            uuid='0815', initrd='initrd-1.2.3', kernel=kernel.name
         )
 
     @patch('kiwi.builder.disk.FileSystem')

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -285,7 +285,8 @@ class TestDiskBuilder(object):
             '0815'
         )
         self.bootloader_config.setup_disk_image_config.assert_called_once_with(
-            initrd='initrd.vmx', kernel='linux.vmx', uuid='0815'
+            initrd='initrd.vmx', kernel='linux.vmx',
+            boot_uuid='0815', root_uuid='0815'
         )
         self.setup.call_edit_boot_config_script.assert_called_once_with(
             'btrfs', 1
@@ -401,7 +402,8 @@ class TestDiskBuilder(object):
             '0815'
         )
         self.bootloader_config.setup_disk_image_config.assert_called_once_with(
-            initrd='initrd-1.2.3', kernel='vmlinuz-1.2.3-default', uuid='0815'
+            initrd='initrd-1.2.3', kernel='vmlinuz-1.2.3-default',
+            boot_uuid='0815', root_uuid='0815'
         )
         self.setup.call_edit_boot_config_script.assert_called_once_with(
             'btrfs', 1
@@ -473,7 +475,8 @@ class TestDiskBuilder(object):
         self.kernel.get_kernel.return_value = kernel
         self.disk_builder.create_disk()
         self.bootloader_config.setup_disk_image_config.assert_called_once_with(
-            uuid='0815', initrd='initrd-1.2.3', kernel=kernel.name
+            initrd='initrd-1.2.3', kernel=kernel.name,
+            boot_uuid='0815', root_uuid='0815'
         )
 
     @patch('kiwi.builder.disk.FileSystem')
@@ -526,7 +529,8 @@ class TestDiskBuilder(object):
         self.kernel.get_kernel.return_value = kernel
         self.disk_builder.create_disk()
         self.bootloader_config.setup_disk_image_config.assert_called_once_with(
-            uuid='0815', initrd='initrd-1.2.3', kernel=kernel.name
+            initrd='initrd-1.2.3', kernel=kernel.name,
+            boot_uuid='0815', root_uuid='0815'
         )
 
     @patch('kiwi.builder.disk.FileSystem')

--- a/test/unit/system_kernel_test.py
+++ b/test/unit/system_kernel_test.py
@@ -34,14 +34,16 @@ class TestKernel(object):
         self.kernel.get_kernel(raise_on_not_found=True)
 
     @patch('os.path.exists')
+    @patch('os.path.realpath')
     @patch('kiwi.command.Command.run')
-    def test_get_kernel(self, mock_run, mock_os):
+    def test_get_kernel(self, mock_run, mock_realpath, mock_os):
         run = namedtuple(
             'run', ['output']
         )
         result = run(output='42')
         mock_os.return_value = True
         mock_run.return_value = result
+        mock_realpath.return_value = 'vmlinux-realpath'
         data = self.kernel.get_kernel()
         mock_run.assert_called_once_with(
             command=['kversion', 'root-dir/boot/vmlinux'],
@@ -49,6 +51,7 @@ class TestKernel(object):
         )
         assert data.filename == 'root-dir/boot/vmlinux'
         assert data.version == '42'
+        assert data.name == 'vmlinux-realpath'
 
     @patch('os.path.exists')
     @patch('kiwi.command.Command.run')


### PR DESCRIPTION
The Kernel instance is the only correct place to ask for the kernel name. This class has the responsibility
to know information about the selected kernel. The additional arch based assumption on the kernel name in the disk builder were wrong. This fixes bnc#1011936