### PR TITLE
Including minimum volume size offset in disk size calculation

### DIFF
--- a/kiwi/storage/setup.py
+++ b/kiwi/storage/setup.py
@@ -312,13 +312,13 @@ class DiskSetup(object):
                 [size_type, req_size] = volume.size.split(':')
                 disk_add_mbytes = 0
                 if size_type == 'freespace':
-                    disk_add_mbytes += int(req_size) + \
-                        Defaults.get_min_volume_mbytes()
+                    disk_add_mbytes += int(req_size)
                 else:
                     disk_add_mbytes += int(req_size) - \
                         data_volume_mbytes.volume[volume.realpath]
                 if disk_add_mbytes > 0:
-                    disk_volume_mbytes += disk_add_mbytes
+                    disk_volume_mbytes += disk_add_mbytes + \
+                        Defaults.get_min_volume_mbytes()
                 else:
                     log.warning(
                         'volume size of %s MB for %s is too small, skipped',
@@ -327,14 +327,14 @@ class DiskSetup(object):
 
         if root_volume:
             if root_volume.size_type == 'freespace':
-                disk_add_mbytes = root_volume.req_size + \
-                    Defaults.get_min_volume_mbytes()
+                disk_add_mbytes = root_volume.req_size
             else:
                 disk_add_mbytes = root_volume.req_size - \
                     root_mbytes + data_volume_mbytes.total
 
             if disk_add_mbytes > 0:
-                disk_volume_mbytes += disk_add_mbytes
+                disk_volume_mbytes += disk_add_mbytes + \
+                    Defaults.get_min_volume_mbytes()
             else:
                 log.warning(
                     'root volume size of %s MB is too small, skipped',

--- a/test/unit/storage_setup_test.py
+++ b/test/unit/storage_setup_test.py
@@ -184,7 +184,8 @@ class TestDiskSetup(object):
             root_size + \
             1024 - root_size + \
             500 + Defaults.get_min_volume_mbytes() + \
-            30 + Defaults.get_min_volume_mbytes()
+            30 + Defaults.get_min_volume_mbytes() + \
+            Defaults.get_min_volume_mbytes()
         assert mock_log_warn.called
 
     @patch('os.path.exists')


### PR DESCRIPTION
Adding an extra space on disk calculation in order to hold `fdisk` offset, LVM metadata or any other kind of data that is needed for volume and partitions handling which not part of the partition's or volume's size.

Fixes #207