### PR TITLE
Custom efi part size

### DIFF
--- a/doc/source/schema.rst
+++ b/doc/source/schema.rst
@@ -286,6 +286,7 @@ List of attributes for ``type``:
 * ``zipl_targettype`` `[?]`_: The device type of the disk zipl should boot. On zFCP devices use SCSI, on DASD devices use CDL or LDL on emulated DASD devices use FBA
 * ``bootpartition`` `[?]`_: specify if an extra boot partition should be used or not. This will overwrite kiwi's default layout
 * ``bootpartsize`` `[?]`_: For images with a separate boot partition this attribute specifies the size in MB. If not set the min bootpart size is set to 200 MB
+* ``efipartsize`` `[?]`_: For images with an EFI fat partition this attribute specifies the size in MB. If not set the min efipart size is set to 20 MB
 * ``bootprofile`` `[?]`_: Specifies the boot profile defined in the boot image description. When kiwi builds the boot image the information is passed as add-profile option
 * ``boottimeout`` `[?]`_: Specifies the boot timeout in seconds prior to launching the default boot option. the unit for the timeout value is seconds if GRUB is used as the boot loader and 1/10 seconds if syslinux is used
 * ``btrfs_root_is_snapshot`` `[?]`_: Tell kiwi to install the system into a btrfs snapshot The snapshot layout is compatible with the snapper management toolkit. By default no snapshots are used

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -353,7 +353,7 @@ class Defaults(object):
         :return: mbsize
         :rtype: int
         """
-        return 200
+        return 20
 
     @classmethod
     def get_recovery_spare_mbytes(self):

--- a/kiwi/firmware.py
+++ b/kiwi/firmware.py
@@ -49,6 +49,7 @@ class FirmWare(object):
         self.arch = platform.machine()
         self.zipl_target_type = xml_state.build_type.get_zipl_targettype()
         self.firmware = xml_state.build_type.get_firmware()
+        self.efipart_mbytes = xml_state.build_type.get_efipartsize()
 
         if not self.firmware:
             self.firmware = Defaults.get_default_firmware(self.arch)
@@ -172,7 +173,10 @@ class FirmWare(object):
         :rtype: int
         """
         if self.efi_mode():
-            return Defaults.get_default_efi_boot_mbytes()
+            if self.efipart_mbytes:
+                return self.efipart_mbytes
+            else:
+                return Defaults.get_default_efi_boot_mbytes()
         else:
             return 0
 

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1594,6 +1594,15 @@ div {
             sch:param [ name = "attr" value = "bootpartsize" ]
             sch:param [ name = "types" value = "oem vmx" ]
         ]
+    k.type.efipartsize.attribute =
+        ## For images with an EFI fat partition this attribute
+        ## specifies the size in MB. If not set the min efipart
+        ## size is set to 20 MB
+        attribute efipartsize { xsd:nonNegativeInteger }
+        >> sch:pattern [ id = "efipartsize" is-a = "image_type"
+            sch:param [ name = "attr" value = "efipartsize" ]
+            sch:param [ name = "types" value = "oem vmx" ]
+        ]
     k.type.bootprofile.attribute =
         ## Specifies the boot profile defined in the boot image
         ## description. When kiwi builds the boot image the
@@ -1953,6 +1962,7 @@ div {
         k.type.zipl_targettype.attribute? &
         k.type.bootpartition.attribute? &
         k.type.bootpartsize.attribute? &
+        k.type.efipartsize.attribute? &
         k.type.bootprofile.attribute? &
         k.type.boottimeout.attribute? &
         k.type.btrfs_root_is_snapshot? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2058,6 +2058,18 @@ size is set to 200 MB</a:documentation>
         <sch:param name="types" value="oem vmx"/>
       </sch:pattern>
     </define>
+    <define name="k.type.efipartsize.attribute">
+      <attribute name="efipartsize">
+        <a:documentation>For images with an EFI fat partition this attribute
+specifies the size in MB. If not set the min efipart
+size is set to 20 MB</a:documentation>
+        <data type="nonNegativeInteger"/>
+      </attribute>
+      <sch:pattern id="efipartsize" is-a="image_type">
+        <sch:param name="attr" value="efipartsize"/>
+        <sch:param name="types" value="oem vmx"/>
+      </sch:pattern>
+    </define>
     <define name="k.type.bootprofile.attribute">
       <attribute name="bootprofile">
         <a:documentation>Specifies the boot profile defined in the boot image
@@ -2592,6 +2604,9 @@ are available on the host. Default timeout is 3 seconds</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.bootpartsize.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.efipartsize.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.bootprofile.attribute"/>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Thu Feb  9 15:32:29 2017 by generateDS.py version 2.24a.
+# Generated Thu Feb  9 16:42:09 2017 by generateDS.py version 2.24a.
 #
 # Command line options:
 #   ('-f', '')
@@ -2481,7 +2481,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, checkprebuilt=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsnocheck=None, fsmountoptions=None, gcelicense=None, hybrid=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, containerconfig=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, efipartsize=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, checkprebuilt=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsnocheck=None, fsmountoptions=None, gcelicense=None, hybrid=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, containerconfig=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2492,6 +2492,7 @@ class type_(GeneratedsSuper):
         self.zipl_targettype = _cast(None, zipl_targettype)
         self.bootpartition = _cast(bool, bootpartition)
         self.bootpartsize = _cast(int, bootpartsize)
+        self.efipartsize = _cast(int, efipartsize)
         self.bootprofile = _cast(None, bootprofile)
         self.boottimeout = _cast(int, boottimeout)
         self.btrfs_root_is_snapshot = _cast(bool, btrfs_root_is_snapshot)
@@ -2626,6 +2627,8 @@ class type_(GeneratedsSuper):
     def set_bootpartition(self, bootpartition): self.bootpartition = bootpartition
     def get_bootpartsize(self): return self.bootpartsize
     def set_bootpartsize(self, bootpartsize): self.bootpartsize = bootpartsize
+    def get_efipartsize(self): return self.efipartsize
+    def set_efipartsize(self, efipartsize): self.efipartsize = efipartsize
     def get_bootprofile(self): return self.bootprofile
     def set_bootprofile(self, bootprofile): self.bootprofile = bootprofile
     def get_boottimeout(self): return self.boottimeout
@@ -2783,6 +2786,9 @@ class type_(GeneratedsSuper):
         if self.bootpartsize is not None and 'bootpartsize' not in already_processed:
             already_processed.add('bootpartsize')
             outfile.write(' bootpartsize="%s"' % self.gds_format_integer(self.bootpartsize, input_name='bootpartsize'))
+        if self.efipartsize is not None and 'efipartsize' not in already_processed:
+            already_processed.add('efipartsize')
+            outfile.write(' efipartsize="%s"' % self.gds_format_integer(self.efipartsize, input_name='efipartsize'))
         if self.bootprofile is not None and 'bootprofile' not in already_processed:
             already_processed.add('bootprofile')
             outfile.write(' bootprofile=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.bootprofile), input_name='bootprofile')), ))
@@ -2986,6 +2992,15 @@ class type_(GeneratedsSuper):
             except ValueError as exp:
                 raise_parse_error(node, 'Bad integer attribute: %s' % exp)
             if self.bootpartsize < 0:
+                raise_parse_error(node, 'Invalid NonNegativeInteger')
+        value = find_attr_value_('efipartsize', node)
+        if value is not None and 'efipartsize' not in already_processed:
+            already_processed.add('efipartsize')
+            try:
+                self.efipartsize = int(value)
+            except ValueError as exp:
+                raise_parse_error(node, 'Bad integer attribute: %s' % exp)
+            if self.efipartsize < 0:
                 raise_parse_error(node, 'Invalid NonNegativeInteger')
         value = find_attr_value_('bootprofile', node)
         if value is not None and 'bootprofile' not in already_processed:

--- a/test/unit/firmware_test.py
+++ b/test/unit/firmware_test.py
@@ -18,8 +18,12 @@ class TestFirmWare(object):
         xml_state.build_type.get_firmware.return_value = 'bios'
         self.firmware_bios = FirmWare(xml_state)
 
+        xml_state.build_type.get_efipartsize.return_value = None
         xml_state.build_type.get_firmware.return_value = 'efi'
         self.firmware_efi = FirmWare(xml_state)
+
+        xml_state.build_type.get_efipartsize.return_value = 42
+        self.firmware_efi_custom_efi_part = FirmWare(xml_state)
 
         xml_state.build_type.get_firmware.return_value = 'ec2'
         self.firmware_ec2 = FirmWare(xml_state)
@@ -99,6 +103,7 @@ class TestFirmWare(object):
     def test_get_efi_partition_size(self):
         assert self.firmware_bios.get_efi_partition_size() == 0
         assert self.firmware_efi.get_efi_partition_size() == 20
+        assert self.firmware_efi_custom_efi_part.get_efi_partition_size() == 42
 
     def test_get_prep_partition_size(self):
         assert self.firmware_ofw.get_prep_partition_size() == 8

--- a/test/unit/firmware_test.py
+++ b/test/unit/firmware_test.py
@@ -98,7 +98,7 @@ class TestFirmWare(object):
 
     def test_get_efi_partition_size(self):
         assert self.firmware_bios.get_efi_partition_size() == 0
-        assert self.firmware_efi.get_efi_partition_size() == 200
+        assert self.firmware_efi.get_efi_partition_size() == 20
 
     def test_get_prep_partition_size(self):
         assert self.firmware_ofw.get_prep_partition_size() == 8


### PR DESCRIPTION
Added efipartsize attribute in type setup
    
The attribute allows to specify a custom size for the EFI partition. Fixes #237
In addition the default EFI partition size has been reduced to 20MB