### PR TITLE
Allow to convert GPT into MBR

### DIFF
--- a/doc/source/schema.rst
+++ b/doc/source/schema.rst
@@ -307,6 +307,7 @@ List of attributes for ``type``:
 * ``hybridpersistent`` `[?]`_: Will trigger the creation of a partition for a COW file to keep data persistent over a reboot
 * ``hybridpersistent_filesystem`` `[?]`_: Set the filesystem to use for persistent writing if a hybrid image is used as disk on e.g a USB Stick. By default the btrfs filesystem is used
 * ``gpt_hybrid_mbr`` `[?]`_: for gpt disk types only: create a hybrid GPT/MBR partition table
+* ``force_mbr`` `[?]`_: Force use of MBR (msdos table) partition table even if the use of the GPT would be the natural choice. On e.g some arm systems an EFI partition layout is required but must not be stored in a GPT. For those rare cases this attribute allows to force the use of the msdos table including all its restrictions in max partition size and amount of partitions
 * ``initrd_system`` `[?]`_: specify which initrd builder to use, default is kiwi's builtin architecture. Be aware that the dracut initrd system does not support all features of the kiwi initrd
 * ``image`` : Specifies the image type
 * ``installboot`` `[?]`_: Specifies the bootloader default boot entry for the" initial boot of a kiwi install image. This value is" only evaluated for grub and ext|syslinux"

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -192,6 +192,7 @@ class DiskBuilder(object):
         self.volume_group_name = xml_state.get_volume_group_name()
         self.mdraid = xml_state.build_type.get_mdraid()
         self.hybrid_mbr = xml_state.build_type.get_gpt_hybrid_mbr()
+        self.force_mbr = xml_state.build_type.get_force_mbr()
         self.luks = xml_state.build_type.get_luks()
         self.luks_os = xml_state.build_type.get_luksOS()
         self.machine = xml_state.get_build_type_machine_section()
@@ -729,9 +730,13 @@ class DiskBuilder(object):
             log.info('--> setting active flag to primary PReP partition')
             self.disk.activate_boot_partition()
 
-        if self.hybrid_mbr:
-            log.info('--> converting partition table to hybrid GPT/MBR')
-            self.disk.create_hybrid_mbr()
+        if self.firmware.efi_mode():
+            if self.force_mbr:
+                log.info('--> converting partition table to MBR')
+                self.disk.create_mbr()
+            elif self.hybrid_mbr:
+                log.info('--> converting partition table to hybrid GPT/MBR')
+                self.disk.create_hybrid_mbr()
 
         self.disk.map_partitions()
 

--- a/kiwi/partitioner/base.py
+++ b/kiwi/partitioner/base.py
@@ -90,3 +90,11 @@ class PartitionerBase(object):
         Implementation in specialized partitioner class
         """
         raise NotImplementedError
+
+    def set_mbr(self):
+        """
+        Turn partition table into MBR (msdos table)
+
+        Implementation in specialized partitioner class
+        """
+        raise NotImplementedError

--- a/kiwi/partitioner/gpt.py
+++ b/kiwi/partitioner/gpt.py
@@ -116,3 +116,23 @@ class PartitionerGpt(PartitionerBase):
         Command.run(
             ['sgdisk', '-h', ':'.join(partition_ids), self.disk_device]
         )
+
+    def set_mbr(self):
+        """
+        Turn partition table into MBR (msdos table)
+        """
+        partition_ids = []
+        efi_partition_number = None
+        for number in range(1, self.partition_id + 1):
+            partition_info = Command.run(
+                ['sgdisk', '-i={0}'.format(number), self.disk_device]
+            )
+            if '(EFI System)' in partition_info.output:
+                efi_partition_number = number
+            partition_ids.append(format(number))
+        Command.run(
+            ['sgdisk', '-m', ':'.join(partition_ids), self.disk_device]
+        )
+        if efi_partition_number:
+            # turn former EFI partition into standard linux partition
+            self.set_flag(efi_partition_number, 't.linux')

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1750,6 +1750,19 @@ div {
             sch:param [ name = "attr" value = "formatoptions" ]
             sch:param [ name = "types" value = "vmx oem" ]
         ]
+    k.type.force_mbr.attribute =
+        ## Force use of MBR (msdos table) partition table even if the
+        ## use of the GPT would be the natural choice. On e.g some
+        ## arm systems an EFI partition layout is required but must
+        ## not be stored in a GPT. For those rare cases this attribute
+        ## allows to force the use of the msdos table including all
+        ## its restrictions in max partition size and amount of
+        ## partitions
+        attribute force_mbr { xsd:boolean }
+        >> sch:pattern [ id = "force_mbr" is-a = "image_type"
+            sch:param [ name = "attr" value = "force_mbr" ]
+            sch:param [ name = "types" value = "vmx oem" ]
+        ]
     k.type.fsnocheck.attribute =
         ## Turn off periodic filesystem checks on ext2/3/4. Obsolete attribute
         ## since KIWI v8
@@ -1786,7 +1799,7 @@ div {
             sch:param [ name = "attr" value = "hybridpersistent_filesystem" ]
             sch:param [ name = "types" value = "iso pxe" ]
         ]
-    k.type.gpt_hybrid_mbr =
+    k.type.gpt_hybrid_mbr.attribute =
         ## for gpt disk types only:
         ## create a hybrid GPT/MBR partition table
         attribute gpt_hybrid_mbr { xsd:boolean }
@@ -1982,7 +1995,8 @@ div {
         k.type.hybrid.attribute? &
         k.type.hybridpersistent.attribute? &
         k.type.hybridpersistent_filesystem.attribute? &
-        k.type.gpt_hybrid_mbr? &
+        k.type.gpt_hybrid_mbr.attribute? &
+        k.type.force_mbr.attribute? &
         k.type.initrd_system.attribute? &
         k.type.image.attribute &
         k.type.installboot.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2288,6 +2288,22 @@ the -o option in the qemu-img call</a:documentation>
         <sch:param name="types" value="vmx oem"/>
       </sch:pattern>
     </define>
+    <define name="k.type.force_mbr.attribute">
+      <attribute name="force_mbr">
+        <a:documentation>Force use of MBR (msdos table) partition table even if the
+use of the GPT would be the natural choice. On e.g some
+arm systems an EFI partition layout is required but must
+not be stored in a GPT. For those rare cases this attribute
+allows to force the use of the msdos table including all
+its restrictions in max partition size and amount of
+partitions</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+      <sch:pattern id="force_mbr" is-a="image_type">
+        <sch:param name="attr" value="force_mbr"/>
+        <sch:param name="types" value="vmx oem"/>
+      </sch:pattern>
+    </define>
     <define name="k.type.fsnocheck.attribute">
       <attribute name="fsnocheck">
         <a:documentation>Turn off periodic filesystem checks on ext2/3/4. Obsolete attribute
@@ -2342,7 +2358,7 @@ the btrfs filesystem is used</a:documentation>
         <sch:param name="types" value="iso pxe"/>
       </sch:pattern>
     </define>
-    <define name="k.type.gpt_hybrid_mbr">
+    <define name="k.type.gpt_hybrid_mbr.attribute">
       <attribute name="gpt_hybrid_mbr">
         <a:documentation>for gpt disk types only:
 create a hybrid GPT/MBR partition table</a:documentation>
@@ -2666,7 +2682,10 @@ are available on the host. Default timeout is 3 seconds</a:documentation>
           <ref name="k.type.hybridpersistent_filesystem.attribute"/>
         </optional>
         <optional>
-          <ref name="k.type.gpt_hybrid_mbr"/>
+          <ref name="k.type.gpt_hybrid_mbr.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.force_mbr.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.initrd_system.attribute"/>

--- a/kiwi/storage/disk.py
+++ b/kiwi/storage/disk.py
@@ -242,6 +242,14 @@ class Disk(DeviceProvider):
         """
         self.partitioner.set_hybrid_mbr()
 
+    def create_mbr(self):
+        """
+        Turn partition table into MBR (msdos table)
+
+        Note: only GPT tables supports this
+        """
+        self.partitioner.set_mbr()
+
     def wipe(self):
         """
         Zap (destroy) any GPT and MBR data structures if present

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Thu Feb  9 16:42:09 2017 by generateDS.py version 2.24a.
+# Generated Mon Feb 20 16:25:49 2017 by generateDS.py version 2.24a.
 #
 # Command line options:
 #   ('-f', '')
@@ -2481,7 +2481,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, efipartsize=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, checkprebuilt=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsnocheck=None, fsmountoptions=None, gcelicense=None, hybrid=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, containerconfig=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, efipartsize=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, checkprebuilt=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsnocheck=None, fsmountoptions=None, gcelicense=None, hybrid=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, containerconfig=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2513,6 +2513,7 @@ class type_(GeneratedsSuper):
         self.hybridpersistent = _cast(bool, hybridpersistent)
         self.hybridpersistent_filesystem = _cast(None, hybridpersistent_filesystem)
         self.gpt_hybrid_mbr = _cast(bool, gpt_hybrid_mbr)
+        self.force_mbr = _cast(bool, force_mbr)
         self.initrd_system = _cast(None, initrd_system)
         self.image = _cast(None, image)
         self.installboot = _cast(None, installboot)
@@ -2669,6 +2670,8 @@ class type_(GeneratedsSuper):
     def set_hybridpersistent_filesystem(self, hybridpersistent_filesystem): self.hybridpersistent_filesystem = hybridpersistent_filesystem
     def get_gpt_hybrid_mbr(self): return self.gpt_hybrid_mbr
     def set_gpt_hybrid_mbr(self, gpt_hybrid_mbr): self.gpt_hybrid_mbr = gpt_hybrid_mbr
+    def get_force_mbr(self): return self.force_mbr
+    def set_force_mbr(self, force_mbr): self.force_mbr = force_mbr
     def get_initrd_system(self): return self.initrd_system
     def set_initrd_system(self, initrd_system): self.initrd_system = initrd_system
     def get_image(self): return self.image
@@ -2849,6 +2852,9 @@ class type_(GeneratedsSuper):
         if self.gpt_hybrid_mbr is not None and 'gpt_hybrid_mbr' not in already_processed:
             already_processed.add('gpt_hybrid_mbr')
             outfile.write(' gpt_hybrid_mbr="%s"' % self.gds_format_boolean(self.gpt_hybrid_mbr, input_name='gpt_hybrid_mbr'))
+        if self.force_mbr is not None and 'force_mbr' not in already_processed:
+            already_processed.add('force_mbr')
+            outfile.write(' force_mbr="%s"' % self.gds_format_boolean(self.force_mbr, input_name='force_mbr'))
         if self.initrd_system is not None and 'initrd_system' not in already_processed:
             already_processed.add('initrd_system')
             outfile.write(' initrd_system=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.initrd_system), input_name='initrd_system')), ))
@@ -3130,6 +3136,15 @@ class type_(GeneratedsSuper):
                 self.gpt_hybrid_mbr = True
             elif value in ('false', '0'):
                 self.gpt_hybrid_mbr = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
+        value = find_attr_value_('force_mbr', node)
+        if value is not None and 'force_mbr' not in already_processed:
+            already_processed.add('force_mbr')
+            if value in ('true', '1'):
+                self.force_mbr = True
+            elif value in ('false', '0'):
+                self.force_mbr = False
             else:
                 raise_parse_error(node, 'Bad boolean attribute')
         value = find_attr_value_('initrd_system', node)

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -693,6 +693,20 @@ class TestDiskBuilder(object):
         self.disk_builder.create_disk()
         self.disk.create_hybrid_mbr.assert_called_once_with()
 
+    @patch('kiwi.builder.disk.FileSystem')
+    @patch_open
+    @patch('kiwi.builder.disk.Command.run')
+    def test_create_disk_force_mbr_requested(
+        self, mock_command, mock_open, mock_fs
+    ):
+        filesystem = mock.Mock()
+        mock_fs.return_value = filesystem
+        self.disk_builder.volume_manager_name = None
+        self.disk_builder.install_media = False
+        self.disk_builder.force_mbr = True
+        self.disk_builder.create_disk()
+        self.disk.create_mbr.assert_called_once_with()
+
     @patch('kiwi.builder.disk.DiskBuilder')
     def test_create(
         self, mock_builder

--- a/test/unit/partitioner_base_test.py
+++ b/test/unit/partitioner_base_test.py
@@ -31,3 +31,7 @@ class TestPartitionerBase(object):
     @raises(NotImplementedError)
     def test_set_hybrid_mbr(self):
         self.partitioner.set_hybrid_mbr()
+
+    @raises(NotImplementedError)
+    def test_set_mbr(self):
+        self.partitioner.set_mbr()

--- a/test/unit/partitioner_gpt_test.py
+++ b/test/unit/partitioner_gpt_test.py
@@ -1,9 +1,9 @@
 
-from mock import patch
+from mock import patch, call
 
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
 from kiwi.partitioner.gpt import PartitionerGpt
 from kiwi.exceptions import *
@@ -62,3 +62,20 @@ class TestPartitionerGpt(object):
         mock_command.assert_called_once_with(
             ['sgdisk', '-h', '1:2:3', '/dev/loop0']
         )
+
+    @patch('kiwi.partitioner.gpt.Command.run')
+    def test_set_mbr(self, mock_command):
+        command_output = mock.Mock()
+        command_output.output = '...(EFI System)'
+        self.partitioner.partition_id = 4
+        mock_command.return_value = command_output
+        self.partitioner.set_mbr()
+        assert mock_command.call_args_list == [
+            call(['sgdisk', '-i=1', '/dev/loop0']),
+            call(['sgdisk', '-i=2', '/dev/loop0']),
+            call(['sgdisk', '-i=3', '/dev/loop0']),
+            call(['sgdisk', '-i=4', '/dev/loop0']),
+            call(['sgdisk', '-m', '1:2:3:4', '/dev/loop0']),
+            call(['sgdisk', '-t', '4:8300', '/dev/loop0'])
+        ]
+      

--- a/test/unit/storage_disk_test.py
+++ b/test/unit/storage_disk_test.py
@@ -245,3 +245,7 @@ class TestDisk(object):
     def test_create_hybrid_mbr(self):
         self.disk.create_hybrid_mbr()
         self.partitioner.set_hybrid_mbr.assert_called_once_with()
+
+    def test_create_mbr(self):
+        self.disk.create_mbr()
+        self.partitioner.set_mbr.assert_called_once_with()


### PR DESCRIPTION
The type attribute force_mbr allows to convert a system selected
for use with a GPT to use an MBR (msdos table). The attribute
only takes effect on image configurations which would select the
GPT partitioner. This Fixes #236

