### PR TITLE
Fix tagging for OCI images

### DIFF
--- a/kiwi/container/docker.py
+++ b/kiwi/container/docker.py
@@ -104,10 +104,10 @@ class ContainerImageDocker(object):
         self.docker_root_dir = mkdtemp(prefix='kiwi_docker_root_dir.')
 
         container_dir = os.sep.join(
-            [self.docker_dir, 'umoci_layout']
+            [self.docker_dir, self.container_name]
         )
         container_name = ':'.join(
-            [container_dir, self.container_name]
+            [container_dir, self.container_tag]
         )
 
         Command.run(

--- a/test/unit/container_image_docker_test.py
+++ b/test/unit/container_image_docker_test.py
@@ -88,29 +88,29 @@ class TestContainerImageDocker(object):
         assert mock_command.call_args_list == [
             call([
                 'umoci', 'init', '--layout',
-                'kiwi_docker_dir/umoci_layout'
+                'kiwi_docker_dir/foo'
             ]),
             call([
                 'umoci', 'new', '--image',
-                'kiwi_docker_dir/umoci_layout:foo'
+                'kiwi_docker_dir/foo:latest'
             ]),
             call([
                 'umoci', 'unpack', '--image',
-                'kiwi_docker_dir/umoci_layout:foo', 'kiwi_docker_root_dir'
+                'kiwi_docker_dir/foo:latest', 'kiwi_docker_root_dir'
             ]),
             call([
                 'umoci', 'repack', '--image',
-                'kiwi_docker_dir/umoci_layout:foo', 'kiwi_docker_root_dir'
+                'kiwi_docker_dir/foo:latest', 'kiwi_docker_root_dir'
             ]),
             call([
                 'umoci', 'config', '--config.cmd=/bin/bash', '--image',
-                'kiwi_docker_dir/umoci_layout:foo', '--tag', 'latest'
+                'kiwi_docker_dir/foo:latest', '--tag', 'latest'
             ]),
             call([
-                'umoci', 'gc', '--layout', 'kiwi_docker_dir/umoci_layout'
+                'umoci', 'gc', '--layout', 'kiwi_docker_dir/foo'
             ]),
             call([
-                 'skopeo', 'copy', 'oci:kiwi_docker_dir/umoci_layout:foo',
+                 'skopeo', 'copy', 'oci:kiwi_docker_dir/foo:latest',
                  'docker-archive:result.tar:foo:latest'
             ])
         ]


### PR DESCRIPTION
This commit fixes the tagging schema for umoci. An OCI image
name is path[:tag], this commit rearranges some variable names to
avoid confusions between names and tags.

Fixes #249