### PR TITLE
Use kernel alias name for default kernel

### DIFF
--- a/kiwi/boot/arch/arm/oemboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/arm/oemboot/suse-SLES12/config.xml
@@ -80,7 +80,7 @@
         <source path="obs://SUSE:SLE-12:GA/standard"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="custom"><!-- empty custom section to allow bootincluding custom kernel --></packages>
     <packages type="bootstrap">

--- a/kiwi/boot/arch/arm/oemboot/suse-leap42.1/config.xml
+++ b/kiwi/boot/arch/arm/oemboot/suse-leap42.1/config.xml
@@ -80,7 +80,7 @@
         <source path="obs://leap/42.1/repo/oss"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="bootstrap">
         <package name="kbd"/>

--- a/kiwi/boot/arch/arm/oemboot/suse-leap42.2/config.xml
+++ b/kiwi/boot/arch/arm/oemboot/suse-leap42.2/config.xml
@@ -80,7 +80,7 @@
         <source path="obs://leap/42.2/repo/oss"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="bootstrap">
         <package name="kbd"/>

--- a/kiwi/boot/arch/arm/oemboot/suse-tumbleweed/config.xml
+++ b/kiwi/boot/arch/arm/oemboot/suse-tumbleweed/config.xml
@@ -81,7 +81,7 @@
         <source path="obs://openSUSE:/Factory:/ARM/standard"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="custom"><!-- empty custom section to allow bootincluding custom kernel --></packages>
     <packages type="bootstrap">

--- a/kiwi/boot/arch/arm/vmxboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/arm/vmxboot/suse-SLES12/config.xml
@@ -67,11 +67,11 @@
         <source path="obs://SUSE:SLE-12:GA/standard"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="pae">
         <package name="kernel-pae" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="custom"><!-- empty custom section to allow bootincluding custom kernel --></packages>
     <packages type="bootstrap">

--- a/kiwi/boot/arch/arm/vmxboot/suse-leap42.1/config.xml
+++ b/kiwi/boot/arch/arm/vmxboot/suse-leap42.1/config.xml
@@ -67,7 +67,7 @@
         <source path="obs://leap/42.1/repo/oss"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="custom"><!-- empty custom section to allow bootincluding custom kernel --></packages>
     <packages type="bootstrap">

--- a/kiwi/boot/arch/arm/vmxboot/suse-leap42.2/config.xml
+++ b/kiwi/boot/arch/arm/vmxboot/suse-leap42.2/config.xml
@@ -67,7 +67,7 @@
         <source path="obs://leap/42.2/repo/oss"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="custom"><!-- empty custom section to allow bootincluding custom kernel --></packages>
     <packages type="bootstrap">

--- a/kiwi/boot/arch/arm/vmxboot/suse-tumbleweed/config.xml
+++ b/kiwi/boot/arch/arm/vmxboot/suse-tumbleweed/config.xml
@@ -67,7 +67,7 @@
         <source path="obs://openSUSE:/Factory:/ARM/standard"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="custom"><!-- empty custom section to allow bootincluding custom kernel --></packages>
     <packages type="bootstrap">

--- a/kiwi/boot/arch/ppc/netboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/ppc/netboot/suse-SLES12/config.xml
@@ -77,7 +77,7 @@
         <source path="obs://SUSE:SLE-12:GA/standard"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="custom"><!-- empty custom section to allow bootincluding custom kernel --></packages>
     <packages type="image" profiles="default">

--- a/kiwi/boot/arch/ppc/oemboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/ppc/oemboot/suse-SLES12/config.xml
@@ -81,7 +81,7 @@
         <source path="obs://SUSE:SLE-12:GA/standard"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="custom"><!-- empty custom section to allow bootincluding custom kernel --></packages>
     <packages type="bootstrap">

--- a/kiwi/boot/arch/ppc/vmxboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/ppc/vmxboot/suse-SLES12/config.xml
@@ -81,7 +81,7 @@
         <source path="obs://SUSE:SLE-12:GA/standard"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="custom"><!-- empty custom section to allow bootincluding custom kernel --></packages>
     <packages type="bootstrap">

--- a/kiwi/boot/arch/s390/netboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/s390/netboot/suse-SLES12/config.xml
@@ -78,7 +78,7 @@
         <source path="obs://SUSE:SLE-12:GA/standard"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="default">
         <package name="atftp"/>

--- a/kiwi/boot/arch/s390/oemboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/s390/oemboot/suse-SLES12/config.xml
@@ -82,7 +82,7 @@
         <source path="obs://SUSE:SLE-12:GA/standard"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="custom"><!-- empty custom section to allow bootincluding custom kernel --></packages>
     <packages type="bootstrap">

--- a/kiwi/boot/arch/s390/vmxboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/s390/vmxboot/suse-SLES12/config.xml
@@ -82,7 +82,7 @@
         <source path="obs://SUSE:SLE-12:GA/standard"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="custom"><!-- empty custom section to allow bootincluding custom kernel --></packages>
     <packages type="bootstrap">

--- a/kiwi/boot/arch/x86_64/isoboot/suse-13.2/config.xml
+++ b/kiwi/boot/arch/x86_64/isoboot/suse-13.2/config.xml
@@ -81,11 +81,11 @@
         <source path="obs://13.2/repo/oss"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="pae">
         <package name="kernel-pae" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xenk">
 <!-- xen kernel only supported on x86_64 -->
@@ -96,7 +96,7 @@
     <packages type="image" profiles="desktop">
         <package name="kernel-desktop" arch="x86_64"/>
         <package name="kernel-desktop" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="custom"><!-- empty custom section to allow bootincluding custom kernel --></packages>
     <packages type="bootstrap">

--- a/kiwi/boot/arch/x86_64/isoboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/x86_64/isoboot/suse-SLES12/config.xml
@@ -85,11 +85,11 @@
         <source path="obs://SUSE:SLE-12:GA/standard"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="pae">
         <package name="kernel-pae" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xenk">
 <!-- xen kernel only supported on x86_64 -->

--- a/kiwi/boot/arch/x86_64/isoboot/suse-leap42.1/config.xml
+++ b/kiwi/boot/arch/x86_64/isoboot/suse-leap42.1/config.xml
@@ -86,11 +86,11 @@
         <source path="obs://leap/42.1/repo/oss"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="pae">
         <package name="kernel-pae" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xenk">
 <!-- xen kernel only supported on x86_64 -->
@@ -101,7 +101,7 @@
     <packages type="image" profiles="desktop">
         <package name="kernel-desktop" arch="x86_64"/>
         <package name="kernel-desktop" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="custom"><!-- empty custom section to allow bootincluding custom kernel --></packages>
     <packages type="bootstrap">

--- a/kiwi/boot/arch/x86_64/isoboot/suse-leap42.2/config.xml
+++ b/kiwi/boot/arch/x86_64/isoboot/suse-leap42.2/config.xml
@@ -86,11 +86,11 @@
         <source path="obs://leap/42.2/repo/oss"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="pae">
         <package name="kernel-pae" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xenk">
 <!-- xen kernel only supported on x86_64 -->
@@ -101,7 +101,7 @@
     <packages type="image" profiles="desktop">
         <package name="kernel-desktop" arch="x86_64"/>
         <package name="kernel-desktop" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="custom"><!-- empty custom section to allow bootincluding custom kernel --></packages>
     <packages type="bootstrap">

--- a/kiwi/boot/arch/x86_64/isoboot/suse-tumbleweed/config.xml
+++ b/kiwi/boot/arch/x86_64/isoboot/suse-tumbleweed/config.xml
@@ -86,11 +86,11 @@
         <source path="obs://factory/repo/oss/"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="pae">
         <package name="kernel-pae" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xenk">
 <!-- xen kernel only supported on x86_64 -->
@@ -101,7 +101,7 @@
     <packages type="image" profiles="desktop">
         <package name="kernel-desktop" arch="x86_64"/>
         <package name="kernel-desktop" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="custom"><!-- empty custom section to allow bootincluding custom kernel --></packages>
     <packages type="bootstrap">

--- a/kiwi/boot/arch/x86_64/netboot/suse-13.2/config.xml
+++ b/kiwi/boot/arch/x86_64/netboot/suse-13.2/config.xml
@@ -117,11 +117,11 @@
         <source path="obs://13.2/repo/oss"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="pae">
         <package name="kernel-pae" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xenk">
 <!-- xen kernel only supported on x86_64 -->
@@ -130,7 +130,7 @@
     <packages type="image" profiles="desktop">
         <package name="kernel-desktop" arch="x86_64"/>
         <package name="kernel-desktop" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xen">
 <!-- xen dom0 support only on x86_64 -->

--- a/kiwi/boot/arch/x86_64/netboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/x86_64/netboot/suse-SLES12/config.xml
@@ -154,11 +154,11 @@
         <source path="obs://SUSE:SLE-12:GA/standard"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="pae">
         <package name="kernel-pae" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xenk">
 <!-- xen kernel only supported on x86_64 -->

--- a/kiwi/boot/arch/x86_64/netboot/suse-leap42.1/config.xml
+++ b/kiwi/boot/arch/x86_64/netboot/suse-leap42.1/config.xml
@@ -122,11 +122,11 @@
         <source path="obs://leap/42.1/repo/oss"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="pae">
         <package name="kernel-pae" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xenk">
 <!-- xen kernel only supported on x86_64 -->
@@ -135,7 +135,7 @@
     <packages type="image" profiles="desktop">
         <package name="kernel-desktop" arch="x86_64"/>
         <package name="kernel-desktop" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xen">
 <!-- xen dom0 support only on x86_64 -->

--- a/kiwi/boot/arch/x86_64/netboot/suse-leap42.2/config.xml
+++ b/kiwi/boot/arch/x86_64/netboot/suse-leap42.2/config.xml
@@ -122,11 +122,11 @@
         <source path="obs://leap/42.2/repo/oss"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="pae">
         <package name="kernel-pae" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xenk">
 <!-- xen kernel only supported on x86_64 -->
@@ -135,7 +135,7 @@
     <packages type="image" profiles="desktop">
         <package name="kernel-desktop" arch="x86_64"/>
         <package name="kernel-desktop" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xen">
 <!-- xen dom0 support only on x86_64 -->

--- a/kiwi/boot/arch/x86_64/netboot/suse-tumbleweed/config.xml
+++ b/kiwi/boot/arch/x86_64/netboot/suse-tumbleweed/config.xml
@@ -122,11 +122,11 @@
         <source path="obs://factory/repo/oss/"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="pae">
         <package name="kernel-pae" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xenk">
 <!-- xen kernel only supported on x86_64 -->
@@ -135,7 +135,7 @@
     <packages type="image" profiles="desktop">
         <package name="kernel-desktop" arch="x86_64"/>
         <package name="kernel-desktop" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xen">
 <!-- xen dom0 support only on x86_64 -->

--- a/kiwi/boot/arch/x86_64/oemboot/suse-13.2/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-13.2/config.xml
@@ -89,11 +89,11 @@
         <source path="obs://13.2/repo/oss"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="pae">
         <package name="kernel-pae" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xenk">
 <!-- xen kernel only supported on x86_64 -->
@@ -107,7 +107,7 @@
     <packages type="image" profiles="desktop">
         <package name="kernel-desktop" arch="x86_64"/>
         <package name="kernel-desktop" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xen,ec2">
         <package name="grub2-x86_64-xen" arch="x86_64"/>

--- a/kiwi/boot/arch/x86_64/oemboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-SLES12/config.xml
@@ -93,11 +93,11 @@
         <source path="obs://SUSE:SLE-12:GA/standard"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="pae">
         <package name="kernel-pae" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xenk">
 <!-- xen kernel only supported on x86_64 -->

--- a/kiwi/boot/arch/x86_64/oemboot/suse-leap42.1/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-leap42.1/config.xml
@@ -94,11 +94,11 @@
         <source path="obs://leap/42.1/repo/oss"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="pae">
         <package name="kernel-pae" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xenk">
 <!-- xen kernel only supported on x86_64 -->
@@ -112,7 +112,7 @@
     <packages type="image" profiles="desktop">
         <package name="kernel-desktop" arch="x86_64"/>
         <package name="kernel-desktop" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xen,ec2">
         <package name="grub2-x86_64-xen" arch="x86_64"/>

--- a/kiwi/boot/arch/x86_64/oemboot/suse-leap42.2/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-leap42.2/config.xml
@@ -94,11 +94,11 @@
         <source path="obs://leap/42.2/repo/oss"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="pae">
         <package name="kernel-pae" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xenk">
 <!-- xen kernel only supported on x86_64 -->
@@ -112,7 +112,7 @@
     <packages type="image" profiles="desktop">
         <package name="kernel-desktop" arch="x86_64"/>
         <package name="kernel-desktop" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xen,ec2">
         <package name="grub2-x86_64-xen" arch="x86_64"/>

--- a/kiwi/boot/arch/x86_64/oemboot/suse-tumbleweed/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-tumbleweed/config.xml
@@ -94,11 +94,11 @@
         <source path="obs://factory/repo/oss/"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="pae">
         <package name="kernel-pae" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xenk">
 <!-- xen kernel only supported on x86_64 -->
@@ -112,7 +112,7 @@
     <packages type="image" profiles="desktop">
         <package name="kernel-desktop" arch="x86_64"/>
         <package name="kernel-desktop" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xen,ec2">
         <package name="grub2-x86_64-xen" arch="x86_64"/>

--- a/kiwi/boot/arch/x86_64/vmxboot/suse-13.2/config.xml
+++ b/kiwi/boot/arch/x86_64/vmxboot/suse-13.2/config.xml
@@ -76,11 +76,11 @@
         <source path="obs://13.2/repo/oss"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="pae">
         <package name="kernel-pae" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xenk">
 <!-- xen kernel only supported on x86_64 -->
@@ -94,7 +94,7 @@
     <packages type="image" profiles="desktop">
         <package name="kernel-desktop" arch="x86_64"/>
         <package name="kernel-desktop" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xen,ec2">
         <package name="grub2-x86_64-xen" arch="x86_64"/>

--- a/kiwi/boot/arch/x86_64/vmxboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/x86_64/vmxboot/suse-SLES12/config.xml
@@ -80,11 +80,11 @@
         <source path="obs://SUSE:SLE-12:GA/standard"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="pae">
         <package name="kernel-pae" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xenk">
 <!-- xen kernel only supported on x86_64 -->

--- a/kiwi/boot/arch/x86_64/vmxboot/suse-leap42.1/config.xml
+++ b/kiwi/boot/arch/x86_64/vmxboot/suse-leap42.1/config.xml
@@ -81,11 +81,11 @@
         <source path="obs://leap/42.1/repo/oss"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="pae">
         <package name="kernel-pae" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xenk">
 <!-- xen kernel only supported on x86_64 -->
@@ -99,7 +99,7 @@
     <packages type="image" profiles="desktop">
         <package name="kernel-desktop" arch="x86_64"/>
         <package name="kernel-desktop" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xen,ec2">
         <package name="grub2-x86_64-xen" arch="x86_64"/>

--- a/kiwi/boot/arch/x86_64/vmxboot/suse-leap42.2/config.xml
+++ b/kiwi/boot/arch/x86_64/vmxboot/suse-leap42.2/config.xml
@@ -81,11 +81,11 @@
         <source path="obs://leap/42.2/repo/oss"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="pae">
         <package name="kernel-pae" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xenk">
 <!-- xen kernel only supported on x86_64 -->
@@ -99,7 +99,7 @@
     <packages type="image" profiles="desktop">
         <package name="kernel-desktop" arch="x86_64"/>
         <package name="kernel-desktop" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xen,ec2">
         <package name="grub2-x86_64-xen" arch="x86_64"/>

--- a/kiwi/boot/arch/x86_64/vmxboot/suse-tumbleweed/config.xml
+++ b/kiwi/boot/arch/x86_64/vmxboot/suse-tumbleweed/config.xml
@@ -81,11 +81,11 @@
         <source path="obs://factory/repo/oss/"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="pae">
         <package name="kernel-pae" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xenk">
 <!-- xen kernel only supported on x86_64 -->
@@ -99,7 +99,7 @@
     <packages type="image" profiles="desktop">
         <package name="kernel-desktop" arch="x86_64"/>
         <package name="kernel-desktop" arch="i686"/>
-        <package name="kernel-default" arch="i586"/>
+        <package name="kernel-base" arch="i586"/>
     </packages>
     <packages type="image" profiles="xen,ec2">
         <package name="grub2-x86_64-xen" arch="x86_64"/>


### PR DESCRIPTION
Instead of a hard requirement to kernel-default we should
better use the kernel-base alias in the boot image
descriptions. This Fixes (bsc#1027610)

