### PR TITLE
Make sure setupMachineID also cares for dbus

### DIFF
--- a/kiwi/boot/functions.sh
+++ b/kiwi/boot/functions.sh
@@ -6262,9 +6262,12 @@ function setupMachineID {
     # systemd-machine-id-setup. Initialize the machine ID
     # in /etc/machine-id. The machine ID is defined to be a
     # unique information. Thus it is required to initialize
-    # it on first boot of the image
+    # it on first boot of the image. In addition the same
+    # machine-id is configured to be used by dbus
     # ----
     systemd-machine-id-setup
+    rm -f /var/lib/dbus/machine-id && \
+        ln -s /etc/machine-id /var/lib/dbus/machine-id
 }
 #======================================
 # activateImage


### PR DESCRIPTION
Systemd and dbus should use the same machine-id. Therefore
a symlink /var/lib/dbus/machine-id pointing to /etc/machine-id
is created right after systemd-machine-id-setup. Fixes #219

