### PR TITLE
Sysconfig bootloader

### DIFF
--- a/doc/source/api/kiwi.utils.rst
+++ b/doc/source/api/kiwi.utils.rst
@@ -35,6 +35,15 @@ Submodules
     :show-inheritance:
 
 
+`kiwi.utils.sysconfig` Module
+------------------------
+
+.. automodule:: kiwi.utils.sysconfig
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
 Module Contents
 ---------------
 

--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -125,6 +125,15 @@ class BootLoaderConfigBase(object):
         """
         raise NotImplementedError
 
+    def setup_sysconfig_bootloader(self):
+        """
+        Create or update etc/sysconfig/bootloader by parameters
+        required according to the bootloader setup
+
+        Implementation in specialized bootloader class required
+        """
+        raise NotImplementedError
+
     def create_efi_path(self, in_sub_dir='boot/efi'):
         """
         Create standard EFI boot directory structure

--- a/kiwi/utils/sysconfig.py
+++ b/kiwi/utils/sysconfig.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2015 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+import os
+
+
+class SysConfig(object):
+    """
+    Read and Write sysconfig style files
+
+    Attributes
+
+    * :attr:`source_file`
+        source file path
+
+    """
+    def __init__(self, source_file):
+        self.source_file = source_file
+        self.data_dict = {}
+        self.data_list = []
+        self._read()
+
+    def __setitem__(self, key, value):
+        if key not in self.data_dict:
+            self.data_list.append(key)
+        self.data_dict[key] = value
+
+    def __getitem__(self, key):
+        return self.data_dict[key]
+
+    def write(self):
+        """
+        Write back source file with changed content but in same order
+        """
+        with open(self.source_file, 'w') as source:
+            for line in self.data_list:
+                if line in self.data_dict:
+                    key = line
+                    value = self.data_dict[key]
+                    source.write('{0}={1}'.format(key, value))
+                else:
+                    source.write(line)
+
+                source.write(os.linesep)
+
+    def _read(self):
+        """
+        Read file into a list and a key/value dictionary
+
+        Only lines which are not considered a comment and
+        containing the structure key=value are parsed into
+        the key/value dictionary. In order to keep the order
+        of lines a list is stored too. Those lines matching
+        the key/value format are stored with their key in
+        the list as a placeholder
+        """
+        if os.path.exists(self.source_file):
+            with open(self.source_file) as source:
+                for line in source.readlines():
+                    line = line.strip()
+                    if '#' not in line and '=' in line:
+                        elements = line.split('=')
+                        key = elements.pop(0).strip()
+                        value = '='.join(elements)
+                        self.data_dict[key] = value
+                        self.data_list.append(key)
+                    else:
+                        self.data_list.append(line)

--- a/test/data/sysconfig_example.txt
+++ b/test/data/sysconfig_example.txt
@@ -1,0 +1,4 @@
+# some name
+name = "Marcus"
+
+some_key = some-value

--- a/test/unit/bootloader_config_base_test.py
+++ b/test/unit/bootloader_config_base_test.py
@@ -56,6 +56,10 @@ class TestBootLoaderConfigBase(object):
     def test_setup_live_boot_images(self):
         self.bootloader.setup_live_boot_images('mbrid')
 
+    @raises(NotImplementedError)
+    def test_setup_sysconfig_bootloader(self):
+        self.bootloader.setup_sysconfig_bootloader()
+
     @patch('kiwi.path.Path.create')
     def test_create_efi_path(self, mock_path):
         self.bootloader.create_efi_path()

--- a/test/unit/utils_sysconfig_test.py
+++ b/test/unit/utils_sysconfig_test.py
@@ -1,0 +1,48 @@
+from mock import patch
+from mock import call
+
+import mock
+
+from .test_helper import patch_open
+
+from kiwi.utils.sysconfig import SysConfig
+
+
+class TestSysConfig(object):
+    def setup(self):
+        self.context_manager_mock = mock.Mock()
+        self.file_mock = mock.Mock()
+        self.enter_mock = mock.Mock()
+        self.exit_mock = mock.Mock()
+        self.enter_mock.return_value = self.file_mock
+        setattr(self.context_manager_mock, '__enter__', self.enter_mock)
+        setattr(self.context_manager_mock, '__exit__', self.exit_mock)
+
+        self.sysconfig = SysConfig('../data/sysconfig_example.txt')
+
+    def test_get_item(self):
+        assert self.sysconfig['name'] == ' "Marcus"'
+
+    def test_set_item_existing(self):
+        self.sysconfig['name'] = 'Bob'
+        assert self.sysconfig['name'] == 'Bob'
+
+    def test_set_item_not_existing(self):
+        self.sysconfig['foo'] = '"bar"'
+        assert self.sysconfig['foo'] == '"bar"'
+        assert self.sysconfig.data_list[-1] == 'foo'
+
+    @patch_open
+    def test_write(self, mock_open):
+        mock_open.return_value = self.context_manager_mock
+        self.sysconfig.write()
+        assert self.file_mock.write.call_args_list == [
+            call('# some name'),
+            call('\n'),
+            call('name= "Marcus"'),
+            call('\n'),
+            call(''),
+            call('\n'),
+            call('some_key= some-value'),
+            call('\n')
+        ]


### PR DESCRIPTION
Completion for grub bootloader configuration
    
The configuration files /etc/sysconfig/bootloader and
/etc/default/grub needs to be created/updated with the
relevant values regarding the bootloader setup done by
kiwi. This Fixes #226