### PR TITLE
Add support for repository credentials

### DIFF
--- a/kiwi/repository/apt.py
+++ b/kiwi/repository/apt.py
@@ -113,7 +113,9 @@ class RepositoryApt(RepositoryBase):
         }
 
     def add_repo(
-        self, name, uri, repo_type='deb', prio=None, dist=None, components=None
+        self, name, uri, repo_type='deb',
+        prio=None, dist=None, components=None,
+        user=None, secret=None, credentials_file=None
     ):
         """
         Add apt_get repository
@@ -124,6 +126,9 @@ class RepositoryApt(RepositoryBase):
         :param int prio: unused
         :param dist: distribution name for non flat deb repos
         :param components: distribution categories
+        :param user: unused
+        :param secret: unused
+        :param credentials_file: unused
         """
         list_file = '/'.join(
             [self.shared_apt_get_dir['sources-dir'], name + '.list']

--- a/kiwi/repository/base.py
+++ b/kiwi/repository/base.py
@@ -65,7 +65,10 @@ class RepositoryBase(object):
         """
         raise NotImplementedError
 
-    def add_repo(self, name, uri, repo_type, prio, dist, components):
+    def add_repo(
+        self, name, uri, repo_type, prio, dist, components,
+        user, secret, credentials_file
+    ):
         """
         Add repository
 
@@ -77,6 +80,9 @@ class RepositoryBase(object):
         :param int prio: unused
         :param dist: unused
         :param components: unused
+        :param user: unused
+        :param secret: unused
+        :param credentials_file: unused
         """
         raise NotImplementedError
 

--- a/kiwi/repository/dnf.py
+++ b/kiwi/repository/dnf.py
@@ -116,7 +116,9 @@ class RepositoryDnf(RepositoryBase):
         }
 
     def add_repo(
-        self, name, uri, repo_type='rpm-md', prio=None, dist=None, components=None
+        self, name, uri, repo_type='rpm-md',
+        prio=None, dist=None, components=None,
+        user=None, secret=None, credentials_file=None
     ):
         """
         Add dnf repository
@@ -127,6 +129,9 @@ class RepositoryDnf(RepositoryBase):
         :param int prio: dnf repostory priority
         :param dist: unused
         :param components: unused
+        :param user: unused
+        :param secret: unused
+        :param credentials_file: unused
         """
         repo_file = self.shared_dnf_dir['reposd-dir'] + '/' + name + '.repo'
         self.repo_names.append(name + '.repo')

--- a/kiwi/repository/yum.py
+++ b/kiwi/repository/yum.py
@@ -116,7 +116,9 @@ class RepositoryYum(RepositoryBase):
         }
 
     def add_repo(
-        self, name, uri, repo_type='rpm-md', prio=None, dist=None, components=None
+        self, name, uri, repo_type='rpm-md',
+        prio=None, dist=None, components=None,
+        user=None, secret=None, credentials_file=None
     ):
         """
         Add yum repository
@@ -127,6 +129,9 @@ class RepositoryYum(RepositoryBase):
         :param int prio: yum repostory priority
         :param dist: unused
         :param components: unused
+        :param user: unused
+        :param secret: unused
+        :param credentials_file: unused
         """
         repo_file = self.shared_yum_dir['reposd-dir'] + '/' + name + '.repo'
         self.repo_names.append(name + '.repo')

--- a/kiwi/solver/repository/__init__.py
+++ b/kiwi/solver/repository/__init__.py
@@ -32,13 +32,13 @@ class SolverRepository(object):
     * :attr:`uri`
         Instance of Uri
     """
-    def __new__(self, uri):
+    def __new__(self, uri, user=None, secret=None):
         if uri.repo_type == 'yast2':
-            return SolverRepositorySUSE(uri)
+            return SolverRepositorySUSE(uri, user, secret)
         elif uri.repo_type == 'rpm-md':
-            return SolverRepositoryRpmMd(uri)
+            return SolverRepositoryRpmMd(uri, user, secret)
         elif uri.repo_type == 'rpm-dir':
-            return SolverRepositoryRpmDir(uri)
+            return SolverRepositoryRpmDir(uri, user, secret)
         else:
             raise KiwiSolverRepositorySetupError(
                 'Support for %s solver repository type not implemented' %

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -102,6 +102,8 @@ class SystemPrepare(object):
         for xml_repo in repository_sections:
             repo_type = xml_repo.get_type()
             repo_source = xml_repo.get_source().get_path()
+            repo_user = xml_repo.get_username()
+            repo_secret = xml_repo.get_password()
             repo_alias = xml_repo.get_alias()
             repo_priority = xml_repo.get_priority()
             repo_dist = xml_repo.get_distribution()
@@ -132,7 +134,8 @@ class SystemPrepare(object):
 
             repo.add_repo(
                 repo_alias, repo_source_translated,
-                repo_type, repo_priority, repo_dist, repo_components
+                repo_type, repo_priority, repo_dist, repo_components,
+                repo_user, repo_secret, uri.credentials_file_name()
             )
             self.uri_list.append(uri)
         repo.cleanup_unused_repos()

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -130,6 +130,8 @@ class SystemSetup(object):
             if repo_marked_for_image_include:
                 repo_type = xml_repo.get_type()
                 repo_source = xml_repo.get_source().get_path()
+                repo_user = xml_repo.get_username()
+                repo_secret = xml_repo.get_password()
                 repo_alias = xml_repo.get_alias()
                 repo_priority = xml_repo.get_priority()
                 repo_dist = xml_repo.get_distribution()
@@ -144,7 +146,8 @@ class SystemSetup(object):
                 log.info('--> Alias: %s', repo_alias)
                 repo.add_repo(
                     repo_alias, repo_source_translated,
-                    repo_type, repo_priority, repo_dist, repo_components
+                    repo_type, repo_priority, repo_dist, repo_components,
+                    repo_user, repo_secret, uri.credentials_file_name()
                 )
 
     def import_shell_environment(self, profile):

--- a/kiwi/system/uri.py
+++ b/kiwi/system/uri.py
@@ -86,20 +86,20 @@ class Uri(object):
         uri = urlparse(self.uri)
         if not uri.scheme:
             raise KiwiUriStyleUnknown(
-                'URI scheme not detected %s' % self.uri
+                'URI scheme not detected {uri}'.format(uri=self.uri)
             )
 
         if uri.scheme == 'obs' and self.repo_type == 'yast2':
             return self._obs_distribution(
-                uri.netloc + uri.path
+                ''.join([uri.netloc, uri.path])
             )
         elif uri.scheme == 'obs':
             return self._obs_project(
-                uri.netloc + uri.path
+                ''.join([uri.netloc, uri.path])
             )
         elif uri.scheme == 'ibs':
             return self._ibs_project(
-                uri.netloc + uri.path
+                ''.join([uri.netloc, uri.path])
             )
         elif uri.scheme == 'dir':
             return self._local_directory(uri.path)
@@ -107,16 +107,29 @@ class Uri(object):
             return self._iso_mount_path(uri.path)
         elif uri.scheme == 'suse':
             return self._suse_buildservice_path(
-                uri.netloc + uri.path
+                ''.join([uri.netloc, uri.path])
             )
-        elif uri.scheme == 'http':
-            return self.uri
-        elif uri.scheme == 'ftp':
-            return self.uri
+        elif uri.scheme == 'http' or uri.scheme == 'ftp':
+            return ''.join([uri.scheme, '://', uri.netloc, uri.path])
         else:
             raise KiwiUriStyleUnknown(
                 'URI schema %s not supported' % self.uri
             )
+
+    def credentials_file_name(self):
+        """
+        Filename to store repository credentials
+        """
+        uri = urlparse(self.uri)
+        # initialize query with default credentials file name.
+        # The information will be overwritten if the uri contains
+        # a parameter query with a credentials parameter
+        query = {'credentials': 'kiwiRepoCredentials'}
+
+        if uri.query:
+            query = dict(params.split('=') for params in uri.query.split('&'))
+
+        return query['credentials']
 
     def alias(self):
         """

--- a/kiwi/tasks/image_info.py
+++ b/kiwi/tasks/image_info.py
@@ -126,8 +126,12 @@ class ImageInfoTask(CliTask):
         solver = Sat()
         for xml_repo in self.xml_state.get_repository_sections():
             repo_source = xml_repo.get_source().get_path()
+            repo_user = xml_repo.get_username()
+            repo_secret = xml_repo.get_password()
             repo_type = xml_repo.get_type()
             solver.add_repository(
-                SolverRepository(Uri(repo_source, repo_type))
+                SolverRepository(
+                    Uri(repo_source, repo_type), repo_user, repo_secret
+                )
             )
         return solver

--- a/test/unit/repository_base_test.py
+++ b/test/unit/repository_base_test.py
@@ -32,7 +32,8 @@ class TestRepositoryBase(object):
     @raises(NotImplementedError)
     def test_add_repo(self):
         self.repo.add_repo(
-            'name', 'uri', 'type', 'prio', 'dist', ['components']
+            'name', 'uri', 'type', 'prio', 'dist', ['components'],
+            'user', 'secret', 'credentials-file'
         )
 
     @raises(NotImplementedError)

--- a/test/unit/repository_zypper_test.py
+++ b/test/unit/repository_zypper_test.py
@@ -20,22 +20,30 @@ class TestRepositoryZypper(object):
     @patch('kiwi.repository.zypper.NamedTemporaryFile')
     @patch_open
     def setup(self, mock_open, mock_temp, mock_command):
+        self.context_manager_mock = mock.Mock()
+        self.file_mock = mock.Mock()
+        self.enter_mock = mock.Mock()
+        self.exit_mock = mock.Mock()
+        self.enter_mock.return_value = self.file_mock
+        setattr(self.context_manager_mock, '__enter__', self.enter_mock)
+        setattr(self.context_manager_mock, '__exit__', self.exit_mock)
+
         tmpfile = mock.Mock()
         tmpfile.name = 'tmpfile'
         mock_temp.return_value = tmpfile
-        root_bind = mock.Mock()
-        root_bind.move_to_root = mock.Mock(
+        self.root_bind = mock.Mock()
+        self.root_bind.move_to_root = mock.Mock(
             return_value=['root-moved-arguments']
         )
-        root_bind.root_dir = '../data'
-        root_bind.shared_location = '/shared-dir'
-        self.repo = RepositoryZypper(root_bind, ['exclude_docs'])
+        self.root_bind.root_dir = '../data'
+        self.root_bind.shared_location = '/shared-dir'
+        self.repo = RepositoryZypper(self.root_bind, ['exclude_docs'])
 
     @patch('kiwi.command.Command.run')
     @patch('kiwi.repository.zypper.NamedTemporaryFile')
     @patch_open
     def test_custom_args_init(self, mock_open, mock_temp, mock_command):
-        self.repo = RepositoryZypper(mock.MagicMock())
+        self.repo = RepositoryZypper(self.root_bind)
         assert self.repo.custom_args == []
 
     @raises(KiwiRepoTypeUnknown)
@@ -96,6 +104,46 @@ class TestRepositoryZypper(object):
                 '/shared-dir/packages.moved', '/shared-dir/packages'
             ])
         ]
+
+    @patch('kiwi.command.Command.run')
+    @patch('kiwi.repository.zypper.Path.wipe')
+    @patch('os.path.exists')
+    @patch_open
+    def test_add_repo_with_credentials(
+        self, mock_open, mock_exists, mock_wipe, mock_command
+    ):
+        mock_open.return_value = self.context_manager_mock
+        exists_results = [False, False, False, True]
+
+        def side_effect(arg):
+            return exists_results.pop()
+
+        mock_exists.side_effect = side_effect
+
+        self.repo.add_repo(
+            name='foo', uri='http://some/repo',
+            user='user', secret='secret', credentials_file='credentials_file'
+        )
+        mock_wipe.assert_called_once_with(
+            '../data/shared-dir/zypper/credentials/credentials_file'
+        )
+        mock_open.assert_called_once_with(
+            '../data/shared-dir/zypper/credentials/credentials_file', 'w'
+        )
+        assert self.file_mock.write.call_args_list == [
+            call('username=user'), call('password=secret')
+        ]
+        mock_command.assert_called_once_with(
+            ['zypper'] + self.repo.zypper_args + [
+                '--root', '../data',
+                'addrepo', '--refresh',
+                '--type', 'YUM',
+                '--keep-packages',
+                '-C',
+                'http://some/repo?credentials=credentials_file',
+                'foo'
+            ], self.repo.command_env
+        )
 
     @patch('kiwi.command.Command.run')
     def test_delete_repo(self, mock_command):

--- a/test/unit/solver_repository_test.py
+++ b/test/unit/solver_repository_test.py
@@ -21,16 +21,16 @@ class TestSolverRepository(object):
     def test_solver_repository_suse(self, mock_suse):
         self.uri.repo_type = 'yast2'
         SolverRepository(self.uri)
-        mock_suse.assert_called_once_with(self.uri)
+        mock_suse.assert_called_once_with(self.uri, None, None)
 
     @patch('kiwi.solver.repository.SolverRepositoryRpmMd')
     def test_solver_repository_rpm_md(self, mock_rpm_md):
         self.uri.repo_type = 'rpm-md'
         SolverRepository(self.uri)
-        mock_rpm_md.assert_called_once_with(self.uri)
+        mock_rpm_md.assert_called_once_with(self.uri, None, None)
 
     @patch('kiwi.solver.repository.SolverRepositoryRpmDir')
     def test_solver_repository_rpm_dir(self, mock_rpm_dir):
         self.uri.repo_type = 'rpm-dir'
         SolverRepository(self.uri)
-        mock_rpm_dir.assert_called_once_with(self.uri)
+        mock_rpm_dir.assert_called_once_with(self.uri, None, None)

--- a/test/unit/system_prepare_test.py
+++ b/test/unit/system_prepare_test.py
@@ -133,6 +133,9 @@ class TestSystemPrepare(object):
         uri.alias = mock.Mock(
             return_value='uri-alias'
         )
+        uri.credentials_file_name = mock.Mock(
+            return_value='credentials-file'
+        )
         repo = mock.Mock()
         mock_repo.return_value = repo
 
@@ -152,8 +155,14 @@ class TestSystemPrepare(object):
             call(), call()
         ]
         assert repo.add_repo.call_args_list == [
-            call('uri-alias', 'uri', 'yast2', 42, None, None),
-            call('uri-alias', 'uri', 'rpm-md', None, None, None)
+            call(
+                'uri-alias', 'uri', 'yast2', 42,
+                None, None, None, None, 'credentials-file'
+            ),
+            call(
+                'uri-alias', 'uri', 'rpm-md', None,
+                None, None, None, None, 'credentials-file'
+            )
         ]
 
     @patch('kiwi.system.prepare.Repository')

--- a/test/unit/system_setup_test.py
+++ b/test/unit/system_setup_test.py
@@ -690,5 +690,8 @@ class TestSystemSetup(object):
             'rpm-md',
             None,
             None,
-            None
+            None,
+            None,
+            None,
+            'kiwiRepoCredentials'
         )

--- a/test/unit/system_uri_test.py
+++ b/test/unit/system_uri_test.py
@@ -48,6 +48,27 @@ class TestUri(object):
             'https://example.com'.encode()).hexdigest(
         )
 
+    def test_credentials_file_name(self):
+        uri = Uri(
+            'http://example.com/foo?credentials=my_credentials&x=2',
+            'rpm-md'
+        )
+        assert uri.credentials_file_name() == 'my_credentials'
+
+    def test_credentials_default_file_name(self):
+        uri = Uri(
+            'http://example.com/foo',
+            'rpm-md'
+        )
+        assert uri.credentials_file_name() == 'kiwiRepoCredentials'
+
+    def test_translate_http_path_with_credentials(self):
+        uri = Uri(
+            'http://example.com/foo?credentials=kiwiRepoCredentials',
+            'rpm-md'
+        )
+        assert uri.translate() == 'http://example.com/foo'
+
     def test_translate_ibs_project(self):
         uri = Uri('ibs://Devel:PubCloud/SLE_12_GA', 'rpm-md')
         assert uri.translate() == \


### PR DESCRIPTION
The package and solver repository classes did not provide an
interface to deal with repository credentials. This commit
add support for the zypper package manager and the generic
urlopen based download method of the solver class. This
Fixes #246

