### PR TITLE
LVM volumes management during grub2 install

### DIFF
--- a/kiwi/volume_manager/btrfs.py
+++ b/kiwi/volume_manager/btrfs.py
@@ -222,7 +222,10 @@ class VolumeManagerBtrfs(VolumeManagerBase):
                     'subvol=' + subvol_name
                 ] + self.custom_filesystem_args['mount_options']
             )
-            volumes[subvol_name.replace('@', '')] = subvol_options
+            volumes[subvol_name.replace('@', '')] = {
+                'volume_options': subvol_options,
+                'volume_device': volume_mount.device
+            }
         return volumes
 
     def mount_volumes(self):

--- a/kiwi/volume_manager/lvm.py
+++ b/kiwi/volume_manager/lvm.py
@@ -196,7 +196,10 @@ class VolumeManagerLVM(VolumeManagerBase):
         for volume_mount in self.mount_list:
             mount_path = '/'.join(volume_mount.mountpoint.split('/')[3:])
             if mount_path:
-                volumes[mount_path] = self.mount_options
+                volumes[mount_path] = {
+                    'volume_options': self.mount_options,
+                    'volume_device': volume_mount.device
+                }
         return volumes
 
     def mount_volumes(self):

--- a/test/unit/bootloader_install_grub2_test.py
+++ b/test/unit/bootloader_install_grub2_test.py
@@ -26,7 +26,10 @@ class TestBootLoaderInstallGrub2(object):
             'root_device': '/dev/mapper/loop0p1',
             'efi_device': '/dev/mapper/loop0p3',
             'prep_device': '/dev/mapper/loop0p2',
-            'system_volumes': {'boot/grub2': 'subvol=@/boot/grub2'},
+            'system_volumes': {'boot/grub2': {
+                'volume_options': 'subvol=@/boot/grub2',
+                'volume_device': 'device'
+            }},
             'firmware': self.firmware,
             'target_removable': None
         }

--- a/test/unit/volume_manager_btrfs_test.py
+++ b/test/unit/volume_manager_btrfs_test.py
@@ -205,7 +205,10 @@ class TestVolumeManagerBtrfs(object):
         self.volume_manager.subvol_mount_list = [volume_mount]
         self.volume_manager.custom_args['root_is_snapshot'] = True
         assert self.volume_manager.get_volumes() == {
-            '/boot/grub2': 'subvol=@/boot/grub2'
+            '/boot/grub2': {
+                'volume_options': 'subvol=@/boot/grub2',
+                'volume_device': 'device'
+            }
         }
 
     @patch('kiwi.volume_manager.btrfs.Command.run')

--- a/test/unit/volume_manager_lvm_test.py
+++ b/test/unit/volume_manager_lvm_test.py
@@ -211,9 +211,13 @@ class TestVolumeManagerLVM(object):
         volume_mount = mock.Mock()
         volume_mount.mountpoint = \
             '/tmp/kiwi_volumes.f2qx_d3y/boot/grub2/x86_64-efi'
+        volume_mount.device = '/dev/mapper/vg1-LVRoot'
         self.volume_manager.mount_list = [volume_mount]
         assert self.volume_manager.get_volumes() == {
-            'boot/grub2/x86_64-efi': 'a,b,c'
+            'boot/grub2/x86_64-efi': {
+                'volume_options': 'a,b,c',
+                'volume_device': '/dev/mapper/vg1-LVRoot'
+            }
         }
 
     def test_get_fstab(self):


### PR DESCRIPTION
Grub installation procedure have been updated to take into account
LVM volumes mountpoint and ensure they are mounted with a
coherent order.

Fixes #205 