### PR TITLE
Added support for package locking for zypper

### DIFF
--- a/doc/source/schema.rst
+++ b/doc/source/schema.rst
@@ -835,7 +835,7 @@ List of attributes for ``configuration``:
 
 * ``source`` : A location where packages can be found to build an installation source from
 * ``dest`` : Destination of a resource
-* ``arch`` `[?]`_: An architecture
+* ``arch`` `[?]`_: A system architecture name, matching the 'uname -m' information Multiple architectures can be combined as comma separated list e.g arch="x86_64,ix86"
 
 .. _k.image.preferences.type.size:
 
@@ -1121,7 +1121,7 @@ Parents:
 List of attributes for ``repopackage``:
 
 * ``name`` : A name
-* ``arch`` `[?]`_: An architecture
+* ``arch`` `[?]`_: A system architecture name, matching the 'uname -m' information Multiple architectures can be combined as comma separated list e.g arch="x86_64,ix86"
 * ``forcerepo`` `[?]`_: Specifies the search priority
 * ``addarch`` `[?]`_: Specifies that this package should additionally add the same package from the given arch
 * ``removearch`` `[?]`_: Specifies that the package with the given arch should be removed
@@ -1187,7 +1187,7 @@ Parents:
 List of attributes for ``repopackage``:
 
 * ``name`` : A name
-* ``arch`` `[?]`_: An architecture
+* ``arch`` `[?]`_: A system architecture name, matching the 'uname -m' information Multiple architectures can be combined as comma separated list e.g arch="x86_64,ix86"
 * ``forcerepo`` `[?]`_: Specifies the search priority
 * ``addarch`` `[?]`_: Specifies that this package should additionally add the same package from the given arch
 * ``removearch`` `[?]`_: Specifies that the package with the given arch should be removed
@@ -1222,7 +1222,7 @@ Parents:
 
 List of attributes for ``target``:
 
-* ``arch`` : An architecture
+* ``arch`` : A system architecture name, matching the 'uname -m' information Multiple architectures can be combined as comma separated list e.g arch="x86_64,ix86"
 
 .. _k.image.instsource.driverupdate.install:
 
@@ -1251,7 +1251,7 @@ Parents:
 List of attributes for ``repopackage``:
 
 * ``name`` : A name
-* ``arch`` `[?]`_: An architecture
+* ``arch`` `[?]`_: A system architecture name, matching the 'uname -m' information Multiple architectures can be combined as comma separated list e.g arch="x86_64,ix86"
 * ``forcerepo`` `[?]`_: Specifies the search priority
 * ``addarch`` `[?]`_: Specifies that this package should additionally add the same package from the given arch
 * ``removearch`` `[?]`_: Specifies that the package with the given arch should be removed
@@ -1287,7 +1287,7 @@ Parents:
 List of attributes for ``repopackage``:
 
 * ``name`` : A name
-* ``arch`` `[?]`_: An architecture
+* ``arch`` `[?]`_: A system architecture name, matching the 'uname -m' information Multiple architectures can be combined as comma separated list e.g arch="x86_64,ix86"
 * ``forcerepo`` `[?]`_: Specifies the search priority
 * ``addarch`` `[?]`_: Specifies that this package should additionally add the same package from the given arch
 * ``removearch`` `[?]`_: Specifies that the package with the given arch should be removed
@@ -1323,7 +1323,7 @@ Parents:
 List of attributes for ``repopackage``:
 
 * ``name`` : A name
-* ``arch`` `[?]`_: An architecture
+* ``arch`` `[?]`_: A system architecture name, matching the 'uname -m' information Multiple architectures can be combined as comma separated list e.g arch="x86_64,ix86"
 * ``forcerepo`` `[?]`_: Specifies the search priority
 * ``addarch`` `[?]`_: Specifies that this package should additionally add the same package from the given arch
 * ``removearch`` `[?]`_: Specifies that the package with the given arch should be removed
@@ -1400,7 +1400,7 @@ Parents:
 List of attributes for ``file``:
 
 * ``name`` : A name
-* ``arch`` `[?]`_: An architecture
+* ``arch`` `[?]`_: A system architecture name, matching the 'uname -m' information Multiple architectures can be combined as comma separated list e.g arch="x86_64,ix86"
 
 .. _k.image.strip:
 
@@ -1433,7 +1433,7 @@ Parents:
 List of attributes for ``file``:
 
 * ``name`` : A name
-* ``arch`` `[?]`_: An architecture
+* ``arch`` `[?]`_: A system architecture name, matching the 'uname -m' information Multiple architectures can be combined as comma separated list e.g arch="x86_64,ix86"
 
 .. _k.image.repository:
 
@@ -1523,6 +1523,7 @@ Parents:
 List of attributes for ``ignore``:
 
 * ``name`` : A name
+* ``arch`` `[?]`_: A system architecture name, matching the 'uname -m' information Multiple architectures can be combined as comma separated list e.g arch="x86_64,ix86"
 
 .. _k.image.packages.namedCollection:
 
@@ -1537,7 +1538,7 @@ Parents:
 List of attributes for ``namedCollection``:
 
 * ``name`` : A name
-* ``arch`` `[?]`_: An architecture
+* ``arch`` `[?]`_: A system architecture name, matching the 'uname -m' information Multiple architectures can be combined as comma separated list e.g arch="x86_64,ix86"
 
 .. _k.image.packages.product:
 
@@ -1552,7 +1553,7 @@ Parents:
 List of attributes for ``product``:
 
 * ``name`` : A name
-* ``arch`` `[?]`_: An architecture
+* ``arch`` `[?]`_: A system architecture name, matching the 'uname -m' information Multiple architectures can be combined as comma separated list e.g arch="x86_64,ix86"
 
 .. _k.image.packages.package:
 
@@ -1567,7 +1568,7 @@ Parents:
 List of attributes for ``package``:
 
 * ``name`` : A name
-* ``arch`` `[?]`_: An architecture
+* ``arch`` `[?]`_: A system architecture name, matching the 'uname -m' information Multiple architectures can be combined as comma separated list e.g arch="x86_64,ix86"
 * ``replaces`` `[?]`_: Replace package with some other package
 * ``bootdelete`` `[?]`_: Indicates that this package should be removed from the boot image (initrd). the attribute is only evaluated if the bootinclude attribute is specified along with it too
 * ``bootinclude`` `[?]`_: Indicates that this package should be part of the boot image (initrd) too. This attribute can be used to include for example branding packages specified in the system image description to become part of the boot image also

--- a/kiwi/package_manager/apt.py
+++ b/kiwi/package_manager/apt.py
@@ -93,6 +93,18 @@ class PackageManagerApt(PackageManagerBase):
             'Product(%s) handling not supported for apt-get', name
         )
 
+    def request_package_lock(self, name):
+        """
+        Queue a package lock(ignore) request
+
+        There is no locking mechanism for the apt package manager
+
+        :param string name: unused
+        """
+        log.warning(
+            'Package locking for (%s) not supported for apt-get', name
+        )
+
     def process_install_requests_bootstrap(self):
         """
         Process package install requests for bootstrap phase (no chroot)

--- a/kiwi/package_manager/base.py
+++ b/kiwi/package_manager/base.py
@@ -49,6 +49,7 @@ class PackageManagerBase(object):
         self.package_requests = []
         self.collection_requests = []
         self.product_requests = []
+        self.lock_requests = []
 
         self.post_init(custom_args)
 
@@ -85,6 +86,16 @@ class PackageManagerBase(object):
     def request_product(self, name):
         """
         Queue a product request
+
+        Implementation in specialized package manager class
+
+        :param string name: unused
+        """
+        raise NotImplementedError
+
+    def request_package_lock(self, name):
+        """
+        Queue a package lock(ignore) request
 
         Implementation in specialized package manager class
 
@@ -182,3 +193,4 @@ class PackageManagerBase(object):
         del self.package_requests[:]
         del self.collection_requests[:]
         del self.product_requests[:]
+        del self.lock_requests[:]

--- a/kiwi/package_manager/yum.py
+++ b/kiwi/package_manager/yum.py
@@ -18,6 +18,7 @@
 import re
 
 # project
+from ..logger import log
 from ..command import Command
 from .base import PackageManagerBase
 from ..exceptions import (
@@ -79,6 +80,18 @@ class PackageManagerYum(PackageManagerBase):
         :param string name: unused
         """
         pass
+
+    def request_package_lock(self, name):
+        """
+        Queue a package lock(ignore) request
+
+        There is no locking mechanism for the yum package manager
+
+        :param string name: unused
+        """
+        log.warning(
+            'Package locking for (%s) not supported for yum', name
+        )
 
     def process_install_requests_bootstrap(self):
         """

--- a/kiwi/package_manager/zypper.py
+++ b/kiwi/package_manager/zypper.py
@@ -16,10 +16,12 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import re
+import os
 
 # project
 from ..command import Command
 from .base import PackageManagerBase
+from ..path import Path
 from ..exceptions import (
     KiwiRpmDatabaseReloadError,
     KiwiRequestError
@@ -89,6 +91,14 @@ class PackageManagerZypper(PackageManagerBase):
         """
         self.product_requests.append('product:' + name)
 
+    def request_package_lock(self, name):
+        """
+        Queue a package lock(ignore) request
+
+        :param string name: package name
+        """
+        self.lock_requests.append(name)
+
     def process_install_requests_bootstrap(self):
         """
         Process package install requests for bootstrap phase (no chroot)
@@ -105,6 +115,29 @@ class PackageManagerZypper(PackageManagerBase):
         """
         Process package install requests for image phase (chroot)
         """
+        if self.lock_requests:
+            # Zypper supports the package lock via the zypper al command
+            # This allows to block a package from being taken into
+            # consideration when the dependency solver runs. However
+            # the request might be ignored by the package manager if
+            # the lock request conflicts with a required package
+            # dependency. e.g setting a lock on the glibc package will
+            # for sure not work in order to keep the system in a
+            # consistent state. Thus such lock requests are primarily
+            # for packages pulled in by a recommendation but not by a
+            # hard requirement.
+            lock_metadata_dir = ''.join([self.root_dir, '/etc/zypp'])
+            if not os.path.exists(lock_metadata_dir):
+                Path.create(lock_metadata_dir)
+            for package in self.lock_requests:
+                Command.run(
+                    [
+                        'chroot', self.root_dir, 'zypper'
+                    ] + self.chroot_zypper_args + [
+                        'al'
+                    ] + self.custom_args + [package],
+                    self.chroot_command_env
+                )
         return Command.call(
             ['chroot', self.root_dir, 'zypper'] + self.chroot_zypper_args + [
                 'install', '--auto-agree-with-licenses'

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -40,6 +40,7 @@ size-type = xsd:token {pattern = "\d*|image"}
 volume-size-type = xsd:token {pattern = "\d+|\d+M|\d+G|all"}
 vhd-tag-type = xsd:token {pattern = "[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}"}
 groups-list = xsd:token {pattern = "[a-zA-Z0-9_\-\.]+(,[a-zA-Z0-9_\-\.]+)*"}
+arch-name = xsd:token {pattern = "(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x)(,(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x))*"}
 
 #==========================================
 # start with image description
@@ -136,8 +137,10 @@ k.displayname.attribute =
     ## for isolinux and grub
     attribute displayname { text }
 k.arch.attribute        =
-    ## An architecture
-    attribute arch { text }
+    ## A system architecture name, matching the 'uname -m' information
+    ## Multiple architectures can be combined as comma separated list
+    ## e.g arch="x86_64,ix86"
+    attribute arch { arch-name }
 k.description.attribute =
     ## A short description
     attribute description { text }
@@ -381,7 +384,10 @@ div {
 #
 div {
     k.ignore.name.attribute = k.name.attribute
-    k.ignore.attlist = k.ignore.name.attribute
+    k.ignore.arch.attribute = k.arch.attribute
+    k.ignore.attlist =
+        k.ignore.name.attribute &
+        k.ignore.arch.attribute?
     k.ignore = 
         ## Ignores a Package
         element ignore {

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -62,6 +62,11 @@
       <param name="pattern">[a-zA-Z0-9_\-\.]+(,[a-zA-Z0-9_\-\.]+)*</param>
     </data>
   </define>
+  <define name="arch-name">
+    <data type="token">
+      <param name="pattern">(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x)(,(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x))*</param>
+    </data>
+  </define>
   <!--
     ==========================================
     start with image description
@@ -233,7 +238,10 @@ for isolinux and grub</a:documentation>
   </define>
   <define name="k.arch.attribute">
     <attribute name="arch">
-      <a:documentation>An architecture</a:documentation>
+      <a:documentation>A system architecture name, matching the 'uname -m' information
+Multiple architectures can be combined as comma separated list
+e.g arch="x86_64,ix86"</a:documentation>
+      <ref name="arch-name"/>
     </attribute>
   </define>
   <define name="k.description.attribute">
@@ -581,8 +589,16 @@ set to utc or localtime.</db:para>
     <define name="k.ignore.name.attribute">
       <ref name="k.name.attribute"/>
     </define>
+    <define name="k.ignore.arch.attribute">
+      <ref name="k.arch.attribute"/>
+    </define>
     <define name="k.ignore.attlist">
-      <ref name="k.ignore.name.attribute"/>
+      <interleave>
+        <ref name="k.ignore.name.attribute"/>
+        <optional>
+          <ref name="k.ignore.arch.attribute"/>
+        </optional>
+      </interleave>
     </define>
     <define name="k.ignore">
       <element name="ignore">

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -366,19 +366,19 @@ class SystemPrepare(object):
     ):
         if packages:
             for package in sorted(packages):
-                log.info('--> package: %s', package)
+                log.info('--> package: {0}'.format(package))
                 manager.request_package(package)
         if collections:
             for collection in sorted(collections):
-                log.info('--> collection: %s', collection)
+                log.info('--> collection: {0}'.format(collection))
                 manager.request_collection(collection)
         if products:
             for product in sorted(products):
-                log.info('--> product: %s', product)
+                log.info('--> product: {0}'.format(product))
                 manager.request_product(product)
         if ignored:
             for package in sorted(ignored):
-                log.info('--> package locked(ignored): %s', package)
+                log.info('--> package locked(ignored): {0}'.format(package))
                 manager.request_package_lock(package)
         return \
             manager.package_requests + \

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -208,6 +208,7 @@ class SystemPrepare(object):
         system_collections = self.xml_state.get_system_collections()
         system_products = self.xml_state.get_system_products()
         system_archives = self.xml_state.get_system_archives()
+        system_packages_ignored = self.xml_state.get_system_ignore_packages()
         # process package installations
         if collection_type == 'onlyRequired':
             manager.process_only_required()
@@ -215,7 +216,8 @@ class SystemPrepare(object):
             manager,
             system_packages,
             system_collections,
-            system_products
+            system_products,
+            system_packages_ignored
         )
         if all_install_items:
             process = CommandProcess(
@@ -360,7 +362,7 @@ class SystemPrepare(object):
             tar.extract(self.root_bind.root_dir)
 
     def _setup_requests(
-        self, manager, packages, collections=None, products=None
+        self, manager, packages, collections=None, products=None, ignored=None
     ):
         if packages:
             for package in sorted(packages):
@@ -374,10 +376,15 @@ class SystemPrepare(object):
             for product in sorted(products):
                 log.info('--> product: %s', product)
                 manager.request_product(product)
+        if ignored:
+            for package in sorted(ignored):
+                log.info('--> package locked(ignored): %s', package)
+                manager.request_package_lock(package)
         return \
             manager.package_requests + \
             manager.collection_requests + \
-            manager.product_requests
+            manager.product_requests + \
+            manager.lock_requests
 
     def __del__(self):
         log.info('Cleaning up %s instance', type(self).__name__)

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Fri Jan 20 09:57:08 2017 by generateDS.py version 2.24a.
+# Generated Wed Feb  1 15:07:34 2017 by generateDS.py version 2.24a.
 #
 # Command line options:
 #   ('-f', '')
@@ -1209,6 +1209,13 @@ class configuration(GeneratedsSuper):
     def set_dest(self, dest): self.dest = dest
     def get_arch(self): return self.arch
     def set_arch(self, arch): self.arch = arch
+    def validate_arch_name(self, value):
+        # Validate type arch-name, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_arch_name_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_arch_name_patterns_, ))
+    validate_arch_name_patterns_ = [['^(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x)(,(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x))*$']]
     def hasContent_(self):
         if (
 
@@ -1242,7 +1249,7 @@ class configuration(GeneratedsSuper):
             outfile.write(' dest=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.dest), input_name='dest')), ))
         if self.arch is not None and 'arch' not in already_processed:
             already_processed.add('arch')
-            outfile.write(' arch=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.arch), input_name='arch')), ))
+            outfile.write(' arch=%s' % (quote_attrib(self.arch), ))
     def exportChildren(self, outfile, level, namespace_='', name_='configuration', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node):
@@ -1265,6 +1272,8 @@ class configuration(GeneratedsSuper):
         if value is not None and 'arch' not in already_processed:
             already_processed.add('arch')
             self.arch = value
+            self.arch = ' '.join(self.arch.split())
+            self.validate_arch_name(self.arch)    # validate type arch-name
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         pass
 # end class configuration
@@ -1293,6 +1302,13 @@ class file(GeneratedsSuper):
     def set_name(self, name): self.name = name
     def get_arch(self): return self.arch
     def set_arch(self, arch): self.arch = arch
+    def validate_arch_name(self, value):
+        # Validate type arch-name, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_arch_name_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_arch_name_patterns_, ))
+    validate_arch_name_patterns_ = [['^(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x)(,(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x))*$']]
     def hasContent_(self):
         if (
 
@@ -1323,7 +1339,7 @@ class file(GeneratedsSuper):
             outfile.write(' name=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.name), input_name='name')), ))
         if self.arch is not None and 'arch' not in already_processed:
             already_processed.add('arch')
-            outfile.write(' arch=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.arch), input_name='arch')), ))
+            outfile.write(' arch=%s' % (quote_attrib(self.arch), ))
     def exportChildren(self, outfile, level, namespace_='', name_='file', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node):
@@ -1342,6 +1358,8 @@ class file(GeneratedsSuper):
         if value is not None and 'arch' not in already_processed:
             already_processed.add('arch')
             self.arch = value
+            self.arch = ' '.join(self.arch.split())
+            self.validate_arch_name(self.arch)    # validate type arch-name
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         pass
 # end class file
@@ -1351,9 +1369,10 @@ class ignore(GeneratedsSuper):
     """Ignores a Package"""
     subclass = None
     superclass = None
-    def __init__(self, name=None):
+    def __init__(self, name=None, arch=None):
         self.original_tagname_ = None
         self.name = _cast(None, name)
+        self.arch = _cast(None, arch)
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -1367,6 +1386,15 @@ class ignore(GeneratedsSuper):
     factory = staticmethod(factory)
     def get_name(self): return self.name
     def set_name(self, name): self.name = name
+    def get_arch(self): return self.arch
+    def set_arch(self, arch): self.arch = arch
+    def validate_arch_name(self, value):
+        # Validate type arch-name, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_arch_name_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_arch_name_patterns_, ))
+    validate_arch_name_patterns_ = [['^(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x)(,(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x))*$']]
     def hasContent_(self):
         if (
 
@@ -1395,6 +1423,9 @@ class ignore(GeneratedsSuper):
         if self.name is not None and 'name' not in already_processed:
             already_processed.add('name')
             outfile.write(' name=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.name), input_name='name')), ))
+        if self.arch is not None and 'arch' not in already_processed:
+            already_processed.add('arch')
+            outfile.write(' arch=%s' % (quote_attrib(self.arch), ))
     def exportChildren(self, outfile, level, namespace_='', name_='ignore', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node):
@@ -1409,6 +1440,12 @@ class ignore(GeneratedsSuper):
         if value is not None and 'name' not in already_processed:
             already_processed.add('name')
             self.name = value
+        value = find_attr_value_('arch', node)
+        if value is not None and 'arch' not in already_processed:
+            already_processed.add('arch')
+            self.arch = value
+            self.arch = ' '.join(self.arch.split())
+            self.validate_arch_name(self.arch)    # validate type arch-name
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         pass
 # end class ignore
@@ -1753,6 +1790,13 @@ class namedCollection(GeneratedsSuper):
     def set_name(self, name): self.name = name
     def get_arch(self): return self.arch
     def set_arch(self, arch): self.arch = arch
+    def validate_arch_name(self, value):
+        # Validate type arch-name, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_arch_name_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_arch_name_patterns_, ))
+    validate_arch_name_patterns_ = [['^(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x)(,(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x))*$']]
     def hasContent_(self):
         if (
 
@@ -1783,7 +1827,7 @@ class namedCollection(GeneratedsSuper):
             outfile.write(' name=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.name), input_name='name')), ))
         if self.arch is not None and 'arch' not in already_processed:
             already_processed.add('arch')
-            outfile.write(' arch=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.arch), input_name='arch')), ))
+            outfile.write(' arch=%s' % (quote_attrib(self.arch), ))
     def exportChildren(self, outfile, level, namespace_='', name_='namedCollection', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node):
@@ -1802,6 +1846,8 @@ class namedCollection(GeneratedsSuper):
         if value is not None and 'arch' not in already_processed:
             already_processed.add('arch')
             self.arch = value
+            self.arch = ' '.join(self.arch.split())
+            self.validate_arch_name(self.arch)    # validate type arch-name
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         pass
 # end class namedCollection
@@ -1830,6 +1876,13 @@ class product(GeneratedsSuper):
     def set_name(self, name): self.name = name
     def get_arch(self): return self.arch
     def set_arch(self, arch): self.arch = arch
+    def validate_arch_name(self, value):
+        # Validate type arch-name, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_arch_name_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_arch_name_patterns_, ))
+    validate_arch_name_patterns_ = [['^(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x)(,(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x))*$']]
     def hasContent_(self):
         if (
 
@@ -1860,7 +1913,7 @@ class product(GeneratedsSuper):
             outfile.write(' name=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.name), input_name='name')), ))
         if self.arch is not None and 'arch' not in already_processed:
             already_processed.add('arch')
-            outfile.write(' arch=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.arch), input_name='arch')), ))
+            outfile.write(' arch=%s' % (quote_attrib(self.arch), ))
     def exportChildren(self, outfile, level, namespace_='', name_='product', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node):
@@ -1879,6 +1932,8 @@ class product(GeneratedsSuper):
         if value is not None and 'arch' not in already_processed:
             already_processed.add('arch')
             self.arch = value
+            self.arch = ' '.join(self.arch.split())
+            self.validate_arch_name(self.arch)    # validate type arch-name
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         pass
 # end class product
@@ -1916,6 +1971,13 @@ class package(GeneratedsSuper):
     def set_bootdelete(self, bootdelete): self.bootdelete = bootdelete
     def get_bootinclude(self): return self.bootinclude
     def set_bootinclude(self, bootinclude): self.bootinclude = bootinclude
+    def validate_arch_name(self, value):
+        # Validate type arch-name, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_arch_name_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_arch_name_patterns_, ))
+    validate_arch_name_patterns_ = [['^(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x)(,(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x))*$']]
     def hasContent_(self):
         if (
 
@@ -1946,7 +2008,7 @@ class package(GeneratedsSuper):
             outfile.write(' name=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.name), input_name='name')), ))
         if self.arch is not None and 'arch' not in already_processed:
             already_processed.add('arch')
-            outfile.write(' arch=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.arch), input_name='arch')), ))
+            outfile.write(' arch=%s' % (quote_attrib(self.arch), ))
         if self.replaces is not None and 'replaces' not in already_processed:
             already_processed.add('replaces')
             outfile.write(' replaces=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.replaces), input_name='replaces')), ))
@@ -1974,6 +2036,8 @@ class package(GeneratedsSuper):
         if value is not None and 'arch' not in already_processed:
             already_processed.add('arch')
             self.arch = value
+            self.arch = ' '.join(self.arch.split())
+            self.validate_arch_name(self.arch)    # validate type arch-name
         value = find_attr_value_('replaces', node)
         if value is not None and 'replaces' not in already_processed:
             already_processed.add('replaces')
@@ -2344,6 +2408,13 @@ class repopackage(GeneratedsSuper):
     def set_script(self, script): self.script = script
     def get_medium(self): return self.medium
     def set_medium(self, medium): self.medium = medium
+    def validate_arch_name(self, value):
+        # Validate type arch-name, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_arch_name_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_arch_name_patterns_, ))
+    validate_arch_name_patterns_ = [['^(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x)(,(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x))*$']]
     def hasContent_(self):
         if (
 
@@ -2374,7 +2445,7 @@ class repopackage(GeneratedsSuper):
             outfile.write(' name=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.name), input_name='name')), ))
         if self.arch is not None and 'arch' not in already_processed:
             already_processed.add('arch')
-            outfile.write(' arch=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.arch), input_name='arch')), ))
+            outfile.write(' arch=%s' % (quote_attrib(self.arch), ))
         if self.forcerepo is not None and 'forcerepo' not in already_processed:
             already_processed.add('forcerepo')
             outfile.write(' forcerepo=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.forcerepo), input_name='forcerepo')), ))
@@ -2414,6 +2485,8 @@ class repopackage(GeneratedsSuper):
         if value is not None and 'arch' not in already_processed:
             already_processed.add('arch')
             self.arch = value
+            self.arch = ' '.join(self.arch.split())
+            self.validate_arch_name(self.arch)    # validate type arch-name
         value = find_attr_value_('forcerepo', node)
         if value is not None and 'forcerepo' not in already_processed:
             already_processed.add('forcerepo')
@@ -5979,6 +6052,13 @@ class target(GeneratedsSuper):
     def set_arch(self, arch): self.arch = arch
     def get_valueOf_(self): return self.valueOf_
     def set_valueOf_(self, valueOf_): self.valueOf_ = valueOf_
+    def validate_arch_name(self, value):
+        # Validate type arch-name, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_arch_name_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_arch_name_patterns_, ))
+    validate_arch_name_patterns_ = [['^(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x)(,(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x))*$']]
     def hasContent_(self):
         if (
             1 if type(self.valueOf_) in [int,float] else self.valueOf_
@@ -6003,7 +6083,7 @@ class target(GeneratedsSuper):
     def exportAttributes(self, outfile, level, already_processed, namespace_='', name_='target'):
         if self.arch is not None and 'arch' not in already_processed:
             already_processed.add('arch')
-            outfile.write(' arch=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.arch), input_name='arch')), ))
+            outfile.write(' arch=%s' % (quote_attrib(self.arch), ))
     def exportChildren(self, outfile, level, namespace_='', name_='target', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node):
@@ -6023,6 +6103,8 @@ class target(GeneratedsSuper):
         if value is not None and 'arch' not in already_processed:
             already_processed.add('arch')
             self.arch = value
+            self.arch = ' '.join(self.arch.split())
+            self.validate_arch_name(self.arch)    # validate type arch-name
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         if not fromsubclass_ and child_.tail is not None:
             obj_ = self.mixedclass_(MixedContainer.CategoryText,

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -313,7 +313,8 @@ class XMLState(object):
         )
         for packages in image_packages_sections:
             for package in packages.get_ignore():
-                result.append(package.get_name())
+                if self.package_matches_host_architecture(package):
+                    result.append(package.get_name())
         return sorted(result)
 
     def get_collection_type(self, section_type='image'):

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -299,6 +299,23 @@ class XMLState(object):
                 result.append(archive.get_name())
         return sorted(result)
 
+    def get_system_ignore_packages(self):
+        """
+        List of ignore packages from the packages sections matching
+        type="image" and type=build_type
+
+        :return: package names
+        :rtype: list
+        """
+        result = []
+        image_packages_sections = self.get_packages_sections(
+            ['image', self.get_build_type_name()]
+        )
+        for packages in image_packages_sections:
+            for package in packages.get_ignore():
+                result.append(package.get_name())
+        return sorted(result)
+
     def get_collection_type(self, section_type='image'):
         """
         Collection type from packages sections matching given section

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -149,6 +149,7 @@
         <package name="kernel-default" replaces="kernel-ec2"/>
         <package name="kernel-default" replaces="xen-tools"/>
         <package name="kernel-default" replaces="xen"/>
+        <ignore name="foo"/>
     </packages>
     <packages type="bootstrap">
         <package name="filesystem"/>

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -124,7 +124,7 @@
         <package name="vim" bootdelete="true"/>
         <package name="openssh"/>
         <archive name="/absolute/path/to/image.tgz" bootinclude="true"/>
-        <package name="foo" arch="some-arch,some-other-arch"/>
+        <package name="foo" arch="s390,aarch64"/>
     </packages>
     <packages type="iso">
         <package name="gfxboot-branding-openSUSE" bootinclude="true" bootdelete="true"/>
@@ -149,7 +149,9 @@
         <package name="kernel-default" replaces="kernel-ec2"/>
         <package name="kernel-default" replaces="xen-tools"/>
         <package name="kernel-default" replaces="xen"/>
-        <ignore name="foo"/>
+        <ignore name="foo" arch="x86_64,aarch64"/>
+        <ignore name="bar" arch="x86_64"/>
+        <ignore name="baz"/>
     </packages>
     <packages type="bootstrap">
         <package name="filesystem"/>

--- a/test/data/example_no_imageinclude_config.xml
+++ b/test/data/example_no_imageinclude_config.xml
@@ -55,7 +55,7 @@
         <package name="vim" bootdelete="true"/>
         <package name="openssh"/>
         <archive name="/absolute/path/to/image.tgz" bootinclude="true"/>
-        <package name="foo" arch="some-arch"/>
+        <package name="foo" arch="s390"/>
     </packages>
     <packages type="bootstrap">
         <package name="filesystem"/>

--- a/test/data/example_runtime_checker_config.xml
+++ b/test/data/example_runtime_checker_config.xml
@@ -117,7 +117,7 @@
         <package name="vim" bootdelete="true"/>
         <package name="openssh"/>
         <archive name="image.tgz" bootinclude="true"/>
-        <package name="foo" arch="some-arch"/>
+        <package name="foo" arch="x86_64"/>
     </packages>
     <packages type="iso">
         <package name="gfxboot-branding-openSUSE" bootinclude="true" bootdelete="true"/>

--- a/test/unit/package_manager_apt_test.py
+++ b/test/unit/package_manager_apt_test.py
@@ -47,6 +47,12 @@ class TestPackageManagerApt(object):
         assert self.manager.product_requests == []
         assert mock_log_warn.called
 
+    @patch('kiwi.logger.log.warning')
+    def test_request_package_lock(self, mock_log_warn):
+        self.manager.request_package_lock('name')
+        assert self.manager.lock_requests == []
+        assert mock_log_warn.called
+
     @raises(KiwiDebootstrapError)
     def test_process_install_requests_bootstrap_no_dist(self):
         self.manager.distribution = None

--- a/test/unit/package_manager_base_test.py
+++ b/test/unit/package_manager_base_test.py
@@ -27,6 +27,10 @@ class TestPackageManagerBase(object):
         self.manager.request_product('name')
 
     @raises(NotImplementedError)
+    def test_request_package_lock(self):
+        self.manager.request_package_lock('name')
+
+    @raises(NotImplementedError)
     def test_process_install_requests_bootstrap(self):
         self.manager.process_install_requests_bootstrap()
 
@@ -67,3 +71,4 @@ class TestPackageManagerBase(object):
         assert self.manager.package_requests == []
         assert self.manager.product_requests == []
         assert self.manager.collection_requests == []
+        assert self.manager.lock_requests == []

--- a/test/unit/package_manager_yum_test.py
+++ b/test/unit/package_manager_yum_test.py
@@ -41,6 +41,12 @@ class TestPackageManagerYum(object):
         self.manager.request_product('name')
         assert self.manager.product_requests == []
 
+    @patch('kiwi.logger.log.warning')
+    def test_request_package_lock(self, mock_log_warn):
+        self.manager.request_package_lock('name')
+        assert self.manager.lock_requests == []
+        assert mock_log_warn.called
+
     @patch('kiwi.command.Command.call')
     @patch('kiwi.command.Command.run')
     def test_process_install_requests_bootstrap(self, mock_run, mock_call):

--- a/test/unit/system_prepare_test.py
+++ b/test/unit/system_prepare_test.py
@@ -252,6 +252,9 @@ class TestSystemPrepare(object):
         self.manager.request_product.assert_any_call(
             'openSUSE'
         )
+        self.manager.request_package_lock.assert_any_call(
+            'foo'
+        )
         self.manager.process_install_requests.assert_called_once_with()
         mock_tar.assert_called_once_with('/absolute/path/to/image.tgz')
         tar.extract.assert_called_once_with('root_dir')

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -104,6 +104,11 @@ class TestXMLState(object):
             '/absolute/path/to/image.tgz'
         ]
 
+    def test_get_system_ignore_packages(self):
+        assert self.state.get_system_ignore_packages() == [
+            'foo'
+        ]
+
     def test_get_system_collection_type(self):
         assert self.state.get_system_collection_type() == 'plusRecommended'
 

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -70,7 +70,7 @@ class TestXMLState(object):
 
     @patch('platform.machine')
     def test_get_system_packages_some_arch(self, mock_machine):
-        mock_machine.return_value = 'some-arch'
+        mock_machine.return_value = 's390'
         description = XMLDescription(
             '../data/example_config.xml'
         )
@@ -106,7 +106,15 @@ class TestXMLState(object):
 
     def test_get_system_ignore_packages(self):
         assert self.state.get_system_ignore_packages() == [
-            'foo'
+            'bar', 'baz', 'foo'
+        ]
+        self.state.host_architecture = 'aarch64'
+        assert self.state.get_system_ignore_packages() == [
+            'baz', 'foo'
+        ]
+        self.state.host_architecture = 's390'
+        assert self.state.get_system_ignore_packages() == [
+            'baz'
         ]
 
     def test_get_system_collection_type(self):


### PR DESCRIPTION
Zypper supports the al (add lock) command which allows to ignore a package in the dependecny resolution process. This is useful to prevent installation of a package which was pulled in by e.g a recommendation flag from the spec file. Packages marked to be ignored are not handled for apt and yum right now. Using this feature together with an unsupported package manager backend results in a warning to the user

A package lock can be set via the XML description as follows:

```xml

<packages type="image">
    <ignore name="package"/>
</packages>
```

The XML description supported that already but kiwi v8 did not had support for it. Thus this completes the zypper package manager support with regards to what the kiwi v7 version could do
