### PR TITLE
Adapt mountpoint to the default toplevel subvolume

### DIFF
--- a/kiwi/volume_manager/base.py
+++ b/kiwi/volume_manager/base.py
@@ -83,6 +83,10 @@ class VolumeManagerBase(DeviceProvider):
         # the device should be released.
         self.device_provider = device_provider
 
+        # An indicator for the mount of the filesystem and its volumes
+        # when mounted for the first time
+        self.volumes_mounted_initially = False
+
         self.root_dir = root_dir
         self.volumes = volumes
         self.volume_group = None

--- a/kiwi/volume_manager/lvm.py
+++ b/kiwi/volume_manager/lvm.py
@@ -211,6 +211,7 @@ class VolumeManagerLVM(VolumeManagerBase):
             volume_mount.mount(
                 options=[self.mount_options]
             )
+        self.volumes_mounted_initially = True
 
     def umount_volumes(self):
         """

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -748,16 +748,13 @@ class XMLState(object):
         selected_filesystem = self.build_type.get_filesystem()
         selected_system_disk = self.get_build_type_system_disk_section()
         volume_management = None
-        if not selected_system_disk:
-            # no systemdisk section exists, no volume management requested
-            pass
-        elif selected_system_disk.get_preferlvm():
+        if selected_system_disk and selected_system_disk.get_preferlvm():
             # LVM volume management is preferred, use it
             volume_management = 'lvm'
         elif selected_filesystem in volume_filesystems:
             # specified filesystem has its own volume management system
             volume_management = selected_filesystem
-        else:
+        elif selected_system_disk:
             # systemdisk section is specified with non volume capable
             # filesystem and no volume management preference. So let's
             # use LVM by default

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -469,6 +469,7 @@ class TestDiskBuilder(object):
         self, mock_command, mock_open, mock_fs
     ):
         self.disk_builder.initrd_system = 'dracut'
+        self.disk_builder.volume_manager_name = None
         kernel = mock.Mock()
         kernel.version = '1.2.3'
         kernel.name = 'vmlinuz-1.2.3'
@@ -491,6 +492,7 @@ class TestDiskBuilder(object):
         mock_open, mock_squashfs, mock_fs
     ):
         self.disk_builder.root_filesystem_is_overlay = True
+        self.disk_builder.volume_manager_name = None
         squashfs = mock.Mock()
         mock_squashfs.return_value = squashfs
         mock_getsize.return_value = 1048576
@@ -523,6 +525,7 @@ class TestDiskBuilder(object):
     ):
         self.disk_builder.initrd_system = 'dracut'
         self.disk_builder.arch = 'aarch64'
+        self.disk_builder.volume_manager_name = None
         kernel = mock.Mock()
         kernel.version = '1.2.3'
         kernel.name = 'Image-1.2.3-default'
@@ -541,6 +544,7 @@ class TestDiskBuilder(object):
         self, mock_command, mock_open, mock_fs
     ):
         self.kernel.get_kernel.return_value = False
+        self.disk_builder.volume_manager_name = None
         self.disk_builder.create_disk()
 
     @patch('kiwi.builder.disk.FileSystem')
@@ -551,6 +555,7 @@ class TestDiskBuilder(object):
         self, mock_command, mock_open, mock_fs
     ):
         self.kernel.get_xen_hypervisor.return_value = False
+        self.disk_builder.volume_manager_name = None
         self.disk_builder.create_disk()
 
     @patch('kiwi.builder.disk.FileSystem')
@@ -682,6 +687,7 @@ class TestDiskBuilder(object):
     ):
         filesystem = mock.Mock()
         mock_fs.return_value = filesystem
+        self.disk_builder.volume_manager_name = None
         self.disk_builder.install_media = False
         self.disk_builder.hybrid_mbr = True
         self.disk_builder.create_disk()
@@ -711,6 +717,7 @@ class TestDiskBuilder(object):
     ):
         filesystem = mock.Mock()
         mock_fs.return_value = filesystem
+        self.disk_builder.volume_manager_name = None
         self.disk_builder.install_media = False
         self.disk_builder.firmware.vboot_mode.return_value = True
         self.disk_builder.firmware.get_vboot_partition_size.return_value = 42


### PR DESCRIPTION
If using root btrfs snapshot, the default toplevel subvolume is set to
`/@/.snapshots/1/snapshot`, thus all defined subvolumes are mounted
under that customized default subvolume. For the first time
subvolumes are mounted it is fine to include `/@/.snapshots/1/snapshot`
prefix as root is not yet set to that specific path, however in any
future mount this path prefix is not needed any more, as the root
gets mounted in` /@/.snapshots/1/snapshot` by default.

This PR handles this behavior by testing the subvolume path
of the specified root mountpoint in order to verify if the
snapshots path prefix should be included or not.

This PR fixes bnc#1015549 
