### PR TITLE
Added runtime check for boot image reference

### DIFF
--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -143,3 +143,35 @@ class RuntimeChecker(object):
             for tool in ['umoci', 'skopeo']:
                 if not Path.which(filename=tool, access_mode=os.X_OK):
                     raise KiwiRuntimeError(message.format(tool))
+
+    def check_boot_image_reference_correctly_setup(self):
+        """
+        If an initrd_system different from "kiwi" is selected for a
+        vmx (simple disk) image build, it does not make sense to setup
+        a reference to a kiwi boot image description, because no kiwi
+        boot image will be built.
+        """
+        message = dedent('''\n
+            Selected initrd_system is: {0}
+
+            The boot attribute selected: '{1}' which is an initrd image
+            used for the 'kiwi' initrd system. This boot image will not be
+            used according to the selected initrd system. Please cleanup
+            your image description:
+
+            1) If the selected initrd system is correct, delete the
+               obsolete boot attribute from the selected '{2}' build type
+
+            2) If the kiwi initrd image should be used, make sure to
+               set initrd_system="kiwi"
+        ''')
+        build_type_name = self.xml_state.get_build_type_name()
+        boot_image_reference = self.xml_state.build_type.get_boot()
+        if build_type_name == 'vmx' and boot_image_reference:
+            initrd_system = self.xml_state.build_type.get_initrd_system()
+            if initrd_system and initrd_system == 'dracut':
+                raise KiwiRuntimeError(
+                    message.format(
+                        initrd_system, boot_image_reference, build_type_name
+                    )
+                )

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -99,6 +99,7 @@ class SystemBuildTask(CliTask):
         self.load_xml_description(
             self.command_args['--description']
         )
+        self.runtime_checker.check_boot_image_reference_correctly_setup()
         self.runtime_checker.check_docker_tool_chain_installed()
         self.runtime_checker.check_volume_setup_has_no_root_definition()
         self.runtime_checker.check_image_include_repos_http_resolvable()

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -99,6 +99,7 @@ class SystemBuildTask(CliTask):
         self.load_xml_description(
             self.command_args['--description']
         )
+        self.runtime_checker.check_consistent_kernel_in_boot_and_system_image()
         self.runtime_checker.check_boot_image_reference_correctly_setup()
         self.runtime_checker.check_docker_tool_chain_installed()
         self.runtime_checker.check_volume_setup_has_no_root_definition()

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -92,6 +92,7 @@ class SystemPrepareTask(CliTask):
         self.load_xml_description(
             self.command_args['--description']
         )
+        self.runtime_checker.check_consistent_kernel_in_boot_and_system_image()
         self.runtime_checker.check_boot_image_reference_correctly_setup()
         self.runtime_checker.check_docker_tool_chain_installed()
         self.runtime_checker.check_volume_setup_has_no_root_definition()

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -92,6 +92,7 @@ class SystemPrepareTask(CliTask):
         self.load_xml_description(
             self.command_args['--description']
         )
+        self.runtime_checker.check_boot_image_reference_correctly_setup()
         self.runtime_checker.check_docker_tool_chain_installed()
         self.runtime_checker.check_volume_setup_has_no_root_definition()
         self.runtime_checker.check_image_include_repos_http_resolvable()

--- a/test/data/oemboot/example-distribution/config.xml
+++ b/test/data/oemboot/example-distribution/config.xml
@@ -89,7 +89,7 @@
         <source path="obs://13.2/repo/oss"/>
     </repository>
     <packages type="image" profiles="std">
-        <package name="kernel-default"/>
+        <package name="kernel-base"/>
     </packages>
     <packages type="image" profiles="pae">
         <package name="kernel-pae" arch="i686"/>

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -76,3 +76,17 @@ class TestRuntimeChecker(object):
         self.xml_state.build_type.set_initrd_system('dracut')
         self.xml_state.build_type.set_boot('boot/some-kiwi-boot-description')
         self.runtime_checker.check_boot_image_reference_correctly_setup()
+
+    @raises(KiwiRuntimeError)
+    @patch('platform.machine')
+    @patch('kiwi.runtime_checker.Defaults.get_boot_image_description_path')
+    def test_check_consistent_kernel_in_boot_and_system_image(
+        self, mock_boot_path, mock_machine
+    ):
+        mock_boot_path.return_value = '../data'
+        mock_machine.return_value = 'x86_64'
+        xml_state = XMLState(
+            self.description.load(), ['vmxFlavour'], 'oem'
+        )
+        runtime_checker = RuntimeChecker(xml_state)
+        runtime_checker.check_consistent_kernel_in_boot_and_system_image()

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -69,3 +69,10 @@ class TestRuntimeChecker(object):
         )
         runtime_checker = RuntimeChecker(xml_state)
         runtime_checker.check_docker_tool_chain_installed()
+
+    @raises(KiwiRuntimeError)
+    def test_check_boot_image_reference_correctly_setup(self):
+        self.xml_state.build_type.set_image('vmx')
+        self.xml_state.build_type.set_initrd_system('dracut')
+        self.xml_state.build_type.set_boot('boot/some-kiwi-boot-description')
+        self.runtime_checker.check_boot_image_reference_correctly_setup()


### PR DESCRIPTION
This one adds two runtime checks regarding boot image and kernel setup

* If a kiwi initrd is used, the kernel used to build the kiwi initrd and the kernel used in the system image must be the same in order to avoid an inconsistent boot setup.

* If an initrd_system different from kiwi is selected for a vmx (simple disk) image, it does not make sense to setup a reference to a kiwi boot image description, because no kiwi boot image will be built. Despite that it does not hurt it's still an inconsistent setup.

Related to (bsc#1027610)
