### PR TITLE
Support package capabilities in sat solver

### DIFF
--- a/kiwi/solver/sat.py
+++ b/kiwi/solver/sat.py
@@ -194,8 +194,12 @@ class Sat(object):
         jobs = []
         for job_name in job_names:
             selection = self.pool.select(
-                job_name, self.Selection.SELECTION_NAME
+                job_name,
+                self.Selection.SELECTION_NAME |
+                self.solv.Selection.SELECTION_PROVIDES
             )
+            if selection.flags() & self.solv.Selection.SELECTION_PROVIDES:
+                log.info('--> Using capability match for {0}'.format(job_name))
             if selection.isempty():
                 if skip_missing:
                     log.info(

--- a/test/unit/solver_sat_test.py
+++ b/test/unit/solver_sat_test.py
@@ -93,6 +93,10 @@ class TestSat(object):
         self.solver.solve = mock.Mock(
             return_value=None
         )
+        self.sat.solv.Selection.SELECTION_PROVIDES = 0
+        self.selection.flags = mock.Mock(
+            return_value=0
+        )
         self.selection.isempty = mock.Mock(
             return_value=True
         )
@@ -126,3 +130,24 @@ class TestSat(object):
         self.sat.solve(packages)
         self.solver.solve.assert_called_once_with(['vim'])
         self.solver.transaction.assert_called_once_with()
+
+    @patch('kiwi.logger.log.info')
+    def test_solve_with_capabilities(self, mock_log_info):
+        packages = ['kernel-base']
+        self.solver.solve = mock.Mock(
+            return_value=None
+        )
+        self.sat.solv.Selection.SELECTION_PROVIDES = 1
+        self.selection.flags = mock.Mock(
+            return_value=1
+        )
+        self.selection.isempty = mock.Mock(
+            return_value=False
+        )
+        self.selection.jobs = mock.Mock(
+            return_value=packages
+        )
+        self.sat.solve(packages)
+        mock_log_info.assert_called_once_with(
+            '--> Using capability match for kernel-base'
+        )


### PR DESCRIPTION
A solver operation can receive a package or pattern name but
a capability name was considered a package name and failed
to resolve. This commit fixes the solver operation with
regards to package capabilities

