### PR TITLE
No relative imports

### DIFF
--- a/kiwi/archive/cpio.py
+++ b/kiwi/archive/cpio.py
@@ -16,7 +16,7 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 # project
-from ..command import Command
+from kiwi.command import Command
 
 
 class ArchiveCpio(object):

--- a/kiwi/archive/tar.py
+++ b/kiwi/archive/tar.py
@@ -18,8 +18,8 @@
 import os
 
 # project
-from ..command import Command
-from ..exceptions import KiwiArchiveTarError
+from kiwi.command import Command
+from kiwi.exceptions import KiwiArchiveTarError
 
 
 class ArchiveTar(object):

--- a/kiwi/boot/image/__init__.py
+++ b/kiwi/boot/image/__init__.py
@@ -16,10 +16,10 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 # project
-from .kiwi import BootImageKiwi
-from .dracut import BootImageDracut
+from kiwi.boot.image.builtin_kiwi import BootImageKiwi
+from kiwi.boot.image.dracut import BootImageDracut
 
-from ...exceptions import (
+from kiwi.exceptions import (
     KiwiBootImageSetupError
 )
 

--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -21,13 +21,13 @@ import pickle
 from tempfile import mkdtemp
 
 # project
-from ...defaults import Defaults
-from ...xml_description import XMLDescription
-from ...xml_state import XMLState
-from ...logger import log
-from ...path import Path
+from kiwi.defaults import Defaults
+from kiwi.xml_description import XMLDescription
+from kiwi.xml_state import XMLState
+from kiwi.logger import log
+from kiwi.path import Path
 
-from ...exceptions import (
+from kiwi.exceptions import (
     KiwiTargetDirectoryNotFound,
     KiwiConfigFileNotFound,
     KiwiBootImageDumpError

--- a/kiwi/boot/image/builtin_kiwi.py
+++ b/kiwi/boot/image/builtin_kiwi.py
@@ -17,16 +17,16 @@
 #
 from tempfile import mkdtemp
 
-from ...defaults import Defaults
-from ...utils.sync import DataSync
-from ...system.prepare import SystemPrepare
-from ...system.profile import Profile
-from ...system.setup import SystemSetup
-from ...logger import log
-from ...archive.cpio import ArchiveCpio
-from ...utils.compress import Compress
-from ...path import Path
-from .base import BootImageBase
+from kiwi.defaults import Defaults
+from kiwi.utils.sync import DataSync
+from kiwi.system.prepare import SystemPrepare
+from kiwi.system.profile import Profile
+from kiwi.system.setup import SystemSetup
+from kiwi.logger import log
+from kiwi.archive.cpio import ArchiveCpio
+from kiwi.utils.compress import Compress
+from kiwi.path import Path
+from kiwi.boot.image.base import BootImageBase
 
 
 class BootImageKiwi(BootImageBase):

--- a/kiwi/boot/image/dracut.py
+++ b/kiwi/boot/image/dracut.py
@@ -18,11 +18,11 @@
 import os
 
 # project
-from ...utils.compress import Compress
-from ...logger import log
-from ...command import Command
-from ...system.kernel import Kernel
-from .base import BootImageBase
+from kiwi.utils.compress import Compress
+from kiwi.logger import log
+from kiwi.command import Command
+from kiwi.system.kernel import Kernel
+from kiwi.boot.image.base import BootImageBase
 
 
 class BootImageDracut(BootImageBase):

--- a/kiwi/bootloader/config/__init__.py
+++ b/kiwi/bootloader/config/__init__.py
@@ -16,11 +16,11 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 # project
-from .grub2 import BootLoaderConfigGrub2
-from .isolinux import BootLoaderConfigIsoLinux
-from .zipl import BootLoaderConfigZipl
+from kiwi.bootloader.config.grub2 import BootLoaderConfigGrub2
+from kiwi.bootloader.config.isolinux import BootLoaderConfigIsoLinux
+from kiwi.bootloader.config.zipl import BootLoaderConfigZipl
 
-from ...exceptions import (
+from kiwi.exceptions import (
     KiwiBootLoaderConfigSetupError
 )
 

--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -18,12 +18,12 @@
 from collections import namedtuple
 
 # project
-from ...logger import log
-from ...storage.setup import DiskSetup
-from ...path import Path
-from ...defaults import Defaults
+from kiwi.logger import log
+from kiwi.storage.setup import DiskSetup
+from kiwi.path import Path
+from kiwi.defaults import Defaults
 
-from ...exceptions import (
+from kiwi.exceptions import (
     KiwiBootLoaderTargetError
 )
 

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -21,15 +21,15 @@ import shutil
 from collections import OrderedDict
 
 # project
-from .base import BootLoaderConfigBase
-from ..template.grub2 import BootLoaderTemplateGrub2
-from ...command import Command
-from ...defaults import Defaults
-from ...firmware import FirmWare
-from ...logger import log
-from ...path import Path
-from ...utils.sync import DataSync
-from ...utils.sysconfig import SysConfig
+from kiwi.bootloader.config.base import BootLoaderConfigBase
+from kiwi.bootloader.template.grub2 import BootLoaderTemplateGrub2
+from kiwi.command import Command
+from kiwi.defaults import Defaults
+from kiwi.firmware import FirmWare
+from kiwi.logger import log
+from kiwi.path import Path
+from kiwi.utils.sync import DataSync
+from kiwi.utils.sysconfig import SysConfig
 
 from ...exceptions import (
     KiwiTemplateError,

--- a/kiwi/bootloader/config/isolinux.py
+++ b/kiwi/bootloader/config/isolinux.py
@@ -19,14 +19,14 @@ import os
 import platform
 
 # project
-from .base import BootLoaderConfigBase
-from ..template.isolinux import BootLoaderTemplateIsoLinux
-from ...utils.sync import DataSync
-from ...logger import log
-from ...path import Path
-from ...defaults import Defaults
+from kiwi.bootloader.config.base import BootLoaderConfigBase
+from kiwi.bootloader.template.isolinux import BootLoaderTemplateIsoLinux
+from kiwi.utils.sync import DataSync
+from kiwi.logger import log
+from kiwi.path import Path
+from kiwi.defaults import Defaults
 
-from ...exceptions import (
+from kiwi.exceptions import (
     KiwiTemplateError,
     KiwiBootLoaderIsoLinuxPlatformError
 )

--- a/kiwi/bootloader/config/zipl.py
+++ b/kiwi/bootloader/config/zipl.py
@@ -20,15 +20,15 @@ import platform
 import re
 
 # project
-from .base import BootLoaderConfigBase
-from ..template.zipl import BootLoaderTemplateZipl
-from ...command import Command
-from ...logger import log
-from ...path import Path
-from ...firmware import FirmWare
-from ...defaults import Defaults
+from kiwi.bootloader.config.base import BootLoaderConfigBase
+from kiwi.bootloader.template.zipl import BootLoaderTemplateZipl
+from kiwi.command import Command
+from kiwi.logger import log
+from kiwi.path import Path
+from kiwi.firmware import FirmWare
+from kiwi.defaults import Defaults
 
-from ...exceptions import (
+from kiwi.exceptions import (
     KiwiTemplateError,
     KiwiBootLoaderZiplPlatformError,
     KiwiBootLoaderZiplSetupError,

--- a/kiwi/bootloader/install/grub2.py
+++ b/kiwi/bootloader/install/grub2.py
@@ -19,14 +19,14 @@ import os
 import platform
 
 # project
-from .base import BootLoaderInstallBase
-from ...command import Command
-from ...logger import log
-from ...defaults import Defaults
-from ...mount_manager import MountManager
-from ...path import Path
+from kiwi.bootloader.install.base import BootLoaderInstallBase
+from kiwi.command import Command
+from kiwi.logger import log
+from kiwi.defaults import Defaults
+from kiwi.mount_manager import MountManager
+from kiwi.path import Path
 
-from ...exceptions import (
+from kiwi.exceptions import (
     KiwiBootLoaderGrubInstallError,
     KiwiBootLoaderGrubPlatformError,
     KiwiBootLoaderGrubDataError

--- a/kiwi/bootloader/install/zipl.py
+++ b/kiwi/bootloader/install/zipl.py
@@ -16,12 +16,12 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 # project
-from .base import BootLoaderInstallBase
-from ...command import Command
-from ...logger import log
-from ...mount_manager import MountManager
+from kiwi.bootloader.install.base import BootLoaderInstallBase
+from kiwi.command import Command
+from kiwi.logger import log
+from kiwi.mount_manager import MountManager
 
-from ...exceptions import (
+from kiwi.exceptions import (
     KiwiBootLoaderZiplInstallError
 )
 

--- a/kiwi/builder/__init__.py
+++ b/kiwi/builder/__init__.py
@@ -16,15 +16,15 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 # project
-from .archive import ArchiveBuilder
-from .filesystem import FileSystemBuilder
-from .container import ContainerBuilder
-from .disk import DiskBuilder
-from .live import LiveImageBuilder
-from .pxe import PxeBuilder
-from ..defaults import Defaults
+from kiwi.builder.archive import ArchiveBuilder
+from kiwi.builder.filesystem import FileSystemBuilder
+from kiwi.builder.container import ContainerBuilder
+from kiwi.builder.disk import DiskBuilder
+from kiwi.builder.live import LiveImageBuilder
+from kiwi.builder.pxe import PxeBuilder
+from kiwi.defaults import Defaults
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiRequestedTypeError
 )
 

--- a/kiwi/builder/archive.py
+++ b/kiwi/builder/archive.py
@@ -18,14 +18,14 @@
 import platform
 
 # project
-from ..defaults import Defaults
-from ..archive.tar import ArchiveTar
-from ..system.setup import SystemSetup
-from ..utils.checksum import Checksum
-from ..logger import log
-from ..system.result import Result
+from kiwi.defaults import Defaults
+from kiwi.archive.tar import ArchiveTar
+from kiwi.system.setup import SystemSetup
+from kiwi.utils.checksum import Checksum
+from kiwi.logger import log
+from kiwi.system.result import Result
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiArchiveSetupError
 )
 

--- a/kiwi/builder/container.py
+++ b/kiwi/builder/container.py
@@ -18,11 +18,11 @@
 import platform
 
 # project
-from ..container import ContainerImage
-from ..container.setup import ContainerSetup
-from ..system.setup import SystemSetup
-from ..logger import log
-from ..system.result import Result
+from kiwi.container import ContainerImage
+from kiwi.container.setup import ContainerSetup
+from kiwi.system.setup import SystemSetup
+from kiwi.logger import log
+from kiwi.system.result import Result
 
 
 class ContainerBuilder(object):

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -22,32 +22,32 @@ from collections import namedtuple
 from tempfile import NamedTemporaryFile
 
 # project
-from ..defaults import Defaults
-from ..bootloader.config import BootLoaderConfig
-from ..bootloader.install import BootLoaderInstall
-from ..system.identifier import SystemIdentifier
-from ..boot.image import BootImage
-from ..boot.image import BootImageKiwi
-from ..storage.setup import DiskSetup
-from ..storage.loop_device import LoopDevice
-from ..firmware import FirmWare
-from ..storage.disk import Disk
-from ..storage.raid_device import RaidDevice
-from ..storage.luks_device import LuksDevice
-from ..filesystem import FileSystem
-from ..filesystem.squashfs import FileSystemSquashFs
-from ..volume_manager import VolumeManager
-from ..logger import log
-from ..command import Command
-from ..system.setup import SystemSetup
-from .install import InstallImageBuilder
-from ..system.kernel import Kernel
-from ..storage.subformat import DiskFormat
-from ..system.result import Result
-from ..utils.block import BlockID
-from ..path import Path
+from kiwi.defaults import Defaults
+from kiwi.bootloader.config import BootLoaderConfig
+from kiwi.bootloader.install import BootLoaderInstall
+from kiwi.system.identifier import SystemIdentifier
+from kiwi.boot.image import BootImage
+from kiwi.boot.image import BootImageKiwi
+from kiwi.storage.setup import DiskSetup
+from kiwi.storage.loop_device import LoopDevice
+from kiwi.firmware import FirmWare
+from kiwi.storage.disk import Disk
+from kiwi.storage.raid_device import RaidDevice
+from kiwi.storage.luks_device import LuksDevice
+from kiwi.filesystem import FileSystem
+from kiwi.filesystem.squashfs import FileSystemSquashFs
+from kiwi.volume_manager import VolumeManager
+from kiwi.logger import log
+from kiwi.command import Command
+from kiwi.system.setup import SystemSetup
+from kiwi.builder.install import InstallImageBuilder
+from kiwi.system.kernel import Kernel
+from kiwi.storage.subformat import DiskFormat
+from kiwi.system.result import Result
+from kiwi.utils.block import BlockID
+from kiwi.path import Path
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiDiskBootImageError,
     KiwiInstallMediaError,
     KiwiVolumeManagerSetupError

--- a/kiwi/builder/filesystem.py
+++ b/kiwi/builder/filesystem.py
@@ -18,16 +18,16 @@
 import platform
 
 # project
-from ..filesystem import FileSystem
-from ..filesystem.setup import FileSystemSetup
-from ..storage.loop_device import LoopDevice
-from ..storage.device_provider import DeviceProvider
-from ..system.setup import SystemSetup
-from ..defaults import Defaults
-from ..logger import log
-from ..system.result import Result
+from kiwi.filesystem import FileSystem
+from kiwi.filesystem.setup import FileSystemSetup
+from kiwi.storage.loop_device import LoopDevice
+from kiwi.storage.device_provider import DeviceProvider
+from kiwi.system.setup import SystemSetup
+from kiwi.defaults import Defaults
+from kiwi.logger import log
+from kiwi.system.result import Result
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiFileSystemSetupError
 )
 

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -19,20 +19,20 @@ from tempfile import mkdtemp
 import platform
 
 # project
-from ..command import Command
-from ..bootloader.config import BootLoaderConfig
-from ..filesystem.squashfs import FileSystemSquashFs
-from ..filesystem.isofs import FileSystemIsoFs
-from ..system.identifier import SystemIdentifier
-from ..path import Path
-from ..utils.checksum import Checksum
-from ..logger import log
-from ..system.kernel import Kernel
-from ..iso import Iso
-from ..utils.compress import Compress
-from ..archive.tar import ArchiveTar
+from kiwi.command import Command
+from kiwi.bootloader.config import BootLoaderConfig
+from kiwi.filesystem.squashfs import FileSystemSquashFs
+from kiwi.filesystem.isofs import FileSystemIsoFs
+from kiwi.system.identifier import SystemIdentifier
+from kiwi.path import Path
+from kiwi.utils.checksum import Checksum
+from kiwi.logger import log
+from kiwi.system.kernel import Kernel
+from kiwi.iso import Iso
+from kiwi.utils.compress import Compress
+from kiwi.archive.tar import ArchiveTar
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiInstallBootImageError
 )
 

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -20,23 +20,23 @@ import platform
 import shutil
 
 # project
-from ..bootloader.config import BootLoaderConfig
-from ..filesystem import FileSystem
-from ..filesystem.isofs import FileSystemIsoFs
-from ..boot.image import BootImage
-from ..system.size import SystemSize
-from ..system.setup import SystemSetup
-from ..firmware import FirmWare
-from ..defaults import Defaults
-from ..path import Path
-from ..system.result import Result
-from ..iso import Iso
-from ..system.identifier import SystemIdentifier
-from ..system.kernel import Kernel
-from ..command import Command
-from ..logger import log
+from kiwi.bootloader.config import BootLoaderConfig
+from kiwi.filesystem import FileSystem
+from kiwi.filesystem.isofs import FileSystemIsoFs
+from kiwi.boot.image import BootImage
+from kiwi.system.size import SystemSize
+from kiwi.system.setup import SystemSetup
+from kiwi.firmware import FirmWare
+from kiwi.defaults import Defaults
+from kiwi.path import Path
+from kiwi.system.result import Result
+from kiwi.iso import Iso
+from kiwi.system.identifier import SystemIdentifier
+from kiwi.system.kernel import Kernel
+from kiwi.command import Command
+from kiwi.logger import log
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiLiveBootImageError
 )
 

--- a/kiwi/builder/pxe.py
+++ b/kiwi/builder/pxe.py
@@ -19,16 +19,16 @@ import os
 import platform
 
 # project
-from ..boot.image import BootImage
-from .filesystem import FileSystemBuilder
-from ..utils.compress import Compress
-from ..utils.checksum import Checksum
-from ..system.setup import SystemSetup
-from ..system.kernel import Kernel
-from ..logger import log
-from ..system.result import Result
+from kiwi.boot.image import BootImage
+from kiwi.builder.filesystem import FileSystemBuilder
+from kiwi.utils.compress import Compress
+from kiwi.utils.checksum import Checksum
+from kiwi.system.setup import SystemSetup
+from kiwi.system.kernel import Kernel
+from kiwi.logger import log
+from kiwi.system.result import Result
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiPxeBootImageError
 )
 

--- a/kiwi/command_process.py
+++ b/kiwi/command_process.py
@@ -21,10 +21,10 @@ import six
 # the bytes type in python3. The bytes type from the
 # builtins generalizes this type to be bytes always
 from builtins import bytes
+from collections import namedtuple
 
 # project
 from .logger import log
-from collections import namedtuple
 
 from .exceptions import (
     KiwiCommandError

--- a/kiwi/container/__init__.py
+++ b/kiwi/container/__init__.py
@@ -16,9 +16,9 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 # project
-from .docker import ContainerImageDocker
+from kiwi.container.docker import ContainerImageDocker
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiContainerImageSetupError
 )
 

--- a/kiwi/container/docker.py
+++ b/kiwi/container/docker.py
@@ -16,14 +16,14 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
+from tempfile import mkdtemp
 
 # project
-from ..defaults import Defaults
-from ..path import Path
-from ..command import Command
-from tempfile import mkdtemp
-from ..utils.sync import DataSync
-from ..utils.compress import Compress
+from kiwi.defaults import Defaults
+from kiwi.path import Path
+from kiwi.command import Command
+from kiwi.utils.sync import DataSync
+from kiwi.utils.compress import Compress
 
 
 class ContainerImageDocker(object):

--- a/kiwi/container/setup/__init__.py
+++ b/kiwi/container/setup/__init__.py
@@ -16,9 +16,9 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 # project
-from .docker import ContainerSetupDocker
+from kiwi.container.setup.docker import ContainerSetupDocker
 
-from ...exceptions import (
+from kiwi.exceptions import (
     KiwiContainerSetupError
 )
 

--- a/kiwi/container/setup/base.py
+++ b/kiwi/container/setup/base.py
@@ -19,10 +19,10 @@ import collections
 import os
 
 # project
-from ...command import Command
-from ...utils.sync import DataSync
+from kiwi.command import Command
+from kiwi.utils.sync import DataSync
 
-from ...exceptions import (
+from kiwi.exceptions import (
     KiwiContainerSetupError
 )
 

--- a/kiwi/container/setup/docker.py
+++ b/kiwi/container/setup/docker.py
@@ -17,7 +17,7 @@
 #
 
 # project
-from .base import ContainerSetupBase
+from kiwi.container.setup.base import ContainerSetupBase
 
 
 class ContainerSetupDocker(ContainerSetupBase):

--- a/kiwi/filesystem/base.py
+++ b/kiwi/filesystem/base.py
@@ -18,11 +18,11 @@
 import os
 
 # project
-from ..logger import log
-from ..utils.sync import DataSync
-from ..mount_manager import MountManager
+from kiwi.logger import log
+from kiwi.utils.sync import DataSync
+from kiwi.mount_manager import MountManager
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiFileSystemSyncError
 )
 

--- a/kiwi/filesystem/btrfs.py
+++ b/kiwi/filesystem/btrfs.py
@@ -16,8 +16,8 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 # project
-from ..command import Command
-from .base import FileSystemBase
+from kiwi.command import Command
+from kiwi.filesystem.base import FileSystemBase
 
 
 class FileSystemBtrfs(FileSystemBase):

--- a/kiwi/filesystem/clicfs.py
+++ b/kiwi/filesystem/clicfs.py
@@ -19,13 +19,13 @@
 from tempfile import mkdtemp
 
 # project
-from .base import FileSystemBase
-from .ext4 import FileSystemExt4
-from ..command import Command
-from ..system.size import SystemSize
-from ..path import Path
-from ..storage.loop_device import LoopDevice
-from ..logger import log
+from kiwi.filesystem.base import FileSystemBase
+from kiwi.filesystem.ext4 import FileSystemExt4
+from kiwi.command import Command
+from kiwi.system.size import SystemSize
+from kiwi.path import Path
+from kiwi.storage.loop_device import LoopDevice
+from kiwi.logger import log
 
 
 class FileSystemClicFs(FileSystemBase):

--- a/kiwi/filesystem/ext2.py
+++ b/kiwi/filesystem/ext2.py
@@ -16,8 +16,8 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 
 # project
-from .base import FileSystemBase
-from ..command import Command
+from kiwi.filesystem.base import FileSystemBase
+from kiwi.command import Command
 
 
 class FileSystemExt2(FileSystemBase):

--- a/kiwi/filesystem/ext3.py
+++ b/kiwi/filesystem/ext3.py
@@ -16,8 +16,8 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 
 # project
-from .base import FileSystemBase
-from ..command import Command
+from kiwi.filesystem.base import FileSystemBase
+from kiwi.command import Command
 
 
 class FileSystemExt3(FileSystemBase):

--- a/kiwi/filesystem/ext4.py
+++ b/kiwi/filesystem/ext4.py
@@ -16,8 +16,8 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 
 # project
-from .base import FileSystemBase
-from ..command import Command
+from kiwi.filesystem.base import FileSystemBase
+from kiwi.command import Command
 
 
 class FileSystemExt4(FileSystemBase):

--- a/kiwi/filesystem/fat16.py
+++ b/kiwi/filesystem/fat16.py
@@ -16,8 +16,8 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 
 # project
-from .base import FileSystemBase
-from ..command import Command
+from kiwi.filesystem.base import FileSystemBase
+from kiwi.command import Command
 
 
 class FileSystemFat16(FileSystemBase):

--- a/kiwi/filesystem/fat32.py
+++ b/kiwi/filesystem/fat32.py
@@ -16,8 +16,8 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 
 # project
-from .base import FileSystemBase
-from ..command import Command
+from kiwi.filesystem.base import FileSystemBase
+from kiwi.command import Command
 
 
 class FileSystemFat32(FileSystemBase):

--- a/kiwi/filesystem/isofs.py
+++ b/kiwi/filesystem/isofs.py
@@ -16,12 +16,12 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 # project
-from .base import FileSystemBase
-from ..command import Command
-from ..iso import Iso
-from ..path import Path
+from kiwi.filesystem.base import FileSystemBase
+from kiwi.command import Command
+from kiwi.iso import Iso
+from kiwi.path import Path
 
-from ..exceptions import KiwiIsoToolError
+from kiwi.exceptions import KiwiIsoToolError
 
 
 class FileSystemIsoFs(FileSystemBase):

--- a/kiwi/filesystem/setup.py
+++ b/kiwi/filesystem/setup.py
@@ -16,9 +16,9 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 # project
-from ..system.size import SystemSize
-from ..logger import log
-from ..defaults import Defaults
+from kiwi.system.size import SystemSize
+from kiwi.logger import log
+from kiwi.defaults import Defaults
 
 
 class FileSystemSetup(object):

--- a/kiwi/filesystem/squashfs.py
+++ b/kiwi/filesystem/squashfs.py
@@ -14,12 +14,11 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
-
 import platform
 
 # project
-from .base import FileSystemBase
-from ..command import Command
+from kiwi.filesystem.base import FileSystemBase
+from kiwi.command import Command
 
 
 class FileSystemSquashFs(FileSystemBase):

--- a/kiwi/filesystem/xfs.py
+++ b/kiwi/filesystem/xfs.py
@@ -16,8 +16,8 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 # project
-from .base import FileSystemBase
-from ..command import Command
+from kiwi.filesystem.base import FileSystemBase
+from kiwi.command import Command
 
 
 class FileSystemXfs(FileSystemBase):

--- a/kiwi/help.py
+++ b/kiwi/help.py
@@ -16,6 +16,7 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import subprocess
+
 # project
 from .exceptions import KiwiHelpNoCommandGiven
 

--- a/kiwi/package_manager/__init__.py
+++ b/kiwi/package_manager/__init__.py
@@ -16,12 +16,12 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 # project
-from .zypper import PackageManagerZypper
-from .yum import PackageManagerYum
-from .apt import PackageManagerApt
-from .dnf import PackageManagerDnf
+from kiwi.package_manager.zypper import PackageManagerZypper
+from kiwi.package_manager.yum import PackageManagerYum
+from kiwi.package_manager.apt import PackageManagerApt
+from kiwi.package_manager.dnf import PackageManagerDnf
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiPackageManagerSetupError
 )
 

--- a/kiwi/package_manager/apt.py
+++ b/kiwi/package_manager/apt.py
@@ -19,13 +19,13 @@ import re
 import os
 
 # project
-from ..command import Command
-from ..mount_manager import MountManager
-from ..logger import log
-from ..utils.sync import DataSync
-from ..path import Path
-from .base import PackageManagerBase
-from ..exceptions import (
+from kiwi.command import Command
+from kiwi.mount_manager import MountManager
+from kiwi.logger import log
+from kiwi.utils.sync import DataSync
+from kiwi.path import Path
+from kiwi.package_manager.base import PackageManagerBase
+from kiwi.exceptions import (
     KiwiDebootstrapError
 )
 

--- a/kiwi/package_manager/dnf.py
+++ b/kiwi/package_manager/dnf.py
@@ -18,10 +18,10 @@
 import re
 
 # project
-from ..logger import log
-from ..command import Command
-from .base import PackageManagerBase
-from ..exceptions import (
+from kiwi.logger import log
+from kiwi.command import Command
+from kiwi.package_manager.base import PackageManagerBase
+from kiwi.exceptions import (
     KiwiRequestError
 )
 

--- a/kiwi/package_manager/yum.py
+++ b/kiwi/package_manager/yum.py
@@ -18,10 +18,10 @@
 import re
 
 # project
-from ..logger import log
-from ..command import Command
-from .base import PackageManagerBase
-from ..exceptions import (
+from kiwi.logger import log
+from kiwi.command import Command
+from kiwi.package_manager.base import PackageManagerBase
+from kiwi.exceptions import (
     KiwiRequestError
 )
 

--- a/kiwi/package_manager/zypper.py
+++ b/kiwi/package_manager/zypper.py
@@ -19,10 +19,10 @@ import re
 import os
 
 # project
-from ..command import Command
-from .base import PackageManagerBase
-from ..path import Path
-from ..exceptions import (
+from kiwi.command import Command
+from kiwi.package_manager.base import PackageManagerBase
+from kiwi.path import Path
+from kiwi.exceptions import (
     KiwiRpmDatabaseReloadError,
     KiwiRequestError
 )

--- a/kiwi/partitioner/__init__.py
+++ b/kiwi/partitioner/__init__.py
@@ -18,11 +18,11 @@
 import platform
 
 # project
-from .gpt import PartitionerGpt
-from .msdos import PartitionerMsDos
-from .dasd import PartitionerDasd
+from kiwi.partitioner.gpt import PartitionerGpt
+from kiwi.partitioner.msdos import PartitionerMsDos
+from kiwi.partitioner.dasd import PartitionerDasd
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiPartitionerSetupError
 )
 

--- a/kiwi/partitioner/dasd.py
+++ b/kiwi/partitioner/dasd.py
@@ -18,9 +18,9 @@
 from tempfile import NamedTemporaryFile
 
 # project
-from ..command import Command
-from ..logger import log
-from .base import PartitionerBase
+from kiwi.command import Command
+from kiwi.logger import log
+from kiwi.partitioner.base import PartitionerBase
 
 
 class PartitionerDasd(PartitionerBase):

--- a/kiwi/partitioner/gpt.py
+++ b/kiwi/partitioner/gpt.py
@@ -16,11 +16,11 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 # project
-from ..command import Command
-from ..logger import log
-from .base import PartitionerBase
+from kiwi.command import Command
+from kiwi.logger import log
+from kiwi.partitioner.base import PartitionerBase
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiPartitionerGptFlagError
 )
 

--- a/kiwi/partitioner/msdos.py
+++ b/kiwi/partitioner/msdos.py
@@ -18,11 +18,11 @@
 from tempfile import NamedTemporaryFile
 
 # project
-from ..command import Command
-from ..logger import log
-from .base import PartitionerBase
+from kiwi.command import Command
+from kiwi.logger import log
+from kiwi.partitioner.base import PartitionerBase
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiPartitionerMsDosFlagError
 )
 

--- a/kiwi/privileges.py
+++ b/kiwi/privileges.py
@@ -17,6 +17,7 @@
 #
 import os
 
+# project
 from .exceptions import (
     KiwiPrivilegesError
 )

--- a/kiwi/repository/__init__.py
+++ b/kiwi/repository/__init__.py
@@ -16,12 +16,12 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 # project
-from .zypper import RepositoryZypper
-from .yum import RepositoryYum
-from .apt import RepositoryApt
-from .dnf import RepositoryDnf
+from kiwi.repository.zypper import RepositoryZypper
+from kiwi.repository.yum import RepositoryYum
+from kiwi.repository.apt import RepositoryApt
+from kiwi.repository.dnf import RepositoryDnf
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiRepositorySetupError
 )
 

--- a/kiwi/repository/apt.py
+++ b/kiwi/repository/apt.py
@@ -19,9 +19,9 @@ import os
 from tempfile import NamedTemporaryFile
 
 # project
-from .template.apt import PackageManagerTemplateAptGet
-from .base import RepositoryBase
-from ..path import Path
+from kiwi.repository.template.apt import PackageManagerTemplateAptGet
+from kiwi.repository.base import RepositoryBase
+from kiwi.path import Path
 
 
 class RepositoryApt(RepositoryBase):

--- a/kiwi/repository/dnf.py
+++ b/kiwi/repository/dnf.py
@@ -20,8 +20,8 @@ from six.moves.configparser import ConfigParser
 from tempfile import NamedTemporaryFile
 
 # project
-from .base import RepositoryBase
-from ..path import Path
+from kiwi.repository.base import RepositoryBase
+from kiwi.path import Path
 
 
 class RepositoryDnf(RepositoryBase):

--- a/kiwi/repository/yum.py
+++ b/kiwi/repository/yum.py
@@ -20,9 +20,9 @@ from six.moves.configparser import ConfigParser
 from tempfile import NamedTemporaryFile
 
 # project
-from ..logger import log
-from .base import RepositoryBase
-from ..path import Path
+from kiwi.logger import log
+from kiwi.repository.base import RepositoryBase
+from kiwi.path import Path
 
 
 class RepositoryYum(RepositoryBase):

--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -20,11 +20,11 @@ from six.moves.configparser import ConfigParser
 from tempfile import NamedTemporaryFile
 
 # project
-from ..command import Command
-from .base import RepositoryBase
-from ..path import Path
+from kiwi.command import Command
+from kiwi.repository.base import RepositoryBase
+from kiwi.path import Path
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiRepoTypeUnknown
 )
 

--- a/kiwi/solver/repository/__init__.py
+++ b/kiwi/solver/repository/__init__.py
@@ -16,11 +16,11 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 # project
-from .suse import SolverRepositorySUSE
-from .rpm_md import SolverRepositoryRpmMd
-from .rpm_dir import SolverRepositoryRpmDir
+from kiwi.solver.repository.suse import SolverRepositorySUSE
+from kiwi.solver.repository.rpm_md import SolverRepositoryRpmMd
+from kiwi.solver.repository.rpm_dir import SolverRepositoryRpmDir
 
-from ...exceptions import KiwiSolverRepositorySetupError
+from kiwi.exceptions import KiwiSolverRepositorySetupError
 
 
 class SolverRepository(object):

--- a/kiwi/solver/repository/base.py
+++ b/kiwi/solver/repository/base.py
@@ -26,10 +26,10 @@ import glob
 import os
 
 # project
-from ...exceptions import KiwiUriOpenError
-from ...path import Path
-from ...command import Command
-from ...defaults import Defaults
+from kiwi.exceptions import KiwiUriOpenError
+from kiwi.path import Path
+from kiwi.command import Command
+from kiwi.defaults import Defaults
 
 
 class SolverRepositoryBase(object):

--- a/kiwi/solver/repository/rpm_dir.py
+++ b/kiwi/solver/repository/rpm_dir.py
@@ -19,8 +19,8 @@ import os
 import glob
 
 # project
-from .base import SolverRepositoryBase
-from ...exceptions import KiwiRpmDirNotRemoteError
+from kiwi.solver.repository.base import SolverRepositoryBase
+from kiwi.exceptions import KiwiRpmDirNotRemoteError
 
 
 class SolverRepositoryRpmDir(SolverRepositoryBase):

--- a/kiwi/solver/repository/rpm_md.py
+++ b/kiwi/solver/repository/rpm_md.py
@@ -19,7 +19,7 @@ import os
 from collections import namedtuple
 
 # project
-from .base import SolverRepositoryBase
+from kiwi.solver.repository.base import SolverRepositoryBase
 
 
 class SolverRepositoryRpmMd(SolverRepositoryBase):

--- a/kiwi/solver/repository/suse.py
+++ b/kiwi/solver/repository/suse.py
@@ -19,7 +19,7 @@ import os
 from collections import namedtuple
 
 # project
-from .base import SolverRepositoryBase
+from kiwi.solver.repository.base import SolverRepositoryBase
 
 
 class SolverRepositorySUSE(SolverRepositoryBase):

--- a/kiwi/solver/sat.py
+++ b/kiwi/solver/sat.py
@@ -21,9 +21,9 @@ from xml.etree import ElementTree
 from xml.dom import minidom
 
 # project
-from ..logger import log
+from kiwi.logger import log
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiSatSolverPluginError,
     KiwiSatSolverJobError,
     KiwiSatSolverJobProblems

--- a/kiwi/solver/sat.py
+++ b/kiwi/solver/sat.py
@@ -45,18 +45,12 @@ class Sat(object):
         """
         try:
             self.solv = importlib.import_module('solv')
-            self.Pool = getattr(
-                importlib.import_module('solv', 'Pool'), 'Pool'
-            )
-            self.Selection = getattr(
-                importlib.import_module('solv', 'Selection'), 'Selection'
-            )
         except Exception as e:
             raise KiwiSatSolverPluginError(
                 '{0}: {1}'.format(type(e).__name__, format(e))
             )
 
-        self.pool = self.Pool()
+        self.pool = self.solv.Pool()
         self.pool.setarch()
 
     def add_repository(self, solver_repository):
@@ -195,7 +189,7 @@ class Sat(object):
         for job_name in job_names:
             selection = self.pool.select(
                 job_name,
-                self.Selection.SELECTION_NAME |
+                self.solv.Selection.SELECTION_NAME |
                 self.solv.Selection.SELECTION_PROVIDES
             )
             if selection.flags() & self.solv.Selection.SELECTION_PROVIDES:

--- a/kiwi/storage/device_provider.py
+++ b/kiwi/storage/device_provider.py
@@ -16,8 +16,8 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 # project
-from ..command import Command
-from ..exceptions import (
+from kiwi.command import Command
+from kiwi.exceptions import (
     KiwiDeviceProviderError
 )
 

--- a/kiwi/storage/disk.py
+++ b/kiwi/storage/disk.py
@@ -20,11 +20,11 @@ from collections import OrderedDict
 from tempfile import NamedTemporaryFile
 
 # project
-from ..command import Command
-from .device_provider import DeviceProvider
-from .mapped_device import MappedDevice
-from ..partitioner import Partitioner
-from ..logger import log
+from kiwi.command import Command
+from kiwi.storage.device_provider import DeviceProvider
+from kiwi.storage.mapped_device import MappedDevice
+from kiwi.partitioner import Partitioner
+from kiwi.logger import log
 
 
 class Disk(DeviceProvider):

--- a/kiwi/storage/loop_device.py
+++ b/kiwi/storage/loop_device.py
@@ -18,11 +18,11 @@
 import os
 
 # project
-from ..command import Command
-from .device_provider import DeviceProvider
-from ..logger import log
+from kiwi.command import Command
+from kiwi.storage.device_provider import DeviceProvider
+from kiwi.logger import log
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiLoopSetupError
 )
 

--- a/kiwi/storage/luks_device.py
+++ b/kiwi/storage/luks_device.py
@@ -18,12 +18,12 @@
 from tempfile import NamedTemporaryFile
 
 # project
-from ..command import Command
-from .device_provider import DeviceProvider
-from .mapped_device import MappedDevice
-from ..logger import log
+from kiwi.command import Command
+from kiwi.storage.device_provider import DeviceProvider
+from kiwi.storage.mapped_device import MappedDevice
+from kiwi.logger import log
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiLuksSetupError
 )
 

--- a/kiwi/storage/mapped_device.py
+++ b/kiwi/storage/mapped_device.py
@@ -18,8 +18,8 @@
 import os
 
 # project
-from .device_provider import DeviceProvider
-from ..exceptions import (
+from kiwi.storage.device_provider import DeviceProvider
+from kiwi.exceptions import (
     KiwiMappedDeviceError
 )
 

--- a/kiwi/storage/raid_device.py
+++ b/kiwi/storage/raid_device.py
@@ -18,12 +18,12 @@
 import os
 
 # project
-from ..command import Command
-from .device_provider import DeviceProvider
-from .mapped_device import MappedDevice
-from ..logger import log
+from kiwi.command import Command
+from kiwi.storage.device_provider import DeviceProvider
+from kiwi.storage.mapped_device import MappedDevice
+from kiwi.logger import log
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiRaidSetupError
 )
 

--- a/kiwi/storage/setup.py
+++ b/kiwi/storage/setup.py
@@ -19,10 +19,10 @@ import os
 from collections import namedtuple
 
 # project
-from ..firmware import FirmWare
-from ..system.size import SystemSize
-from ..defaults import Defaults
-from ..logger import log
+from kiwi.firmware import FirmWare
+from kiwi.system.size import SystemSize
+from kiwi.defaults import Defaults
+from kiwi.logger import log
 
 
 class DiskSetup(object):

--- a/kiwi/storage/subformat/__init__.py
+++ b/kiwi/storage/subformat/__init__.py
@@ -16,16 +16,16 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 # project
-from .qcow2 import DiskFormatQcow2
-from .vhd import DiskFormatVhd
-from .vhdfixed import DiskFormatVhdFixed
-from .vmdk import DiskFormatVmdk
-from .gce import DiskFormatGce
-from .vdi import DiskFormatVdi
-from .base import DiskFormatBase
-from .vagrant_libvirt import DiskFormatVagrantLibVirt
+from kiwi.storage.subformat.qcow2 import DiskFormatQcow2
+from kiwi.storage.subformat.vhd import DiskFormatVhd
+from kiwi.storage.subformat.vhdfixed import DiskFormatVhdFixed
+from kiwi.storage.subformat.vmdk import DiskFormatVmdk
+from kiwi.storage.subformat.gce import DiskFormatGce
+from kiwi.storage.subformat.vdi import DiskFormatVdi
+from kiwi.storage.subformat.base import DiskFormatBase
+from kiwi.storage.subformat.vagrant_libvirt import DiskFormatVagrantLibVirt
 
-from ...exceptions import (
+from kiwi.exceptions import (
     KiwiDiskFormatSetupError
 )
 

--- a/kiwi/storage/subformat/base.py
+++ b/kiwi/storage/subformat/base.py
@@ -19,15 +19,16 @@ import os
 import platform
 from collections import OrderedDict
 
-from ...exceptions import (
+# project
+from kiwi.command import Command
+from kiwi.defaults import Defaults
+from kiwi.path import Path
+from kiwi.logger import log
+
+from kiwi.exceptions import (
     KiwiFormatSetupError,
     KiwiResizeRawDiskError
 )
-
-from ...command import Command
-from ...defaults import Defaults
-from ...path import Path
-from ...logger import log
 
 
 class DiskFormatBase(object):

--- a/kiwi/storage/subformat/gce.py
+++ b/kiwi/storage/subformat/gce.py
@@ -19,9 +19,9 @@ from collections import OrderedDict
 from tempfile import mkdtemp
 
 # project
-from ...command import Command
-from .base import DiskFormatBase
-from ...archive.tar import ArchiveTar
+from kiwi.command import Command
+from kiwi.storage.subformat.base import DiskFormatBase
+from kiwi.archive.tar import ArchiveTar
 
 
 class DiskFormatGce(DiskFormatBase):

--- a/kiwi/storage/subformat/qcow2.py
+++ b/kiwi/storage/subformat/qcow2.py
@@ -17,8 +17,8 @@
 
 
 # project
-from .base import DiskFormatBase
-from ...command import Command
+from kiwi.storage.subformat.base import DiskFormatBase
+from kiwi.command import Command
 
 
 class DiskFormatQcow2(DiskFormatBase):

--- a/kiwi/storage/subformat/vagrant_libvirt.py
+++ b/kiwi/storage/subformat/vagrant_libvirt.py
@@ -22,11 +22,11 @@ from textwrap import dedent
 from tempfile import mkdtemp
 
 # project
-from .base import DiskFormatBase
-from .qcow2 import DiskFormatQcow2
-from ...command import Command
+from kiwi.storage.subformat.base import DiskFormatBase
+from kiwi.storage.subformat.qcow2 import DiskFormatQcow2
+from kiwi.command import Command
 
-from ...exceptions import (
+from kiwi.exceptions import (
     KiwiFormatSetupError
 )
 

--- a/kiwi/storage/subformat/vdi.py
+++ b/kiwi/storage/subformat/vdi.py
@@ -17,8 +17,8 @@
 
 
 # project
-from .base import DiskFormatBase
-from ...command import Command
+from kiwi.storage.subformat.base import DiskFormatBase
+from kiwi.command import Command
 
 
 class DiskFormatVdi(DiskFormatBase):

--- a/kiwi/storage/subformat/vhd.py
+++ b/kiwi/storage/subformat/vhd.py
@@ -16,8 +16,8 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 # project
-from .base import DiskFormatBase
-from ...command import Command
+from kiwi.storage.subformat.base import DiskFormatBase
+from kiwi.command import Command
 
 
 class DiskFormatVhd(DiskFormatBase):

--- a/kiwi/storage/subformat/vhdfixed.py
+++ b/kiwi/storage/subformat/vhdfixed.py
@@ -21,10 +21,10 @@ from binascii import unhexlify
 import re
 
 # project
-from .base import DiskFormatBase
-from ...command import Command
+from kiwi.storage.subformat.base import DiskFormatBase
+from kiwi.command import Command
 
-from ...exceptions import (
+from kiwi.exceptions import (
     KiwiVhdTagError
 )
 

--- a/kiwi/storage/subformat/vmdk.py
+++ b/kiwi/storage/subformat/vmdk.py
@@ -24,10 +24,12 @@ import re
 from builtins import bytes
 
 # project
-from .base import DiskFormatBase
-from ...command import Command
-from ...logger import log
-from .template.vmware_settings import VmwareSettingsTemplate
+from kiwi.storage.subformat.base import DiskFormatBase
+from kiwi.command import Command
+from kiwi.logger import log
+from kiwi.storage.subformat.template.vmware_settings import (
+    VmwareSettingsTemplate
+)
 
 from ...exceptions import (
     KiwiVmdkToolsError,

--- a/kiwi/system/kernel.py
+++ b/kiwi/system/kernel.py
@@ -19,9 +19,9 @@ import os
 from collections import namedtuple
 
 # project
-from ..command import Command
+from kiwi.command import Command
 
-from ..exceptions import KiwiKernelLookupError
+from kiwi.exceptions import KiwiKernelLookupError
 
 
 class Kernel(object):

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -18,17 +18,17 @@
 import os
 
 # project
-from .root_init import RootInit
-from .root_bind import RootBind
-from ..repository import Repository
-from ..package_manager import PackageManager
-from ..command_process import CommandProcess
-from .uri import Uri
-from ..archive.tar import ArchiveTar
+from kiwi.system.root_init import RootInit
+from kiwi.system.root_bind import RootBind
+from kiwi.repository import Repository
+from kiwi.package_manager import PackageManager
+from kiwi.command_process import CommandProcess
+from kiwi.system.uri import Uri
+from kiwi.archive.tar import ArchiveTar
 
-from ..logger import log
+from kiwi.logger import log
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiBootStrapPhaseFailed,
     KiwiSystemUpdateFailed,
     KiwiSystemInstallPackagesFailed,

--- a/kiwi/system/profile.py
+++ b/kiwi/system/profile.py
@@ -19,8 +19,8 @@ import collections
 from tempfile import NamedTemporaryFile
 
 # project
-from .shell import Shell
-from ..defaults import Defaults
+from kiwi.system.shell import Shell
+from kiwi.defaults import Defaults
 
 
 class Profile(object):

--- a/kiwi/system/result.py
+++ b/kiwi/system/result.py
@@ -20,9 +20,9 @@ import pickle
 import os
 
 # project
-from ..logger import log
+from kiwi.logger import log
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiResultError
 )
 

--- a/kiwi/system/root_bind.py
+++ b/kiwi/system/root_bind.py
@@ -19,13 +19,13 @@ import os
 import shutil
 
 # project
-from ..command import Command
-from ..defaults import Defaults
-from ..logger import log
-from ..path import Path
-from ..mount_manager import MountManager
+from kiwi.command import Command
+from kiwi.defaults import Defaults
+from kiwi.logger import log
+from kiwi.path import Path
+from kiwi.mount_manager import MountManager
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiMountKernelFileSystemsError,
     KiwiMountSharedDirectoryError,
     KiwiSetupIntermediateConfigError

--- a/kiwi/system/root_init.py
+++ b/kiwi/system/root_init.py
@@ -22,12 +22,12 @@ from shutil import rmtree
 import os
 
 # project
-from ..utils.sync import DataSync
-from ..command import Command
-from ..path import Path
-from ..defaults import Defaults
+from kiwi.utils.sync import DataSync
+from kiwi.command import Command
+from kiwi.path import Path
+from kiwi.defaults import Defaults
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiRootDirExists,
     KiwiRootInitCreationError
 )

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -22,22 +22,22 @@ from collections import namedtuple
 from tempfile import NamedTemporaryFile
 
 # project
-from .uri import Uri
-from ..repository import Repository
-from ..system.root_bind import RootBind
-from ..system.root_init import RootInit
-from ..command import Command
-from ..command_process import CommandProcess
-from ..utils.sync import DataSync
-from ..logger import log
-from ..defaults import Defaults
-from .users import Users
-from .shell import Shell
-from ..path import Path
-from ..archive.tar import ArchiveTar
-from ..utils.compress import Compress
+from kiwi.system.uri import Uri
+from kiwi.repository import Repository
+from kiwi.system.root_bind import RootBind
+from kiwi.system.root_init import RootInit
+from kiwi.command import Command
+from kiwi.command_process import CommandProcess
+from kiwi.utils.sync import DataSync
+from kiwi.logger import log
+from kiwi.defaults import Defaults
+from kiwi.system.users import Users
+from kiwi.system.shell import Shell
+from kiwi.path import Path
+from kiwi.archive.tar import ArchiveTar
+from kiwi.utils.compress import Compress
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiImportDescriptionError,
     KiwiScriptFailed
 )

--- a/kiwi/system/shell.py
+++ b/kiwi/system/shell.py
@@ -18,8 +18,8 @@
 from tempfile import NamedTemporaryFile
 
 # project
-from ..command import Command
-from ..defaults import Defaults
+from kiwi.command import Command
+from kiwi.defaults import Defaults
 
 
 class Shell(object):

--- a/kiwi/system/size.py
+++ b/kiwi/system/size.py
@@ -16,8 +16,8 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 # project
-from ..command import Command
-from ..defaults import Defaults
+from kiwi.command import Command
+from kiwi.defaults import Defaults
 
 
 class SystemSize(object):

--- a/kiwi/system/uri.py
+++ b/kiwi/system/uri.py
@@ -21,10 +21,10 @@ from six.moves.urllib.parse import urlparse
 import hashlib
 
 # project
-from ..mount_manager import MountManager
-from ..path import Path
+from kiwi.mount_manager import MountManager
+from kiwi.path import Path
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiUriStyleUnknown,
     KiwiUriTypeUnknown
 )

--- a/kiwi/system/users.py
+++ b/kiwi/system/users.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
-from ..command import Command
+from kiwi.command import Command
 
 
 class Users(object):

--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -20,12 +20,12 @@ import logging
 import glob
 
 # project
-from ..cli import Cli
-from ..xml_state import XMLState
-from ..xml_description import XMLDescription
-from ..runtime_checker import RuntimeChecker
+from kiwi.cli import Cli
+from kiwi.xml_state import XMLState
+from kiwi.xml_description import XMLDescription
+from kiwi.runtime_checker import RuntimeChecker
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiConfigFileNotFound
 )
 

--- a/kiwi/tasks/image_info.py
+++ b/kiwi/tasks/image_info.py
@@ -46,12 +46,12 @@ options:
         shasum, etc...
 """
 # project
-from .base import CliTask
-from ..help import Help
-from ..utils.output import DataOutput
-from ..solver.sat import Sat
-from ..solver.repository import SolverRepository
-from ..system.uri import Uri
+from kiwi.tasks.base import CliTask
+from kiwi.help import Help
+from kiwi.utils.output import DataOutput
+from kiwi.solver.sat import Sat
+from kiwi.solver.repository import SolverRepository
+from kiwi.system.uri import Uri
 
 
 class ImageInfoTask(CliTask):

--- a/kiwi/tasks/image_resize.py
+++ b/kiwi/tasks/image_resize.py
@@ -47,12 +47,12 @@ import re
 import math
 
 # project
-from .base import CliTask
-from ..help import Help
-from ..logger import log
-from ..storage.subformat import DiskFormat
+from kiwi.tasks.base import CliTask
+from kiwi.help import Help
+from kiwi.logger import log
+from kiwi.storage.subformat import DiskFormat
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiImageResizeError
 )
 

--- a/kiwi/tasks/result_bundle.py
+++ b/kiwi/tasks/result_bundle.py
@@ -43,16 +43,16 @@ from collections import OrderedDict
 import os
 
 # project
-from .base import CliTask
-from ..help import Help
-from ..system.result import Result
-from ..logger import log
-from ..path import Path
-from ..utils.compress import Compress
-from ..utils.checksum import Checksum
-from ..command import Command
+from kiwi.tasks.base import CliTask
+from kiwi.help import Help
+from kiwi.system.result import Result
+from kiwi.logger import log
+from kiwi.path import Path
+from kiwi.utils.compress import Compress
+from kiwi.utils.checksum import Checksum
+from kiwi.command import Command
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiBundleError
 )
 

--- a/kiwi/tasks/result_list.py
+++ b/kiwi/tasks/result_list.py
@@ -31,10 +31,10 @@ options:
 import os
 
 # project
-from .base import CliTask
-from ..help import Help
-from ..system.result import Result
-from ..logger import log
+from kiwi.tasks.base import CliTask
+from kiwi.help import Help
+from kiwi.system.result import Result
+from kiwi.logger import log
 
 
 class ResultListTask(CliTask):

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -56,16 +56,16 @@ options:
         the target directory to store the system image file(s)
 """
 # project
-from .base import CliTask
-from ..help import Help
-from ..system.prepare import SystemPrepare
-from ..system.setup import SystemSetup
-from ..builder import ImageBuilder
-from ..system.profile import Profile
-from ..defaults import Defaults
-from ..privileges import Privileges
-from ..path import Path
-from ..logger import log
+from kiwi.tasks.base import CliTask
+from kiwi.help import Help
+from kiwi.system.prepare import SystemPrepare
+from kiwi.system.setup import SystemSetup
+from kiwi.builder import ImageBuilder
+from kiwi.system.profile import Profile
+from kiwi.defaults import Defaults
+from kiwi.privileges import Privileges
+from kiwi.path import Path
+from kiwi.logger import log
 
 
 class SystemBuildTask(CliTask):

--- a/kiwi/tasks/system_create.py
+++ b/kiwi/tasks/system_create.py
@@ -38,13 +38,13 @@ options:
 import os
 
 # project
-from .base import CliTask
-from ..help import Help
-from ..builder import ImageBuilder
-from ..system.setup import SystemSetup
-from ..privileges import Privileges
-from ..path import Path
-from ..logger import log
+from kiwi.tasks.base import CliTask
+from kiwi.help import Help
+from kiwi.builder import ImageBuilder
+from kiwi.system.setup import SystemSetup
+from kiwi.privileges import Privileges
+from kiwi.path import Path
+from kiwi.logger import log
 
 
 class SystemCreateTask(CliTask):

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -60,14 +60,14 @@ options:
         repository in the XML description
 """
 # project
-from .base import CliTask
-from ..help import Help
-from ..privileges import Privileges
-from ..system.prepare import SystemPrepare
-from ..system.setup import SystemSetup
-from ..defaults import Defaults
-from ..system.profile import Profile
-from ..logger import log
+from kiwi.tasks.base import CliTask
+from kiwi.help import Help
+from kiwi.privileges import Privileges
+from kiwi.system.prepare import SystemPrepare
+from kiwi.system.setup import SystemSetup
+from kiwi.defaults import Defaults
+from kiwi.system.profile import Profile
+from kiwi.logger import log
 
 
 class SystemPrepareTask(CliTask):

--- a/kiwi/tasks/system_update.py
+++ b/kiwi/tasks/system_update.py
@@ -39,12 +39,12 @@ options:
         path to the root directory of the image
 """
 # project
-from .base import CliTask
-from ..privileges import Privileges
-from ..help import Help
-from ..system.prepare import SystemPrepare
+from kiwi.tasks.base import CliTask
+from kiwi.privileges import Privileges
+from kiwi.help import Help
+from kiwi.system.prepare import SystemPrepare
 
-from ..logger import log
+from kiwi.logger import log
 
 
 class SystemUpdateTask(CliTask):

--- a/kiwi/utils/block.py
+++ b/kiwi/utils/block.py
@@ -18,7 +18,7 @@
 import os
 
 # project
-from ..command import Command
+from kiwi.command import Command
 
 
 class BlockID(object):

--- a/kiwi/utils/checksum.py
+++ b/kiwi/utils/checksum.py
@@ -20,10 +20,10 @@ from collections import namedtuple
 import hashlib
 
 # project
-from ..command import Command
-from .compress import Compress
+from kiwi.command import Command
+from kiwi.utils.compress import Compress
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiFileNotFound
 )
 

--- a/kiwi/utils/compress.py
+++ b/kiwi/utils/compress.py
@@ -19,9 +19,9 @@ import os
 from tempfile import NamedTemporaryFile
 
 # project
-from ..command import Command
+from kiwi.command import Command
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiFileNotFound,
     KiwiCompressionFormatUnknown
 )

--- a/kiwi/utils/output.py
+++ b/kiwi/utils/output.py
@@ -20,8 +20,8 @@ import os
 from tempfile import NamedTemporaryFile
 
 # project
-from ..path import Path
-from ..logger import log
+from kiwi.path import Path
+from kiwi.logger import log
 
 
 class DataOutput(object):

--- a/kiwi/utils/sync.py
+++ b/kiwi/utils/sync.py
@@ -18,8 +18,8 @@
 import xattr
 
 # project
-from ..logger import log
-from ..command import Command
+from kiwi.logger import log
+from kiwi.command import Command
 
 
 class DataSync(object):

--- a/kiwi/volume_manager/__init__.py
+++ b/kiwi/volume_manager/__init__.py
@@ -16,10 +16,10 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 # project
-from .lvm import VolumeManagerLVM
-from .btrfs import VolumeManagerBtrfs
+from kiwi.volume_manager.lvm import VolumeManagerLVM
+from kiwi.volume_manager.btrfs import VolumeManagerBtrfs
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiVolumeManagerSetupError
 )
 

--- a/kiwi/volume_manager/base.py
+++ b/kiwi/volume_manager/base.py
@@ -20,17 +20,17 @@ from tempfile import mkdtemp
 import os
 
 # project
-from ..logger import log
-from ..command import Command
-from ..storage.device_provider import DeviceProvider
-from ..mount_manager import MountManager
-from ..storage.mapped_device import MappedDevice
-from ..utils.sync import DataSync
-from ..path import Path
-from ..system.size import SystemSize
-from ..defaults import Defaults
+from kiwi.logger import log
+from kiwi.command import Command
+from kiwi.storage.device_provider import DeviceProvider
+from kiwi.mount_manager import MountManager
+from kiwi.storage.mapped_device import MappedDevice
+from kiwi.utils.sync import DataSync
+from kiwi.path import Path
+from kiwi.system.size import SystemSize
+from kiwi.defaults import Defaults
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiVolumeManagerSetupError
 )
 

--- a/kiwi/volume_manager/btrfs.py
+++ b/kiwi/volume_manager/btrfs.py
@@ -22,17 +22,17 @@ from xml.etree import ElementTree
 from xml.dom import minidom
 
 # project
-from ..command import Command
-from .base import VolumeManagerBase
-from ..mount_manager import MountManager
-from ..storage.mapped_device import MappedDevice
-from ..filesystem import FileSystem
-from ..utils.sync import DataSync
-from ..utils.block import BlockID
-from ..path import Path
-from ..logger import log
+from kiwi.command import Command
+from kiwi.volume_manager.base import VolumeManagerBase
+from kiwi.mount_manager import MountManager
+from kiwi.storage.mapped_device import MappedDevice
+from kiwi.filesystem import FileSystem
+from kiwi.utils.sync import DataSync
+from kiwi.utils.block import BlockID
+from kiwi.path import Path
+from kiwi.logger import log
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiVolumeRootIDError
 )
 

--- a/kiwi/volume_manager/lvm.py
+++ b/kiwi/volume_manager/lvm.py
@@ -16,15 +16,15 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 # project
-from .base import VolumeManagerBase
-from ..command import Command
-from ..mount_manager import MountManager
-from ..storage.mapped_device import MappedDevice
-from ..filesystem import FileSystem
-from ..path import Path
-from ..logger import log
+from kiwi.volume_manager.base import VolumeManagerBase
+from kiwi.command import Command
+from kiwi.mount_manager import MountManager
+from kiwi.storage.mapped_device import MappedDevice
+from kiwi.filesystem import FileSystem
+from kiwi.path import Path
+from kiwi.logger import log
 
-from ..exceptions import (
+from kiwi.exceptions import (
     KiwiVolumeGroupConflict
 )
 

--- a/test/unit/archive_cpio_test.py
+++ b/test/unit/archive_cpio_test.py
@@ -1,9 +1,4 @@
-
 from mock import patch
-
-import mock
-
-from .test_helper import *
 
 from kiwi.archive.cpio import ArchiveCpio
 

--- a/test/unit/archive_tar_test.py
+++ b/test/unit/archive_tar_test.py
@@ -1,11 +1,12 @@
-
 from mock import patch, call
 
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
 from kiwi.archive.tar import ArchiveTar
+
+from kiwi.exceptions import KiwiArchiveTarError
 
 
 class TestArchiveTar(object):
@@ -16,7 +17,7 @@ class TestArchiveTar(object):
         mock_command.return_value = command
         self.archive = ArchiveTar('foo.tar')
 
-    @raises(kiwi.exceptions.KiwiArchiveTarError)
+    @raises(KiwiArchiveTarError)
     @patch('kiwi.archive.tar.Command.run')
     def test_invalid_tar_command_version(self, mock_command):
         command = mock.Mock()
@@ -89,7 +90,7 @@ class TestArchiveTar(object):
                     '-c', '-f', 'foo.tar', 'foo', 'bar'
                 ]
             )
-        ] 
+        ]
         mock_command.assert_has_calls(calls)
         assert mock_command.call_count == 2
 
@@ -109,7 +110,7 @@ class TestArchiveTar(object):
                     '--exclude', './foo', '--exclude', './bar'
                 ]
             )
-        ] 
+        ]
         mock_command.assert_has_calls(calls)
         assert mock_command.call_count == 2
 

--- a/test/unit/boot_image_base_test.py
+++ b/test/unit/boot_image_base_test.py
@@ -1,11 +1,14 @@
-
 from mock import patch
-from mock import call
+
 import mock
 
-from .test_helper import *
+from .test_helper import raises, patch_open
 
-from kiwi.exceptions import *
+from kiwi.exceptions import (
+    KiwiTargetDirectoryNotFound,
+    KiwiBootImageDumpError
+)
+
 from kiwi.boot.image.base import BootImageBase
 
 

--- a/test/unit/boot_image_builtin_kiwi_test.py
+++ b/test/unit/boot_image_builtin_kiwi_test.py
@@ -1,4 +1,3 @@
-import sys
 import mock
 
 from mock import patch
@@ -6,12 +5,12 @@ from mock import call
 
 import kiwi
 
-from .test_helper import *
+from .test_helper import raises
 
 from kiwi.boot.image.builtin_kiwi import BootImageKiwi
 from kiwi.xml_description import XMLDescription
 from kiwi.xml_state import XMLState
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiConfigFileNotFound
 
 
 class TestBootImageKiwi(object):

--- a/test/unit/boot_image_dracut_test.py
+++ b/test/unit/boot_image_dracut_test.py
@@ -1,17 +1,11 @@
-import sys
 import mock
 
 from mock import patch
 from mock import call
 
-import kiwi
-
-from .test_helper import *
-
 from kiwi.boot.image.dracut import BootImageDracut
 from kiwi.xml_description import XMLDescription
 from kiwi.xml_state import XMLState
-from kiwi.exceptions import *
 
 
 class TestBootImageKiwi(object):

--- a/test/unit/boot_image_kiwi_test.py
+++ b/test/unit/boot_image_kiwi_test.py
@@ -8,7 +8,7 @@ import kiwi
 
 from .test_helper import *
 
-from kiwi.boot.image.kiwi import BootImageKiwi
+from kiwi.boot.image.builtin_kiwi import BootImageKiwi
 from kiwi.xml_description import XMLDescription
 from kiwi.xml_state import XMLState
 from kiwi.exceptions import *
@@ -33,13 +33,13 @@ class TestBootImageKiwi(object):
         self.system_prepare.setup_repositories = mock.Mock(
             return_value=self.manager
         )
-        kiwi.boot.image.kiwi.SystemPrepare = mock.Mock(
+        kiwi.boot.image.builtin_kiwi.SystemPrepare = mock.Mock(
             return_value=self.system_prepare
         )
-        kiwi.boot.image.kiwi.SystemSetup = mock.Mock(
+        kiwi.boot.image.builtin_kiwi.SystemSetup = mock.Mock(
             return_value=self.setup
         )
-        kiwi.boot.image.kiwi.Profile = mock.Mock(
+        kiwi.boot.image.builtin_kiwi.Profile = mock.Mock(
             return_value=self.profile
         )
         mock_mkdtemp.return_value = 'boot-directory'
@@ -80,13 +80,13 @@ class TestBootImageKiwi(object):
         mock_os_path.return_value = False
         self.boot_image.prepare()
 
-    @patch('kiwi.boot.image.kiwi.ArchiveCpio')
-    @patch('kiwi.boot.image.kiwi.Compress')
-    @patch('kiwi.boot.image.kiwi.Path.create')
-    @patch('kiwi.boot.image.kiwi.Path.wipe')
-    @patch('kiwi.boot.image.kiwi.DataSync')
+    @patch('kiwi.boot.image.builtin_kiwi.ArchiveCpio')
+    @patch('kiwi.boot.image.builtin_kiwi.Compress')
+    @patch('kiwi.boot.image.builtin_kiwi.Path.create')
+    @patch('kiwi.boot.image.builtin_kiwi.Path.wipe')
+    @patch('kiwi.boot.image.builtin_kiwi.DataSync')
     @patch('kiwi.boot.image.base.BootImageBase.is_prepared')
-    @patch('kiwi.boot.image.kiwi.mkdtemp')
+    @patch('kiwi.boot.image.builtin_kiwi.mkdtemp')
     def test_create_initrd(
         self, mock_mkdtemp, mock_prepared, mock_sync,
         mock_wipe, mock_create, mock_compress, mock_cpio

--- a/test/unit/boot_image_test.py
+++ b/test/unit/boot_image_test.py
@@ -1,11 +1,10 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiBootImageSetupError
 from kiwi.boot.image import BootImage
 
 

--- a/test/unit/bootloader_config_base_test.py
+++ b/test/unit/bootloader_config_base_test.py
@@ -2,11 +2,11 @@ from mock import patch
 from mock import call
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
 from kiwi.xml_state import XMLState
 from kiwi.xml_description import XMLDescription
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiBootLoaderTargetError
 from kiwi.bootloader.config.base import BootLoaderConfigBase
 
 

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -1,4 +1,3 @@
-
 from mock import patch
 from mock import call
 
@@ -6,11 +5,21 @@ import mock
 
 import kiwi
 
-from .test_helper import *
+from .test_helper import raises, patch_open
 
 from kiwi.xml_state import XMLState
+
 from kiwi.xml_description import XMLDescription
-from kiwi.exceptions import *
+
+from kiwi.exceptions import (
+    KiwiBootLoaderGrubPlatformError,
+    KiwiBootLoaderGrubSecureBootError,
+    KiwiTemplateError,
+    KiwiBootLoaderGrubDataError,
+    KiwiBootLoaderGrubFontError,
+    KiwiBootLoaderGrubModulesError
+)
+
 from kiwi.bootloader.config.grub2 import BootLoaderConfigGrub2
 
 

--- a/test/unit/bootloader_config_isolinux_test.py
+++ b/test/unit/bootloader_config_isolinux_test.py
@@ -1,4 +1,3 @@
-
 from mock import patch
 from mock import call
 
@@ -6,11 +5,14 @@ import mock
 
 import kiwi
 
-from .test_helper import *
+from .test_helper import raises, patch_open
 
 from kiwi.xml_state import XMLState
 from kiwi.xml_description import XMLDescription
-from kiwi.exceptions import *
+from kiwi.exceptions import (
+    KiwiBootLoaderIsoLinuxPlatformError,
+    KiwiTemplateError
+)
 from kiwi.bootloader.config.isolinux import BootLoaderConfigIsoLinux
 
 

--- a/test/unit/bootloader_config_test.py
+++ b/test/unit/bootloader_config_test.py
@@ -1,11 +1,10 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiBootLoaderConfigSetupError
 from kiwi.bootloader.config import BootLoaderConfig
 
 

--- a/test/unit/bootloader_config_zipl_test.py
+++ b/test/unit/bootloader_config_zipl_test.py
@@ -1,18 +1,20 @@
-
 from mock import patch
-from mock import call
 
 import mock
 
 import kiwi
 
-from .test_helper import *
+from .test_helper import raises, patch_open
 
 from collections import namedtuple
 
-from kiwi.xml_state import XMLState
-from kiwi.xml_description import XMLDescription
-from kiwi.exceptions import *
+from kiwi.exceptions import (
+    KiwiBootLoaderZiplPlatformError,
+    KiwiBootLoaderZiplSetupError,
+    KiwiDiskGeometryError,
+    KiwiTemplateError
+)
+
 from kiwi.bootloader.config.zipl import BootLoaderConfigZipl
 
 

--- a/test/unit/bootloader_install_base_test.py
+++ b/test/unit/bootloader_install_base_test.py
@@ -1,11 +1,7 @@
-
-from mock import patch
-
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
-from kiwi.exceptions import *
 from kiwi.bootloader.install.base import BootLoaderInstallBase
 
 

--- a/test/unit/bootloader_install_grub2_test.py
+++ b/test/unit/bootloader_install_grub2_test.py
@@ -1,13 +1,18 @@
-
 from mock import patch
 from mock import call
 
 import mock
-import kiwi
-from .test_helper import *
 
-from kiwi.exceptions import *
+from .test_helper import raises
+
+from kiwi.exceptions import (
+    KiwiBootLoaderGrubInstallError,
+    KiwiBootLoaderGrubDataError,
+    KiwiBootLoaderGrubPlatformError
+)
+
 from kiwi.bootloader.install.grub2 import BootLoaderInstallGrub2
+
 from kiwi.defaults import Defaults
 
 

--- a/test/unit/bootloader_install_test.py
+++ b/test/unit/bootloader_install_test.py
@@ -3,9 +3,9 @@ from mock import patch
 
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiBootLoaderInstallSetupError
 from kiwi.bootloader.install import BootLoaderInstall
 
 

--- a/test/unit/bootloader_install_zipl_test.py
+++ b/test/unit/bootloader_install_zipl_test.py
@@ -1,12 +1,12 @@
-
 from mock import patch
 from mock import call
 
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiBootLoaderZiplInstallError
+
 from kiwi.bootloader.install.zipl import BootLoaderInstallZipl
 
 

--- a/test/unit/bootloader_template_grub2_test.py
+++ b/test/unit/bootloader_template_grub2_test.py
@@ -1,10 +1,3 @@
-
-from mock import patch
-
-import mock
-
-from .test_helper import *
-
 from kiwi.bootloader.template.grub2 import BootLoaderTemplateGrub2
 
 

--- a/test/unit/bootloader_template_isolinux_test.py
+++ b/test/unit/bootloader_template_isolinux_test.py
@@ -1,10 +1,3 @@
-
-from mock import patch
-
-import mock
-
-from .test_helper import *
-
 from kiwi.bootloader.template.isolinux import BootLoaderTemplateIsoLinux
 
 

--- a/test/unit/bootloader_template_zipl_test.py
+++ b/test/unit/bootloader_template_zipl_test.py
@@ -1,10 +1,3 @@
-
-from mock import patch
-
-import mock
-
-from .test_helper import *
-
 from kiwi.bootloader.template.zipl import BootLoaderTemplateZipl
 
 

--- a/test/unit/builder_archive_test.py
+++ b/test/unit/builder_archive_test.py
@@ -1,12 +1,11 @@
-
 from mock import patch
 
 import mock
 import kiwi
 
-from .test_helper import *
+from .test_helper import raises
 
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiArchiveSetupError
 from kiwi.builder.archive import ArchiveBuilder
 
 

--- a/test/unit/builder_container_test.py
+++ b/test/unit/builder_container_test.py
@@ -1,10 +1,7 @@
-
 from mock import patch
 from mock import call
 import mock
 import kiwi
-
-from .test_helper import *
 
 from kiwi.builder.container import ContainerBuilder
 

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -1,11 +1,19 @@
 import mock
 from mock import call
+from mock import patch
 
 import kiwi
 
-from .test_helper import *
+from .test_helper import raises, patch_open
+
 from collections import OrderedDict
-from kiwi.exceptions import *
+
+from kiwi.exceptions import (
+    KiwiDiskBootImageError,
+    KiwiInstallMediaError,
+    KiwiVolumeManagerSetupError
+)
+
 from kiwi.xml_description import XMLDescription
 from kiwi.xml_state import XMLState
 from kiwi.builder.disk import DiskBuilder

--- a/test/unit/builder_filesystem_test.py
+++ b/test/unit/builder_filesystem_test.py
@@ -1,12 +1,11 @@
-
 from mock import patch
 
 import mock
 import kiwi
 
-from .test_helper import *
+from .test_helper import raises
 
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiFileSystemSetupError
 from kiwi.builder.filesystem import FileSystemBuilder
 
 

--- a/test/unit/builder_install_test.py
+++ b/test/unit/builder_install_test.py
@@ -1,12 +1,13 @@
-
 from mock import patch
 from mock import call
+
 import mock
 import kiwi
 
-from .test_helper import *
+from .test_helper import raises, patch_open
 
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiInstallBootImageError
+
 from kiwi.builder.install import InstallImageBuilder
 
 

--- a/test/unit/builder_live_test.py
+++ b/test/unit/builder_live_test.py
@@ -1,12 +1,12 @@
-
 from mock import patch
 from mock import call
 import mock
 import kiwi
 
-from .test_helper import *
+from .test_helper import raises, patch_open
 
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiLiveBootImageError
+
 from kiwi.builder.live import LiveImageBuilder
 
 

--- a/test/unit/builder_pxe_test.py
+++ b/test/unit/builder_pxe_test.py
@@ -1,15 +1,14 @@
-
 from mock import patch
 
 import mock
 
 import kiwi
 
-from .test_helper import *
+from .test_helper import raises
 
 from collections import namedtuple
 
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiPxeBootImageError
 from kiwi.builder.pxe import PxeBuilder
 
 

--- a/test/unit/builder_test.py
+++ b/test/unit/builder_test.py
@@ -1,11 +1,11 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiRequestedTypeError
+
 from kiwi.builder import ImageBuilder
 
 

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -2,10 +2,15 @@ import sys
 
 from mock import patch
 
-from .test_helper import *
+from .test_helper import argv_kiwi_tests, raises
 
 from kiwi.cli import Cli
-from kiwi.exceptions import *
+from kiwi.exceptions import (
+    KiwiCompatError,
+    KiwiLoadCommandUndefined,
+    KiwiCommandNotLoaded,
+    KiwiUnknownServiceName
+)
 
 
 class TestCli(object):

--- a/test/unit/command_process_test.py
+++ b/test/unit/command_process_test.py
@@ -1,7 +1,8 @@
 from mock import call
+from mock import patch
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
 from kiwi.exceptions import KiwiCommandError
 from kiwi.command_process import CommandProcess

--- a/test/unit/command_test.py
+++ b/test/unit/command_test.py
@@ -1,4 +1,3 @@
-
 from mock import patch
 from collections import namedtuple
 
@@ -6,7 +5,7 @@ import mock
 
 import os
 
-from .test_helper import *
+from .test_helper import raises
 
 from kiwi.exceptions import (
     KiwiCommandError,
@@ -59,8 +58,8 @@ class TestCommand(object):
     def test_run_does_not_raise_error_if_command_not_found(self, mock_which):
         mock_which.return_value = None
         result = Command.run(['command', 'args'], os.environ, False)
-        assert result.error == None
-        assert result.output == None
+        assert result.error is None
+        assert result.output is None
         assert result.returncode == -1
 
     @patch('os.access')
@@ -101,13 +100,6 @@ class TestCommand(object):
         mock_select.return_value = [True, False, False]
         mock_process = mock.Mock()
         mock_popen.return_value = mock_process
-        command_call = namedtuple(
-            'command', [
-                'output', 'output_available',
-                'error', 'error_available',
-                'process'
-            ]
-        )
         call = Command.call(['command', 'args'])
         assert call.output_available()
         assert call.error_available()
@@ -118,7 +110,7 @@ class TestCommand(object):
     @raises(KiwiCommandError)
     @patch('kiwi.path.Path.which')
     @patch('subprocess.Popen')
-    def test_call_failure(self,mock_popen, mock_which):
+    def test_call_failure(self, mock_popen, mock_which):
         mock_which.return_value = 'command'
         mock_popen.side_effect = KiwiCommandError('Call failure')
-        call = Command.call(['command', 'args'])
+        Command.call(['command', 'args'])

--- a/test/unit/container_image_docker_test.py
+++ b/test/unit/container_image_docker_test.py
@@ -3,9 +3,6 @@ from mock import patch
 
 import mock
 
-from .test_helper import *
-
-from kiwi.exceptions import *
 from kiwi.container.docker import ContainerImageDocker
 
 
@@ -18,37 +15,37 @@ class TestContainerImageDocker(object):
         )
 
     def test_init_custom_args(self):
-        docker = ContainerImageDocker(
+        ContainerImageDocker(
             'root_dir', {
                 'container_name': 'foo',
                 'container_tag': '1.0',
                 'entry_command': [
                     "--config.entrypoint=/bin/bash",
                     "--config.entrypoint=-x"
-                 ],
+                ],
                 'entry_subcommand': [
                     "--config.cmd=ls",
                     "--config.cmd=-l"
-                 ],
-                 'maintainer': ['--author=tux'],
-                 'user': ['--config.user=root'],
-                 'workingdir': ['--config.workingdir=/root'],
-                 'expose_ports': [
-                     "--config.exposedports=80",
-                     "--config.exposedports=42"
-                 ],
-                 'volumes': [
-                     "--config.volume=/var/log",
-                     "--config.volume=/tmp"
-                 ],
-                 'environment': [
-                     "--config.env=PATH=/bin'",
-                     "--config.env=FOO=bar"
-                 ],
-                 'labels': [
-                     "--config.label=a=value",
-                     "--config.label=b=value"
-                 ]
+                ],
+                'maintainer': ['--author=tux'],
+                'user': ['--config.user=root'],
+                'workingdir': ['--config.workingdir=/root'],
+                'expose_ports': [
+                    "--config.exposedports=80",
+                    "--config.exposedports=42"
+                ],
+                'volumes': [
+                    "--config.volume=/var/log",
+                    "--config.volume=/tmp"
+                ],
+                'environment': [
+                    "--config.env=PATH=/bin'",
+                    "--config.env=FOO=bar"
+                ],
+                'labels': [
+                    "--config.label=a=value",
+                    "--config.label=b=value"
+                ]
             }
         )
 
@@ -110,8 +107,8 @@ class TestContainerImageDocker(object):
                 'umoci', 'gc', '--layout', 'kiwi_docker_dir/umoci_layout'
             ]),
             call([
-                 'skopeo', 'copy', 'oci:kiwi_docker_dir/umoci_layout:latest',
-                 'docker-archive:result.tar:foo/bar:latest'
+                'skopeo', 'copy', 'oci:kiwi_docker_dir/umoci_layout:latest',
+                'docker-archive:result.tar:foo/bar:latest'
             ])
         ]
         mock_sync.assert_called_once_with(

--- a/test/unit/container_image_test.py
+++ b/test/unit/container_image_test.py
@@ -1,11 +1,9 @@
-
 from mock import patch
 
-import mock
+from .test_helper import raises
 
-from .test_helper import *
+from kiwi.exceptions import KiwiContainerImageSetupError
 
-from kiwi.exceptions import *
 from kiwi.container import ContainerImage
 
 

--- a/test/unit/container_setup_base_test.py
+++ b/test/unit/container_setup_base_test.py
@@ -1,11 +1,10 @@
-
 from mock import patch
 from mock import call
 import mock
 
-from .test_helper import *
+from .test_helper import raises, patch_open
 
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiContainerSetupError
 from kiwi.container.setup.base import ContainerSetupBase
 
 

--- a/test/unit/container_setup_docker_test.py
+++ b/test/unit/container_setup_docker_test.py
@@ -1,13 +1,9 @@
-
 from mock import patch
 from mock import call
 import mock
 
-import kiwi
+from .test_helper import patch_open
 
-from .test_helper import *
-
-from kiwi.exceptions import *
 from kiwi.container.setup.docker import ContainerSetupDocker
 
 

--- a/test/unit/container_setup_test.py
+++ b/test/unit/container_setup_test.py
@@ -1,11 +1,9 @@
-
 from mock import patch
 
-import mock
+from .test_helper import raises
 
-from .test_helper import *
+from kiwi.exceptions import KiwiContainerSetupError
 
-from kiwi.exceptions import *
 from kiwi.container.setup import ContainerSetup
 
 

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -1,5 +1,4 @@
 import sys
-from mock import patch
 
 import mock
 

--- a/test/unit/filesystem_base_test.py
+++ b/test/unit/filesystem_base_test.py
@@ -3,9 +3,9 @@ from mock import patch
 
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiFileSystemSyncError
 from kiwi.filesystem.base import FileSystemBase
 
 

--- a/test/unit/filesystem_btrfs_test.py
+++ b/test/unit/filesystem_btrfs_test.py
@@ -1,11 +1,7 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
-
-from kiwi.exceptions import *
 from kiwi.filesystem.btrfs import FileSystemBtrfs
 
 

--- a/test/unit/filesystem_clicfs_test.py
+++ b/test/unit/filesystem_clicfs_test.py
@@ -1,11 +1,7 @@
-
 from mock import patch
 from mock import call
 import mock
 
-from .test_helper import *
-
-from kiwi.exceptions import *
 from kiwi.filesystem.clicfs import FileSystemClicFs
 
 

--- a/test/unit/filesystem_ext2_test.py
+++ b/test/unit/filesystem_ext2_test.py
@@ -1,11 +1,7 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
-
-from kiwi.exceptions import *
 from kiwi.filesystem.ext2 import FileSystemExt2
 
 

--- a/test/unit/filesystem_ext3_test.py
+++ b/test/unit/filesystem_ext3_test.py
@@ -1,11 +1,7 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
-
-from kiwi.exceptions import *
 from kiwi.filesystem.ext3 import FileSystemExt3
 
 

--- a/test/unit/filesystem_ext4_test.py
+++ b/test/unit/filesystem_ext4_test.py
@@ -1,11 +1,7 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
-
-from kiwi.exceptions import *
 from kiwi.filesystem.ext4 import FileSystemExt4
 
 

--- a/test/unit/filesystem_fat16_test.py
+++ b/test/unit/filesystem_fat16_test.py
@@ -1,11 +1,7 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
-
-from kiwi.exceptions import *
 from kiwi.filesystem.fat16 import FileSystemFat16
 
 

--- a/test/unit/filesystem_fat32_test.py
+++ b/test/unit/filesystem_fat32_test.py
@@ -1,11 +1,7 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
-
-from kiwi.exceptions import *
 from kiwi.filesystem.fat32 import FileSystemFat32
 
 

--- a/test/unit/filesystem_isofs_test.py
+++ b/test/unit/filesystem_isofs_test.py
@@ -1,11 +1,12 @@
-
 from mock import patch
 from mock import call
+
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiIsoToolError
+
 from kiwi.filesystem.isofs import FileSystemIsoFs
 
 

--- a/test/unit/filesystem_setup_test.py
+++ b/test/unit/filesystem_setup_test.py
@@ -1,11 +1,7 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
-
-from collections import namedtuple
 from kiwi.filesystem.setup import FileSystemSetup
 
 

--- a/test/unit/filesystem_squashfs_test.py
+++ b/test/unit/filesystem_squashfs_test.py
@@ -1,11 +1,7 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
-
-from kiwi.exceptions import *
 from kiwi.filesystem.squashfs import FileSystemSquashFs
 
 
@@ -30,7 +26,7 @@ class TestFileSystemSquashfs(object):
     @patch('platform.machine')
     @patch('kiwi.filesystem.squashfs.Command.run')
     def test_create_on_file_exclude_data(self, mock_command, mock_machine):
-        mock_machine.return_value = 'ppc64le' 
+        mock_machine.return_value = 'ppc64le'
         self.squashfs.create_on_file('myimage', 'label', ['foo'])
         mock_command.assert_called_once_with(
             [

--- a/test/unit/filesystem_test.py
+++ b/test/unit/filesystem_test.py
@@ -1,11 +1,10 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiFileSystemSetupError
 from kiwi.filesystem import FileSystem
 
 

--- a/test/unit/filesystem_xfs_test.py
+++ b/test/unit/filesystem_xfs_test.py
@@ -1,11 +1,7 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
-
-from kiwi.exceptions import *
 from kiwi.filesystem.xfs import FileSystemXfs
 
 

--- a/test/unit/firmware_test.py
+++ b/test/unit/firmware_test.py
@@ -1,11 +1,10 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiNotImplementedError
 from kiwi.firmware import FirmWare
 
 

--- a/test/unit/help_test.py
+++ b/test/unit/help_test.py
@@ -1,11 +1,10 @@
-import sys
-
 from mock import patch
 
-from .test_helper import *
+from .test_helper import raises
 
 from kiwi.help import Help
-from kiwi.exceptions import *
+
+from kiwi.exceptions import KiwiHelpNoCommandGiven
 
 
 class TestHelp(object):

--- a/test/unit/iso_test.py
+++ b/test/unit/iso_test.py
@@ -1,11 +1,15 @@
-from mock import call
+from mock import call, patch
 import mock
 import struct
-from .test_helper import *
+from .test_helper import raises, patch_open
 import sys
 from builtins import bytes
 
-from kiwi.exceptions import *
+from kiwi.exceptions import (
+    KiwiIsoLoaderError,
+    KiwiIsoToolError,
+    KiwiIsoMetaDataError
+)
 
 from kiwi.iso import Iso
 from collections import namedtuple
@@ -198,7 +202,6 @@ class TestIso(object):
         mock_command.return_value = output_type(output=output_data)
         result = self.iso.isols('some-iso')
         assert result[2158].name == 'header_end'
-
 
     def test_create_header_end_block(self):
         temp_file = NamedTemporaryFile()

--- a/test/unit/logger_test.py
+++ b/test/unit/logger_test.py
@@ -1,15 +1,21 @@
-
 from mock import patch
 from mock import call
 from collections import namedtuple
 
-from .test_helper import *
+from .test_helper import raises
 import logging
 
-from kiwi.logger import *
-from kiwi.exceptions import (
-    KiwiLogFileSetupFailed
+from kiwi.logger import (
+    LoggerSchedulerFilter,
+    ColorFormatter,
+    InfoFilter,
+    DebugFilter,
+    ErrorFilter,
+    WarningFilter,
+    log
 )
+
+from kiwi.exceptions import KiwiLogFileSetupFailed
 
 
 class TestLoggerSchedulerFilter(object):

--- a/test/unit/mount_manager_test.py
+++ b/test/unit/mount_manager_test.py
@@ -1,11 +1,7 @@
-
 from mock import patch
 from mock import call
 import mock
 
-from .test_helper import *
-
-from kiwi.exceptions import *
 from kiwi.mount_manager import MountManager
 
 

--- a/test/unit/package_manager_apt_test.py
+++ b/test/unit/package_manager_apt_test.py
@@ -1,10 +1,8 @@
-
 from mock import patch
 from mock import call
 import mock
-import re
 
-from .test_helper import *
+from .test_helper import raises
 
 from kiwi.package_manager.apt import PackageManagerApt
 from kiwi.exceptions import KiwiDebootstrapError
@@ -105,7 +103,7 @@ class TestPackageManagerApt(object):
                 ['env']),
             call([
                 'bash', '-c',
-                'rm -r -f root-dir.debootstrap &&' + \
+                'rm -r -f root-dir.debootstrap &&' +
                 ' chroot root-dir apt-get root-moved-arguments update'],
                 ['env'])
         ]
@@ -120,7 +118,7 @@ class TestPackageManagerApt(object):
     def test_process_install_requests(self, mock_run, mock_call):
         self.manager.request_package('vim')
         self.manager.process_install_requests()
-        chroot_apt_get_args = self.manager.root_bind.move_to_root(
+        self.manager.root_bind.move_to_root(
             self.manager.apt_get_args
         )
         mock_call.assert_called_once_with([
@@ -143,7 +141,7 @@ class TestPackageManagerApt(object):
     @patch('kiwi.command.Command.call')
     def test_update(self, mock_call):
         self.manager.update()
-        chroot_apt_get_args = self.manager.root_bind.move_to_root(
+        self.manager.root_bind.move_to_root(
             self.manager.apt_get_args
         )
         mock_call.assert_called_once_with([

--- a/test/unit/package_manager_base_test.py
+++ b/test/unit/package_manager_base_test.py
@@ -1,9 +1,6 @@
-
-from mock import patch
-
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
 from kiwi.package_manager.base import PackageManagerBase
 

--- a/test/unit/package_manager_dnf_test.py
+++ b/test/unit/package_manager_dnf_test.py
@@ -1,8 +1,6 @@
-
 from mock import patch
 
 import mock
-import re
 
 from .test_helper import raises
 
@@ -71,7 +69,7 @@ class TestPackageManagerDnf(object):
         self.manager.request_package('vim')
         self.manager.request_collection('collection')
         self.manager.process_install_requests()
-        chroot_dnf_args = self.manager.root_bind.move_to_root(
+        self.manager.root_bind.move_to_root(
             self.manager.dnf_args
         )
         mock_run.assert_called_once_with(
@@ -117,7 +115,7 @@ class TestPackageManagerDnf(object):
     @patch('kiwi.command.Command.call')
     def test_update(self, mock_call):
         self.manager.update()
-        chroot_dnf_args = self.manager.root_bind.move_to_root(
+        self.manager.root_bind.move_to_root(
             self.manager.dnf_args
         )
         mock_call.assert_called_once_with(

--- a/test/unit/package_manager_test.py
+++ b/test/unit/package_manager_test.py
@@ -1,12 +1,12 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
 from kiwi.package_manager import PackageManager
-from kiwi.exceptions import *
+
+from kiwi.exceptions import KiwiPackageManagerSetupError
 
 
 class TestPackageManager(object):

--- a/test/unit/package_manager_yum_test.py
+++ b/test/unit/package_manager_yum_test.py
@@ -1,13 +1,12 @@
-
 from mock import patch
 
 import mock
-import re
 
-from .test_helper import *
+from .test_helper import raises
 
 from kiwi.package_manager.yum import PackageManagerYum
-from kiwi.exceptions import *
+
+from kiwi.exceptions import KiwiRequestError
 
 
 class TestPackageManagerYum(object):
@@ -71,7 +70,7 @@ class TestPackageManagerYum(object):
         self.manager.request_package('vim')
         self.manager.request_collection('collection')
         self.manager.process_install_requests()
-        chroot_yum_args = self.manager.root_bind.move_to_root(
+        self.manager.root_bind.move_to_root(
             self.manager.yum_args
         )
         mock_run.assert_called_once_with(
@@ -117,7 +116,7 @@ class TestPackageManagerYum(object):
     @patch('kiwi.command.Command.call')
     def test_update(self, mock_call):
         self.manager.update()
-        chroot_yum_args = self.manager.root_bind.move_to_root(
+        self.manager.root_bind.move_to_root(
             self.manager.yum_args
         )
         mock_call.assert_called_once_with(

--- a/test/unit/package_manager_zypper_test.py
+++ b/test/unit/package_manager_zypper_test.py
@@ -1,13 +1,14 @@
-
 from mock import patch
 
 import mock
-import re
 
-from .test_helper import *
+from .test_helper import raises
 
 from kiwi.package_manager.zypper import PackageManagerZypper
-from kiwi.exceptions import *
+from kiwi.exceptions import (
+    KiwiRequestError,
+    KiwiRpmDatabaseReloadError
+)
 
 
 class TestPackageManagerZypper(object):
@@ -36,10 +37,9 @@ class TestPackageManagerZypper(object):
             self.manager.zypper_args
         )
         self.chroot_command_env = self.manager.command_env
+        zypp_conf = self.manager.command_env['ZYPP_CONF']
         self.chroot_command_env['ZYPP_CONF'] = \
-            self.manager.root_bind.move_to_root(
-                [self.manager.command_env['ZYPP_CONF']]
-            )[0]
+            self.manager.root_bind.move_to_root(zypp_conf)[0]
 
     def test_request_package(self):
         self.manager.request_package('name')

--- a/test/unit/partitioner_base_test.py
+++ b/test/unit/partitioner_base_test.py
@@ -1,12 +1,8 @@
-
-from mock import patch
-
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
 from kiwi.partitioner.base import PartitionerBase
-from kiwi.exceptions import *
 
 
 class TestPartitionerBase(object):

--- a/test/unit/partitioner_dasd_test.py
+++ b/test/unit/partitioner_dasd_test.py
@@ -1,13 +1,10 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
+from .test_helper import patch_open
 
-from collections import namedtuple
 from kiwi.partitioner.dasd import PartitionerDasd
-from kiwi.exceptions import *
 
 
 class TestPartitionerDasd(object):

--- a/test/unit/partitioner_gpt_test.py
+++ b/test/unit/partitioner_gpt_test.py
@@ -1,4 +1,3 @@
-
 from mock import patch, call
 
 import mock
@@ -6,7 +5,7 @@ import mock
 from .test_helper import raises
 
 from kiwi.partitioner.gpt import PartitionerGpt
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiPartitionerGptFlagError
 
 
 class TestPartitionerGpt(object):
@@ -78,4 +77,3 @@ class TestPartitionerGpt(object):
             call(['sgdisk', '-m', '1:2:3:4', '/dev/loop0']),
             call(['sgdisk', '-t', '4:8300', '/dev/loop0'])
         ]
-      

--- a/test/unit/partitioner_msdos_test.py
+++ b/test/unit/partitioner_msdos_test.py
@@ -1,13 +1,14 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
+from .test_helper import patch_open, raises
 
 from collections import namedtuple
+
 from kiwi.partitioner.msdos import PartitionerMsDos
-from kiwi.exceptions import *
+
+from kiwi.exceptions import KiwiPartitionerMsDosFlagError
 
 
 class TestPartitionerMsDos(object):

--- a/test/unit/partitioner_test.py
+++ b/test/unit/partitioner_test.py
@@ -1,12 +1,12 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
 from kiwi.partitioner import Partitioner
-from kiwi.exceptions import *
+
+from kiwi.exceptions import KiwiPartitionerSetupError
 
 
 class TestPartitioner(object):

--- a/test/unit/path_test.py
+++ b/test/unit/path_test.py
@@ -1,11 +1,7 @@
 from mock import patch
 
-import mock
 import os
 
-from .test_helper import *
-
-from kiwi.exceptions import *
 from kiwi.path import Path
 
 
@@ -59,7 +55,7 @@ class TestPath(object):
             'alternative/some-file'
         mock_access.return_value = False
         mock_env.return_value = '/usr/local/bin:/usr/bin:/bin'
-        assert Path.which('some-file', access_mode=os.X_OK) == None
+        assert Path.which('some-file', access_mode=os.X_OK) is None
         mock_access.return_value = True
         assert Path.which('some-file', access_mode=os.X_OK) == \
             '/usr/local/bin/some-file'

--- a/test/unit/privileges_test.py
+++ b/test/unit/privileges_test.py
@@ -1,11 +1,8 @@
-
 from mock import patch
 
-import mock
+from .test_helper import raises
 
-from .test_helper import *
-
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiPrivilegesError
 from kiwi.privileges import Privileges
 
 

--- a/test/unit/repository_apt_test.py
+++ b/test/unit/repository_apt_test.py
@@ -1,13 +1,10 @@
-
 from mock import patch
-from mock import call
 
 import mock
 
-from .test_helper import *
+from .test_helper import patch_open
 
 from kiwi.repository.apt import RepositoryApt
-from kiwi.system.root_bind import RootBind
 
 
 class TestRepositoryApt(object):

--- a/test/unit/repository_base_test.py
+++ b/test/unit/repository_base_test.py
@@ -1,17 +1,8 @@
-
-from mock import patch
-
 import mock
 
-from .test_helper import *
-
-from kiwi.exceptions import (
-    KiwiUriStyleUnknown,
-    KiwiUriTypeUnknown
-)
+from .test_helper import raises
 
 from kiwi.repository.base import RepositoryBase
-from kiwi.system.root_bind import RootBind
 
 
 class TestRepositoryBase(object):

--- a/test/unit/repository_dnf_test.py
+++ b/test/unit/repository_dnf_test.py
@@ -7,7 +7,6 @@ from .test_helper import patch_open
 import mock
 
 from kiwi.repository.dnf import RepositoryDnf
-from kiwi.system.root_bind import RootBind
 
 
 class TestRepositoryDnf(object):

--- a/test/unit/repository_template_apt_test.py
+++ b/test/unit/repository_template_apt_test.py
@@ -1,10 +1,3 @@
-
-from mock import patch
-
-import mock
-
-from .test_helper import *
-
 from kiwi.repository.template.apt import PackageManagerTemplateAptGet
 
 

--- a/test/unit/repository_test.py
+++ b/test/unit/repository_test.py
@@ -1,12 +1,12 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
 from kiwi.repository import Repository
-from kiwi.exceptions import *
+
+from kiwi.exceptions import KiwiRepositorySetupError
 
 
 class TestRepository(object):

--- a/test/unit/repository_yum_test.py
+++ b/test/unit/repository_yum_test.py
@@ -1,13 +1,11 @@
-
 from mock import patch
 from mock import call
 
 import mock
 
-from .test_helper import *
+from .test_helper import patch_open
 
 from kiwi.repository.yum import RepositoryYum
-from kiwi.system.root_bind import RootBind
 
 
 class TestRepositoryYum(object):

--- a/test/unit/repository_zypper_test.py
+++ b/test/unit/repository_zypper_test.py
@@ -1,18 +1,16 @@
-
 from mock import patch
 from mock import call
 
 import mock
 import os
 
-from .test_helper import *
+from .test_helper import raises, patch_open
 
 from kiwi.exceptions import (
     KiwiRepoTypeUnknown
 )
 
 from kiwi.repository.zypper import RepositoryZypper
-from kiwi.system.root_bind import RootBind
 
 
 class TestRepositoryZypper(object):

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -1,14 +1,11 @@
-import sys
-import os
-
 from mock import patch
 
-from .test_helper import *
+from .test_helper import raises
 
 from kiwi.xml_state import XMLState
 from kiwi.xml_description import XMLDescription
 from kiwi.runtime_checker import RuntimeChecker
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiRuntimeError
 
 
 class TestRuntimeChecker(object):

--- a/test/unit/shell_test.py
+++ b/test/unit/shell_test.py
@@ -1,12 +1,7 @@
-
 from mock import patch
 
-import mock
-
-from .test_helper import *
-
-from kiwi.exceptions import *
 from kiwi.system.shell import Shell
+
 from kiwi.defaults import Defaults
 
 

--- a/test/unit/solver_repository_rpm_dir_test.py
+++ b/test/unit/solver_repository_rpm_dir_test.py
@@ -1,4 +1,4 @@
-from mock import patch, call
+from mock import patch
 
 import mock
 

--- a/test/unit/solver_repository_rpm_md_test.py
+++ b/test/unit/solver_repository_rpm_md_test.py
@@ -4,8 +4,6 @@ import mock
 
 from lxml import etree
 
-from .test_helper import raises
-
 from kiwi.solver.repository.rpm_md import SolverRepositoryRpmMd
 from kiwi.solver.repository.base import SolverRepositoryBase
 

--- a/test/unit/solver_repository_suse_test.py
+++ b/test/unit/solver_repository_suse_test.py
@@ -1,10 +1,8 @@
-from mock import patch, call
+from mock import patch
 
 import mock
 
 from lxml import etree
-
-from .test_helper import raises
 
 from kiwi.solver.repository.suse import SolverRepositorySUSE
 from kiwi.solver.repository.base import SolverRepositoryBase

--- a/test/unit/solver_sat_test.py
+++ b/test/unit/solver_sat_test.py
@@ -30,9 +30,7 @@ class TestSat(object):
         self.sat.pool.select = mock.Mock(
             return_value=self.selection
         )
-        assert mock_import_module.call_args_list == [
-            call('solv'), call('solv', 'Pool'), call('solv', 'Selection')
-        ]
+        mock_import_module.assert_called_once_with('solv')
 
     @patch('importlib.import_module')
     @raises(KiwiSatSolverPluginError)

--- a/test/unit/storage_device_provider_test.py
+++ b/test/unit/storage_device_provider_test.py
@@ -1,11 +1,11 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiDeviceProviderError
+
 from kiwi.storage.device_provider import DeviceProvider
 
 

--- a/test/unit/storage_disk_test.py
+++ b/test/unit/storage_disk_test.py
@@ -1,11 +1,9 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
+from .test_helper import patch_open
 
-from kiwi.exceptions import *
 from kiwi.storage.disk import Disk
 
 
@@ -132,14 +130,14 @@ class TestDisk(object):
         assert self.disk.public_partition_id_map['kiwi_PrepPart'] == 1
 
     @patch('kiwi.storage.disk.Command.run')
-    def test_device_map_loop(self, mock_command):
+    def test_device_map_efi_partition(self, mock_command):
         self.disk.create_efi_partition(100)
         self.disk.map_partitions()
         assert self.disk.partition_map == {'efi': '/dev/mapper/loop0p1'}
         self.disk.is_mapped = False
 
     @patch('kiwi.storage.disk.Command.run')
-    def test_device_map_loop(self, mock_command):
+    def test_device_map_prep_partition(self, mock_command):
         self.disk.create_prep_partition(8)
         self.disk.map_partitions()
         assert self.disk.partition_map == {'prep': '/dev/mapper/loop0p1'}

--- a/test/unit/storage_loop_device_test.py
+++ b/test/unit/storage_loop_device_test.py
@@ -1,11 +1,9 @@
-
 from mock import patch
 
-import mock
+from .test_helper import raises
 
-from .test_helper import *
+from kiwi.exceptions import KiwiLoopSetupError
 
-from kiwi.exceptions import *
 from kiwi.storage.loop_device import LoopDevice
 
 

--- a/test/unit/storage_luks_device_test.py
+++ b/test/unit/storage_luks_device_test.py
@@ -1,11 +1,10 @@
-
 from mock import patch
 from mock import call
 import mock
 
-from .test_helper import *
+from .test_helper import raises, patch_open
 
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiLuksSetupError
 from kiwi.storage.luks_device import LuksDevice
 
 

--- a/test/unit/storage_mapped_device_test.py
+++ b/test/unit/storage_mapped_device_test.py
@@ -3,9 +3,9 @@ from mock import patch
 
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiMappedDeviceError
 from kiwi.storage.mapped_device import MappedDevice
 
 

--- a/test/unit/storage_raid_device_test.py
+++ b/test/unit/storage_raid_device_test.py
@@ -1,11 +1,10 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
+from .test_helper import raises, patch_open
 
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiRaidSetupError
 from kiwi.storage.raid_device import RaidDevice
 
 

--- a/test/unit/storage_setup_test.py
+++ b/test/unit/storage_setup_test.py
@@ -1,17 +1,14 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
-
 import kiwi
 
-from kiwi.exceptions import *
 from kiwi.storage.setup import DiskSetup
 from kiwi.xml_state import XMLState
 from kiwi.xml_description import XMLDescription
 from kiwi.defaults import Defaults
+
 
 class TestDiskSetup(object):
     @patch('platform.machine')

--- a/test/unit/storage_subformat_base_test.py
+++ b/test/unit/storage_subformat_base_test.py
@@ -1,11 +1,14 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
-from kiwi.exceptions import *
+from kiwi.exceptions import (
+    KiwiFormatSetupError,
+    KiwiResizeRawDiskError
+)
+
 from kiwi.storage.subformat.base import DiskFormatBase
 
 
@@ -73,7 +76,7 @@ class TestDiskFormatBase(object):
     @patch('kiwi.storage.subformat.base.Command.run')
     def test_resize_raw_disk(self, mock_command, mock_getsize):
         mock_getsize.return_value = 42
-        assert self.disk_format.resize_raw_disk(1024) == True
+        assert self.disk_format.resize_raw_disk(1024) is True
         mock_command.assert_called_once_with(
             [
                 'qemu-img', 'resize',
@@ -84,12 +87,12 @@ class TestDiskFormatBase(object):
     @patch('os.path.getsize')
     def test_resize_raw_disk_same_size(self, mock_getsize):
         mock_getsize.return_value = 42
-        assert self.disk_format.resize_raw_disk(42) == False
+        assert self.disk_format.resize_raw_disk(42) is False
 
     @patch('os.path.exists')
     def test_has_raw_disk(self, mock_exists):
         mock_exists.return_value = True
-        assert self.disk_format.has_raw_disk() == True
+        assert self.disk_format.has_raw_disk() is True
         mock_exists.assert_called_once_with(
             'target_dir/some-disk-image.x86_64-1.2.3.raw'
         )

--- a/test/unit/storage_subformat_gce_test.py
+++ b/test/unit/storage_subformat_gce_test.py
@@ -1,11 +1,9 @@
-
 from mock import patch
 from mock import call
 import mock
 
-from .test_helper import *
+from .test_helper import patch_open
 
-from kiwi.exceptions import *
 from kiwi.storage.subformat.gce import DiskFormatGce
 
 

--- a/test/unit/storage_subformat_qcow2_test.py
+++ b/test/unit/storage_subformat_qcow2_test.py
@@ -1,11 +1,7 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
-
-from kiwi.exceptions import *
 from kiwi.storage.subformat.qcow2 import DiskFormatQcow2
 
 

--- a/test/unit/storage_subformat_template_vmware_settings_test.py
+++ b/test/unit/storage_subformat_template_vmware_settings_test.py
@@ -1,9 +1,3 @@
-from mock import patch
-
-import mock
-
-from .test_helper import *
-
 from kiwi.storage.subformat.template.vmware_settings import (
     VmwareSettingsTemplate
 )

--- a/test/unit/storage_subformat_test.py
+++ b/test/unit/storage_subformat_test.py
@@ -1,11 +1,11 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiDiskFormatSetupError
+
 from kiwi.storage.subformat import DiskFormat
 
 

--- a/test/unit/storage_subformat_vdi_test.py
+++ b/test/unit/storage_subformat_vdi_test.py
@@ -1,11 +1,7 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
-
-from kiwi.exceptions import *
 from kiwi.storage.subformat.vdi import DiskFormatVdi
 
 

--- a/test/unit/storage_subformat_vhd_test.py
+++ b/test/unit/storage_subformat_vhd_test.py
@@ -1,11 +1,7 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
-
-from kiwi.exceptions import *
 from kiwi.storage.subformat.vhd import DiskFormatVhd
 
 

--- a/test/unit/storage_subformat_vhdfixed_test.py
+++ b/test/unit/storage_subformat_vhdfixed_test.py
@@ -1,9 +1,14 @@
+import sys
+
 from mock import call
+from mock import patch
+
 import mock
 
-from .test_helper import *
+from .test_helper import raises, patch_open
 
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiVhdTagError
+
 from kiwi.storage.subformat.vhdfixed import DiskFormatVhdFixed
 
 from builtins import bytes

--- a/test/unit/storage_subformat_vmdk_test.py
+++ b/test/unit/storage_subformat_vmdk_test.py
@@ -1,14 +1,17 @@
-
 from mock import patch
 from mock import call
 import mock
 import os
 
-from .test_helper import *
+from .test_helper import raises, patch_open
 
 from textwrap import dedent
 
-from kiwi.exceptions import *
+from kiwi.exceptions import (
+    KiwiVmdkToolsError,
+    KiwiTemplateError
+)
+
 from kiwi.storage.subformat.vmdk import DiskFormatVmdk
 
 from builtins import bytes

--- a/test/unit/system_identifier_test.py
+++ b/test/unit/system_identifier_test.py
@@ -1,9 +1,8 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
+from .test_helper import patch_open
 
 from kiwi.system.identifier import SystemIdentifier
 

--- a/test/unit/system_prepare_test.py
+++ b/test/unit/system_prepare_test.py
@@ -1,9 +1,8 @@
-
 from mock import patch
 from mock import call
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
 from kiwi.exceptions import (
     KiwiBootStrapPhaseFailed,
@@ -13,12 +12,9 @@ from kiwi.exceptions import (
     KiwiInstallPhaseFailed
 )
 
-import kiwi
-
 from kiwi.system.prepare import SystemPrepare
 from kiwi.xml_description import XMLDescription
 from kiwi.xml_state import XMLState
-from kiwi.command import Command
 
 
 class TestSystemPrepare(object):

--- a/test/unit/system_profile_test.py
+++ b/test/unit/system_profile_test.py
@@ -1,15 +1,7 @@
-
 from mock import patch
 
 import mock
 import os
-
-from .test_helper import *
-
-from kiwi.exceptions import (
-    KiwiUriStyleUnknown,
-    KiwiUriTypeUnknown
-)
 
 from kiwi.system.profile import Profile
 from kiwi.xml_state import XMLState

--- a/test/unit/system_result_test.py
+++ b/test/unit/system_result_test.py
@@ -1,12 +1,11 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
+from .test_helper import patch_open, raises
 
 from kiwi.system.result import Result
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiResultError
 
 
 class TestResult(object):

--- a/test/unit/system_root_bind_test.py
+++ b/test/unit/system_root_bind_test.py
@@ -1,9 +1,8 @@
-
 from mock import patch
 from mock import call
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
 from kiwi.exceptions import (
     KiwiMountKernelFileSystemsError,
@@ -12,8 +11,6 @@ from kiwi.exceptions import (
 )
 
 from kiwi.system.root_bind import RootBind
-
-from kiwi.exceptions import *
 
 
 class TestRootBind(object):
@@ -129,7 +126,7 @@ class TestRootBind(object):
         self.mount_manager.umount_lazy.assert_called_once_with()
         mock_remove_hierarchy.assert_called_once_with('root-dir/mountpoint')
         mock_command.assert_called_once_with(
-           ['rm', '-f', 'root-dir/foo.kiwi', 'root-dir/foo']
+            ['rm', '-f', 'root-dir/foo.kiwi', 'root-dir/foo']
         )
         mock_move.assert_called_once_with(
             'root-dir/foo.rpmnew', 'root-dir/foo'

--- a/test/unit/system_root_init_test.py
+++ b/test/unit/system_root_init_test.py
@@ -2,7 +2,7 @@ from mock import patch
 from mock import call
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
 from kiwi.exceptions import (
     KiwiRootDirExists,
@@ -116,7 +116,7 @@ class TestRootInit(object):
             ]),
             call([
                 'cp',
-                 '/var/adm/fillup-templates/passwd.aaa_base',
+                '/var/adm/fillup-templates/passwd.aaa_base',
                 'tmpdir/etc/passwd'
             ]),
             call([

--- a/test/unit/system_setup_test.py
+++ b/test/unit/system_setup_test.py
@@ -4,13 +4,16 @@ from mock import call
 
 import mock
 
-from .test_helper import *
+from .test_helper import raises, patch_open
 from collections import namedtuple
 
 from kiwi.system.setup import SystemSetup
 from kiwi.xml_description import XMLDescription
 from kiwi.xml_state import XMLState
-from kiwi.exceptions import *
+from kiwi.exceptions import (
+    KiwiScriptFailed,
+    KiwiImportDescriptionError
+)
 from kiwi.defaults import Defaults
 
 
@@ -302,15 +305,15 @@ class TestSystemSetup(object):
         calls = [
             call('users'),
             call('kiwi'),
-            call('admin') 
-        ] 
+            call('admin')
+        ]
         users.group_exists.assert_has_calls(calls)
 
         calls = [
             call('users', []),
             call('kiwi', []),
-            call('admin', []) 
-        ] 
+            call('admin', [])
+        ]
         users.group_add.assert_has_calls(calls)
 
     @patch('kiwi.system.setup.Users')
@@ -329,7 +332,7 @@ class TestSystemSetup(object):
             call('root'),
             call('tux'),
             call('kiwi')
-        ] 
+        ]
         users.user_exists.assert_has_calls(calls)
 
         calls = [
@@ -344,7 +347,7 @@ class TestSystemSetup(object):
             call(
                 'tux', [
                     '-p', 'password-hash',
-                    '-g', 'users', 
+                    '-g', 'users',
                     '-m', '-d', '/home/tux'
                 ]
             ),

--- a/test/unit/system_size_test.py
+++ b/test/unit/system_size_test.py
@@ -1,11 +1,7 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
-
-from collections import namedtuple
 from kiwi.system.size import SystemSize
 
 

--- a/test/unit/system_uri_test.py
+++ b/test/unit/system_uri_test.py
@@ -2,9 +2,13 @@ from mock import patch
 
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
-from kiwi.exceptions import *
+from kiwi.exceptions import (
+    KiwiUriStyleUnknown,
+    KiwiUriTypeUnknown
+)
+
 from kiwi.system.uri import Uri
 
 import hashlib
@@ -135,7 +139,7 @@ class TestUri(object):
         )
         mock_manager.return_value = manager
         uri = Uri('iso:///image/CDs/openSUSE-13.2-DVD-x86_64.iso', 'yast2')
-        result = uri.translate()
+        uri.translate()
         uri.__del__()
         manager.umount.assert_called_once_with()
         mock_wipe.assert_called_once_with(manager.mountpoint)

--- a/test/unit/tasks_base_test.py
+++ b/test/unit/tasks_base_test.py
@@ -1,9 +1,7 @@
-import mock
-
 from mock import patch
 
 import logging
-from .test_helper import raises, argv_kiwi_tests
+from .test_helper import raises
 
 from kiwi.tasks.base import CliTask
 from kiwi.exceptions import KiwiConfigFileNotFound

--- a/test/unit/tasks_image_info_test.py
+++ b/test/unit/tasks_image_info_test.py
@@ -1,9 +1,14 @@
 import sys
 import mock
+
 from mock import patch, call
+
 import kiwi
-from .test_helper import patch, argv_kiwi_tests
+
+from .test_helper import argv_kiwi_tests
+
 from kiwi.tasks.image_info import ImageInfoTask
+
 from collections import namedtuple
 
 

--- a/test/unit/tasks_result_bundle_test.py
+++ b/test/unit/tasks_result_bundle_test.py
@@ -2,11 +2,11 @@ import sys
 import mock
 
 from mock import patch
-from mock import call
+
 import kiwi
 
-from .test_helper import patch, raises, argv_kiwi_tests, patch_open
-from kiwi.exceptions import *
+from .test_helper import raises, argv_kiwi_tests, patch_open
+from kiwi.exceptions import KiwiBundleError
 from kiwi.tasks.result_bundle import ResultBundleTask
 from kiwi.system.result import Result
 

--- a/test/unit/tasks_result_list_test.py
+++ b/test/unit/tasks_result_list_test.py
@@ -5,8 +5,7 @@ from mock import patch
 
 import kiwi
 
-from .test_helper import patch, argv_kiwi_tests
-from kiwi.exceptions import *
+from .test_helper import argv_kiwi_tests
 from kiwi.tasks.result_list import ResultListTask
 
 

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -5,10 +5,9 @@ from mock import patch
 
 import kiwi
 
-from .test_helper import patch, argv_kiwi_tests
+from .test_helper import argv_kiwi_tests
 
 from kiwi.tasks.system_build import SystemBuildTask
-from kiwi.exceptions import *
 
 
 class TestSystemBuildTask(object):

--- a/test/unit/tasks_system_create_test.py
+++ b/test/unit/tasks_system_create_test.py
@@ -1,14 +1,11 @@
 import sys
 import mock
 
-from mock import patch
-
 import kiwi
 
-from .test_helper import patch, argv_kiwi_tests
+from .test_helper import argv_kiwi_tests
 
 from kiwi.tasks.system_create import SystemCreateTask
-from kiwi.exceptions import *
 
 
 class TestSystemCreateTask(object):

--- a/test/unit/tasks_system_prepare_test.py
+++ b/test/unit/tasks_system_prepare_test.py
@@ -5,7 +5,7 @@ from mock import patch
 
 import kiwi
 
-from .test_helper import patch, argv_kiwi_tests
+from .test_helper import argv_kiwi_tests
 
 from kiwi.tasks.system_prepare import SystemPrepareTask
 
@@ -33,7 +33,7 @@ class TestSystemPrepareTask(object):
         self.system_prepare.setup_repositories = mock.Mock(
             return_value=self.manager
         )
-        
+
         self.setup = mock.Mock()
         kiwi.tasks.system_prepare.SystemSetup = mock.Mock(
             return_value=self.setup

--- a/test/unit/tasks_system_update_test.py
+++ b/test/unit/tasks_system_update_test.py
@@ -1,11 +1,9 @@
 import sys
 import mock
 
-from mock import patch
-
 import kiwi
 
-from .test_helper import patch, argv_kiwi_tests
+from .test_helper import argv_kiwi_tests
 
 from kiwi.tasks.system_update import SystemUpdateTask
 

--- a/test/unit/test_helper.py
+++ b/test/unit/test_helper.py
@@ -46,6 +46,7 @@ class raises(object):
         newfunc = wraps(func)(newfunc)
         return newfunc
 
+
 def mock_open(data=None):
     '''
     Mock "open" function.

--- a/test/unit/users_test.py
+++ b/test/unit/users_test.py
@@ -1,9 +1,4 @@
-
 from mock import patch
-
-import mock
-
-from .test_helper import *
 
 from kiwi.system.users import Users
 

--- a/test/unit/utils_block_test.py
+++ b/test/unit/utils_block_test.py
@@ -1,9 +1,5 @@
 from mock import patch
 
-import mock
-
-from .test_helper import *
-
 from kiwi.utils.block import BlockID
 
 

--- a/test/unit/utils_checksum_test.py
+++ b/test/unit/utils_checksum_test.py
@@ -1,9 +1,10 @@
 from mock import call
+from mock import patch
 import mock
 
-from .test_helper import *
+from .test_helper import raises, patch_open
 
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiFileNotFound
 from kiwi.utils.checksum import Checksum
 
 from builtins import bytes

--- a/test/unit/utils_compress_test.py
+++ b/test/unit/utils_compress_test.py
@@ -1,12 +1,14 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
 from kiwi.utils.compress import Compress
-from kiwi.exceptions import *
+from kiwi.exceptions import (
+    KiwiFileNotFound,
+    KiwiCompressionFormatUnknown
+)
 
 
 class TestCompress(object):

--- a/test/unit/utils_output_test.py
+++ b/test/unit/utils_output_test.py
@@ -1,7 +1,5 @@
-import sys
 from mock import patch
 from kiwi.utils.output import DataOutput
-from kiwi.logger import log
 import json
 import mock
 

--- a/test/unit/utils_sync_test.py
+++ b/test/unit/utils_sync_test.py
@@ -1,11 +1,5 @@
-
 from mock import patch
 
-import mock
-
-from .test_helper import *
-
-from kiwi.exceptions import *
 from kiwi.utils.sync import DataSync
 
 
@@ -38,7 +32,7 @@ class TestDataSync(object):
         )
 
     @patch('xattr.getxattr')
-    def test_target_supports_extended_attributes(self, mock_getxattr):
+    def test_target_does_not_support_extended_attributes(self, mock_getxattr):
         mock_getxattr.side_effect = OSError(
             """[Errno 95] Operation not supported: b'/boot/efi"""
         )

--- a/test/unit/utils_sysconfig_test.py
+++ b/test/unit/utils_sysconfig_test.py
@@ -1,4 +1,3 @@
-from mock import patch
 from mock import call
 
 import mock

--- a/test/unit/volume_manager_base_test.py
+++ b/test/unit/volume_manager_base_test.py
@@ -1,12 +1,11 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
 from collections import namedtuple
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiVolumeManagerSetupError
 from kiwi.volume_manager.base import VolumeManagerBase
 
 

--- a/test/unit/volume_manager_btrfs_test.py
+++ b/test/unit/volume_manager_btrfs_test.py
@@ -1,7 +1,6 @@
 from mock import patch
 from mock import call
 import mock
-import os
 
 import datetime
 
@@ -10,7 +9,7 @@ from lxml import etree
 from xml.dom import minidom
 from collections import namedtuple
 
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiVolumeRootIDError
 from kiwi.volume_manager.btrfs import VolumeManagerBtrfs
 
 
@@ -180,7 +179,7 @@ class TestVolumeManagerBtrfs(object):
                 'tmpdir/@/', self.volume_type(
                     name='myvol', size='size:500', realpath='/data',
                     mountpoint='LVdata', fullsize=False, attributes=[])
-                ),
+            ),
             call('tmpdir/@/', self.volume_type(
                 name='LVetc', size='freespace:200', realpath='/etc',
                 mountpoint='/etc', fullsize=False, attributes=[])
@@ -205,8 +204,8 @@ class TestVolumeManagerBtrfs(object):
         ]
         assert mock_mount.call_args_list == [
             call(
-               device='/dev/storage',
-               mountpoint='tmpdir/@/.snapshots/1/snapshot/data'
+                device='/dev/storage',
+                mountpoint='tmpdir/@/.snapshots/1/snapshot/data'
             ),
             call(
                 device='/dev/storage',

--- a/test/unit/volume_manager_lvm_test.py
+++ b/test/unit/volume_manager_lvm_test.py
@@ -1,13 +1,14 @@
-
 from mock import patch
 from mock import call
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 from collections import namedtuple
 
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiVolumeGroupConflict
+
 from kiwi.volume_manager.lvm import VolumeManagerLVM
+
 from kiwi.defaults import Defaults
 
 
@@ -147,8 +148,9 @@ class TestVolumeManagerLVM(object):
             call(
                 'root_dir', self.volume_type(
                     name='LVRoot', size='freespace:100', realpath='/',
-                    mountpoint=None, fullsize=False, attributes=[])
-                ),
+                    mountpoint=None, fullsize=False, attributes=[]
+                )
+            ),
             call(
                 'root_dir', self.volume_type(
                     name='myvol', size='size:500', realpath='/data',

--- a/test/unit/volume_manager_test.py
+++ b/test/unit/volume_manager_test.py
@@ -1,11 +1,11 @@
-
 from mock import patch
 
 import mock
 
-from .test_helper import *
+from .test_helper import raises
 
-from kiwi.exceptions import *
+from kiwi.exceptions import KiwiVolumeManagerSetupError
+
 from kiwi.volume_manager import VolumeManager
 
 

--- a/test/unit/xml_description_test.py
+++ b/test/unit/xml_description_test.py
@@ -1,8 +1,9 @@
+from mock import patch
 import mock
 from builtins import bytes
 from lxml import etree
 
-from .test_helper import *
+from .test_helper import raises
 from collections import namedtuple
 
 from kiwi.exceptions import (
@@ -192,10 +193,10 @@ class TestSchema(object):
         )
         mock_validation_report = mock.Mock()
         mock_validation_report.getroot = mock.Mock(
-            return_value = name_spaces(nsmap="")
+            return_value=name_spaces(nsmap="")
         )
         mock_validation_report.xpath = mock.Mock(
-            return_value = [
+            return_value=[
                 validation_report(text='wrong attribute 1'),
                 validation_report(text='wrong attribute 2')
             ]
@@ -241,10 +242,10 @@ class TestSchema(object):
         )
         mock_validation_report = mock.Mock()
         mock_validation_report.getroot = mock.Mock(
-            return_value = name_spaces(nsmap="")
+            return_value=name_spaces(nsmap="")
         )
         mock_validation_report.xpath = mock.Mock(
-            return_value = [
+            return_value=[
                 validation_report(text='wrong attribute 1'),
                 validation_report(text='wrong attribute 2')
             ]

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -1,13 +1,14 @@
-
 from mock import patch
 
-import mock
-
-from .test_helper import *
+from .test_helper import raises
 
 from kiwi.xml_state import XMLState
 from kiwi.xml_description import XMLDescription
-from kiwi.exceptions import *
+from kiwi.exceptions import (
+    KiwiTypeNotFound,
+    KiwiDistributionNameError,
+    KiwiProfileNotFound
+)
 from collections import namedtuple
 
 
@@ -40,10 +41,10 @@ class TestXMLState(object):
     @patch('kiwi.xml_state.XMLState.get_preferences_sections')
     def test_get_rpm_excludedocs_without_entry(self, mock_preferences):
         mock_preferences.return_value = []
-        assert self.state.get_rpm_excludedocs() == False
+        assert self.state.get_rpm_excludedocs() is False
 
     def test_get_rpm_excludedocs(self):
-        assert self.state.get_rpm_excludedocs() == True
+        assert self.state.get_rpm_excludedocs() is True
 
     def test_get_package_manager(self):
         assert self.state.get_package_manager() == 'zypper'
@@ -368,13 +369,13 @@ class TestXMLState(object):
         assert len(users) == 3
         assert any(u.get_name() == 'root' for u in users)
         assert any(u.get_name() == 'tux' for u in users)
-        assert any(u.get_name() == 'kiwi' for u in users) 
+        assert any(u.get_name() == 'kiwi' for u in users)
 
     def test_get_user_groups(self):
         description = XMLDescription('../data/example_multiple_users_config.xml')
         xml_data = description.load()
         state = XMLState(xml_data)
-        
+
         assert len(state.get_user_groups('root')) == 0
         assert len(state.get_user_groups('tux')) == 1
         assert any(grp == 'users' for grp in state.get_user_groups('tux'))
@@ -504,7 +505,7 @@ class TestXMLState(object):
             '../data/example_no_imageinclude_config.xml'
         )
         xml_data = description.load()
-        state = XMLState(xml_data) 
+        state = XMLState(xml_data)
         assert not state.has_repositories_marked_as_imageinclude()
 
     def test_get_build_type_vmconfig_entries(self):


### PR DESCRIPTION
This is a cleanup and future python code quality pull request for:

* Prevent use of project relative import statements. For details on the motivation of this change please visit: https://wiki.python.org/moin/FutureProofPython

* Flake cleanup for unit tests

* Fixed import of solv module. Allow python3-solv and python-solv to work as expected
  
