### PR TITLE
Allow unix device names in oem-unattended-id setup

### DIFF
--- a/kiwi/boot/arch/arm/oemboot/dump
+++ b/kiwi/boot/arch/arm/oemboot/dump
@@ -948,6 +948,13 @@ function identifyDevice {
         fi
     fi
     if [ $found -eq 0 ];then
+        ux_device=/dev/$kiwi_oemunattended_id
+        if [ -e $ux_device ];then
+            found=1
+            break
+        fi
+    fi
+    if [ $found -eq 0 ];then
         systemException \
             "Storage ID: $kiwi_oemunattended_id not found" \
         "reboot"

--- a/kiwi/boot/arch/ppc/oemboot/dump
+++ b/kiwi/boot/arch/ppc/oemboot/dump
@@ -948,6 +948,13 @@ function identifyDevice {
         fi
     fi
     if [ $found -eq 0 ];then
+        ux_device=/dev/$kiwi_oemunattended_id
+        if [ -e $ux_device ];then
+            found=1
+            break
+        fi
+    fi
+    if [ $found -eq 0 ];then
         systemException \
             "Storage ID: $kiwi_oemunattended_id not found" \
         "reboot"

--- a/kiwi/boot/arch/s390/oemboot/dump
+++ b/kiwi/boot/arch/s390/oemboot/dump
@@ -948,6 +948,20 @@ function identifyDevice {
         fi
     fi
     if [ $found -eq 0 ];then
+        ux_device=/dev/$kiwi_oemunattended_id
+        if [ -e $ux_device ];then
+            found=1
+            break
+        fi
+    fi
+    if [ $found -eq 0 ];then
+        ux_device=/dev/$kiwi_oemunattended_id
+        if [ -e $ux_device ];then
+            found=1
+            break
+        fi
+    fi
+    if [ $found -eq 0 ];then
         systemException \
             "Storage ID: $kiwi_oemunattended_id not found" \
         "reboot"

--- a/kiwi/boot/arch/x86_64/oemboot/dump
+++ b/kiwi/boot/arch/x86_64/oemboot/dump
@@ -948,6 +948,13 @@ function identifyDevice {
         fi
     fi
     if [ $found -eq 0 ];then
+        ux_device=/dev/$kiwi_oemunattended_id
+        if [ -e $ux_device ];then
+            found=1
+            break
+        fi
+    fi
+    if [ $found -eq 0 ];then
         systemException \
             "Storage ID: $kiwi_oemunattended_id not found" \
         "reboot"


### PR DESCRIPTION
In order to allow a raw device name in oem-unattended-id
the /dev tree has been added to search list. This is useful
if e.g a ramdisk device which is not part of any /dev/disk/...
or /dev/mapper device map should be used as target disk for
the deployment. Thus a setup to stick the deployment to
e.g /dev/ram1 would look like this

<oem-unattended-id>ram1</oem-unattended-id>

This Fixes #221

