### PR TITLE
Refactor docker container creation

### DIFF
--- a/doc/source/schema.rst
+++ b/doc/source/schema.rst
@@ -341,10 +341,196 @@ Provides metadata information for containers
 Parents:
    These elements contain ``containerconfig``: :ref:`k.image.preferences.type`
 
+Children:
+   The following elements occur in ``containerconfig``: :ref:`entrypoint <k.image.preferences.type.containerconfig.entrypoint>` `[?]`_, :ref:`subcommand <k.image.preferences.type.containerconfig.subcommand>` `[?]`_, :ref:`expose <k.image.preferences.type.containerconfig.expose>` `[?]`_, :ref:`volumes <k.image.preferences.type.containerconfig.volumes>` `[?]`_, :ref:`environment <k.image.preferences.type.containerconfig.environment>` `[?]`_, :ref:`labels <k.image.preferences.type.containerconfig.labels>` `[?]`_
+
 List of attributes for ``containerconfig``:
 
-* ``name`` : Specifies a name for the container. This is usually the the tag name of the container as read if the container image is imported via the docker load command
-* ``entry_command`` `[?]`_: Specifies the default command to run if the container is called via the docker run command.
+* ``name`` : Specifies a name for the container. This is usually the the repository name of the container as read if the container image is imported via the docker load command
+* ``tag`` `[?]`_: Specifies a tag for the container. This is usually the the tag name of the container as read if the container image is imported via the docker load command
+* ``maintainer`` `[?]`_: Specifies a maintainer for the container.
+* ``user`` `[?]`_: Specifies a user for the container.
+* ``workingdir`` `[?]`_: Specifies the default working directory of the container
+
+.. _k.image.preferences.type.containerconfig.entrypoint:
+
+entrypoint
+::::::::::
+
+Provides details for the entry point command. This includes the execution name and its parameters. Arguments can be optionally specified
+
+Parents:
+   These elements contain ``entrypoint``: :ref:`k.image.preferences.type.containerconfig`
+
+Children:
+   The following elements occur in ``entrypoint``: :ref:`argument <k.image.preferences.type.containerconfig.entrypoint.argument>` `[*]`_
+
+List of attributes for ``entrypoint``:
+
+* ``execute`` : Specifies the entry point program name to execute
+
+.. _k.image.preferences.type.containerconfig.entrypoint.argument:
+
+argument
+;;;;;;;;
+
+Provides details about a command argument
+
+Parents:
+   These elements contain ``argument``: :ref:`k.image.preferences.type.containerconfig.entrypoint`, :ref:`k.image.preferences.type.containerconfig.subcommand`
+
+List of attributes for ``argument``:
+
+* ``name`` : Specifies a command argument name
+
+.. _k.image.preferences.type.containerconfig.subcommand:
+
+subcommand
+::::::::::
+
+Provides details for the subcommand command. This includes the execution name and its parameters. Arguments can be optionally specified. The subcommand is appended the command information from the entrypoint. It is in the responsibility of the author to make sure the combination of entrypoint and subcommand forms a valid execution command
+
+Parents:
+   These elements contain ``subcommand``: :ref:`k.image.preferences.type.containerconfig`
+
+Children:
+   The following elements occur in ``subcommand``: :ref:`argument <k.image.preferences.type.containerconfig.subcommand.argument>` `[*]`_
+
+List of attributes for ``subcommand``:
+
+* ``execute`` : Specifies the subcommand program name to execute
+
+.. _k.image.preferences.type.containerconfig.subcommand.argument:
+
+argument
+;;;;;;;;
+
+Provides details about a command argument
+
+Parents:
+   These elements contain ``argument``: :ref:`k.image.preferences.type.containerconfig.entrypoint`, :ref:`k.image.preferences.type.containerconfig.subcommand`
+
+List of attributes for ``argument``:
+
+* ``name`` : Specifies a command argument name
+
+.. _k.image.preferences.type.containerconfig.expose:
+
+expose
+::::::
+
+Provides details about network ports which should be exposed from the container. At least one port must be configured
+
+Parents:
+   These elements contain ``expose``: :ref:`k.image.preferences.type.containerconfig`
+
+Children:
+   The following elements occur in ``expose``: :ref:`port <k.image.preferences.type.containerconfig.expose.port>` `[+]`_
+
+
+.. _k.image.preferences.type.containerconfig.expose.port:
+
+port
+;;;;
+
+Provides details about an exposed port.
+
+Parents:
+   These elements contain ``port``: :ref:`k.image.preferences.type.containerconfig.expose`
+
+List of attributes for ``port``:
+
+* ``number`` : Specifies the port number to expose
+
+.. _k.image.preferences.type.containerconfig.volumes:
+
+volumes
+:::::::
+
+Provides details about storage volumes in the container At least one volume must be configured
+
+Parents:
+   These elements contain ``volumes``: :ref:`k.image.preferences.type.containerconfig`
+
+Children:
+   The following elements occur in ``volumes``: :ref:`volume <k.image.preferences.type.containerconfig.volumes.volume>` `[+]`_
+
+
+.. _k.image.preferences.type.containerconfig.volumes.volume:
+
+volume
+;;;;;;
+
+Specify which parts of the filesystem should be on an extra volume.
+
+Parents:
+   These elements contain ``volume``: :ref:`k.image.preferences.type.containerconfig.volumes`, :ref:`k.image.preferences.type.systemdisk`
+
+List of attributes for ``volume``:
+
+* ``copy_on_write`` `[?]`_: Apply the filesystem copy-on-write attribute for this volume
+* ``freespace`` `[?]`_: free space to be added to this volume. The value is used as MB by default but you can add "M" and/or "G" as postfix
+* ``mountpoint`` `[?]`_: volume path. The mountpoint specifies a path which has to exist inside the root directory.
+* ``name`` : volume name. The name of the volume. if mountpoint is not specified the name specifies a path which has to exist inside the root directory.
+* ``size`` `[?]`_: absolute size of the volume. If the size value is too small to store all data kiwi will exit. The value is used as MB by default but you can add "M" and/or "G" as postfix
+
+.. _k.image.preferences.type.containerconfig.environment:
+
+environment
+:::::::::::
+
+Provides details about the container environment variables At least one environment variable must be configured
+
+Parents:
+   These elements contain ``environment``: :ref:`k.image.preferences.type.containerconfig`
+
+Children:
+   The following elements occur in ``environment``: :ref:`env <k.image.preferences.type.containerconfig.environment.env>` `[+]`_
+
+
+.. _k.image.preferences.type.containerconfig.environment.env:
+
+env
+;;;
+
+Provides details about an environment variable
+
+Parents:
+   These elements contain ``env``: :ref:`k.image.preferences.type.containerconfig.environment`
+
+List of attributes for ``env``:
+
+* ``name`` : Specifies the environment variable name
+* ``value`` : Specifies the environment variable value
+
+.. _k.image.preferences.type.containerconfig.labels:
+
+labels
+::::::
+
+Provides details about container labels At least one label must be configured
+
+Parents:
+   These elements contain ``labels``: :ref:`k.image.preferences.type.containerconfig`
+
+Children:
+   The following elements occur in ``labels``: :ref:`label <k.image.preferences.type.containerconfig.labels.label>` `[+]`_
+
+
+.. _k.image.preferences.type.containerconfig.labels.label:
+
+label
+;;;;;
+
+Provides details about a container label
+
+Parents:
+   These elements contain ``label``: :ref:`k.image.preferences.type.containerconfig.labels`
+
+List of attributes for ``label``:
+
+* ``name`` : Specifies the label name
+* ``value`` : Specifies the label value
 
 .. _k.image.preferences.type.machine:
 
@@ -882,7 +1068,7 @@ volume
 Specify which parts of the filesystem should be on an extra volume.
 
 Parents:
-   These elements contain ``volume``: :ref:`k.image.preferences.type.systemdisk`
+   These elements contain ``volume``: :ref:`k.image.preferences.type.containerconfig.volumes`, :ref:`k.image.preferences.type.systemdisk`
 
 List of attributes for ``volume``:
 

--- a/kiwi/builder/container.py
+++ b/kiwi/builder/container.py
@@ -55,8 +55,7 @@ class ContainerBuilder(object):
     def __init__(self, xml_state, target_dir, root_dir):
         self.root_dir = root_dir
         self.target_dir = target_dir
-        self.container_config = \
-            xml_state.get_build_type_containerconfig_section()
+        self.container_config = xml_state.get_container_config()
         self.requested_container_type = xml_state.get_build_type_name()
         self.system_setup = SystemSetup(
             xml_state=xml_state, root_dir=self.root_dir
@@ -81,24 +80,19 @@ class ContainerBuilder(object):
 
         * image="docker"
         """
-        setup_options = {}
-        if self.container_config and self.container_config.get_name():
-            setup_options['container_name'] = self.container_config.get_name()
-
-        container_setup = ContainerSetup(
-            self.requested_container_type, self.root_dir, setup_options
-        )
-        log.info('Setting up %s container', self.requested_container_type)
         log.info(
-            '--> Container name: %s', container_setup.get_container_name()
+            'Setting up %s container', self.requested_container_type
+        )
+        container_setup = ContainerSetup(
+            self.requested_container_type, self.root_dir, self.container_config
         )
         container_setup.setup()
 
         log.info(
-            '--> Creating container archive'
+            '--> Creating container image'
         )
         container_image = ContainerImage(
-            self.requested_container_type, self.root_dir
+            self.requested_container_type, self.root_dir, self.container_config
         )
         container_image.create(
             self.filename

--- a/kiwi/container/__init__.py
+++ b/kiwi/container/__init__.py
@@ -30,9 +30,9 @@ class ContainerImage(object):
     :param string name: container system name
     :param string root_dir: root directory path name
     """
-    def __new__(self, name, root_dir):
+    def __new__(self, name, root_dir, custom_args=None):
         if name == 'docker':
-            return ContainerImageDocker(root_dir)
+            return ContainerImageDocker(root_dir, custom_args)
         else:
             raise KiwiContainerImageSetupError(
                 'Support for %s container not implemented' % name

--- a/kiwi/container/docker.py
+++ b/kiwi/container/docker.py
@@ -15,9 +15,15 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+import os
+
 # project
-from ..archive.tar import ArchiveTar
 from ..defaults import Defaults
+from ..path import Path
+from ..command import Command
+from tempfile import mkdtemp
+from ..utils.sync import DataSync
+from ..utils.compress import Compress
 
 
 class ContainerImageDocker(object):
@@ -28,9 +34,60 @@ class ContainerImageDocker(object):
 
     * :attr:`root_dir`
         root directory path name
+
+    * :attr:`custom_args`
+        representation of the containerconfig and its subsections
     """
-    def __init__(self, root_dir):
+    def __init__(self, root_dir, custom_args=None):
         self.root_dir = root_dir
+        self.docker_dir = None
+        self.docker_root_dir = None
+
+        self.container_name = []
+        self.container_tag = 'latest'
+        self.entry_command = ['--config.cmd=/bin/bash']
+        self.entry_subcommand = []
+        self.maintainer = []
+        self.user = []
+        self.workingdir = []
+        self.expose_ports = []
+        self.volumes = []
+        self.environment = []
+        self.labels = []
+
+        if custom_args:
+            if 'container_name' in custom_args:
+                self.container_name = custom_args['container_name']
+
+            if 'container_tag' in custom_args:
+                self.container_tag = custom_args['container_tag']
+
+            if 'entry_command' in custom_args:
+                self.entry_command = custom_args['entry_command']
+
+            if 'entry_subcommand' in custom_args:
+                self.entry_subcommand = custom_args['entry_subcommand']
+
+            if 'maintainer' in custom_args:
+                self.maintainer = custom_args['maintainer']
+
+            if 'user' in custom_args:
+                self.user = custom_args['user']
+
+            if 'workingdir' in custom_args:
+                self.workingdir = custom_args['workingdir']
+
+            if 'expose_ports' in custom_args:
+                self.expose_ports = custom_args['expose_ports']
+
+            if 'volumes' in custom_args:
+                self.volumes = custom_args['volumes']
+
+            if 'environment' in custom_args:
+                self.environment = custom_args['environment']
+
+            if 'labels' in custom_args:
+                self.labels = custom_args['labels']
 
     def create(self, filename):
         """
@@ -39,14 +96,82 @@ class ContainerImageDocker(object):
         :param string filename: archive file name
         """
         exclude_list = [
-            'image', '.profile', '.kconfig', 'boot',
+            'image', '.profile', '.kconfig', 'boot', 'dev', 'sys', 'proc',
             Defaults.get_shared_cache_location()
         ]
-        # replace potential suffix from filename because
-        # it is added by the archive creation call
-        archive = ArchiveTar(
-            filename.replace('.xz', '')
+
+        self.docker_dir = mkdtemp(prefix='kiwi_docker_dir.')
+        self.docker_root_dir = mkdtemp(prefix='kiwi_docker_root_dir.')
+
+        container_dir = os.sep.join(
+            [self.docker_dir, 'umoci_layout']
         )
-        archive.create_xz_compressed(
-            source_dir=self.root_dir, exclude=exclude_list
+        container_name = ':'.join(
+            [container_dir, self.container_name]
         )
+
+        Command.run(
+            ['umoci', 'init', '--layout', container_dir]
+        )
+        Command.run(
+            ['umoci', 'new', '--image', container_name]
+        )
+        Command.run(
+            ['umoci', 'unpack', '--image', container_name, self.docker_root_dir]
+        )
+        docker_root = DataSync(
+            ''.join([self.root_dir, os.sep]),
+            os.sep.join([self.docker_root_dir, 'rootfs'])
+        )
+        docker_root.sync_data(
+            options=['-a', '-H', '-X', '-A'], exclude=exclude_list
+        )
+        Command.run(
+            ['umoci', 'repack', '--image', container_name, self.docker_root_dir]
+        )
+        Command.run(
+            [
+                'umoci', 'config'
+            ] +
+            self.maintainer +
+            self.user +
+            self.workingdir +
+            self.entry_command +
+            self.entry_subcommand +
+            self.expose_ports +
+            self.volumes +
+            self.environment +
+            self.labels +
+            [
+                '--image', container_name,
+                '--tag', self.container_tag
+            ]
+        )
+        Command.run(
+            ['umoci', 'gc', '--layout', container_dir]
+        )
+
+        docker_tarfile = filename.replace('.xz', '')
+
+        # make sure the target tar file does not exist
+        # skopeo doesn't support force overwrite
+        Path.wipe(docker_tarfile)
+
+        Command.run(
+            [
+                'skopeo', 'copy', 'oci:{0}'.format(
+                    container_name
+                ),
+                'docker-archive:{0}:{1}:{2}'.format(
+                    docker_tarfile, self.container_name, self.container_tag
+                )
+            ]
+        )
+        compressor = Compress(docker_tarfile)
+        compressor.xz()
+
+    def __del__(self):
+        if self.docker_dir:
+            Path.wipe(self.docker_dir)
+        if self.docker_root_dir:
+            Path.wipe(self.docker_root_dir)

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -2391,24 +2391,49 @@ div {
     ]
     k.containerconfig.name.attribute =
         ## Specifies a name for the container. This is usually the
-        ## the tag name of the container as read if the container
+        ## the repository name of the container as read if the container
         ## image is imported via the docker load command
         attribute name { text }
         >> sch:pattern [ id = "name" is-a = "container_type"
             sch:param [ name = "attr" value = "name" ]
             sch:param [ name = "types" value = "docker" ]
         ]
-    k.containerconfig.entry_command.attribute =
-        ## Specifies the default command to run if the container is
-        ## called via the docker run command.
-        attribute entry_command { text }
-        >> sch:pattern [ id = "entry_command" is-a = "container_type"
-            sch:param [ name = "attr" value = "entry_command" ]
+    k.containerconfig.tag.attribute =
+        ## Specifies a tag for the container. This is usually the
+        ## the tag name of the container as read if the container
+        ## image is imported via the docker load command
+        attribute tag { text }
+        >> sch:pattern [ id = "tag" is-a = "container_type"
+            sch:param [ name = "attr" value = "tag" ]
+            sch:param [ name = "types" value = "docker" ]
+        ]
+    k.containerconfig.maintainer.attribute =
+        ## Specifies a maintainer for the container.
+        attribute maintainer { text }
+        >> sch:pattern [ id = "maintainer" is-a = "container_type"
+            sch:param [ name = "attr" value = "maintainer" ]
+            sch:param [ name = "types" value = "docker" ]
+        ]
+    k.containerconfig.user.attribute =
+        ## Specifies a user for the container.
+        attribute user { text }
+        >> sch:pattern [ id = "user" is-a = "container_type"
+            sch:param [ name = "attr" value = "user" ]
+            sch:param [ name = "types" value = "docker" ]
+        ]
+    k.containerconfig.workingdir.attribute =
+        ## Specifies the default working directory of the container
+        attribute workingdir { text }
+        >> sch:pattern [ id = "workingdir" is-a = "container_type"
+            sch:param [ name = "attr" value = "workingdir" ]
             sch:param [ name = "types" value = "docker" ]
         ]
     k.containerconfig.attlist =
         k.containerconfig.name.attribute &
-        k.containerconfig.entry_command.attribute?
+        k.containerconfig.tag.attribute? &
+        k.containerconfig.maintainer.attribute? &
+        k.containerconfig.user.attribute? &
+        k.containerconfig.workingdir.attribute?
 
     k.containerconfig =
         ## Provides metadata information for containers
@@ -2422,7 +2447,202 @@ div {
         ]
         ]
         element containerconfig {
-            k.containerconfig.attlist
+            k.containerconfig.attlist &
+            k.entrypoint? &
+            k.subcommand? &
+            k.expose? &
+            k.volumes? &
+            k.environment? &
+            k.labels?
+        }
+}
+
+#==========================================
+# main block: <entrypoint>
+#
+div {
+    k.entrypoint.execute.attribute =
+        ## Specifies the entry point program name to execute
+        attribute execute { text }
+
+    k.entrypoint.attlist =
+        k.entrypoint.execute.attribute
+
+    k.entrypoint =
+        ## Provides details for the entry point command. This
+        ## includes the execution name and its parameters. Arguments
+        ## can be optionally specified
+        element entrypoint {
+            k.entrypoint.attlist &
+            k.argument*
+        }
+}
+
+#==========================================
+# main block: <subcommand>
+#
+div {
+    k.subcommand.execute.attribute =
+        ## Specifies the subcommand program name to execute
+        attribute execute { text }
+
+    k.subcommand.attlist =
+        k.subcommand.execute.attribute
+
+    k.subcommand =
+        ## Provides details for the subcommand command. This
+        ## includes the execution name and its parameters. Arguments
+        ## can be optionally specified. The subcommand is appended
+        ## the command information from the entrypoint. It is in
+        ## the responsibility of the author to make sure the
+        ## combination of entrypoint and subcommand forms a valid
+        ## execution command
+        element subcommand {
+            k.subcommand.attlist &
+            k.argument*
+        }
+}
+
+#==========================================
+# main block: <argument>
+#
+div {
+    k.argument.name.attribute =
+        ## Specifies a command argument name
+        attribute name { text }
+
+    k.argument.attlist =
+        k.argument.name.attribute
+
+    k.argument =
+        ## Provides details about a command argument
+        element argument {
+            k.argument.attlist &
+            empty
+        }
+}
+
+#==========================================
+# main block: <expose>
+#
+div {
+    k.expose.attlist = empty
+    k.expose =
+        ## Provides details about network ports which should be
+        ## exposed from the container. At least one port must
+        ## be configured
+        element expose {
+            k.expose.attlist &
+            k.port+
+        }
+}
+
+#==========================================
+# main block: <port>
+#
+div {
+    k.port.number.attribute =
+        ## Specifies the port number to expose
+        attribute number { xsd:nonNegativeInteger }
+
+    k.port.attlist =
+        k.port.number.attribute
+
+    k.port =
+        ## Provides details about an exposed port.
+        element port {
+            k.port.attlist &
+            empty
+        }
+}
+
+#==========================================
+# main block: <volumes>
+#
+div {
+    k.volumes.attlist = empty
+    k.volumes =
+        ## Provides details about storage volumes in the container
+        ## At least one volume must be configured
+        element volumes {
+            k.volumes.attlist &
+            k.volume+
+        }
+}
+
+#==========================================
+# main block: <environment>
+#
+div {
+    k.environment.attlist = empty
+    k.environment =
+        ## Provides details about the container environment variables
+        ## At least one environment variable must be configured
+        element environment {
+            k.environment.attlist &
+            k.env+
+        }
+}
+
+#==========================================
+# main block: <env>
+#
+div {
+    k.env.name.attribute =
+        ## Specifies the environment variable name
+        attribute name { text }
+
+    k.env.value.attribute =
+        ## Specifies the environment variable value
+        attribute value { text }
+
+    k.env.attlist =
+        k.env.name.attribute &
+        k.env.value.attribute
+
+    k.env =
+        ## Provides details about an environment variable
+        element env {
+            k.env.attlist &
+            empty
+        }
+}
+
+#==========================================
+# main block: <labels>
+#
+div {
+    k.labels.attlist = empty
+    k.labels =
+        ## Provides details about container labels
+        ## At least one label must be configured
+        element labels {
+            k.labels.attlist &
+            k.label+
+        }
+}
+
+#==========================================
+# main block: <label>
+#
+div {
+    k.label.name.attribute =
+        ## Specifies the label name
+        attribute name { text }
+
+    k.label.value.attribute =
+        ## Specifies the label value
+        attribute value { text }
+
+    k.label.attlist =
+        k.label.name.attribute &
+        k.label.value.attribute
+
+    k.label =
+        ## Provides details about a container label
+        element label {
+            k.label.attlist &
+            empty
         }
 }
 

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -3356,7 +3356,7 @@ a standard image description created by a kiwi user.</a:documentation>
     <define name="k.containerconfig.name.attribute">
       <attribute name="name">
         <a:documentation>Specifies a name for the container. This is usually the
-the tag name of the container as read if the container
+the repository name of the container as read if the container
 image is imported via the docker load command</a:documentation>
       </attribute>
       <sch:pattern id="name" is-a="container_type">
@@ -3364,13 +3364,41 @@ image is imported via the docker load command</a:documentation>
         <sch:param name="types" value="docker"/>
       </sch:pattern>
     </define>
-    <define name="k.containerconfig.entry_command.attribute">
-      <attribute name="entry_command">
-        <a:documentation>Specifies the default command to run if the container is
-called via the docker run command.</a:documentation>
+    <define name="k.containerconfig.tag.attribute">
+      <attribute name="tag">
+        <a:documentation>Specifies a tag for the container. This is usually the
+the tag name of the container as read if the container
+image is imported via the docker load command</a:documentation>
       </attribute>
-      <sch:pattern id="entry_command" is-a="container_type">
-        <sch:param name="attr" value="entry_command"/>
+      <sch:pattern id="tag" is-a="container_type">
+        <sch:param name="attr" value="tag"/>
+        <sch:param name="types" value="docker"/>
+      </sch:pattern>
+    </define>
+    <define name="k.containerconfig.maintainer.attribute">
+      <attribute name="maintainer">
+        <a:documentation>Specifies a maintainer for the container.</a:documentation>
+      </attribute>
+      <sch:pattern id="maintainer" is-a="container_type">
+        <sch:param name="attr" value="maintainer"/>
+        <sch:param name="types" value="docker"/>
+      </sch:pattern>
+    </define>
+    <define name="k.containerconfig.user.attribute">
+      <attribute name="user">
+        <a:documentation>Specifies a user for the container.</a:documentation>
+      </attribute>
+      <sch:pattern id="user" is-a="container_type">
+        <sch:param name="attr" value="user"/>
+        <sch:param name="types" value="docker"/>
+      </sch:pattern>
+    </define>
+    <define name="k.containerconfig.workingdir.attribute">
+      <attribute name="workingdir">
+        <a:documentation>Specifies the default working directory of the container</a:documentation>
+      </attribute>
+      <sch:pattern id="workingdir" is-a="container_type">
+        <sch:param name="attr" value="workingdir"/>
         <sch:param name="types" value="docker"/>
       </sch:pattern>
     </define>
@@ -3378,7 +3406,16 @@ called via the docker run command.</a:documentation>
       <interleave>
         <ref name="k.containerconfig.name.attribute"/>
         <optional>
-          <ref name="k.containerconfig.entry_command.attribute"/>
+          <ref name="k.containerconfig.tag.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.containerconfig.maintainer.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.containerconfig.user.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.containerconfig.workingdir.attribute"/>
         </optional>
       </interleave>
     </define>
@@ -3386,7 +3423,289 @@ called via the docker run command.</a:documentation>
       <element name="containerconfig">
         <a:documentation>Provides metadata information for containers</a:documentation>
         <db:para>The containerconfig element provides metadata informationto setup a container in order to be prepared for use withthe container engine tool chain. container specific datashould be provided in an additional subsection whereas thissection provides globally useful container information</db:para>
-        <ref name="k.containerconfig.attlist"/>
+        <interleave>
+          <ref name="k.containerconfig.attlist"/>
+          <optional>
+            <ref name="k.entrypoint"/>
+          </optional>
+          <optional>
+            <ref name="k.subcommand"/>
+          </optional>
+          <optional>
+            <ref name="k.expose"/>
+          </optional>
+          <optional>
+            <ref name="k.volumes"/>
+          </optional>
+          <optional>
+            <ref name="k.environment"/>
+          </optional>
+          <optional>
+            <ref name="k.labels"/>
+          </optional>
+        </interleave>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    main block: <entrypoint>
+    
+  -->
+  <div>
+    <define name="k.entrypoint.execute.attribute">
+      <attribute name="execute">
+        <a:documentation>Specifies the entry point program name to execute</a:documentation>
+      </attribute>
+    </define>
+    <define name="k.entrypoint.attlist">
+      <ref name="k.entrypoint.execute.attribute"/>
+    </define>
+    <define name="k.entrypoint">
+      <element name="entrypoint">
+        <a:documentation>Provides details for the entry point command. This
+includes the execution name and its parameters. Arguments
+can be optionally specified</a:documentation>
+        <interleave>
+          <ref name="k.entrypoint.attlist"/>
+          <zeroOrMore>
+            <ref name="k.argument"/>
+          </zeroOrMore>
+        </interleave>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    main block: <subcommand>
+    
+  -->
+  <div>
+    <define name="k.subcommand.execute.attribute">
+      <attribute name="execute">
+        <a:documentation>Specifies the subcommand program name to execute</a:documentation>
+      </attribute>
+    </define>
+    <define name="k.subcommand.attlist">
+      <ref name="k.subcommand.execute.attribute"/>
+    </define>
+    <define name="k.subcommand">
+      <element name="subcommand">
+        <a:documentation>Provides details for the subcommand command. This
+includes the execution name and its parameters. Arguments
+can be optionally specified. The subcommand is appended
+the command information from the entrypoint. It is in
+the responsibility of the author to make sure the
+combination of entrypoint and subcommand forms a valid
+execution command</a:documentation>
+        <interleave>
+          <ref name="k.subcommand.attlist"/>
+          <zeroOrMore>
+            <ref name="k.argument"/>
+          </zeroOrMore>
+        </interleave>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    main block: <argument>
+    
+  -->
+  <div>
+    <define name="k.argument.name.attribute">
+      <attribute name="name">
+        <a:documentation>Specifies a command argument name</a:documentation>
+      </attribute>
+    </define>
+    <define name="k.argument.attlist">
+      <ref name="k.argument.name.attribute"/>
+    </define>
+    <define name="k.argument">
+      <element name="argument">
+        <a:documentation>Provides details about a command argument</a:documentation>
+        <interleave>
+          <ref name="k.argument.attlist"/>
+          <empty/>
+        </interleave>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    main block: <expose>
+    
+  -->
+  <div>
+    <define name="k.expose.attlist">
+      <empty/>
+    </define>
+    <define name="k.expose">
+      <element name="expose">
+        <a:documentation>Provides details about network ports which should be
+exposed from the container. At least one port must
+be configured</a:documentation>
+        <interleave>
+          <ref name="k.expose.attlist"/>
+          <oneOrMore>
+            <ref name="k.port"/>
+          </oneOrMore>
+        </interleave>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    main block: <port>
+    
+  -->
+  <div>
+    <define name="k.port.number.attribute">
+      <attribute name="number">
+        <a:documentation>Specifies the port number to expose</a:documentation>
+        <data type="nonNegativeInteger"/>
+      </attribute>
+    </define>
+    <define name="k.port.attlist">
+      <ref name="k.port.number.attribute"/>
+    </define>
+    <define name="k.port">
+      <element name="port">
+        <a:documentation>Provides details about an exposed port.</a:documentation>
+        <interleave>
+          <ref name="k.port.attlist"/>
+          <empty/>
+        </interleave>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    main block: <volumes>
+    
+  -->
+  <div>
+    <define name="k.volumes.attlist">
+      <empty/>
+    </define>
+    <define name="k.volumes">
+      <element name="volumes">
+        <a:documentation>Provides details about storage volumes in the container
+At least one volume must be configured</a:documentation>
+        <interleave>
+          <ref name="k.volumes.attlist"/>
+          <oneOrMore>
+            <ref name="k.volume"/>
+          </oneOrMore>
+        </interleave>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    main block: <environment>
+    
+  -->
+  <div>
+    <define name="k.environment.attlist">
+      <empty/>
+    </define>
+    <define name="k.environment">
+      <element name="environment">
+        <a:documentation>Provides details about the container environment variables
+At least one environment variable must be configured</a:documentation>
+        <interleave>
+          <ref name="k.environment.attlist"/>
+          <oneOrMore>
+            <ref name="k.env"/>
+          </oneOrMore>
+        </interleave>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    main block: <env>
+    
+  -->
+  <div>
+    <define name="k.env.name.attribute">
+      <attribute name="name">
+        <a:documentation>Specifies the environment variable name</a:documentation>
+      </attribute>
+    </define>
+    <define name="k.env.value.attribute">
+      <attribute name="value">
+        <a:documentation>Specifies the environment variable value</a:documentation>
+      </attribute>
+    </define>
+    <define name="k.env.attlist">
+      <interleave>
+        <ref name="k.env.name.attribute"/>
+        <ref name="k.env.value.attribute"/>
+      </interleave>
+    </define>
+    <define name="k.env">
+      <element name="env">
+        <a:documentation>Provides details about an environment variable</a:documentation>
+        <interleave>
+          <ref name="k.env.attlist"/>
+          <empty/>
+        </interleave>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    main block: <labels>
+    
+  -->
+  <div>
+    <define name="k.labels.attlist">
+      <empty/>
+    </define>
+    <define name="k.labels">
+      <element name="labels">
+        <a:documentation>Provides details about container labels
+At least one label must be configured</a:documentation>
+        <interleave>
+          <ref name="k.labels.attlist"/>
+          <oneOrMore>
+            <ref name="k.label"/>
+          </oneOrMore>
+        </interleave>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
+    main block: <label>
+    
+  -->
+  <div>
+    <define name="k.label.name.attribute">
+      <attribute name="name">
+        <a:documentation>Specifies the label name</a:documentation>
+      </attribute>
+    </define>
+    <define name="k.label.value.attribute">
+      <attribute name="value">
+        <a:documentation>Specifies the label value</a:documentation>
+      </attribute>
+    </define>
+    <define name="k.label.attlist">
+      <interleave>
+        <ref name="k.label.name.attribute"/>
+        <ref name="k.label.value.attribute"/>
+      </interleave>
+    </define>
+    <define name="k.label">
+      <element name="label">
+        <a:documentation>Provides details about a container label</a:documentation>
+        <interleave>
+          <ref name="k.label.attlist"/>
+          <empty/>
+        </interleave>
       </element>
     </define>
   </div>

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -99,6 +99,7 @@ class SystemBuildTask(CliTask):
         self.load_xml_description(
             self.command_args['--description']
         )
+        self.runtime_checker.check_docker_tool_chain_installed()
         self.runtime_checker.check_volume_setup_has_no_root_definition()
         self.runtime_checker.check_image_include_repos_http_resolvable()
         self.runtime_checker.check_target_directory_not_in_shared_cache(

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -92,6 +92,7 @@ class SystemPrepareTask(CliTask):
         self.load_xml_description(
             self.command_args['--description']
         )
+        self.runtime_checker.check_docker_tool_chain_installed()
         self.runtime_checker.check_volume_setup_has_no_root_definition()
         self.runtime_checker.check_image_include_repos_http_resolvable()
         self.runtime_checker.check_target_directory_not_in_shared_cache(

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Thu Feb 23 15:36:50 2017 by generateDS.py version 2.24a.
+# Generated Mon Feb 27 15:23:58 2017 by generateDS.py version 2.24a.
 #
 # Command line options:
 #   ('-f', '')
@@ -4494,10 +4494,37 @@ class containerconfig(GeneratedsSuper):
     """Provides metadata information for containers"""
     subclass = None
     superclass = None
-    def __init__(self, name=None, entry_command=None):
+    def __init__(self, name=None, tag=None, maintainer=None, user=None, workingdir=None, entrypoint=None, subcommand=None, expose=None, volumes=None, environment=None, labels=None):
         self.original_tagname_ = None
         self.name = _cast(None, name)
-        self.entry_command = _cast(None, entry_command)
+        self.tag = _cast(None, tag)
+        self.maintainer = _cast(None, maintainer)
+        self.user = _cast(None, user)
+        self.workingdir = _cast(None, workingdir)
+        if entrypoint is None:
+            self.entrypoint = []
+        else:
+            self.entrypoint = entrypoint
+        if subcommand is None:
+            self.subcommand = []
+        else:
+            self.subcommand = subcommand
+        if expose is None:
+            self.expose = []
+        else:
+            self.expose = expose
+        if volumes is None:
+            self.volumes = []
+        else:
+            self.volumes = volumes
+        if environment is None:
+            self.environment = []
+        else:
+            self.environment = environment
+        if labels is None:
+            self.labels = []
+        else:
+            self.labels = labels
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -4509,13 +4536,54 @@ class containerconfig(GeneratedsSuper):
         else:
             return containerconfig(*args_, **kwargs_)
     factory = staticmethod(factory)
+    def get_entrypoint(self): return self.entrypoint
+    def set_entrypoint(self, entrypoint): self.entrypoint = entrypoint
+    def add_entrypoint(self, value): self.entrypoint.append(value)
+    def insert_entrypoint_at(self, index, value): self.entrypoint.insert(index, value)
+    def replace_entrypoint_at(self, index, value): self.entrypoint[index] = value
+    def get_subcommand(self): return self.subcommand
+    def set_subcommand(self, subcommand): self.subcommand = subcommand
+    def add_subcommand(self, value): self.subcommand.append(value)
+    def insert_subcommand_at(self, index, value): self.subcommand.insert(index, value)
+    def replace_subcommand_at(self, index, value): self.subcommand[index] = value
+    def get_expose(self): return self.expose
+    def set_expose(self, expose): self.expose = expose
+    def add_expose(self, value): self.expose.append(value)
+    def insert_expose_at(self, index, value): self.expose.insert(index, value)
+    def replace_expose_at(self, index, value): self.expose[index] = value
+    def get_volumes(self): return self.volumes
+    def set_volumes(self, volumes): self.volumes = volumes
+    def add_volumes(self, value): self.volumes.append(value)
+    def insert_volumes_at(self, index, value): self.volumes.insert(index, value)
+    def replace_volumes_at(self, index, value): self.volumes[index] = value
+    def get_environment(self): return self.environment
+    def set_environment(self, environment): self.environment = environment
+    def add_environment(self, value): self.environment.append(value)
+    def insert_environment_at(self, index, value): self.environment.insert(index, value)
+    def replace_environment_at(self, index, value): self.environment[index] = value
+    def get_labels(self): return self.labels
+    def set_labels(self, labels): self.labels = labels
+    def add_labels(self, value): self.labels.append(value)
+    def insert_labels_at(self, index, value): self.labels.insert(index, value)
+    def replace_labels_at(self, index, value): self.labels[index] = value
     def get_name(self): return self.name
     def set_name(self, name): self.name = name
-    def get_entry_command(self): return self.entry_command
-    def set_entry_command(self, entry_command): self.entry_command = entry_command
+    def get_tag(self): return self.tag
+    def set_tag(self, tag): self.tag = tag
+    def get_maintainer(self): return self.maintainer
+    def set_maintainer(self, maintainer): self.maintainer = maintainer
+    def get_user(self): return self.user
+    def set_user(self, user): self.user = user
+    def get_workingdir(self): return self.workingdir
+    def set_workingdir(self, workingdir): self.workingdir = workingdir
     def hasContent_(self):
         if (
-
+            self.entrypoint or
+            self.subcommand or
+            self.expose or
+            self.volumes or
+            self.environment or
+            self.labels
         ):
             return True
         else:
@@ -4534,6 +4602,7 @@ class containerconfig(GeneratedsSuper):
         if self.hasContent_():
             outfile.write('>%s' % (eol_, ))
             self.exportChildren(outfile, level + 1, namespace_='', name_='containerconfig', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
             outfile.write('</%s%s>%s' % (namespace_, name_, eol_))
         else:
             outfile.write('/>%s' % (eol_, ))
@@ -4541,10 +4610,325 @@ class containerconfig(GeneratedsSuper):
         if self.name is not None and 'name' not in already_processed:
             already_processed.add('name')
             outfile.write(' name=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.name), input_name='name')), ))
-        if self.entry_command is not None and 'entry_command' not in already_processed:
-            already_processed.add('entry_command')
-            outfile.write(' entry_command=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.entry_command), input_name='entry_command')), ))
+        if self.tag is not None and 'tag' not in already_processed:
+            already_processed.add('tag')
+            outfile.write(' tag=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.tag), input_name='tag')), ))
+        if self.maintainer is not None and 'maintainer' not in already_processed:
+            already_processed.add('maintainer')
+            outfile.write(' maintainer=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.maintainer), input_name='maintainer')), ))
+        if self.user is not None and 'user' not in already_processed:
+            already_processed.add('user')
+            outfile.write(' user=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.user), input_name='user')), ))
+        if self.workingdir is not None and 'workingdir' not in already_processed:
+            already_processed.add('workingdir')
+            outfile.write(' workingdir=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.workingdir), input_name='workingdir')), ))
     def exportChildren(self, outfile, level, namespace_='', name_='containerconfig', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for entrypoint_ in self.entrypoint:
+            entrypoint_.export(outfile, level, namespace_, name_='entrypoint', pretty_print=pretty_print)
+        for subcommand_ in self.subcommand:
+            subcommand_.export(outfile, level, namespace_, name_='subcommand', pretty_print=pretty_print)
+        for expose_ in self.expose:
+            expose_.export(outfile, level, namespace_, name_='expose', pretty_print=pretty_print)
+        for volumes_ in self.volumes:
+            volumes_.export(outfile, level, namespace_, name_='volumes', pretty_print=pretty_print)
+        for environment_ in self.environment:
+            environment_.export(outfile, level, namespace_, name_='environment', pretty_print=pretty_print)
+        for labels_ in self.labels:
+            labels_.export(outfile, level, namespace_, name_='labels', pretty_print=pretty_print)
+    def build(self, node):
+        already_processed = set()
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        value = find_attr_value_('name', node)
+        if value is not None and 'name' not in already_processed:
+            already_processed.add('name')
+            self.name = value
+        value = find_attr_value_('tag', node)
+        if value is not None and 'tag' not in already_processed:
+            already_processed.add('tag')
+            self.tag = value
+        value = find_attr_value_('maintainer', node)
+        if value is not None and 'maintainer' not in already_processed:
+            already_processed.add('maintainer')
+            self.maintainer = value
+        value = find_attr_value_('user', node)
+        if value is not None and 'user' not in already_processed:
+            already_processed.add('user')
+            self.user = value
+        value = find_attr_value_('workingdir', node)
+        if value is not None and 'workingdir' not in already_processed:
+            already_processed.add('workingdir')
+            self.workingdir = value
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
+        if nodeName_ == 'entrypoint':
+            obj_ = entrypoint.factory()
+            obj_.build(child_)
+            self.entrypoint.append(obj_)
+            obj_.original_tagname_ = 'entrypoint'
+        elif nodeName_ == 'subcommand':
+            obj_ = subcommand.factory()
+            obj_.build(child_)
+            self.subcommand.append(obj_)
+            obj_.original_tagname_ = 'subcommand'
+        elif nodeName_ == 'expose':
+            obj_ = expose.factory()
+            obj_.build(child_)
+            self.expose.append(obj_)
+            obj_.original_tagname_ = 'expose'
+        elif nodeName_ == 'volumes':
+            obj_ = volumes.factory()
+            obj_.build(child_)
+            self.volumes.append(obj_)
+            obj_.original_tagname_ = 'volumes'
+        elif nodeName_ == 'environment':
+            obj_ = environment.factory()
+            obj_.build(child_)
+            self.environment.append(obj_)
+            obj_.original_tagname_ = 'environment'
+        elif nodeName_ == 'labels':
+            obj_ = labels.factory()
+            obj_.build(child_)
+            self.labels.append(obj_)
+            obj_.original_tagname_ = 'labels'
+# end class containerconfig
+
+
+class entrypoint(GeneratedsSuper):
+    """Provides details for the entry point command. This includes the
+    execution name and its parameters. Arguments can be optionally
+    specified"""
+    subclass = None
+    superclass = None
+    def __init__(self, execute=None, argument=None):
+        self.original_tagname_ = None
+        self.execute = _cast(None, execute)
+        if argument is None:
+            self.argument = []
+        else:
+            self.argument = argument
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, entrypoint)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if entrypoint.subclass:
+            return entrypoint.subclass(*args_, **kwargs_)
+        else:
+            return entrypoint(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_argument(self): return self.argument
+    def set_argument(self, argument): self.argument = argument
+    def add_argument(self, value): self.argument.append(value)
+    def insert_argument_at(self, index, value): self.argument.insert(index, value)
+    def replace_argument_at(self, index, value): self.argument[index] = value
+    def get_execute(self): return self.execute
+    def set_execute(self, execute): self.execute = execute
+    def hasContent_(self):
+        if (
+            self.argument
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespace_='', name_='entrypoint', namespacedef_='', pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None:
+            name_ = self.original_tagname_
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespace_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespace_, name_='entrypoint')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespace_='', name_='entrypoint', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespace_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespace_='', name_='entrypoint'):
+        if self.execute is not None and 'execute' not in already_processed:
+            already_processed.add('execute')
+            outfile.write(' execute=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.execute), input_name='execute')), ))
+    def exportChildren(self, outfile, level, namespace_='', name_='entrypoint', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for argument_ in self.argument:
+            argument_.export(outfile, level, namespace_, name_='argument', pretty_print=pretty_print)
+    def build(self, node):
+        already_processed = set()
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        value = find_attr_value_('execute', node)
+        if value is not None and 'execute' not in already_processed:
+            already_processed.add('execute')
+            self.execute = value
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
+        if nodeName_ == 'argument':
+            obj_ = argument.factory()
+            obj_.build(child_)
+            self.argument.append(obj_)
+            obj_.original_tagname_ = 'argument'
+# end class entrypoint
+
+
+class subcommand(GeneratedsSuper):
+    """Provides details for the subcommand command. This includes the
+    execution name and its parameters. Arguments can be optionally
+    specified. The subcommand is appended the command information
+    from the entrypoint. It is in the responsibility of the author
+    to make sure the combination of entrypoint and subcommand forms
+    a valid execution command"""
+    subclass = None
+    superclass = None
+    def __init__(self, execute=None, argument=None):
+        self.original_tagname_ = None
+        self.execute = _cast(None, execute)
+        if argument is None:
+            self.argument = []
+        else:
+            self.argument = argument
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, subcommand)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if subcommand.subclass:
+            return subcommand.subclass(*args_, **kwargs_)
+        else:
+            return subcommand(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_argument(self): return self.argument
+    def set_argument(self, argument): self.argument = argument
+    def add_argument(self, value): self.argument.append(value)
+    def insert_argument_at(self, index, value): self.argument.insert(index, value)
+    def replace_argument_at(self, index, value): self.argument[index] = value
+    def get_execute(self): return self.execute
+    def set_execute(self, execute): self.execute = execute
+    def hasContent_(self):
+        if (
+            self.argument
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespace_='', name_='subcommand', namespacedef_='', pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None:
+            name_ = self.original_tagname_
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespace_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespace_, name_='subcommand')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespace_='', name_='subcommand', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespace_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespace_='', name_='subcommand'):
+        if self.execute is not None and 'execute' not in already_processed:
+            already_processed.add('execute')
+            outfile.write(' execute=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.execute), input_name='execute')), ))
+    def exportChildren(self, outfile, level, namespace_='', name_='subcommand', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for argument_ in self.argument:
+            argument_.export(outfile, level, namespace_, name_='argument', pretty_print=pretty_print)
+    def build(self, node):
+        already_processed = set()
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        value = find_attr_value_('execute', node)
+        if value is not None and 'execute' not in already_processed:
+            already_processed.add('execute')
+            self.execute = value
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
+        if nodeName_ == 'argument':
+            obj_ = argument.factory()
+            obj_.build(child_)
+            self.argument.append(obj_)
+            obj_.original_tagname_ = 'argument'
+# end class subcommand
+
+
+class argument(GeneratedsSuper):
+    """Provides details about a command argument"""
+    subclass = None
+    superclass = None
+    def __init__(self, name=None):
+        self.original_tagname_ = None
+        self.name = _cast(None, name)
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, argument)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if argument.subclass:
+            return argument.subclass(*args_, **kwargs_)
+        else:
+            return argument(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_name(self): return self.name
+    def set_name(self, name): self.name = name
+    def hasContent_(self):
+        if (
+
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespace_='', name_='argument', namespacedef_='', pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None:
+            name_ = self.original_tagname_
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespace_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespace_, name_='argument')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespace_='', name_='argument', pretty_print=pretty_print)
+            outfile.write('</%s%s>%s' % (namespace_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespace_='', name_='argument'):
+        if self.name is not None and 'name' not in already_processed:
+            already_processed.add('name')
+            outfile.write(' name=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.name), input_name='name')), ))
+    def exportChildren(self, outfile, level, namespace_='', name_='argument', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node):
         already_processed = set()
@@ -4558,13 +4942,551 @@ class containerconfig(GeneratedsSuper):
         if value is not None and 'name' not in already_processed:
             already_processed.add('name')
             self.name = value
-        value = find_attr_value_('entry_command', node)
-        if value is not None and 'entry_command' not in already_processed:
-            already_processed.add('entry_command')
-            self.entry_command = value
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         pass
-# end class containerconfig
+# end class argument
+
+
+class expose(GeneratedsSuper):
+    """Provides details about network ports which should be exposed from
+    the container. At least one port must be configured"""
+    subclass = None
+    superclass = None
+    def __init__(self, port=None):
+        self.original_tagname_ = None
+        if port is None:
+            self.port = []
+        else:
+            self.port = port
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, expose)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if expose.subclass:
+            return expose.subclass(*args_, **kwargs_)
+        else:
+            return expose(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_port(self): return self.port
+    def set_port(self, port): self.port = port
+    def add_port(self, value): self.port.append(value)
+    def insert_port_at(self, index, value): self.port.insert(index, value)
+    def replace_port_at(self, index, value): self.port[index] = value
+    def hasContent_(self):
+        if (
+            self.port
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespace_='', name_='expose', namespacedef_='', pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None:
+            name_ = self.original_tagname_
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespace_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespace_, name_='expose')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespace_='', name_='expose', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespace_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespace_='', name_='expose'):
+        pass
+    def exportChildren(self, outfile, level, namespace_='', name_='expose', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for port_ in self.port:
+            port_.export(outfile, level, namespace_, name_='port', pretty_print=pretty_print)
+    def build(self, node):
+        already_processed = set()
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        pass
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
+        if nodeName_ == 'port':
+            obj_ = port.factory()
+            obj_.build(child_)
+            self.port.append(obj_)
+            obj_.original_tagname_ = 'port'
+# end class expose
+
+
+class port(GeneratedsSuper):
+    """Provides details about an exposed port."""
+    subclass = None
+    superclass = None
+    def __init__(self, number=None):
+        self.original_tagname_ = None
+        self.number = _cast(int, number)
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, port)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if port.subclass:
+            return port.subclass(*args_, **kwargs_)
+        else:
+            return port(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_number(self): return self.number
+    def set_number(self, number): self.number = number
+    def hasContent_(self):
+        if (
+
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespace_='', name_='port', namespacedef_='', pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None:
+            name_ = self.original_tagname_
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespace_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespace_, name_='port')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespace_='', name_='port', pretty_print=pretty_print)
+            outfile.write('</%s%s>%s' % (namespace_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespace_='', name_='port'):
+        if self.number is not None and 'number' not in already_processed:
+            already_processed.add('number')
+            outfile.write(' number="%s"' % self.gds_format_integer(self.number, input_name='number'))
+    def exportChildren(self, outfile, level, namespace_='', name_='port', fromsubclass_=False, pretty_print=True):
+        pass
+    def build(self, node):
+        already_processed = set()
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        value = find_attr_value_('number', node)
+        if value is not None and 'number' not in already_processed:
+            already_processed.add('number')
+            try:
+                self.number = int(value)
+            except ValueError as exp:
+                raise_parse_error(node, 'Bad integer attribute: %s' % exp)
+            if self.number < 0:
+                raise_parse_error(node, 'Invalid NonNegativeInteger')
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
+        pass
+# end class port
+
+
+class volumes(GeneratedsSuper):
+    """Provides details about storage volumes in the container At least one
+    volume must be configured"""
+    subclass = None
+    superclass = None
+    def __init__(self, volume=None):
+        self.original_tagname_ = None
+        if volume is None:
+            self.volume = []
+        else:
+            self.volume = volume
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, volumes)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if volumes.subclass:
+            return volumes.subclass(*args_, **kwargs_)
+        else:
+            return volumes(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_volume(self): return self.volume
+    def set_volume(self, volume): self.volume = volume
+    def add_volume(self, value): self.volume.append(value)
+    def insert_volume_at(self, index, value): self.volume.insert(index, value)
+    def replace_volume_at(self, index, value): self.volume[index] = value
+    def hasContent_(self):
+        if (
+            self.volume
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespace_='', name_='volumes', namespacedef_='', pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None:
+            name_ = self.original_tagname_
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespace_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespace_, name_='volumes')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespace_='', name_='volumes', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespace_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespace_='', name_='volumes'):
+        pass
+    def exportChildren(self, outfile, level, namespace_='', name_='volumes', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for volume_ in self.volume:
+            volume_.export(outfile, level, namespace_, name_='volume', pretty_print=pretty_print)
+    def build(self, node):
+        already_processed = set()
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        pass
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
+        if nodeName_ == 'volume':
+            obj_ = volume.factory()
+            obj_.build(child_)
+            self.volume.append(obj_)
+            obj_.original_tagname_ = 'volume'
+# end class volumes
+
+
+class environment(GeneratedsSuper):
+    """Provides details about the container environment variables At least
+    one environment variable must be configured"""
+    subclass = None
+    superclass = None
+    def __init__(self, env=None):
+        self.original_tagname_ = None
+        if env is None:
+            self.env = []
+        else:
+            self.env = env
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, environment)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if environment.subclass:
+            return environment.subclass(*args_, **kwargs_)
+        else:
+            return environment(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_env(self): return self.env
+    def set_env(self, env): self.env = env
+    def add_env(self, value): self.env.append(value)
+    def insert_env_at(self, index, value): self.env.insert(index, value)
+    def replace_env_at(self, index, value): self.env[index] = value
+    def hasContent_(self):
+        if (
+            self.env
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespace_='', name_='environment', namespacedef_='', pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None:
+            name_ = self.original_tagname_
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespace_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespace_, name_='environment')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespace_='', name_='environment', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespace_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespace_='', name_='environment'):
+        pass
+    def exportChildren(self, outfile, level, namespace_='', name_='environment', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for env_ in self.env:
+            env_.export(outfile, level, namespace_, name_='env', pretty_print=pretty_print)
+    def build(self, node):
+        already_processed = set()
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        pass
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
+        if nodeName_ == 'env':
+            obj_ = env.factory()
+            obj_.build(child_)
+            self.env.append(obj_)
+            obj_.original_tagname_ = 'env'
+# end class environment
+
+
+class env(GeneratedsSuper):
+    """Provides details about an environment variable"""
+    subclass = None
+    superclass = None
+    def __init__(self, name=None, value=None):
+        self.original_tagname_ = None
+        self.name = _cast(None, name)
+        self.value = _cast(None, value)
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, env)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if env.subclass:
+            return env.subclass(*args_, **kwargs_)
+        else:
+            return env(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_name(self): return self.name
+    def set_name(self, name): self.name = name
+    def get_value(self): return self.value
+    def set_value(self, value): self.value = value
+    def hasContent_(self):
+        if (
+
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespace_='', name_='env', namespacedef_='', pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None:
+            name_ = self.original_tagname_
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespace_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespace_, name_='env')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespace_='', name_='env', pretty_print=pretty_print)
+            outfile.write('</%s%s>%s' % (namespace_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespace_='', name_='env'):
+        if self.name is not None and 'name' not in already_processed:
+            already_processed.add('name')
+            outfile.write(' name=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.name), input_name='name')), ))
+        if self.value is not None and 'value' not in already_processed:
+            already_processed.add('value')
+            outfile.write(' value=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.value), input_name='value')), ))
+    def exportChildren(self, outfile, level, namespace_='', name_='env', fromsubclass_=False, pretty_print=True):
+        pass
+    def build(self, node):
+        already_processed = set()
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        value = find_attr_value_('name', node)
+        if value is not None and 'name' not in already_processed:
+            already_processed.add('name')
+            self.name = value
+        value = find_attr_value_('value', node)
+        if value is not None and 'value' not in already_processed:
+            already_processed.add('value')
+            self.value = value
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
+        pass
+# end class env
+
+
+class labels(GeneratedsSuper):
+    """Provides details about container labels At least one label must be
+    configured"""
+    subclass = None
+    superclass = None
+    def __init__(self, label=None):
+        self.original_tagname_ = None
+        if label is None:
+            self.label = []
+        else:
+            self.label = label
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, labels)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if labels.subclass:
+            return labels.subclass(*args_, **kwargs_)
+        else:
+            return labels(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_label(self): return self.label
+    def set_label(self, label): self.label = label
+    def add_label(self, value): self.label.append(value)
+    def insert_label_at(self, index, value): self.label.insert(index, value)
+    def replace_label_at(self, index, value): self.label[index] = value
+    def hasContent_(self):
+        if (
+            self.label
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespace_='', name_='labels', namespacedef_='', pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None:
+            name_ = self.original_tagname_
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespace_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespace_, name_='labels')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespace_='', name_='labels', pretty_print=pretty_print)
+            showIndent(outfile, level, pretty_print)
+            outfile.write('</%s%s>%s' % (namespace_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespace_='', name_='labels'):
+        pass
+    def exportChildren(self, outfile, level, namespace_='', name_='labels', fromsubclass_=False, pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        for label_ in self.label:
+            label_.export(outfile, level, namespace_, name_='label', pretty_print=pretty_print)
+    def build(self, node):
+        already_processed = set()
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        pass
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
+        if nodeName_ == 'label':
+            obj_ = label.factory()
+            obj_.build(child_)
+            self.label.append(obj_)
+            obj_.original_tagname_ = 'label'
+# end class labels
+
+
+class label(GeneratedsSuper):
+    """Provides details about a container label"""
+    subclass = None
+    superclass = None
+    def __init__(self, name=None, value=None):
+        self.original_tagname_ = None
+        self.name = _cast(None, name)
+        self.value = _cast(None, value)
+    def factory(*args_, **kwargs_):
+        if CurrentSubclassModule_ is not None:
+            subclass = getSubclassFromModule_(
+                CurrentSubclassModule_, label)
+            if subclass is not None:
+                return subclass(*args_, **kwargs_)
+        if label.subclass:
+            return label.subclass(*args_, **kwargs_)
+        else:
+            return label(*args_, **kwargs_)
+    factory = staticmethod(factory)
+    def get_name(self): return self.name
+    def set_name(self, name): self.name = name
+    def get_value(self): return self.value
+    def set_value(self, value): self.value = value
+    def hasContent_(self):
+        if (
+
+        ):
+            return True
+        else:
+            return False
+    def export(self, outfile, level, namespace_='', name_='label', namespacedef_='', pretty_print=True):
+        if pretty_print:
+            eol_ = '\n'
+        else:
+            eol_ = ''
+        if self.original_tagname_ is not None:
+            name_ = self.original_tagname_
+        showIndent(outfile, level, pretty_print)
+        outfile.write('<%s%s%s' % (namespace_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
+        already_processed = set()
+        self.exportAttributes(outfile, level, already_processed, namespace_, name_='label')
+        if self.hasContent_():
+            outfile.write('>%s' % (eol_, ))
+            self.exportChildren(outfile, level + 1, namespace_='', name_='label', pretty_print=pretty_print)
+            outfile.write('</%s%s>%s' % (namespace_, name_, eol_))
+        else:
+            outfile.write('/>%s' % (eol_, ))
+    def exportAttributes(self, outfile, level, already_processed, namespace_='', name_='label'):
+        if self.name is not None and 'name' not in already_processed:
+            already_processed.add('name')
+            outfile.write(' name=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.name), input_name='name')), ))
+        if self.value is not None and 'value' not in already_processed:
+            already_processed.add('value')
+            outfile.write(' value=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.value), input_name='value')), ))
+    def exportChildren(self, outfile, level, namespace_='', name_='label', fromsubclass_=False, pretty_print=True):
+        pass
+    def build(self, node):
+        already_processed = set()
+        self.buildAttributes(node, node.attrib, already_processed)
+        for child in node:
+            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
+            self.buildChildren(child, node, nodeName_)
+        return self
+    def buildAttributes(self, node, attrs, already_processed):
+        value = find_attr_value_('name', node)
+        if value is not None and 'name' not in already_processed:
+            already_processed.add('name')
+            self.name = value
+        value = find_attr_value_('value', node)
+        if value is not None and 'value' not in already_processed:
+            already_processed.add('value')
+            self.value = value
+    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
+        pass
+# end class label
 
 
 class oemconfig(GeneratedsSuper):
@@ -6403,15 +7325,22 @@ if __name__ == '__main__':
 
 __all__ = [
     "archive",
+    "argument",
     "configuration",
     "containerconfig",
     "description",
     "drivers",
+    "entrypoint",
+    "env",
+    "environment",
+    "expose",
     "extension",
     "file",
     "ignore",
     "image",
     "k_source",
+    "label",
+    "labels",
     "machine",
     "namedCollection",
     "oemconfig",
@@ -6419,6 +7348,7 @@ __all__ = [
     "packages",
     "partition",
     "partitions",
+    "port",
     "preferences",
     "product",
     "profile",
@@ -6428,6 +7358,7 @@ __all__ = [
     "size",
     "source",
     "strip",
+    "subcommand",
     "systemdisk",
     "type_",
     "union",
@@ -6437,5 +7368,6 @@ __all__ = [
     "vmdisk",
     "vmdvd",
     "vmnic",
-    "volume"
+    "volume",
+    "volumes"
 ]

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -100,7 +100,30 @@
             </machine>
         </type>
         <type image="docker">
-            <containerconfig name="container_name"/>
+            <containerconfig name="container_name" maintainer="tux" user="root" workingdir="/root" tag="container_tag">
+                <entrypoint execute="/bin/bash">
+                    <argument name="-x"/>
+                </entrypoint>
+                <subcommand execute="ls">
+                    <argument name="-l"/>
+                </subcommand>
+                <expose>
+                    <port number="80"/>
+                    <port number="8080"/>
+                </expose>
+                <volumes> 
+                    <volume name="/tmp"/>
+                    <volume name="/var/log"/>
+                </volumes>
+                <environment> 
+                    <env name="PATH" value="/bin:/usr/bin:/home/user/bin"/>
+                    <env name="SOMEVAR" value="somevalue"/>
+                </environment>
+                <labels> 
+                    <label name="somelabel" value="labelvalue"/>
+                    <label name="someotherlabel" value="anotherlabelvalue"/>
+                </labels>
+            </containerconfig>
         </type>
     </preferences>
     <users>

--- a/test/data/example_runtime_checker_config.xml
+++ b/test/data/example_runtime_checker_config.xml
@@ -28,6 +28,7 @@
     <profiles>
         <profile name="xenFlavour" description="VMX with Xen kernel"/>
         <profile name="ec2Flavour" description="VMX with EC2/Xen kernel"/>
+        <profile name="docker" description="docker image"/>
         <profile name="vmxFlavour" description="VMX with default kernel" import="true"/>
     </profiles>
     <preferences>
@@ -58,6 +59,9 @@
         <rpm-excludedocs>true</rpm-excludedocs>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
+    </preferences>
+    <preferences profiles="docker">
+        <type image="docker"/>
     </preferences>
     <preferences profiles="ec2Flavour">
         <type image="vmx" filesystem="ext3" boot="vmxboot/example-distribution" bootprofile="ec2" bootkernel="ec2k" bootloader="grub2" kernelcmdline="xencons=xvc0 console=xvc0 multipath=off splash" firmware="ec2"/>

--- a/test/unit/builder_container_test.py
+++ b/test/unit/builder_container_test.py
@@ -14,12 +14,12 @@ class TestContainerBuilder(object):
     def setup(self, mock_machine):
         mock_machine.return_value = 'x86_64'
         xml_state = mock.Mock()
-        container_config = mock.Mock()
-        container_config.get_name = mock.Mock(
-            return_value='my-container'
-        )
-        xml_state.get_build_type_containerconfig_section = mock.Mock(
-            return_value=container_config
+        self.container_config = {
+            'container_name': 'my-container',
+            'entry_command': ["--config.cmd='/bin/bash'"]
+        }
+        xml_state.get_container_config = mock.Mock(
+            return_value=self.container_config
         )
         xml_state.get_image_version = mock.Mock(
             return_value='1.2.3'
@@ -50,11 +50,11 @@ class TestContainerBuilder(object):
         self.setup.export_rpm_package_list.return_value = '.packages'
         self.container.create()
         mock_setup.assert_called_once_with(
-            'docker', 'root_dir', {'container_name': 'my-container'}
+            'docker', 'root_dir', self.container_config
         )
         container_setup.setup.assert_called_once_with()
         mock_image.assert_called_once_with(
-            'docker', 'root_dir'
+            'docker', 'root_dir', self.container_config
         )
         container_image.create.assert_called_once_with(
             'target_dir/image_name.x86_64-1.2.3.docker.tar.xz'

--- a/test/unit/container_image_docker_test.py
+++ b/test/unit/container_image_docker_test.py
@@ -1,4 +1,4 @@
-
+from mock import call
 from mock import patch
 
 import mock
@@ -11,16 +11,118 @@ from kiwi.container.docker import ContainerImageDocker
 
 class TestContainerImageDocker(object):
     def setup(self):
-        self.docker = ContainerImageDocker('root_dir')
-
-    @patch('kiwi.container.docker.ArchiveTar')
-    def test_create(self, mock_archive):
-        archive = mock.Mock()
-        mock_archive.return_value = archive
-        self.docker.create('result.tar.xz')
-        mock_archive.assert_called_once_with('result.tar')
-        archive.create_xz_compressed.assert_called_once_with(
-            exclude=[
-                'image', '.profile', '.kconfig', 'boot', 'var/cache/kiwi'
-            ], source_dir='root_dir'
+        self.docker = ContainerImageDocker(
+            'root_dir', {
+                'container_name': 'foo'
+            }
         )
+
+    def test_init_custom_args(self):
+        docker = ContainerImageDocker(
+            'root_dir', {
+                'container_name': 'foo',
+                'container_tag': 'bar',
+                'entry_command': [
+                    "--config.entrypoint=/bin/bash",
+                    "--config.entrypoint=-x"
+                 ],
+                'entry_subcommand': [
+                    "--config.cmd=ls",
+                    "--config.cmd=-l"
+                 ],
+                 'maintainer': ['--author=tux'],
+                 'user': ['--config.user=root'],
+                 'workingdir': ['--config.workingdir=/root'],
+                 'expose_ports': [
+                     "--config.exposedports=80",
+                     "--config.exposedports=42"
+                 ],
+                 'volumes': [
+                     "--config.volume=/var/log",
+                     "--config.volume=/tmp"
+                 ],
+                 'environment': [
+                     "--config.env=PATH=/bin'",
+                     "--config.env=FOO=bar"
+                 ],
+                 'labels': [
+                     "--config.label=a=value",
+                     "--config.label=b=value"
+                 ]
+            }
+        )
+
+    @patch('kiwi.container.docker.Path.wipe')
+    def test_del(self, mock_wipe):
+        docker = ContainerImageDocker('root_dir')
+        docker.docker_dir = 'dir_a'
+        docker.docker_root_dir = 'dir_b'
+        docker.__del__()
+        assert mock_wipe.call_args_list == [
+            call('dir_a'), call('dir_b')
+        ]
+
+    @patch('kiwi.container.docker.Compress')
+    @patch('kiwi.container.docker.Command.run')
+    @patch('kiwi.container.docker.DataSync')
+    @patch('kiwi.container.docker.mkdtemp')
+    @patch('kiwi.container.docker.Path.wipe')
+    def test_create(
+        self, mock_wipe, mock_mkdtemp, mock_sync, mock_command, mock_compress
+    ):
+        compressor = mock.Mock()
+        mock_compress.return_value = compressor
+        docker_root = mock.Mock()
+        mock_sync.return_value = docker_root
+        tmpdirs = ['kiwi_docker_root_dir', 'kiwi_docker_dir']
+
+        def call_mkdtemp(prefix):
+            return tmpdirs.pop()
+
+        mock_mkdtemp.side_effect = call_mkdtemp
+
+        self.docker.create('result.tar.xz')
+
+        mock_wipe.assert_called_once_with('result.tar')
+
+        assert mock_command.call_args_list == [
+            call([
+                'umoci', 'init', '--layout',
+                'kiwi_docker_dir/umoci_layout'
+            ]),
+            call([
+                'umoci', 'new', '--image',
+                'kiwi_docker_dir/umoci_layout:foo'
+            ]),
+            call([
+                'umoci', 'unpack', '--image',
+                'kiwi_docker_dir/umoci_layout:foo', 'kiwi_docker_root_dir'
+            ]),
+            call([
+                'umoci', 'repack', '--image',
+                'kiwi_docker_dir/umoci_layout:foo', 'kiwi_docker_root_dir'
+            ]),
+            call([
+                'umoci', 'config', '--config.cmd=/bin/bash', '--image',
+                'kiwi_docker_dir/umoci_layout:foo', '--tag', 'latest'
+            ]),
+            call([
+                'umoci', 'gc', '--layout', 'kiwi_docker_dir/umoci_layout'
+            ]),
+            call([
+                 'skopeo', 'copy', 'oci:kiwi_docker_dir/umoci_layout:foo',
+                 'docker-archive:result.tar:foo:latest'
+            ])
+        ]
+        mock_sync.assert_called_once_with(
+            'root_dir/', 'kiwi_docker_root_dir/rootfs'
+        )
+        docker_root.sync_data.assert_called_once_with(
+            exclude=[
+                'image', '.profile', '.kconfig', 'boot', 'dev', 'sys', 'proc',
+                'var/cache/kiwi'
+            ],
+            options=['-a', '-H', '-X', '-A']
+        )
+        mock_compress.assert_called_once_with('result.tar')
+        compressor.xz.assert_called_once_with()

--- a/test/unit/container_image_test.py
+++ b/test/unit/container_image_test.py
@@ -17,4 +17,4 @@ class TestContainerImage(object):
     @patch('kiwi.container.ContainerImageDocker')
     def test_container_image_docker(self, mock_docker):
         ContainerImage('docker', 'root_dir')
-        mock_docker.assert_called_once_with('root_dir')
+        mock_docker.assert_called_once_with('root_dir', None)

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -13,11 +13,11 @@ from kiwi.exceptions import *
 
 class TestRuntimeChecker(object):
     def setup(self):
-        description = XMLDescription(
+        self.description = XMLDescription(
             '../data/example_runtime_checker_config.xml'
         )
         self.xml_state = XMLState(
-            description.load()
+            self.description.load()
         )
         self.runtime_checker = RuntimeChecker(self.xml_state)
 
@@ -59,3 +59,13 @@ class TestRuntimeChecker(object):
     @raises(KiwiRuntimeError)
     def test_check_volume_setup_has_no_root_definition(self):
         self.runtime_checker.check_volume_setup_has_no_root_definition()
+
+    @patch('kiwi.runtime_checker.Path.which')
+    @raises(KiwiRuntimeError)
+    def test_check_docker_tool_chain_installed(self, mock_which):
+        mock_which.return_value = False
+        xml_state = XMLState(
+            self.description.load(), ['docker'], 'docker'
+        )
+        runtime_checker = RuntimeChecker(xml_state)
+        runtime_checker.check_docker_tool_chain_installed()

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -82,6 +82,7 @@ class TestSystemBuildTask(object):
         self._init_command_args()
         self.task.command_args['build'] = True
         self.task.process()
+        self.runtime_checker.check_docker_tool_chain_installed.assert_called_once_with()
         self.runtime_checker.check_image_include_repos_http_resolvable.assert_called_once_with()
         self.runtime_checker.check_target_directory_not_in_shared_cache.assert_called_once_with('some-target')
         self.runtime_checker.check_repositories_configured.assert_called_once_with()

--- a/test/unit/tasks_system_prepare_test.py
+++ b/test/unit/tasks_system_prepare_test.py
@@ -70,6 +70,7 @@ class TestSystemPrepareTask(object):
         self._init_command_args()
         self.task.command_args['prepare'] = True
         self.task.process()
+        self.runtime_checker.check_docker_tool_chain_installed.assert_called_once_with()
         self.runtime_checker.check_image_include_repos_http_resolvable.assert_called_once_with()
         self.runtime_checker.check_target_directory_not_in_shared_cache.assert_called_once_with('../data/root-dir')
         self.runtime_checker.check_repositories_configured.assert_called_once_with()

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -497,8 +497,12 @@ class TestXMLState(object):
     def test_has_repositories_marked_as_imageinclude(self):
         assert self.state.has_repositories_marked_as_imageinclude()
 
-    def test_has_repositories_marked_as_imageinclude_without_any_imageinclude(self):
-        description = XMLDescription('../data/example_no_imageinclude_config.xml')
+    def test_has_repositories_marked_as_imageinclude_without_any_imageinclude(
+        self
+    ):
+        description = XMLDescription(
+            '../data/example_no_imageinclude_config.xml'
+        )
         xml_data = description.load()
         state = XMLState(xml_data) 
         assert not state.has_repositories_marked_as_imageinclude()
@@ -520,12 +524,54 @@ class TestXMLState(object):
         state = XMLState(xml_data)
         assert state.get_build_type_vmconfig_entries() == []
 
-    def test_get_build_type_docker_container_name(self):
+    def test_get_build_type_docker_containerconfig_section(self):
         description = XMLDescription('../data/example_config.xml')
         xml_data = description.load()
         state = XMLState(xml_data, ['vmxFlavour'], 'docker')
-        assert state.get_build_type_containerconfig_section().get_name() == \
+        containerconfig = state.get_build_type_containerconfig_section()
+        assert containerconfig.get_name() == \
             'container_name'
+        assert containerconfig.get_maintainer() == \
+            'tux'
+        assert containerconfig.get_workingdir() == \
+            '/root'
+
+    def test_get_container_config(self):
+        expected_config = {
+            'labels': [
+                '--config.label=somelabel=labelvalue',
+                '--config.label=someotherlabel=anotherlabelvalue'
+            ],
+            'maintainer': ['--author=tux'],
+            'entry_subcommand': [
+                '--config.cmd=ls',
+                '--config.cmd=-l'
+            ],
+            'container_name': 'container_name',
+            'container_tag': 'container_tag',
+            'workingdir': ['--config.workingdir=/root'],
+            'environment': [
+                '--config.env=PATH=/bin:/usr/bin:/home/user/bin',
+                '--config.env=SOMEVAR=somevalue'
+            ],
+            'user': ['--config.user=root'],
+            'volumes': [
+                '--config.volume=/tmp',
+                '--config.volume=/var/log'
+            ],
+            'entry_command': [
+                '--config.entrypoint=/bin/bash',
+                '--config.entrypoint=-x'
+            ],
+            'expose_ports': [
+                '--config.exposedports=80',
+                '--config.exposedports=8080'
+            ]
+        }
+        description = XMLDescription('../data/example_config.xml')
+        xml_data = description.load()
+        state = XMLState(xml_data, ['vmxFlavour'], 'docker')
+        assert state.get_container_config() == expected_config
 
     def test_get_spare_part(self):
         assert self.state.get_build_type_spare_part_size() == 200


### PR DESCRIPTION
Instead of creating a simple tarball the tools umoci and skopeo from the docker tool chain are used to create official docker images. The way to specify a docker image type has changed as follows

```xml
<type image="docker">
        <containerconfig name="..." maintainer="..." user="..." workingdir="...">
            <entrypoint execute="command">
                <argument name="option"/>
                ...
            </entrypoint>
            <subcommand execute="command">
                <argument name="option"/>
                ...
            </subcommand>
            <expose>
                <port number="..."/>
                ...
            </expose>
            <volumes>
                <volume name="..."/>
                ...
            </volumes>
            <environment>
                <env name="variable" value="value"/>
                ...
            </environment>
            <labels>
                <label name="..." value="..."/>
                ...
            </labels>
        </containerconfig>
    </type>
```

