### PR TITLE
Btrfs filesystem attributes

### DIFF
--- a/doc/source/schema.rst
+++ b/doc/source/schema.rst
@@ -882,6 +882,7 @@ Parents:
 
 List of attributes for ``volume``:
 
+* ``copy_on_write`` `[?]`_: Apply the filesystem copy-on-write attribute for this volume
 * ``freespace`` `[?]`_: free space to be added to this volume. The value is used as MB by default but you can add "M" and/or "G" as postfix
 * ``mountpoint`` `[?]`_: volume path. The mountpoint specifies a path which has to exist inside the root directory.
 * ``name`` : volume name. The name of the volume. if mountpoint is not specified the name specifies a path which has to exist inside the root directory.

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -2353,7 +2353,11 @@ div {
         ## The value is used as MB by default but you can
         ## add "M" and/or "G" as postfix
         attribute size { volume-size-type }
+    k.volume.copy_on_write.attribute =
+        ## Apply the filesystem copy-on-write attribute for this volume
+        attribute copy_on_write { xsd:boolean }
     k.volume.attlist =
+        k.volume.copy_on_write.attribute? &
         k.volume.freespace.attribute? &
         k.volume.mountpoint.attribute? &
         k.volume.name.attribute &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -3301,8 +3301,17 @@ add "M" and/or "G" as postfix</a:documentation>
         <ref name="volume-size-type"/>
       </attribute>
     </define>
+    <define name="k.volume.copy_on_write.attribute">
+      <attribute name="copy_on_write">
+        <a:documentation>Apply the filesystem copy-on-write attribute for this volume</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+    </define>
     <define name="k.volume.attlist">
       <interleave>
+        <optional>
+          <ref name="k.volume.copy_on_write.attribute"/>
+        </optional>
         <optional>
           <ref name="k.volume.freespace.attribute"/>
         </optional>

--- a/kiwi/volume_manager/base.py
+++ b/kiwi/volume_manager/base.py
@@ -20,6 +20,8 @@ from tempfile import mkdtemp
 import os
 
 # project
+from ..logger import log
+from ..command import Command
 from ..storage.device_provider import DeviceProvider
 from ..mount_manager import MountManager
 from ..storage.mapped_device import MappedDevice
@@ -145,6 +147,19 @@ class VolumeManagerBase(DeviceProvider):
         :param string filesystem_name: unused
         """
         raise NotImplementedError
+
+    def apply_attributes_on_volume(self, toplevel, volume):
+        for attribute in volume.attributes:
+            if attribute == 'no-copy-on-write':
+                log.info(
+                    '--> setting {0} for {1}'.format(attribute, volume.realpath)
+                )
+                Command.run(
+                    [
+                        'chattr', '+C',
+                        os.path.normpath(toplevel + volume.realpath)
+                    ]
+                )
 
     def get_fstab(self, persistency_type, filesystem_name):
         """

--- a/kiwi/volume_manager/btrfs.py
+++ b/kiwi/volume_manager/btrfs.py
@@ -162,6 +162,9 @@ class VolumeManagerBtrfs(VolumeManagerBase):
                         os.path.normpath(toplevel + volume.realpath)
                     ]
                 )
+                self.apply_attributes_on_volume(
+                    toplevel, volume
+                )
                 if self.custom_args['root_is_snapshot']:
                     snapshot = self.mountpoint + '/@/.snapshots/1/snapshot/'
                     volume_mount = MountManager(

--- a/kiwi/volume_manager/lvm.py
+++ b/kiwi/volume_manager/lvm.py
@@ -135,6 +135,9 @@ class VolumeManagerLVM(VolumeManagerBase):
                     volume.name, self.volume_group
                 ]
             )
+            self.apply_attributes_on_volume(
+                self.root_dir, volume
+            )
             self._add_to_volume_map(volume.name)
             self._create_filesystem(
                 volume.name, filesystem_name

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Mon Jan  9 10:51:35 2017 by generateDS.py version 2.24a.
+# Generated Fri Jan 20 09:57:08 2017 by generateDS.py version 2.24a.
 #
 # Command line options:
 #   ('-f', '')
@@ -4267,8 +4267,9 @@ class volume(GeneratedsSuper):
     """Specify which parts of the filesystem should be on an extra volume."""
     subclass = None
     superclass = None
-    def __init__(self, freespace=None, mountpoint=None, name=None, size=None):
+    def __init__(self, copy_on_write=None, freespace=None, mountpoint=None, name=None, size=None):
         self.original_tagname_ = None
+        self.copy_on_write = _cast(bool, copy_on_write)
         self.freespace = _cast(None, freespace)
         self.mountpoint = _cast(None, mountpoint)
         self.name = _cast(None, name)
@@ -4284,6 +4285,8 @@ class volume(GeneratedsSuper):
         else:
             return volume(*args_, **kwargs_)
     factory = staticmethod(factory)
+    def get_copy_on_write(self): return self.copy_on_write
+    def set_copy_on_write(self, copy_on_write): self.copy_on_write = copy_on_write
     def get_freespace(self): return self.freespace
     def set_freespace(self, freespace): self.freespace = freespace
     def get_mountpoint(self): return self.mountpoint
@@ -4324,6 +4327,9 @@ class volume(GeneratedsSuper):
         else:
             outfile.write('/>%s' % (eol_, ))
     def exportAttributes(self, outfile, level, already_processed, namespace_='', name_='volume'):
+        if self.copy_on_write is not None and 'copy_on_write' not in already_processed:
+            already_processed.add('copy_on_write')
+            outfile.write(' copy_on_write="%s"' % self.gds_format_boolean(self.copy_on_write, input_name='copy_on_write'))
         if self.freespace is not None and 'freespace' not in already_processed:
             already_processed.add('freespace')
             outfile.write(' freespace=%s' % (quote_attrib(self.freespace), ))
@@ -4346,6 +4352,15 @@ class volume(GeneratedsSuper):
             self.buildChildren(child, node, nodeName_)
         return self
     def buildAttributes(self, node, attrs, already_processed):
+        value = find_attr_value_('copy_on_write', node)
+        if value is not None and 'copy_on_write' not in already_processed:
+            already_processed.add('copy_on_write')
+            if value in ('true', '1'):
+                self.copy_on_write = True
+            elif value in ('false', '0'):
+                self.copy_on_write = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
         value = find_attr_value_('freespace', node)
         if value is not None and 'freespace' not in already_processed:
             already_processed.add('freespace')

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -638,6 +638,7 @@ class XMLState(object):
           is set the volume name is used as data path.
         * mountpoint: volume mount point and volume data path
         * fullsize: takes all space true|false
+        * attributes: volume attributes handled via chattr
 
         :return: volume data
         :rtype: list
@@ -653,7 +654,8 @@ class XMLState(object):
                 'size',
                 'realpath',
                 'mountpoint',
-                'fullsize'
+                'fullsize',
+                'attributes'
             ]
         )
 
@@ -670,6 +672,13 @@ class XMLState(object):
                 size = volume.get_size()
                 freespace = volume.get_freespace()
                 fullsize = False
+                attributes = []
+
+                if volume.get_copy_on_write() is False:
+                    # by default copy-on-write is switched on for any
+                    # filesystem. Thus only if no copy on write is requested
+                    # the attribute is handled
+                    attributes.append('no-copy-on-write')
 
                 if '@root' in name:
                     # setup root volume, it takes a fixed volume name and
@@ -710,7 +719,8 @@ class XMLState(object):
                         size=size,
                         fullsize=fullsize,
                         mountpoint=mountpoint,
-                        realpath=realpath
+                        realpath=realpath,
+                        attributes=attributes
                     )
                 )
 
@@ -731,7 +741,8 @@ class XMLState(object):
                     size=size,
                     fullsize=fullsize,
                     mountpoint=None,
-                    realpath='/'
+                    realpath='/',
+                    attributes=[]
                 )
             )
 

--- a/test/data/example_lvm_default_config.xml
+++ b/test/data/example_lvm_default_config.xml
@@ -23,7 +23,7 @@
             <systemdisk>
                 <volume name="usr/lib" size="1G"/>
                 <volume name="@root" freespace="500M"/>
-                <volume name="etc_volume" mountpoint="etc"/>
+                <volume name="etc_volume" mountpoint="etc" copy_on_write="false"/>
                 <volume name="bin_volume" size="all" mountpoint="/usr/bin"/>
             </systemdisk>
             <oemconfig>

--- a/test/unit/volume_manager_base_test.py
+++ b/test/unit/volume_manager_base_test.py
@@ -19,7 +19,8 @@ class TestVolumeManagerBase(object):
                 'size',
                 'realpath',
                 'mountpoint',
-                'fullsize'
+                'fullsize',
+                'attributes'
             ]
         )
         mock_path.return_value = True
@@ -84,7 +85,7 @@ class TestVolumeManagerBase(object):
         self.volume_manager.volumes = [
             self.volume_type(
                 name='LVetc', size='freespace:200', realpath='/etc',
-                mountpoint='/etc', fullsize=False
+                mountpoint='/etc', fullsize=False, attributes=[]
             )
         ]
         self.volume_manager.create_volume_paths_in_root_dir()
@@ -94,11 +95,11 @@ class TestVolumeManagerBase(object):
         self.volume_manager.volumes = [
             self.volume_type(
                 name='LVetc', size='freespace:200', realpath='/etc',
-                mountpoint='/etc', fullsize=False
+                mountpoint='/etc', fullsize=False, attributes=[]
             ),
             self.volume_type(
                 name='LVRoot', size='size:500', realpath='/',
-                mountpoint='/', fullsize=True
+                mountpoint='/', fullsize=True, attributes=[]
             )
         ]
         volume_list = self.volume_manager.get_canonical_volume_list()
@@ -170,6 +171,19 @@ class TestVolumeManagerBase(object):
     @raises(KiwiVolumeManagerSetupError)
     def test_set_property_readonly_root(self):
         self.volume_manager.set_property_readonly_root()
+
+    @patch('kiwi.volume_manager.base.Command.run')
+    def test_apply_attributes_on_volume(self, mock_command):
+        self.volume_manager.apply_attributes_on_volume(
+            'toplevel', self.volume_type(
+                name='LVetc', size='freespace:200', realpath='/etc',
+                mountpoint='/etc', fullsize=False,
+                attributes=['no-copy-on-write']
+            )
+        )
+        mock_command.assert_called_once_with(
+            ['chattr', '+C', 'toplevel/etc']
+        )
 
     def test_destructor(self):
         # does nothing by default, just pass

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -223,29 +223,34 @@ class TestXMLState(object):
                 'size',
                 'realpath',
                 'mountpoint',
-                'fullsize'
+                'fullsize',
+                'attributes'
             ]
         )
         assert state.get_volumes() == [
             volume_type(
                 name='usr_lib', size='size:1024',
                 realpath='usr/lib',
-                mountpoint='usr/lib', fullsize=False
+                mountpoint='usr/lib', fullsize=False,
+                attributes=[]
             ),
             volume_type(
                 name='LVRoot', size='freespace:500',
                 realpath='/',
-                mountpoint=None, fullsize=False
+                mountpoint=None, fullsize=False,
+                attributes=[]
             ),
             volume_type(
                 name='etc_volume', size='freespace:30',
                 realpath='etc',
-                mountpoint='etc', fullsize=False
+                mountpoint='etc', fullsize=False,
+                attributes=['no-copy-on-write']
             ),
             volume_type(
                 name='bin_volume', size=None,
                 realpath='/usr/bin',
-                mountpoint='/usr/bin', fullsize=True
+                mountpoint='/usr/bin', fullsize=True,
+                attributes=[]
             )
         ]
 
@@ -259,13 +264,15 @@ class TestXMLState(object):
                 'size',
                 'realpath',
                 'mountpoint',
-                'fullsize'
+                'fullsize',
+                'attributes'
             ]
         )
         assert state.get_volumes() == [
             volume_type(
                 name='LVRoot', size=None, realpath='/',
-                mountpoint=None, fullsize=True
+                mountpoint=None, fullsize=True,
+                attributes=[]
             )
         ]
 
@@ -281,17 +288,20 @@ class TestXMLState(object):
                 'size',
                 'realpath',
                 'mountpoint',
-                'fullsize'
+                'fullsize',
+                'attributes'
             ]
         )
         assert state.get_volumes() == [
             volume_type(
                 name='usr', size=None, realpath='usr',
-                mountpoint='usr', fullsize=True
+                mountpoint='usr', fullsize=True,
+                attributes=[]
             ),
             volume_type(
                 name='LVRoot', size='freespace:30', realpath='/',
-                mountpoint=None, fullsize=False
+                mountpoint=None, fullsize=False,
+                attributes=[]
             )
         ]
 


### PR DESCRIPTION
Added volume attribute copy_on_write
    
The copy_on_write attribute allows to activate or deactivate
the copy on write functionality for the desired volume.
This Fixes #218

A user can specify the attribute as the following example shows:

```xml
<systemdisk>
    <volume name="var/crash" copy_on_write="false"/>
</systemdisk>
```

