### PR TITLE
Derived docker images

### DIFF
--- a/doc/source/schema.rst
+++ b/doc/source/schema.rst
@@ -330,6 +330,7 @@ List of attributes for ``type``:
 * ``vhdfixedtag`` `[?]`_: Specifies the GUID in a fixed format VHD
 * ``volid`` `[?]`_: for the iso type only: Specifies the volume ID (volume name or label) to be written into the master block. There is space for 32 characters.
 * ``wwid_wait_timeout`` `[?]`_: Specifies the wait period in seconds after launching the multipath daemon to wait until all presented devices are available on the host. Default timeout is 3 seconds
+* ``derived_from`` `[?]`_: Specifies the image URI of the container image. The image created by KIWI will use the specified container as the base root to work on.
 
 .. _k.image.preferences.type.containerconfig:
 

--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -745,3 +745,10 @@ class KiwiVolumeRootIDError(KiwiError):
     Exception raised if the root volume can not be found. This
     concept currently exists only for the btrfs subvolume system.
     """
+
+
+class KiwiRootImportError(KiwiError):
+    """
+    Exception is raised when something fails during the root import
+    procedure.
+    """

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1965,6 +1965,15 @@ div {
             sch:param [ name = "attr" value = "wwid_wait_timeout" ]
             sch:param [ name = "types" value = "oem" ]
         ]
+    k.type.derived_from.attribute =
+        ## Specifies the image URI of the container image. The image created
+        ## by KIWI will use the specified container as the base root
+        ## to work on.
+        attribute derived_from { text }
+        >> sch:pattern [ id = "derived_from" is-a = "image_type"
+            sch:param [ name = "attr" value = "derived_from" ]
+            sch:param [ name = "types" value = "docker" ]
+        ]
     k.type.attlist =
         k.type.boot.attribute? &
         k.type.bootfilesystem.attribute? &
@@ -2018,7 +2027,8 @@ div {
         k.type.vga.attribute? &
         k.type.vhdfixedtag.attribute? &
         k.type.volid.attribute? &
-        k.type.wwid_wait_timeout.attribute?
+        k.type.wwid_wait_timeout.attribute? &
+        k.type.derived_from.attribute?
     k.type =
         ## The Image Type of the Logical Extend
         element type { 

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2593,6 +2593,17 @@ are available on the host. Default timeout is 3 seconds</a:documentation>
         <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
+    <define name="k.type.derived_from.attribute">
+      <attribute name="derived_from">
+        <a:documentation>Specifies the image URI of the container image. The image created
+by KIWI will use the specified container as the base root
+to work on.</a:documentation>
+      </attribute>
+      <sch:pattern id="derived_from" is-a="image_type">
+        <sch:param name="attr" value="derived_from"/>
+        <sch:param name="types" value="docker"/>
+      </sch:pattern>
+    </define>
     <define name="k.type.attlist">
       <interleave>
         <optional>
@@ -2751,6 +2762,9 @@ are available on the host. Default timeout is 3 seconds</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.wwid_wait_timeout.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.derived_from.attribute"/>
         </optional>
       </interleave>
     </define>

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -19,6 +19,7 @@ import os
 
 # project
 from .root_init import RootInit
+from .root_import import RootImport
 from .root_bind import RootBind
 from ..repository import Repository
 from ..package_manager import PackageManager
@@ -66,6 +67,10 @@ class SystemPrepare(object):
             root_dir, allow_existing
         )
         root.create()
+        base_image = xml_state.build_type.get_derived_from()
+        if base_image:
+            root_import = RootImport(xml_state, root_dir, base_image)
+            root_import.sync_data()
         root_bind = RootBind(
             root
         )

--- a/kiwi/system/root_import.py
+++ b/kiwi/system/root_import.py
@@ -40,7 +40,6 @@ class RootImport(object):
 
     * :attr:`image_type`
         type of the image to import, currently only docker is supported
-    
     """
     def __init__(self, xml_state, root_dir, image_uri, image_type='docker'):
         base_image = None

--- a/kiwi/system/root_import.py
+++ b/kiwi/system/root_import.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2015 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import os
+import shutil
+
+# project
+from .uri import Uri
+from ..container import ContainerImage
+from ..path import Path
+from ..exceptions import KiwiRootImportError
+
+
+class RootImport(object):
+    """
+    Imports the root system from an already packed image.
+
+    * :attr:`xml_state`
+
+    * :attr:`root_dir`
+        root directory path name
+
+    * :attr:`base_image`
+        packed image that contains the root system to be imported
+
+    * :attr:`image_type`
+        type of the image to import, currently only docker is supported
+    
+    """
+    def __init__(self, xml_state, root_dir, image_uri, image_type='docker'):
+        base_image = None
+
+        uri = Uri(image_uri, 'images')
+        if uri.is_remote():
+            raise KiwiRootImportError(
+                'Only local imports are supported'
+            )
+        else:
+            base_image = uri.translate()
+            if not os.path.exists(base_image):
+                raise KiwiRootImportError(
+                    'Could not stat base image file: {0}'.format(base_image)
+                )
+
+        self.root_dir = root_dir
+        self.base_image = base_image
+        self.image_type = image_type
+        self.xml_state = xml_state
+
+    def sync_data(self):
+        """
+        Synchronizes the root system of `base_image` into the root_dir
+        and keep the original `base_image` file into the `root_dir/image`
+        folder for later use.
+        """
+        image = ContainerImage(
+            self.image_type, self.root_dir
+        )
+        image.unpack_to_root_dir(self.base_image)
+
+        # Keep base image so it can be used in later steps
+        dest_dir = os.sep.join([self.root_dir, 'image'])
+        Path.create(dest_dir)
+        shutil.copy(self.base_image, dest_dir)
+
+        # Update the xml state so the base image will always be local
+        # in later steps
+        self.xml_state.build_type.set_derived_from(
+            'file://image/{0}'.format(os.path.basename(self.base_image))
+        )

--- a/kiwi/system/uri.py
+++ b/kiwi/system/uri.py
@@ -71,6 +71,7 @@ class Uri(object):
         self.local_uri_type = {
             'iso': True,
             'dir': True,
+            'file': True,
             'suse': True
         }
 
@@ -102,7 +103,9 @@ class Uri(object):
                 uri.netloc + uri.path
             )
         elif uri.scheme == 'dir':
-            return self._local_directory(uri.path)
+            return self._local_path(uri.path)
+        elif uri.scheme == 'file':
+            return self._local_path(uri.path)
         elif uri.scheme == 'iso':
             return self._iso_mount_path(uri.path)
         elif uri.scheme == 'suse':
@@ -165,7 +168,7 @@ class Uri(object):
         iso_mount.mount()
         return iso_mount.mountpoint
 
-    def _local_directory(self, path):
+    def _local_path(self, path):
         return os.path.normpath(path)
 
     def _obs_project(self, name):
@@ -192,7 +195,7 @@ class Uri(object):
         the image it arranges the repos for each build in a special
         environment, the so called build worker.
         """
-        return self._local_directory(
+        return self._local_path(
             '/usr/src/packages/SOURCES/repos/' + name
         )
 

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Mon Feb 27 15:23:58 2017 by generateDS.py version 2.24a.
+# Generated Tue Feb 28 13:26:12 2017 by generateDS.py version 2.24a.
 #
 # Command line options:
 #   ('-f', '')
@@ -13,7 +13,7 @@
 #   kiwi/schema/kiwi.xsd
 #
 # Command line:
-#   /home/ms/Project/kiwi/.tox/2.7/bin/generateDS.py -f --external-encoding="utf-8" -o "kiwi/xml_parse.py" kiwi/schema/kiwi.xsd
+#   /home/david/workspaces/kiwi/.env2.7/bin/generateDS.py -f --external-encoding="utf-8" -o "kiwi/xml_parse.py" kiwi/schema/kiwi.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -2481,7 +2481,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, efipartsize=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, checkprebuilt=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsnocheck=None, fsmountoptions=None, gcelicense=None, hybrid=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, containerconfig=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, efipartsize=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, checkprebuilt=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsnocheck=None, fsmountoptions=None, gcelicense=None, hybrid=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, containerconfig=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2536,6 +2536,7 @@ class type_(GeneratedsSuper):
         self.vhdfixedtag = _cast(None, vhdfixedtag)
         self.volid = _cast(None, volid)
         self.wwid_wait_timeout = _cast(int, wwid_wait_timeout)
+        self.derived_from = _cast(None, derived_from)
         if containerconfig is None:
             self.containerconfig = []
         else:
@@ -2716,6 +2717,8 @@ class type_(GeneratedsSuper):
     def set_volid(self, volid): self.volid = volid
     def get_wwid_wait_timeout(self): return self.wwid_wait_timeout
     def set_wwid_wait_timeout(self, wwid_wait_timeout): self.wwid_wait_timeout = wwid_wait_timeout
+    def get_derived_from(self): return self.derived_from
+    def set_derived_from(self, derived_from): self.derived_from = derived_from
     def validate_partition_size_type(self, value):
         # Validate type partition-size-type, a restriction on xs:token.
         if value is not None and Validate_simpletypes_:
@@ -2921,6 +2924,9 @@ class type_(GeneratedsSuper):
         if self.wwid_wait_timeout is not None and 'wwid_wait_timeout' not in already_processed:
             already_processed.add('wwid_wait_timeout')
             outfile.write(' wwid_wait_timeout="%s"' % self.gds_format_integer(self.wwid_wait_timeout, input_name='wwid_wait_timeout'))
+        if self.derived_from is not None and 'derived_from' not in already_processed:
+            already_processed.add('derived_from')
+            outfile.write(' derived_from=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.derived_from), input_name='derived_from')), ))
     def exportChildren(self, outfile, level, namespace_='', name_='type', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -3294,6 +3300,10 @@ class type_(GeneratedsSuper):
                 raise_parse_error(node, 'Bad integer attribute: %s' % exp)
             if self.wwid_wait_timeout < 0:
                 raise_parse_error(node, 'Invalid NonNegativeInteger')
+        value = find_attr_value_('derived_from', node)
+        if value is not None and 'derived_from' not in already_processed:
+            already_processed.add('derived_from')
+            self.derived_from = value
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         if nodeName_ == 'containerconfig':
             obj_ = containerconfig.factory()

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -99,7 +99,7 @@
                 <vmnic driver="e1000" interface="0" mode="bridged"/>
             </machine>
         </type>
-        <type image="docker">
+        <type image="docker" derived_from="file:///image.tar.xz">
             <containerconfig name="container_name" maintainer="tux" user="root" workingdir="/root" tag="container_tag">
                 <entrypoint execute="/bin/bash">
                     <argument name="-x"/>

--- a/test/unit/builder_container_test.py
+++ b/test/unit/builder_container_test.py
@@ -30,6 +30,9 @@ class TestContainerBuilder(object):
         xml_state.xml_data.get_name = mock.Mock(
             return_value='image_name'
         )
+        xml_state.build_type.get_derived_from = mock.Mock(
+            return_value='file://image/image.tar.xz'
+        )
         self.setup = mock.Mock()
         kiwi.builder.container.SystemSetup = mock.Mock(
             return_value=self.setup
@@ -41,13 +44,14 @@ class TestContainerBuilder(object):
 
     @patch('kiwi.builder.container.ContainerSetup')
     @patch('kiwi.builder.container.ContainerImage')
-    def test_create(self, mock_image, mock_setup):
+    def test_create_base_image(self, mock_image, mock_setup):
         container_setup = mock.Mock()
         mock_setup.return_value = container_setup
         container_image = mock.Mock()
         mock_image.return_value = container_image
         self.setup.export_rpm_package_verification.return_value = '.verified'
         self.setup.export_rpm_package_list.return_value = '.packages'
+        self.container.base_image = None
         self.container.create()
         mock_setup.assert_called_once_with(
             'docker', 'root_dir', self.container_config
@@ -57,7 +61,52 @@ class TestContainerBuilder(object):
             'docker', 'root_dir', self.container_config
         )
         container_image.create.assert_called_once_with(
-            'target_dir/image_name.x86_64-1.2.3.docker.tar.xz'
+            'target_dir/image_name.x86_64-1.2.3.docker.tar.xz',
+            None  
+        )
+        assert self.container.result.add.call_args_list == [
+            call(
+                key='container',
+                filename='target_dir/image_name.x86_64-1.2.3.docker.tar.xz',
+                use_for_bundle=True,
+                compress=False,
+                shasum=True
+            ),
+            call(
+                key='image_packages',
+                filename='.packages',
+                use_for_bundle=True,
+                compress=False,
+                shasum=False
+            ),
+            call(
+                key='image_verified',
+                filename='.verified',
+                use_for_bundle=True,
+                compress=False,
+                shasum=False
+            )
+        ]
+        self.setup.export_rpm_package_verification.assert_called_once_with(
+            'target_dir'
+        )
+        self.setup.export_rpm_package_list.assert_called_once_with(
+            'target_dir'
+        )
+
+    @patch('kiwi.builder.container.ContainerImage')
+    def test_create_derived_image(self, mock_image):
+        container_image = mock.Mock()
+        mock_image.return_value = container_image
+        self.setup.export_rpm_package_verification.return_value = '.verified'
+        self.setup.export_rpm_package_list.return_value = '.packages'
+        self.container.create()
+        mock_image.assert_called_once_with(
+            'docker', 'root_dir', self.container_config
+        )
+        container_image.create.assert_called_once_with(
+            'target_dir/image_name.x86_64-1.2.3.docker.tar.xz',
+            'root_dir/image/image.tar.xz'
         )
         assert self.container.result.add.call_args_list == [
             call(

--- a/test/unit/container_image_docker_test.py
+++ b/test/unit/container_image_docker_test.py
@@ -10,10 +10,18 @@ from kiwi.container.docker import ContainerImageDocker
 
 
 class TestContainerImageDocker(object):
-    def setup(self):
+
+    @patch('kiwi.container.docker.mkdtemp') 
+    def setup(self, mock_mkdtemp):
+        tmpdirs = ['kiwi_docker_root_dir', 'kiwi_docker_dir']
+
+        def call_mkdtemp(prefix):
+            return tmpdirs.pop()
+
+        mock_mkdtemp.side_effect = call_mkdtemp
         self.docker = ContainerImageDocker(
             'root_dir', {
-                'container_name': 'foo'
+                'container_name': 'foo/bar'
             }
         )
 
@@ -21,7 +29,7 @@ class TestContainerImageDocker(object):
         docker = ContainerImageDocker(
             'root_dir', {
                 'container_name': 'foo',
-                'container_tag': 'bar',
+                'container_tag': '1.0',
                 'entry_command': [
                     "--config.entrypoint=/bin/bash",
                     "--config.entrypoint=-x"
@@ -54,64 +62,54 @@ class TestContainerImageDocker(object):
 
     @patch('kiwi.container.docker.Path.wipe')
     def test_del(self, mock_wipe):
-        docker = ContainerImageDocker('root_dir')
-        docker.docker_dir = 'dir_a'
-        docker.docker_root_dir = 'dir_b'
-        docker.__del__()
+        self.docker.__del__()
         assert mock_wipe.call_args_list == [
-            call('dir_a'), call('dir_b')
+            call('kiwi_docker_dir'), call('kiwi_docker_root_dir')
         ]
 
     @patch('kiwi.container.docker.Compress')
     @patch('kiwi.container.docker.Command.run')
     @patch('kiwi.container.docker.DataSync')
-    @patch('kiwi.container.docker.mkdtemp')
     @patch('kiwi.container.docker.Path.wipe')
-    def test_create(
-        self, mock_wipe, mock_mkdtemp, mock_sync, mock_command, mock_compress
+    def test_create_base_image(
+        self, mock_wipe, mock_sync, mock_command, mock_compress
     ):
         compressor = mock.Mock()
         mock_compress.return_value = compressor
         docker_root = mock.Mock()
         mock_sync.return_value = docker_root
-        tmpdirs = ['kiwi_docker_root_dir', 'kiwi_docker_dir']
 
-        def call_mkdtemp(prefix):
-            return tmpdirs.pop()
-
-        mock_mkdtemp.side_effect = call_mkdtemp
-
-        self.docker.create('result.tar.xz')
+        self.docker.create('result.tar.xz', None)
 
         mock_wipe.assert_called_once_with('result.tar')
 
         assert mock_command.call_args_list == [
             call([
                 'umoci', 'init', '--layout',
-                'kiwi_docker_dir/foo'
+                'kiwi_docker_dir/umoci_layout'
             ]),
             call([
                 'umoci', 'new', '--image',
-                'kiwi_docker_dir/foo:latest'
+                'kiwi_docker_dir/umoci_layout:latest'
             ]),
             call([
                 'umoci', 'unpack', '--image',
-                'kiwi_docker_dir/foo:latest', 'kiwi_docker_root_dir'
+                'kiwi_docker_dir/umoci_layout:latest', 'kiwi_docker_root_dir'
             ]),
             call([
                 'umoci', 'repack', '--image',
-                'kiwi_docker_dir/foo:latest', 'kiwi_docker_root_dir'
+                'kiwi_docker_dir/umoci_layout:latest', 'kiwi_docker_root_dir'
             ]),
             call([
                 'umoci', 'config', '--config.cmd=/bin/bash', '--image',
-                'kiwi_docker_dir/foo:latest', '--tag', 'latest'
+                'kiwi_docker_dir/umoci_layout:latest', '--tag', 'latest'
             ]),
             call([
-                'umoci', 'gc', '--layout', 'kiwi_docker_dir/foo'
+                'umoci', 'gc', '--layout', 'kiwi_docker_dir/umoci_layout'
             ]),
             call([
-                 'skopeo', 'copy', 'oci:kiwi_docker_dir/foo:latest',
-                 'docker-archive:result.tar:foo:latest'
+                 'skopeo', 'copy', 'oci:kiwi_docker_dir/umoci_layout:latest',
+                 'docker-archive:result.tar:foo/bar:latest'
             ])
         ]
         mock_sync.assert_called_once_with(
@@ -126,3 +124,123 @@ class TestContainerImageDocker(object):
         )
         mock_compress.assert_called_once_with('result.tar')
         compressor.xz.assert_called_once_with()
+
+    @patch('kiwi.container.docker.mkdtemp')
+    @patch('kiwi.container.docker.Compress')
+    @patch('kiwi.container.docker.Command.run')
+    @patch('kiwi.container.docker.DataSync')
+    @patch('kiwi.container.docker.Path.wipe')
+    def test_create_derived_image(
+        self, mock_wipe, mock_sync, mock_command, mock_compress, mock_mkdtemp
+    ):
+        tmpdirs = ['kiwi_docker_root_dir', 'kiwi_docker_dir']
+
+        def call_mkdtemp(prefix):
+            return tmpdirs.pop()
+
+        mock_mkdtemp.side_effect = call_mkdtemp
+        docker = ContainerImageDocker(
+            'root_dir', {
+                'container_name': 'foo/bar',
+                'container_tag': '1.0'
+            }
+        )
+        compressor = mock.Mock()
+        compressor.uncompressed_filename = 'base_image.tar'
+        mock_compress.return_value = compressor
+
+        docker_root = mock.Mock()
+        mock_sync.return_value = docker_root
+
+        docker.create('result.tar.xz', 'base_image.tar.xz')
+
+        compressor.uncompress.assert_called_once_with(True)
+        mock_wipe.assert_called_once_with('result.tar')
+
+        assert mock_command.call_args_list == [
+            call([
+                'skopeo', 'copy', 'docker-archive:base_image.tar',
+                'oci:kiwi_docker_dir/umoci_layout:1.0'
+            ]),
+            call([
+                'umoci', 'unpack', '--image',
+                'kiwi_docker_dir/umoci_layout:1.0', 'kiwi_docker_root_dir'
+            ]),
+            call([
+                'umoci', 'repack', '--image',
+                'kiwi_docker_dir/umoci_layout:1.0', 'kiwi_docker_root_dir'
+            ]),
+            call([
+                'umoci', 'config', '--config.cmd=/bin/bash', '--image',
+                'kiwi_docker_dir/umoci_layout:1.0', '--tag', '1.0'
+            ]),
+            call([
+                'umoci', 'gc', '--layout', 'kiwi_docker_dir/umoci_layout'
+            ]),
+            call([
+                 'skopeo', 'copy', 'oci:kiwi_docker_dir/umoci_layout:1.0',
+                 'docker-archive:result.tar:foo/bar:1.0'
+            ])
+        ]
+        mock_sync.assert_called_once_with(
+            'root_dir/', 'kiwi_docker_root_dir/rootfs'
+        )
+        docker_root.sync_data.assert_called_once_with(
+            exclude=[
+                'image', '.profile', '.kconfig', 'boot', 'dev', 'sys', 'proc',
+                'var/cache/kiwi'
+            ],
+            options=['-a', '-H', '-X', '-A']
+        )
+        assert mock_compress.call_args_list == [
+            call('base_image.tar.xz'), call('result.tar')
+        ]
+        compressor.xz.assert_called_once_with()
+
+    @patch('kiwi.container.docker.mkdtemp')
+    @patch('kiwi.container.docker.Compress')
+    @patch('kiwi.container.docker.Command.run')
+    @patch('kiwi.container.docker.DataSync')
+    def test_unpack_to_root_dir(
+        self, mock_sync, mock_command, mock_compress, mock_mkdtemp
+    ):
+        tmpdirs = ['kiwi_docker_root_dir', 'kiwi_docker_dir']
+
+        def call_mkdtemp(prefix):
+            return tmpdirs.pop()
+
+        mock_mkdtemp.side_effect = call_mkdtemp
+        docker = ContainerImageDocker(
+            'root_dir', {
+                'container_name': 'foo/bar',
+                'container_tag': '1.0'
+            }
+        )
+        compressor = mock.Mock()
+        compressor.uncompressed_filename = 'base_image.tar'
+        mock_compress.return_value = compressor
+
+        docker_root = mock.Mock()
+        mock_sync.return_value = docker_root
+
+        docker.unpack_to_root_dir('base_image.tar.xz')
+
+        mock_compress.assert_called_once_with('base_image.tar.xz')
+        compressor.uncompress.assert_called_once_with(True)
+
+        assert mock_command.call_args_list == [
+            call([
+                'skopeo', 'copy', 'docker-archive:base_image.tar',
+                'oci:kiwi_docker_dir/umoci_layout:1.0'
+            ]),
+            call([
+                'umoci', 'unpack', '--image',
+                'kiwi_docker_dir/umoci_layout:1.0', 'kiwi_docker_root_dir'
+            ]),
+        ]
+        mock_sync.assert_called_once_with(
+            'kiwi_docker_root_dir/rootfs/', 'root_dir/'
+        )
+        docker_root.sync_data.assert_called_once_with(
+            options=['-a', '-H', '-X', '-A']
+        )

--- a/test/unit/system_prepare_test.py
+++ b/test/unit/system_prepare_test.py
@@ -60,6 +60,46 @@ class TestSystemPrepare(object):
         root_bind.setup_intermediate_config.assert_called_once_with()
         root_bind.mount_kernel_file_systems.assert_called_once_with()
 
+    @patch('kiwi.system.prepare.RootImport')
+    @patch('kiwi.system.prepare.RootInit')
+    @patch('kiwi.system.prepare.RootBind')
+    def test_init_with_derived_from_image(
+        self, mock_root_bind, mock_root_init, mock_root_import
+    ):
+        description = XMLDescription(
+            description='../data/example_config.xml',
+            derived_from='derived/description'
+        )
+        xml = description.load()
+
+        root_init = mock.MagicMock()
+        mock_root_init.return_value = root_init
+        root_import = mock.Mock()
+        root_import.sync_data = mock.Mock()
+        mock_root_import.return_value = root_import
+        root_bind = mock.MagicMock()
+        root_bind.root_dir = 'root_dir'
+        mock_root_bind.return_value = root_bind
+        state = XMLState(
+            xml, profiles=['vmxFlavour'], build_type='docker'
+        )
+        system = SystemPrepare(
+            xml_state=state, root_dir='root_dir',
+        )
+        mock_root_init.assert_called_once_with(
+            'root_dir', False
+        )
+        root_init.create.assert_called_once_with()
+        mock_root_import.assert_called_once_with(
+            state, 'root_dir', 'file:///image.tar.xz'
+        )
+        root_import.sync_data.assert_called_once_with()
+        mock_root_bind.assert_called_once_with(
+            root_init
+        )
+        root_bind.setup_intermediate_config.assert_called_once_with()
+        root_bind.mount_kernel_file_systems.assert_called_once_with()
+
     @raises(KiwiBootStrapPhaseFailed)
     @patch('kiwi.system.prepare.CommandProcess.poll_show_progress')
     def test_install_bootstrap_packages_raises(self, mock_poll):

--- a/test/unit/system_root_import_test.py
+++ b/test/unit/system_root_import_test.py
@@ -1,0 +1,50 @@
+import mock
+from mock import patch
+from mock import call
+
+from .test_helper import *
+
+from kiwi.system.root_import import RootImport
+from kiwi.exceptions import KiwiRootImportError
+
+class TestRootImport(object):
+    @patch('os.path.exists') 
+    def test_init(self, mock_path):
+        mock_path.return_value = True
+        xml_state = mock.Mock()
+        root_import = RootImport(xml_state, 'root_dir', 'file:///image.tar.xz')
+        assert(root_import.base_image == '/image.tar.xz')
+
+    @raises(KiwiRootImportError)
+    def test_init_remote_uri(self):
+        xml_state = mock.Mock()
+        RootImport(xml_state, 'root_dir', 'http://example.com/image.tar.xz')
+
+    @raises(KiwiRootImportError)
+    @patch('os.path.exists')
+    def test_init_non_existing_image(self, mock_path):
+        mock_path.return_value = False
+        xml_state = mock.Mock()
+        RootImport(xml_state, 'root_dir', 'file:///image.tar.xz')
+
+    @patch('os.path.exists')
+    @patch('kiwi.system.root_import.ContainerImage')
+    @patch('kiwi.path.Path.create')
+    @patch('shutil.copy')
+    def test_sync_data(
+        self, mock_copy, mock_path, mock_container, mock_path_exists
+    ):
+        xml_state = mock.Mock()
+        container = mock.Mock()
+        mock_container.return_value = container
+        mock_path_exists.return_value = True
+
+        root_import = RootImport(xml_state, 'root_dir', 'file:///image.tar.xz')
+        root_import.sync_data()
+
+        mock_path.assert_called_once_with('root_dir/image')
+        mock_copy.assert_called_once_with('/image.tar.xz', 'root_dir/image')
+        xml_state.build_type.set_derived_from.assert_called_once_with(
+            'file://image/image.tar.xz'
+        )
+


### PR DESCRIPTION
This PR extends KIWI to support derived docker images. Now a layered docker image can be built on top of a given compressed docker images file. Attribute `derived_from` has been added for docker image type to reference the base image.

Type section for derived images looks like:
```xml
<type image="docker" derived_from="file:///someimagefile.tar.xz">
```