### PR TITLE
Support container names with slashes

### DIFF
--- a/kiwi/container/docker.py
+++ b/kiwi/container/docker.py
@@ -107,18 +107,11 @@ class ContainerImageDocker(object):
         self.docker_root_dir = mkdtemp(prefix='kiwi_docker_root_dir.')
 
         container_dir = os.sep.join(
-            [self.docker_dir, self.container_name]
+            [self.docker_dir, 'umoci_layout']
         )
         container_name = ':'.join(
             [container_dir, self.container_tag]
         )
-
-        # Create container subdirectories if needed
-        # umoci is not capable to create subdirectories e.g. opensuse/leap
-        if os.sep in self.container_name:
-            Path.create(os.sep.join(
-                [self.docker_dir, os.path.dirname(self.container_name)]
-            ))
 
         Command.run(
             ['umoci', 'init', '--layout', container_dir]

--- a/kiwi/container/docker.py
+++ b/kiwi/container/docker.py
@@ -113,6 +113,13 @@ class ContainerImageDocker(object):
             [container_dir, self.container_tag]
         )
 
+        # Create container subdirectories if needed
+        # umoci is not capable to create subdirectories e.g. opensuse/leap
+        if os.sep in self.container_name:
+            Path.create(os.sep.join(
+                [self.docker_dir, os.path.dirname(self.container_name)]
+            ))
+
         Command.run(
             ['umoci', 'init', '--layout', container_dir]
         )

--- a/test/unit/container_image_docker_test.py
+++ b/test/unit/container_image_docker_test.py
@@ -87,33 +87,30 @@ class TestContainerImageDocker(object):
 
         assert mock_command.call_args_list == [
             call([
-                'mkdir', '-p', 'kiwi_docker_dir/foo'
-            ]),
-            call([
                 'umoci', 'init', '--layout',
-                'kiwi_docker_dir/foo/bar'
+                'kiwi_docker_dir/umoci_layout'
             ]),
             call([
                 'umoci', 'new', '--image',
-                'kiwi_docker_dir/foo/bar:latest'
+                'kiwi_docker_dir/umoci_layout:latest'
             ]),
             call([
                 'umoci', 'unpack', '--image',
-                'kiwi_docker_dir/foo/bar:latest', 'kiwi_docker_root_dir'
+                'kiwi_docker_dir/umoci_layout:latest', 'kiwi_docker_root_dir'
             ]),
             call([
                 'umoci', 'repack', '--image',
-                'kiwi_docker_dir/foo/bar:latest', 'kiwi_docker_root_dir'
+                'kiwi_docker_dir/umoci_layout:latest', 'kiwi_docker_root_dir'
             ]),
             call([
                 'umoci', 'config', '--config.cmd=/bin/bash', '--image',
-                'kiwi_docker_dir/foo/bar:latest', '--tag', 'latest'
+                'kiwi_docker_dir/umoci_layout:latest', '--tag', 'latest'
             ]),
             call([
-                'umoci', 'gc', '--layout', 'kiwi_docker_dir/foo/bar'
+                'umoci', 'gc', '--layout', 'kiwi_docker_dir/umoci_layout'
             ]),
             call([
-                 'skopeo', 'copy', 'oci:kiwi_docker_dir/foo/bar:latest',
+                 'skopeo', 'copy', 'oci:kiwi_docker_dir/umoci_layout:latest',
                  'docker-archive:result.tar:foo/bar:latest'
             ])
         ]

--- a/test/unit/container_image_docker_test.py
+++ b/test/unit/container_image_docker_test.py
@@ -13,7 +13,7 @@ class TestContainerImageDocker(object):
     def setup(self):
         self.docker = ContainerImageDocker(
             'root_dir', {
-                'container_name': 'foo'
+                'container_name': 'foo/bar'
             }
         )
 
@@ -21,7 +21,7 @@ class TestContainerImageDocker(object):
         docker = ContainerImageDocker(
             'root_dir', {
                 'container_name': 'foo',
-                'container_tag': 'bar',
+                'container_tag': '1.0',
                 'entry_command': [
                     "--config.entrypoint=/bin/bash",
                     "--config.entrypoint=-x"
@@ -87,31 +87,34 @@ class TestContainerImageDocker(object):
 
         assert mock_command.call_args_list == [
             call([
+                'mkdir', '-p', 'kiwi_docker_dir/foo'
+            ]),
+            call([
                 'umoci', 'init', '--layout',
-                'kiwi_docker_dir/foo'
+                'kiwi_docker_dir/foo/bar'
             ]),
             call([
                 'umoci', 'new', '--image',
-                'kiwi_docker_dir/foo:latest'
+                'kiwi_docker_dir/foo/bar:latest'
             ]),
             call([
                 'umoci', 'unpack', '--image',
-                'kiwi_docker_dir/foo:latest', 'kiwi_docker_root_dir'
+                'kiwi_docker_dir/foo/bar:latest', 'kiwi_docker_root_dir'
             ]),
             call([
                 'umoci', 'repack', '--image',
-                'kiwi_docker_dir/foo:latest', 'kiwi_docker_root_dir'
+                'kiwi_docker_dir/foo/bar:latest', 'kiwi_docker_root_dir'
             ]),
             call([
                 'umoci', 'config', '--config.cmd=/bin/bash', '--image',
-                'kiwi_docker_dir/foo:latest', '--tag', 'latest'
+                'kiwi_docker_dir/foo/bar:latest', '--tag', 'latest'
             ]),
             call([
-                'umoci', 'gc', '--layout', 'kiwi_docker_dir/foo'
+                'umoci', 'gc', '--layout', 'kiwi_docker_dir/foo/bar'
             ]),
             call([
-                 'skopeo', 'copy', 'oci:kiwi_docker_dir/foo:latest',
-                 'docker-archive:result.tar:foo:latest'
+                 'skopeo', 'copy', 'oci:kiwi_docker_dir/foo/bar:latest',
+                 'docker-archive:result.tar:foo/bar:latest'
             ])
         ]
         mock_sync.assert_called_once_with(


### PR DESCRIPTION
This commit provides a patch in order to enable container_name
attribute values with slashes. Given that OCI images names are in
the shape of path[:tag], appropriate subdirectories need to be created
if the container name contains slashes.

Fixes #253
