### PR TITLE
Fix default reposdir path for DNF

### DIFF
--- a/kiwi/repository/dnf.py
+++ b/kiwi/repository/dnf.py
@@ -97,7 +97,7 @@ class RepositoryDnf(RepositoryBase):
         in the default places
         """
         self.shared_dnf_dir['reposd-dir'] = \
-            self.root_dir + '/etc/yum/repos.d'
+            self.root_dir + '/etc/yum.repos.d'
         self.shared_dnf_dir['cache-dir'] = \
             self.root_dir + '/var/cache/dnf'
         self.shared_dnf_dir['pluginconf-dir'] = \

--- a/test/unit/repository_dnf_test.py
+++ b/test/unit/repository_dnf_test.py
@@ -62,7 +62,7 @@ class TestRepositoryDnf(object):
 
         assert runtime_dnf_config.set.call_args_list == [
             call('main', 'cachedir', '../data/var/cache/dnf'),
-            call('main', 'reposdir', '../data/etc/yum/repos.d'),
+            call('main', 'reposdir', '../data/etc/yum.repos.d'),
             call('main', 'pluginconfpath', '../data/etc/dnf/plugins'),
             call('main', 'keepcache', '1'),
             call('main', 'debuglevel', '2'),


### PR DESCRIPTION
The default reposdir path for DNF is wrong (subtle one-character change that I missed during initial review).

Changes proposed in this pull request:
* `/etc/yum/repos.d` -> `/etc/yum.repos.d`
