### PR TITLE
Include compression optimization flags for mksquashfs command

### DIFF
--- a/kiwi/filesystem/squashfs.py
+++ b/kiwi/filesystem/squashfs.py
@@ -14,7 +14,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
-#
+
+import platform
+
 # project
 from .base import FileSystemBase
 from ..command import Command
@@ -41,6 +43,15 @@ class FileSystemSquashFs(FileSystemBase):
             self.custom_args['create_options'].append('-comp')
             self.custom_args['create_options'].append('xz')
 
+        if '-Xbcj' not in self.custom_args['create_options']:
+            host_architecture = platform.machine()
+            if '86' in host_architecture:
+                self.custom_args['create_options'].append('-Xbcj')
+                self.custom_args['create_options'].append('x86')
+            if 'ppc' in host_architecture:
+                self.custom_args['create_options'].append('-Xbcj')
+                self.custom_args['create_options'].append('powerpc')
+
         if exclude:
             exclude_options.append('-e')
             for item in exclude:
@@ -48,6 +59,6 @@ class FileSystemSquashFs(FileSystemBase):
 
         Command.run(
             [
-                'mksquashfs', self.root_dir, filename, '-noappend'
+                'mksquashfs', self.root_dir, filename, '-noappend', '-b', '1M'
             ] + self.custom_args['create_options'] + exclude_options
         )

--- a/test/unit/filesystem_squashfs_test.py
+++ b/test/unit/filesystem_squashfs_test.py
@@ -15,19 +15,38 @@ class TestFileSystemSquashfs(object):
         mock_exists.return_value = True
         self.squashfs = FileSystemSquashFs(mock.Mock(), 'root_dir')
 
+    @patch('platform.machine')
     @patch('kiwi.filesystem.squashfs.Command.run')
-    def test_create_on_file(self, mock_command):
+    def test_create_on_file(self, mock_command, mock_machine):
+        mock_machine.return_value = 'x86_64'
         self.squashfs.create_on_file('myimage', 'label')
         mock_command.assert_called_once_with(
-            ['mksquashfs', 'root_dir', 'myimage', '-noappend', '-comp', 'xz']
+            [
+                'mksquashfs', 'root_dir', 'myimage', '-noappend',
+                '-b', '1M', '-comp', 'xz', '-Xbcj', 'x86'
+            ]
         )
 
+    @patch('platform.machine')
     @patch('kiwi.filesystem.squashfs.Command.run')
-    def test_create_on_file_exclude_data(self, mock_command):
+    def test_create_on_file_exclude_data(self, mock_command, mock_machine):
+        mock_machine.return_value = 'ppc64le' 
         self.squashfs.create_on_file('myimage', 'label', ['foo'])
         mock_command.assert_called_once_with(
             [
+                'mksquashfs', 'root_dir', 'myimage', '-noappend',
+                '-b', '1M', '-comp', 'xz', '-Xbcj', 'powerpc', '-e', 'foo'
+            ]
+        )
+
+    @patch('platform.machine')
+    @patch('kiwi.filesystem.squashfs.Command.run')
+    def test_create_on_file_unkown_arch(self, mock_command, mock_machine):
+        mock_machine.return_value = 'aarch64'
+        self.squashfs.create_on_file('myimage', 'label')
+        mock_command.assert_called_once_with(
+            [
                 'mksquashfs', 'root_dir', 'myimage',
-                '-noappend', '-comp', 'xz', '-e', 'foo'
+                '-noappend', '-b', '1M', '-comp', 'xz'
             ]
         )


### PR DESCRIPTION
This commit includes some flags for mksquashfs command in other to
achieve higher compression rates. Also note that those flags were
already present in KIWI former versions, thus they have been
included again for compatibility reasons.

Fixes #242