### PR TITLE
Import root system from a given image

### DIFF
--- a/doc/source/schema.rst
+++ b/doc/source/schema.rst
@@ -330,6 +330,7 @@ List of attributes for ``type``:
 * ``vhdfixedtag`` `[?]`_: Specifies the GUID in a fixed format VHD
 * ``volid`` `[?]`_: for the iso type only: Specifies the volume ID (volume name or label) to be written into the master block. There is space for 32 characters.
 * ``wwid_wait_timeout`` `[?]`_: Specifies the wait period in seconds after launching the multipath daemon to wait until all presented devices are available on the host. Default timeout is 3 seconds
+* ``derived_from`` `[?]`_: Specifies the image URI of the container image. The image created by KIWI will use the specified container as the base root to work on.
 
 .. _k.image.preferences.type.containerconfig:
 

--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -745,3 +745,10 @@ class KiwiVolumeRootIDError(KiwiError):
     Exception raised if the root volume can not be found. This
     concept currently exists only for the btrfs subvolume system.
     """
+
+
+class KiwiRootImportError(KiwiError):
+    """
+    Exception is raised when something fails during the root import
+    procedure.
+    """

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1965,6 +1965,15 @@ div {
             sch:param [ name = "attr" value = "wwid_wait_timeout" ]
             sch:param [ name = "types" value = "oem" ]
         ]
+    k.type.derived_from.attribute =
+        ## Specifies the image URI of the container image. The image created
+        ## by KIWI will use the specified container as the base root
+        ## to work on.
+        attribute derived_from { text }
+        >> sch:pattern [ id = "derived_from" is-a = "image_type"
+            sch:param [ name = "attr" value = "derived_from" ]
+            sch:param [ name = "types" value = "docker" ]
+        ]
     k.type.attlist =
         k.type.boot.attribute? &
         k.type.bootfilesystem.attribute? &
@@ -2018,7 +2027,8 @@ div {
         k.type.vga.attribute? &
         k.type.vhdfixedtag.attribute? &
         k.type.volid.attribute? &
-        k.type.wwid_wait_timeout.attribute?
+        k.type.wwid_wait_timeout.attribute? &
+        k.type.derived_from.attribute?
     k.type =
         ## The Image Type of the Logical Extend
         element type { 

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2593,6 +2593,17 @@ are available on the host. Default timeout is 3 seconds</a:documentation>
         <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
+    <define name="k.type.derived_from.attribute">
+      <attribute name="derived_from">
+        <a:documentation>Specifies the image URI of the container image. The image created
+by KIWI will use the specified container as the base root
+to work on.</a:documentation>
+      </attribute>
+      <sch:pattern id="derived_from" is-a="image_type">
+        <sch:param name="attr" value="derived_from"/>
+        <sch:param name="types" value="docker"/>
+      </sch:pattern>
+    </define>
     <define name="k.type.attlist">
       <interleave>
         <optional>
@@ -2751,6 +2762,9 @@ are available on the host. Default timeout is 3 seconds</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.wwid_wait_timeout.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.derived_from.attribute"/>
         </optional>
       </interleave>
     </define>

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -19,6 +19,7 @@ import os
 
 # project
 from kiwi.system.root_init import RootInit
+from kiwi.system.root_import import RootImport
 from kiwi.system.root_bind import RootBind
 from kiwi.repository import Repository
 from kiwi.package_manager import PackageManager
@@ -66,6 +67,12 @@ class SystemPrepare(object):
             root_dir, allow_existing
         )
         root.create()
+        image_uri = xml_state.build_type.get_derived_from()
+        if image_uri:
+            root_import = RootImport(
+                root_dir, image_uri, xml_state.build_type.get_image()
+            )
+            root_import.sync_data()
         root_bind = RootBind(
             root
         )

--- a/kiwi/system/root_import/__init__.py
+++ b/kiwi/system/root_import/__init__.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2015 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+# project
+from kiwi.system.root_import.docker import RootImportDocker
+from kiwi.exceptions import KiwiRootImportError
+from kiwi.logger import log
+
+
+class RootImport(object):
+    """
+    Root import factory
+
+    Attibutes
+
+    * :attr:`root_dir`
+        root directory path name
+
+    * :attr:`image_uri`
+        a uri to an image containing a the root system
+
+    * :attr:`image_type`
+        type of the image to import
+    """
+    def __new__(self, root_dir, image_uri, image_type):
+        if image_type == 'docker':
+            root_import = RootImportDocker(root_dir, image_uri)
+        else:
+            raise KiwiRootImportError(
+                'Support to import {0} images not implemented'.format(
+                    image_type
+                )
+            )
+
+        log.info(
+            'Importing root from a {0} image type'.format(image_type)
+        )
+        return root_import

--- a/kiwi/system/root_import/base.py
+++ b/kiwi/system/root_import/base.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2015 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+import os
+
+# project
+from kiwi.system.uri import Uri
+from kiwi.exceptions import KiwiRootImportError
+
+
+class RootImportBase(object):
+    """
+    Imports the root system from an already packed image.
+
+    * :attr:`root_dir`
+        root directory path name
+
+    * :attr:`image_file`
+        local image file to import
+
+    * :attr:`tmp_root_dir`
+        temporary directory where image_file is extracted
+    """
+    def __init__(self, root_dir, image_uri):
+        uri = Uri(image_uri, 'images')
+        if uri.is_remote():
+            raise KiwiRootImportError(
+                'Only local imports are supported'
+            )
+        else:
+            self.image_file = uri.translate()
+            if not os.path.exists(self.image_file):
+                raise KiwiRootImportError(
+                    'Could not stat base image file: {0}'.format(self.image_file)
+                )
+
+        self.root_dir = root_dir
+        self.post_init()
+
+    def post_init(self):
+        """
+        Post initalization method
+
+        Implementation in specialized root import class
+        """
+        pass
+
+    def sync_data(self):
+        """
+        Synchronizes the root system of `image_file` into the root_dir
+
+        Implementation in specialized root import class
+        """
+        raise NotImplementedError

--- a/kiwi/system/root_import/docker.py
+++ b/kiwi/system/root_import/docker.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2015 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+from tempfile import mkdtemp
+import os
+
+# project
+from kiwi.system.root_import.base import RootImportBase
+from kiwi.path import Path
+from kiwi.utils.sync import DataSync
+from kiwi.utils.compress import Compress
+from kiwi.command import Command
+
+
+class RootImportDocker(RootImportBase):
+    """
+    Implements the base class for importing a root system from
+    a docker image compressed tarball file.
+    """
+    def post_init(self):
+        """
+        Post initialization method
+        """
+        self.uncompressed_image = None
+        self.oci_unpack_dir = None
+        self.oci_layout_dir = None
+
+    def sync_data(self):
+        compressor = Compress(self.image_file)
+        compressor.uncompress(True)
+        self.uncompressed_image = compressor.uncompressed_filename
+
+        self.oci_layout_dir = mkdtemp(prefix='kiwi_layout_dir.')
+        self.oci_unpack_dir = mkdtemp(prefix='kiwi_unpack_dir.')
+
+        Command.run([
+            'skopeo', 'copy',
+            'docker-archive:{0}'.format(self.uncompressed_image),
+            'oci:{0}'.format(self.oci_layout_dir)
+        ])
+        Command.run([
+            'umoci', 'unpack', '--image',
+            self.oci_layout_dir, self.oci_unpack_dir
+        ])
+
+        synchronizer = DataSync(
+            os.sep.join([self.oci_unpack_dir, 'rootfs', '']),
+            ''.join([self.root_dir, os.sep])
+        )
+        synchronizer.sync_data(options=['-a', '-H', '-X', '-A'])
+
+    def __del__(self):
+        if self.oci_layout_dir:
+            Path.wipe(self.oci_layout_dir)
+        if self.oci_unpack_dir:
+            Path.wipe(self.oci_unpack_dir)
+        if self.uncompressed_image:
+            Path.wipe(self.uncompressed_image)

--- a/kiwi/system/uri.py
+++ b/kiwi/system/uri.py
@@ -71,6 +71,7 @@ class Uri(object):
         self.local_uri_type = {
             'iso': True,
             'dir': True,
+            'file': True,
             'suse': True
         }
 
@@ -102,7 +103,9 @@ class Uri(object):
                 ''.join([uri.netloc, uri.path])
             )
         elif uri.scheme == 'dir':
-            return self._local_directory(uri.path)
+            return self._local_path(uri.path)
+        elif uri.scheme == 'file':
+            return self._local_path(uri.path)
         elif uri.scheme == 'iso':
             return self._iso_mount_path(uri.path)
         elif uri.scheme == 'suse':
@@ -178,7 +181,7 @@ class Uri(object):
         iso_mount.mount()
         return iso_mount.mountpoint
 
-    def _local_directory(self, path):
+    def _local_path(self, path):
         return os.path.normpath(path)
 
     def _obs_project(self, name):
@@ -205,7 +208,7 @@ class Uri(object):
         the image it arranges the repos for each build in a special
         environment, the so called build worker.
         """
-        return self._local_directory(
+        return self._local_path(
             '/usr/src/packages/SOURCES/repos/' + name
         )
 

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Mon Feb 27 15:23:58 2017 by generateDS.py version 2.24a.
+# Generated Tue Mar  7 12:28:29 2017 by generateDS.py version 2.24a.
 #
 # Command line options:
 #   ('-f', '')
@@ -13,7 +13,7 @@
 #   kiwi/schema/kiwi.xsd
 #
 # Command line:
-#   /home/ms/Project/kiwi/.tox/2.7/bin/generateDS.py -f --external-encoding="utf-8" -o "kiwi/xml_parse.py" kiwi/schema/kiwi.xsd
+#   /home/david/workspaces/kiwi/.env2.7/bin/generateDS.py -f --external-encoding="utf-8" -o "kiwi/xml_parse.py" kiwi/schema/kiwi.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -2481,7 +2481,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, efipartsize=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, checkprebuilt=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsnocheck=None, fsmountoptions=None, gcelicense=None, hybrid=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, containerconfig=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, efipartsize=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, checkprebuilt=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsnocheck=None, fsmountoptions=None, gcelicense=None, hybrid=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, containerconfig=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2536,6 +2536,7 @@ class type_(GeneratedsSuper):
         self.vhdfixedtag = _cast(None, vhdfixedtag)
         self.volid = _cast(None, volid)
         self.wwid_wait_timeout = _cast(int, wwid_wait_timeout)
+        self.derived_from = _cast(None, derived_from)
         if containerconfig is None:
             self.containerconfig = []
         else:
@@ -2716,6 +2717,8 @@ class type_(GeneratedsSuper):
     def set_volid(self, volid): self.volid = volid
     def get_wwid_wait_timeout(self): return self.wwid_wait_timeout
     def set_wwid_wait_timeout(self, wwid_wait_timeout): self.wwid_wait_timeout = wwid_wait_timeout
+    def get_derived_from(self): return self.derived_from
+    def set_derived_from(self, derived_from): self.derived_from = derived_from
     def validate_partition_size_type(self, value):
         # Validate type partition-size-type, a restriction on xs:token.
         if value is not None and Validate_simpletypes_:
@@ -2921,6 +2924,9 @@ class type_(GeneratedsSuper):
         if self.wwid_wait_timeout is not None and 'wwid_wait_timeout' not in already_processed:
             already_processed.add('wwid_wait_timeout')
             outfile.write(' wwid_wait_timeout="%s"' % self.gds_format_integer(self.wwid_wait_timeout, input_name='wwid_wait_timeout'))
+        if self.derived_from is not None and 'derived_from' not in already_processed:
+            already_processed.add('derived_from')
+            outfile.write(' derived_from=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.derived_from), input_name='derived_from')), ))
     def exportChildren(self, outfile, level, namespace_='', name_='type', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -3294,6 +3300,10 @@ class type_(GeneratedsSuper):
                 raise_parse_error(node, 'Bad integer attribute: %s' % exp)
             if self.wwid_wait_timeout < 0:
                 raise_parse_error(node, 'Invalid NonNegativeInteger')
+        value = find_attr_value_('derived_from', node)
+        if value is not None and 'derived_from' not in already_processed:
+            already_processed.add('derived_from')
+            self.derived_from = value
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         if nodeName_ == 'containerconfig':
             obj_ = containerconfig.factory()

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -99,7 +99,7 @@
                 <vmnic driver="e1000" interface="0" mode="bridged"/>
             </machine>
         </type>
-        <type image="docker">
+        <type image="docker" derived_from="file:///image.tar.xz">
             <containerconfig name="container_name" maintainer="tux" user="root" workingdir="/root" tag="container_tag">
                 <entrypoint execute="/bin/bash">
                     <argument name="-x"/>

--- a/test/unit/system_root_import_base_test.py
+++ b/test/unit/system_root_import_base_test.py
@@ -1,0 +1,33 @@
+import mock
+from mock import patch
+from mock import call
+
+from .test_helper import raises
+
+from kiwi.system.root_import.base import RootImportBase
+from kiwi.exceptions import KiwiRootImportError
+
+class TestRootImportBase(object):
+    @patch('os.path.exists')
+    def test_init(self, mock_path):
+        mock_path.return_value = True
+        RootImportBase('root_dir', 'file:///image.tar.xz')
+        mock_path.assert_called_once_with('/image.tar.xz')
+
+    @raises(KiwiRootImportError)
+    def test_init_remote_uri(self):
+        RootImportBase('root_dir', 'http://example.com/image.tar.xz')
+
+    @patch('os.path.exists')
+    @raises(KiwiRootImportError)
+    def test_init_non_existing(self, mock_path):
+        mock_path.return_value = False
+        RootImportBase('root_dir', 'file:///image.tar.xz')
+        mock_path.assert_called_once_with('/image.tar.xz')
+
+    @raises(NotImplementedError)
+    @patch('os.path.exists') 
+    def test_data_sync(self, mock_path):
+        mock_path.return_value = True
+        root_import = RootImportBase('root_dir', 'file:///image.tar.xz')
+        root_import.sync_data()

--- a/test/unit/system_root_import_docker_test.py
+++ b/test/unit/system_root_import_docker_test.py
@@ -1,0 +1,72 @@
+import mock
+from mock import patch
+from mock import call
+
+from .test_helper import raises
+
+from kiwi.system.root_import.docker import RootImportDocker
+from kiwi.exceptions import KiwiRootImportError
+
+class TestRootImportDocker(object):
+    @patch('os.path.exists')
+    def setup(self, mock_path):
+        mock_path.return_value = True
+        self.docker_import = RootImportDocker(
+            'root_dir', 'file:///image.tar.xz'
+        )
+        assert self.docker_import.image_file == '/image.tar.xz'
+
+    @patch('kiwi.system.root_import.docker.Compress')
+    @patch('kiwi.system.root_import.docker.Command.run')
+    @patch('kiwi.system.root_import.docker.DataSync')
+    @patch('kiwi.system.root_import.docker.mkdtemp') 
+    def test_sync_data(
+            self, mock_mkdtemp, mock_sync, mock_run, mock_compress
+        ):
+        uncompress = mock.Mock()
+        uncompress.uncompressed_filename = 'tmp_uncompressed'
+        mock_compress.return_value = uncompress
+
+        tmpdirs = ['kiwi_unpack_dir', 'kiwi_layout_dir']
+
+        def call_mkdtemp(prefix):
+            return tmpdirs.pop()
+
+        mock_mkdtemp.side_effect = call_mkdtemp
+
+        sync = mock.Mock()
+        mock_sync.return_value = sync
+
+        self.docker_import.sync_data()
+        
+        mock_compress.assert_called_once_with('/image.tar.xz')
+        uncompress.uncompress.assert_called_once_with(True)
+
+        assert mock_run.call_args_list == [
+            call([
+                'skopeo', 'copy', 'docker-archive:tmp_uncompressed',
+                'oci:kiwi_layout_dir'
+            ]),
+            call([
+                'umoci', 'unpack', '--image',
+                'kiwi_layout_dir', 'kiwi_unpack_dir'
+            ])
+        ]
+
+        mock_sync.assert_called_once_with(
+            'kiwi_unpack_dir/rootfs/', 'root_dir/'
+        )
+        sync.sync_data.assert_called_once_with(
+            options=['-a', '-H', '-X', '-A']
+        )
+
+    @patch('kiwi.system.root_import.docker.Path.wipe')
+    def test_del(self, mock_path):
+        self.docker_import.oci_layout_dir = 'layout_dir'
+        self.docker_import.oci_unpack_dir = 'unpack_dir'
+        self.docker_import.uncompressed_image = 'uncompressed_file'
+        self.docker_import.__del__()
+
+        assert mock_path.call_args_list == [
+            call('layout_dir'), call('unpack_dir'), call('uncompressed_file')
+        ]

--- a/test/unit/system_root_import_test.py
+++ b/test/unit/system_root_import_test.py
@@ -1,0 +1,21 @@
+import mock
+from mock import patch
+from mock import call
+
+from .test_helper import raises
+
+from kiwi.system.root_import import RootImport
+from kiwi.exceptions import KiwiRootImportError
+
+class TestRootImport(object):
+    @patch('kiwi.system.root_import.RootImportDocker')
+    def test_docker_import(self, mock_docker_import):
+        RootImport('root_dir', 'file:///image.tar.xz', 'docker')
+        mock_docker_import.assert_called_once_with(
+            'root_dir', 'file:///image.tar.xz'
+        )
+
+    @raises(KiwiRootImportError)
+    def test_not_implemented_import(self):
+        RootImport('root_dir', 'file:///image.tar.xz', 'foo')
+    


### PR DESCRIPTION
This commit includes the root import feature. A `derived_from`
attribute has been included with the `<type>` section to make
reference to the image file to import. The image format to import
is assumed to be the same as the build type to import.

Currently, the only format supported is docker
