### PR TITLE
Spare partition

### DIFF
--- a/doc/source/schema.rst
+++ b/doc/source/schema.rst
@@ -321,9 +321,9 @@ List of attributes for ``type``:
 * ``primary`` `[?]`_: Specifies the primary type (choose KIWI option type)
 * ``ramonly`` `[?]`_: for use with overlay filesystems only: will force any COW action to happen in RAM
 * ``rootfs_label`` `[?]`_: label to set for the root filesystem. By default ROOT is used
+* ``spare_part`` `[?]`_: Request a spare partition right before the root partition of the requested size. The attribute takes a size value and allows a unit in MB or GB, e.g 200M. If no unit is given the value is considered to be mbytes. A spare partition can only be configured for the disk image types oem and vmx
 * ``target_blocksize`` `[?]`_: Specifies the image blocksize in bytes which has to match the logical (SSZ) blocksize of the target storage device. By default 512 byte is used which works on many disks However 4096 byte disks are coming. You can check the desired target by calling: blockdev --report device
 * ``target_removable`` `[?]`_: Indicate if the target disk for oem images is deployed to a removable device e.g a USB stick or not. This only affects the EFI setup if requested and in the end avoids the creation of a custom boot menu entry in the firmware of the target machine. By default the target disk is expected to be non-removable
-* ``vbootsize`` `[?]`_: For images with a an extra virtual boot space specifies the size in MB. If not set the min vboot size is set to 10 MB
 * ``vga`` `[?]`_: Specifies the kernel framebuffer mode. More information about the possible values can be found by calling hwinfo --framebuffer or in /usr/src/linux/Documentation/fb/vesafb.txt
 * ``vhdfixedtag`` `[?]`_: Specifies the GUID in a fixed format VHD
 * ``volid`` `[?]`_: for the iso type only: Specifies the volume ID (volume name or label) to be written into the master block. There is space for 32 characters.

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -177,6 +177,7 @@ class DiskBuilder(object):
         self.root_dir = root_dir
         self.target_dir = target_dir
         self.xml_state = xml_state
+        self.spare_part_mbsize = xml_state.get_build_type_spare_part_size()
         self.persistency_type = xml_state.build_type.get_devicepersistency()
         self.root_filesystem_is_overlay = xml_state.build_type.get_overlayroot()
         self.custom_root_mount_args = xml_state.get_fs_mount_option_list()
@@ -683,6 +684,12 @@ class DiskBuilder(object):
             log.info('--> creating boot partition')
             self.disk.create_boot_partition(
                 self.disk_setup.boot_partition_size()
+            )
+
+        if self.spare_part_mbsize:
+            log.info('--> creating spare partition')
+            self.disk.create_spare_partition(
+                self.spare_part_mbsize
             )
 
         if self.root_filesystem_is_overlay:

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -661,12 +661,6 @@ class DiskBuilder(object):
 
     def _build_and_map_disk_partitions(self):
         self.disk.wipe()
-        if self.firmware.vboot_mode():
-            log.info('--> creating Virtual boot partition')
-            self.disk.create_vboot_partition(
-                self.firmware.get_vboot_partition_size()
-            )
-
         if self.firmware.legacy_bios_mode():
             log.info('--> creating EFI CSM(legacy bios) partition')
             self.disk.create_efi_csm_partition(

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -346,16 +346,6 @@ class Defaults(object):
         return 300
 
     @classmethod
-    def get_default_vboot_mbytes(self):
-        """
-        Implements default virtual partition size in mbytes
-
-        :return: mbsize
-        :rtype: int
-        """
-        return 10
-
-    @classmethod
     def get_default_efi_boot_mbytes(self):
         """
         Implements default EFI partition size in mbytes
@@ -420,14 +410,14 @@ class Defaults(object):
             'x86_64': ['efi', 'uefi', 'bios', 'ec2hvm', 'ec2'],
             'i586': ['bios'],
             'i686': ['bios'],
-            'aarch64': ['efi', 'uefi', 'vboot'],
-            'arm64': ['efi', 'uefi', 'vboot'],
-            'armv5el': ['efi', 'uefi', 'vboot'],
-            'armv5tel': ['efi', 'uefi', 'vboot'],
-            'armv6hl': ['efi', 'uefi', 'vboot'],
-            'armv6l': ['efi', 'uefi', 'vboot'],
-            'armv7hl': ['efi', 'uefi', 'vboot'],
-            'armv7l': ['efi', 'uefi', 'vboot'],
+            'aarch64': ['efi', 'uefi'],
+            'arm64': ['efi', 'uefi'],
+            'armv5el': ['efi', 'uefi'],
+            'armv5tel': ['efi', 'uefi'],
+            'armv6hl': ['efi', 'uefi'],
+            'armv6l': ['efi', 'uefi'],
+            'armv7hl': ['efi', 'uefi'],
+            'armv7l': ['efi', 'uefi'],
             'ppc': ['ofw'],
             'ppc64': ['ofw', 'opal'],
             'ppc64le': ['ofw', 'opal'],
@@ -473,7 +463,7 @@ class Defaults(object):
         :return: firmware names
         :rtype: list
         """
-        return ['efi', 'uefi', 'vboot']
+        return ['efi', 'uefi']
 
     @classmethod
     def get_ec2_capable_firmware_names(self):

--- a/kiwi/firmware.py
+++ b/kiwi/firmware.py
@@ -42,16 +42,12 @@ class FirmWare(object):
     * :attr:`zipl_target_type`
         XML configured zipl target type
 
-    * :attr:`vboot_mbsize`
-        XML configured virtual boot partition size
-
     * :attr:`firmware`
         XML configured firmware name
     """
     def __init__(self, xml_state):
         self.arch = platform.machine()
         self.zipl_target_type = xml_state.build_type.get_zipl_targettype()
-        self.vboot_mbsize = xml_state.build_type.get_vbootsize()
         self.firmware = xml_state.build_type.get_firmware()
 
         if not self.firmware:
@@ -154,17 +150,6 @@ class FirmWare(object):
         else:
             return False
 
-    def vboot_mode(self):
-        """
-        Check if vboot (virtual boot partition) mode is requested
-
-        :rtype: bool
-        """
-        if self.efi_mode() == 'vboot':
-            return True
-        else:
-            return False
-
     def get_legacy_bios_partition_size(self):
         """
         Size of legacy bios_grub partition if legacy BIOS mode is
@@ -188,22 +173,6 @@ class FirmWare(object):
         """
         if self.efi_mode():
             return Defaults.get_default_efi_boot_mbytes()
-        else:
-            return 0
-
-    def get_vboot_partition_size(self):
-        """
-        Size of virtual boot partition.
-        Returns 0 if no such partition is needed
-
-        :return: mbsize
-        :rtype: int
-        """
-        if self.vboot_mode():
-            if self.vboot_mbsize:
-                return self.vboot_mbsize
-            else:
-                return Defaults.get_default_vboot_mbytes()
         else:
             return 0
 

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -38,6 +38,7 @@ locale-name = xsd:token {pattern = "[a-z]{2}_[A-Z]{2}(,[a-z]{2}_[A-Z]{2})*"}
 mac-address-type = xsd:token {pattern = "([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}"}
 size-type = xsd:token {pattern = "\d*|image"}
 volume-size-type = xsd:token {pattern = "\d+|\d+M|\d+G|all"}
+partition-size-type = xsd:token {pattern = "\d+|\d+M|\d+G"}
 vhd-tag-type = xsd:token {pattern = "[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}"}
 groups-list = xsd:token {pattern = "[a-zA-Z0-9_\-\.]+(,[a-zA-Z0-9_\-\.]+)*"}
 arch-name = xsd:token {pattern = "(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x)(,(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x))*"}
@@ -1558,6 +1559,17 @@ div {
             sch:param [ name = "attr" value = "target_removable" ]
             sch:param [ name = "types" value = "oem vmx" ]
         ]
+    k.type.spare_part =
+        ## Request a spare partition right before the root partition
+        ## of the requested size. The attribute takes a size value
+        ## and allows a unit in MB or GB, e.g 200M. If no unit is given
+        ## the value is considered to be mbytes. A spare partition
+        ## can only be configured for the disk image types oem and vmx
+        attribute spare_part { partition-size-type }
+        >> sch:pattern [ id = "spare_part" is-a = "image_type"
+            sch:param [ name = "attr" value = "spare_part" ]
+            sch:param [ name = "types" value = "oem vmx" ]
+        ]
     k.type.zipl_targettype.attribute =
         ## The device type of the disk zipl should boot. On zFCP
         ## devices use SCSI, on DASD devices use CDL or LDL on
@@ -1972,6 +1984,7 @@ div {
         k.type.primary.attribute? &
         k.type.ramonly.attribute? &
         k.type.rootfs_label.attribute? &
+        k.type.spare_part? &
         k.type.target_blocksize? &
         k.type.target_removable? &
         k.type.vga.attribute? &

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1578,15 +1578,6 @@ div {
             sch:param [ name = "attr" value = "bootpartsize" ]
             sch:param [ name = "types" value = "oem vmx" ]
         ]
-    k.type.vbootsize.attribute =
-        ## For images with a an extra virtual boot space
-        ## specifies the size in MB. If not set the min vboot
-        ## size is set to 10 MB
-        attribute vbootsize { xsd:nonNegativeInteger }
-        >> sch:pattern [ id = "vbootsize" is-a = "image_type"
-            sch:param [ name = "attr" value = "vbootsize" ]
-            sch:param [ name = "types" value = "oem vmx" ]
-        ]
     k.type.bootprofile.attribute =
         ## Specifies the boot profile defined in the boot image
         ## description. When kiwi builds the boot image the
@@ -1673,7 +1664,7 @@ div {
         ## the standard x86 bios firmware setup is used
         attribute firmware {
             "bios" | "ec2" | "ec2hvm" | "efi" |
-            "uefi" | "vboot" | "ofw" | "opal"
+            "uefi" | "ofw" | "opal"
         }
         >> sch:pattern [ id = "firmware" is-a = "image_type"
             sch:param [ name = "attr" value = "firmware" ]
@@ -1983,7 +1974,6 @@ div {
         k.type.rootfs_label.attribute? &
         k.type.target_blocksize? &
         k.type.target_removable? &
-        k.type.vbootsize.attribute? &
         k.type.vga.attribute? &
         k.type.vhdfixedtag.attribute? &
         k.type.volid.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -52,6 +52,11 @@
       <param name="pattern">\d+|\d+M|\d+G|all</param>
     </data>
   </define>
+  <define name="partition-size-type">
+    <data type="token">
+      <param name="pattern">\d+|\d+M|\d+G</param>
+    </data>
+  </define>
   <define name="vhd-tag-type">
     <data type="token">
       <param name="pattern">[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}</param>
@@ -2005,6 +2010,20 @@ expected to be non-removable</a:documentation>
         <sch:param name="types" value="oem vmx"/>
       </sch:pattern>
     </define>
+    <define name="k.type.spare_part">
+      <attribute name="spare_part">
+        <a:documentation>Request a spare partition right before the root partition
+of the requested size. The attribute takes a size value
+and allows a unit in MB or GB, e.g 200M. If no unit is given
+the value is considered to be mbytes. A spare partition
+can only be configured for the disk image types oem and vmx</a:documentation>
+        <ref name="partition-size-type"/>
+      </attribute>
+      <sch:pattern id="spare_part" is-a="image_type">
+        <sch:param name="attr" value="spare_part"/>
+        <sch:param name="types" value="oem vmx"/>
+      </sch:pattern>
+    </define>
     <define name="k.type.zipl_targettype.attribute">
       <attribute name="zipl_targettype">
         <a:documentation>The device type of the disk zipl should boot. On zFCP
@@ -2671,6 +2690,9 @@ are available on the host. Default timeout is 3 seconds</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.rootfs_label.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.spare_part"/>
         </optional>
         <optional>
           <ref name="k.type.target_blocksize"/>

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2034,18 +2034,6 @@ size is set to 200 MB</a:documentation>
         <sch:param name="types" value="oem vmx"/>
       </sch:pattern>
     </define>
-    <define name="k.type.vbootsize.attribute">
-      <attribute name="vbootsize">
-        <a:documentation>For images with a an extra virtual boot space
-specifies the size in MB. If not set the min vboot
-size is set to 10 MB</a:documentation>
-        <data type="nonNegativeInteger"/>
-      </attribute>
-      <sch:pattern id="vbootsize" is-a="image_type">
-        <sch:param name="attr" value="vbootsize"/>
-        <sch:param name="types" value="oem vmx"/>
-      </sch:pattern>
-    </define>
     <define name="k.type.bootprofile.attribute">
       <attribute name="bootprofile">
         <a:documentation>Specifies the boot profile defined in the boot image
@@ -2170,7 +2158,6 @@ the standard x86 bios firmware setup is used</a:documentation>
           <value>ec2hvm</value>
           <value>efi</value>
           <value>uefi</value>
-          <value>vboot</value>
           <value>ofw</value>
           <value>opal</value>
         </choice>
@@ -2690,9 +2677,6 @@ are available on the host. Default timeout is 3 seconds</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.target_removable"/>
-        </optional>
-        <optional>
-          <ref name="k.type.vbootsize.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.vga.attribute"/>

--- a/kiwi/storage/disk.py
+++ b/kiwi/storage/disk.py
@@ -181,6 +181,18 @@ class Disk(DeviceProvider):
         self._add_to_map('prep')
         self._add_to_public_id_map('kiwi_PrepPart')
 
+    def create_spare_partition(self, mbsize):
+        """
+        Create spare partition for custom use
+
+        Populates kiwi_SparePart(id)
+
+        :param int mbsize: partition size
+        """
+        self.partitioner.create('p.spare', mbsize, 't.linux')
+        self._add_to_map('spare')
+        self._add_to_public_id_map('kiwi_SparePart')
+
     def create_efi_csm_partition(self, mbsize):
         """
         Create EFI bios grub partition

--- a/kiwi/storage/disk.py
+++ b/kiwi/storage/disk.py
@@ -205,18 +205,6 @@ class Disk(DeviceProvider):
         self._add_to_map('efi')
         self._add_to_public_id_map('kiwi_EfiPart')
 
-    def create_vboot_partition(self, mbsize):
-        """
-        Create virtual boot partition
-
-        Populates kiwi_VbootPart(id)
-
-        :param int mbsize: partition size
-        """
-        self.partitioner.create('p.vboot', mbsize, 't.linux')
-        self._add_to_map('vboot')
-        self._add_to_public_id_map('kiwi_VbootPart')
-
     def activate_boot_partition(self):
         """
         Activate boot partition

--- a/kiwi/storage/setup.py
+++ b/kiwi/storage/setup.py
@@ -84,6 +84,7 @@ class DiskSetup(object):
         self.filesystem = xml_state.build_type.get_filesystem()
         self.bootpart_requested = xml_state.build_type.get_bootpartition()
         self.bootpart_mbytes = xml_state.build_type.get_bootpartsize()
+        self.spare_part_mbytes = xml_state.get_build_type_spare_part_size()
         self.mdraid = xml_state.build_type.get_mdraid()
         self.luks = xml_state.build_type.get_luks()
         self.volume_manager = xml_state.get_volume_management()
@@ -145,6 +146,12 @@ class DiskSetup(object):
             calculated_disk_mbytes += boot_mbytes
             log.info(
                 '--> boot partition adding %s MB', boot_mbytes
+            )
+
+        if self.spare_part_mbytes:
+            calculated_disk_mbytes += self.spare_part_mbytes
+            log.info(
+                '--> spare partition adding %s MB', self.spare_part_mbytes
             )
 
         efi_mbytes = self.firmware.get_efi_partition_size()

--- a/kiwi/storage/setup.py
+++ b/kiwi/storage/setup.py
@@ -132,14 +132,6 @@ class DiskSetup(object):
                         '--> volume(s) size setup adding %s MB', volume_mbytes
                     )
 
-        vboot_mbytes = self.firmware.get_vboot_partition_size()
-        if vboot_mbytes:
-            calculated_disk_mbytes += vboot_mbytes
-            log.info(
-                '--> virtual boot partition adding %s MB',
-                vboot_mbytes
-            )
-
         legacy_bios_mbytes = self.firmware.get_legacy_bios_partition_size()
         if legacy_bios_mbytes:
             calculated_disk_mbytes += legacy_bios_mbytes

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Wed Feb  8 15:46:20 2017 by generateDS.py version 2.24a.
+# Generated Wed Feb  8 16:21:03 2017 by generateDS.py version 2.24a.
 #
 # Command line options:
 #   ('-f', '')
@@ -2481,7 +2481,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, checkprebuilt=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsnocheck=None, fsmountoptions=None, gcelicense=None, hybrid=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, containerconfig=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, checkprebuilt=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsnocheck=None, fsmountoptions=None, gcelicense=None, hybrid=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, containerconfig=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2527,6 +2527,7 @@ class type_(GeneratedsSuper):
         self.primary = _cast(bool, primary)
         self.ramonly = _cast(bool, ramonly)
         self.rootfs_label = _cast(None, rootfs_label)
+        self.spare_part = _cast(None, spare_part)
         self.target_blocksize = _cast(int, target_blocksize)
         self.target_removable = _cast(bool, target_removable)
         self.vga = _cast(None, vga)
@@ -2695,6 +2696,8 @@ class type_(GeneratedsSuper):
     def set_ramonly(self, ramonly): self.ramonly = ramonly
     def get_rootfs_label(self): return self.rootfs_label
     def set_rootfs_label(self, rootfs_label): self.rootfs_label = rootfs_label
+    def get_spare_part(self): return self.spare_part
+    def set_spare_part(self, spare_part): self.spare_part = spare_part
     def get_target_blocksize(self): return self.target_blocksize
     def set_target_blocksize(self, target_blocksize): self.target_blocksize = target_blocksize
     def get_target_removable(self): return self.target_removable
@@ -2707,6 +2710,13 @@ class type_(GeneratedsSuper):
     def set_volid(self, volid): self.volid = volid
     def get_wwid_wait_timeout(self): return self.wwid_wait_timeout
     def set_wwid_wait_timeout(self, wwid_wait_timeout): self.wwid_wait_timeout = wwid_wait_timeout
+    def validate_partition_size_type(self, value):
+        # Validate type partition-size-type, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_partition_size_type_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_partition_size_type_patterns_, ))
+    validate_partition_size_type_patterns_ = [['^\\d+|\\d+M|\\d+G$']]
     def validate_vhd_tag_type(self, value):
         # Validate type vhd-tag-type, a restriction on xs:token.
         if value is not None and Validate_simpletypes_:
@@ -2878,6 +2888,9 @@ class type_(GeneratedsSuper):
         if self.rootfs_label is not None and 'rootfs_label' not in already_processed:
             already_processed.add('rootfs_label')
             outfile.write(' rootfs_label=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.rootfs_label), input_name='rootfs_label')), ))
+        if self.spare_part is not None and 'spare_part' not in already_processed:
+            already_processed.add('spare_part')
+            outfile.write(' spare_part=%s' % (quote_attrib(self.spare_part), ))
         if self.target_blocksize is not None and 'target_blocksize' not in already_processed:
             already_processed.add('target_blocksize')
             outfile.write(' target_blocksize="%s"' % self.gds_format_integer(self.target_blocksize, input_name='target_blocksize'))
@@ -3204,6 +3217,12 @@ class type_(GeneratedsSuper):
         if value is not None and 'rootfs_label' not in already_processed:
             already_processed.add('rootfs_label')
             self.rootfs_label = value
+        value = find_attr_value_('spare_part', node)
+        if value is not None and 'spare_part' not in already_processed:
+            already_processed.add('spare_part')
+            self.spare_part = value
+            self.spare_part = ' '.join(self.spare_part.split())
+            self.validate_partition_size_type(self.spare_part)    # validate type partition-size-type
         value = find_attr_value_('target_blocksize', node)
         if value is not None and 'target_blocksize' not in already_processed:
             already_processed.add('target_blocksize')

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Thu Feb  2 15:44:52 2017 by generateDS.py version 2.24a.
+# Generated Wed Feb  8 15:46:20 2017 by generateDS.py version 2.24a.
 #
 # Command line options:
 #   ('-f', '')
@@ -2481,7 +2481,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, checkprebuilt=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsnocheck=None, fsmountoptions=None, gcelicense=None, hybrid=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, target_blocksize=None, target_removable=None, vbootsize=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, containerconfig=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, checkprebuilt=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsnocheck=None, fsmountoptions=None, gcelicense=None, hybrid=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, containerconfig=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2529,7 +2529,6 @@ class type_(GeneratedsSuper):
         self.rootfs_label = _cast(None, rootfs_label)
         self.target_blocksize = _cast(int, target_blocksize)
         self.target_removable = _cast(bool, target_removable)
-        self.vbootsize = _cast(int, vbootsize)
         self.vga = _cast(None, vga)
         self.vhdfixedtag = _cast(None, vhdfixedtag)
         self.volid = _cast(None, volid)
@@ -2700,8 +2699,6 @@ class type_(GeneratedsSuper):
     def set_target_blocksize(self, target_blocksize): self.target_blocksize = target_blocksize
     def get_target_removable(self): return self.target_removable
     def set_target_removable(self, target_removable): self.target_removable = target_removable
-    def get_vbootsize(self): return self.vbootsize
-    def set_vbootsize(self, vbootsize): self.vbootsize = vbootsize
     def get_vga(self): return self.vga
     def set_vga(self, vga): self.vga = vga
     def get_vhdfixedtag(self): return self.vhdfixedtag
@@ -2887,9 +2884,6 @@ class type_(GeneratedsSuper):
         if self.target_removable is not None and 'target_removable' not in already_processed:
             already_processed.add('target_removable')
             outfile.write(' target_removable="%s"' % self.gds_format_boolean(self.target_removable, input_name='target_removable'))
-        if self.vbootsize is not None and 'vbootsize' not in already_processed:
-            already_processed.add('vbootsize')
-            outfile.write(' vbootsize="%s"' % self.gds_format_integer(self.vbootsize, input_name='vbootsize'))
         if self.vga is not None and 'vga' not in already_processed:
             already_processed.add('vga')
             outfile.write(' vga=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.vga), input_name='vga')), ))
@@ -3228,15 +3222,6 @@ class type_(GeneratedsSuper):
                 self.target_removable = False
             else:
                 raise_parse_error(node, 'Bad boolean attribute')
-        value = find_attr_value_('vbootsize', node)
-        if value is not None and 'vbootsize' not in already_processed:
-            already_processed.add('vbootsize')
-            try:
-                self.vbootsize = int(value)
-            except ValueError as exp:
-                raise_parse_error(node, 'Bad integer attribute: %s' % exp)
-            if self.vbootsize < 0:
-                raise_parse_error(node, 'Invalid NonNegativeInteger')
         value = find_attr_value_('vga', node)
         if value is not None and 'vga' not in already_processed:
             already_processed.add('vga')

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -581,6 +581,18 @@ class XMLState(object):
                 mbytes=value, additive=additive
             )
 
+    def get_build_type_spare_part_size(self):
+        """
+        Size information for the spare_part size from the build
+        type. If no unit is set the value is treated as mbytes
+
+        :return: mbytes
+        :rtype: int
+        """
+        spare_part_size = self.build_type.get_spare_part()
+        if spare_part_size:
+            return self._to_mega_byte(spare_part_size)
+
     def get_volume_group_name(self):
         """
         Volume group name from systemdisk section

--- a/test/data/example_arm_disk_size_config.xml
+++ b/test/data/example_arm_disk_size_config.xml
@@ -19,7 +19,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" bootloader="grub2"/>
+        <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" bootloader="grub2" spare_part="42M"/>
     </preferences>
     <repository type="yast2">
         <source path="obs://13.2/repo/oss"/>

--- a/test/data/example_arm_disk_size_config.xml
+++ b/test/data/example_arm_disk_size_config.xml
@@ -19,7 +19,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" bootloader="grub2" firmware="vboot" vbootsize="42"/>
+        <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" bootloader="grub2"/>
     </preferences>
     <repository type="yast2">
         <source path="obs://13.2/repo/oss"/>

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -34,7 +34,7 @@
         <locale>de_DE</locale>
     </preferences>
     <preferences>
-        <type bootloader="grub2" image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async" btrfs_root_is_snapshot="true">
+        <type bootloader="grub2" image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async" btrfs_root_is_snapshot="true" spare_part="200M">
             <size unit="G" additive="true">1</size>
             <systemdisk name="mydisk"/>
             <machine memory="512" domain="domU">

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -712,21 +712,6 @@ class TestDiskBuilder(object):
     @patch('kiwi.builder.disk.FileSystem')
     @patch_open
     @patch('kiwi.builder.disk.Command.run')
-    def test_create_disk_vboot_firmware_requested(
-        self, mock_command, mock_open, mock_fs
-    ):
-        filesystem = mock.Mock()
-        mock_fs.return_value = filesystem
-        self.disk_builder.volume_manager_name = None
-        self.disk_builder.install_media = False
-        self.disk_builder.firmware.vboot_mode.return_value = True
-        self.disk_builder.firmware.get_vboot_partition_size.return_value = 42
-        self.disk_builder.create_disk()
-        self.disk.create_vboot_partition.assert_called_once_with(42)
-
-    @patch('kiwi.builder.disk.FileSystem')
-    @patch_open
-    @patch('kiwi.builder.disk.Command.run')
     def test_create_disk_format(self, mock_command, mock_open, mock_fs):
         result_instance = mock.Mock()
         filesystem = mock.Mock()

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -712,6 +712,20 @@ class TestDiskBuilder(object):
     @patch('kiwi.builder.disk.FileSystem')
     @patch_open
     @patch('kiwi.builder.disk.Command.run')
+    def test_create_disk_spare_part_requested(
+        self, mock_command, mock_open, mock_fs
+    ):
+        filesystem = mock.Mock()
+        mock_fs.return_value = filesystem
+        self.disk_builder.volume_manager_name = None
+        self.disk_builder.install_media = False
+        self.disk_builder.spare_part_mbsize = 42
+        self.disk_builder.create_disk()
+        self.disk.create_spare_partition.assert_called_once_with(42)
+
+    @patch('kiwi.builder.disk.FileSystem')
+    @patch_open
+    @patch('kiwi.builder.disk.Command.run')
     def test_create_disk_format(self, mock_command, mock_open, mock_fs):
         result_instance = mock.Mock()
         filesystem = mock.Mock()

--- a/test/unit/firmware_test.py
+++ b/test/unit/firmware_test.py
@@ -44,9 +44,6 @@ class TestFirmWare(object):
         self.firmware_opal = FirmWare(xml_state)
 
         mock_platform.return_value = 'arm64'
-        xml_state.build_type.get_firmware.return_value = 'vboot'
-        xml_state.build_type.get_vbootsize.return_value = None
-        self.firmware_vboot = FirmWare(xml_state)
 
     @raises(KiwiNotImplementedError)
     def test_firmware_unsupported(self):
@@ -69,9 +66,6 @@ class TestFirmWare(object):
     def test_get_partition_table_type_ppc_opal_mode(self):
         assert self.firmware_opal.get_partition_table_type() == 'gpt'
 
-    def test_get_partition_table_type_arm_vboot_move(self):
-        assert self.firmware_vboot.get_partition_table_type() == 'gpt'
-
     def test_legacy_bios_mode(self):
         assert self.firmware_bios.legacy_bios_mode() is False
         assert self.firmware_efi.legacy_bios_mode() is True
@@ -79,10 +73,6 @@ class TestFirmWare(object):
     def test_legacy_bios_mode_non_x86_platform(self):
         self.firmware_efi.arch = 'arm64'
         assert self.firmware_efi.legacy_bios_mode() is False
-
-    def test_vboot_mode(self):
-        assert self.firmware_vboot.vboot_mode() is True
-        assert self.firmware_bios.vboot_mode() is False
 
     def test_ec2_mode(self):
         assert self.firmware_ec2.ec2_mode() == 'ec2'
@@ -112,9 +102,3 @@ class TestFirmWare(object):
 
     def test_get_prep_partition_size(self):
         assert self.firmware_ofw.get_prep_partition_size() == 8
-
-    def test_get_vboot_partition_size(self):
-        assert self.firmware_vboot.get_vboot_partition_size() == 10
-        self.firmware_vboot.vboot_mbsize = 42
-        assert self.firmware_vboot.get_vboot_partition_size() == 42
-        assert self.firmware_bios.get_vboot_partition_size() == 0

--- a/test/unit/storage_disk_test.py
+++ b/test/unit/storage_disk_test.py
@@ -116,6 +116,13 @@ class TestDisk(object):
         )
         assert self.disk.public_partition_id_map['kiwi_EfiPart'] == 1
 
+    def test_create_spare_partition(self):
+        self.disk.create_spare_partition(42)
+        self.partitioner.create.assert_called_once_with(
+            'p.spare', 42, 't.linux'
+        )
+        assert self.disk.public_partition_id_map['kiwi_SparePart'] == 1
+
     @patch('kiwi.storage.disk.Command.run')
     def test_create_prep_partition(self, mock_command):
         self.disk.create_prep_partition(8)

--- a/test/unit/storage_disk_test.py
+++ b/test/unit/storage_disk_test.py
@@ -116,13 +116,6 @@ class TestDisk(object):
         )
         assert self.disk.public_partition_id_map['kiwi_EfiPart'] == 1
 
-    def test_create_vboot_partition(self):
-        self.disk.create_vboot_partition(42)
-        self.partitioner.create.assert_called_once_with(
-            'p.vboot', 42, 't.linux'
-        )
-        assert self.disk.public_partition_id_map['kiwi_VbootPart'] == 1
-
     @patch('kiwi.storage.disk.Command.run')
     def test_create_prep_partition(self, mock_command):
         self.disk.create_prep_partition(8)

--- a/test/unit/storage_setup_test.py
+++ b/test/unit/storage_setup_test.py
@@ -134,6 +134,14 @@ class TestDiskSetup(object):
             Defaults.get_default_prep_mbytes() + \
             self.size.accumulate_mbyte_file_sizes.return_value
 
+    def test_get_disksize_mbytes_with_spare_partition(self):
+        configured_spare_part_size = 42
+        assert self.setup_arm.get_disksize_mbytes() == \
+            configured_spare_part_size + \
+            Defaults.get_default_efi_boot_mbytes() + \
+            Defaults.get_default_boot_mbytes() + \
+            self.size.accumulate_mbyte_file_sizes.return_value
+
     def test_get_disksize_mbytes_configured_additive(self):
         self.setup.configured_size = mock.Mock()
         self.setup.build_type_name = 'vmx'

--- a/test/unit/storage_setup_test.py
+++ b/test/unit/storage_setup_test.py
@@ -134,14 +134,6 @@ class TestDiskSetup(object):
             Defaults.get_default_prep_mbytes() + \
             self.size.accumulate_mbyte_file_sizes.return_value
 
-    def test_get_disksize_mbytes_with_vboot_partition(self):
-        configured_vboot_size = 42
-        assert self.setup_arm.get_disksize_mbytes() == \
-            configured_vboot_size + \
-            Defaults.get_default_efi_boot_mbytes() + \
-            Defaults.get_default_boot_mbytes() + \
-            self.size.accumulate_mbyte_file_sizes.return_value
-
     def test_get_disksize_mbytes_configured_additive(self):
         self.setup.configured_size = mock.Mock()
         self.setup.build_type_name = 'vmx'

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -526,3 +526,6 @@ class TestXMLState(object):
         state = XMLState(xml_data, ['vmxFlavour'], 'docker')
         assert state.get_build_type_containerconfig_section().get_name() == \
             'container_name'
+
+    def test_get_spare_part(self):
+        assert self.state.get_build_type_spare_part_size() == 200


### PR DESCRIPTION
Added handling for spare_part attribute
    
Add a spare partition right before the root partition of the configured size. Fixes #234
In addition delete all traces of the vboot firmware