### PR TITLE
Support for layered docker images

### DIFF
--- a/kiwi/builder/container.py
+++ b/kiwi/builder/container.py
@@ -25,6 +25,7 @@ from kiwi.system.setup import SystemSetup
 from kiwi.logger import log
 from kiwi.system.result import Result
 from kiwi.utils.checksum import Checksum
+from kiwi.defaults import Defaults
 from kiwi.exceptions import KiwiContainerBuilderError
 
 
@@ -60,31 +61,24 @@ class ContainerBuilder(object):
         self.target_dir = target_dir
         self.container_config = xml_state.get_container_config()
         self.requested_container_type = xml_state.get_build_type_name()
-        self.base_image_uri = xml_state.get_derived_from_image_uri()
         self.base_image = None
         self.base_image_md5 = None
 
-        if self.base_image_uri:
-            base_image_origin = self.base_image_uri.translate()
+        if xml_state.get_derived_from_image_uri():
             # The base image is expected to be unpacked by the kiwi
             # prepare step and stored inside of the root_dir/image directory.
             # In addition a md5 file of the image is expected too
-            self.base_image = os.path.normpath(
-                os.sep.join(
-                    [
-                        root_dir, 'image',
-                        base_image_origin.replace('.tar.xz', '')
-                    ]
-                )
+            self.base_image = Defaults.get_imported_root_image(
+                self.root_dir
             )
+            self.base_image_md5 = ''.join([self.base_image, '.md5'])
+
             if not os.path.exists(self.base_image):
                 raise KiwiContainerBuilderError(
                     'Unpacked Base image {0} not found'.format(
                         self.base_image
                     )
                 )
-
-            self.base_image_md5 = ''.join([self.base_image, '.md5'])
             if not os.path.exists(self.base_image_md5):
                 raise KiwiContainerBuilderError(
                     'Base image MD5 sum {0} not found at'.format(

--- a/kiwi/container/docker.py
+++ b/kiwi/container/docker.py
@@ -117,13 +117,9 @@ class ContainerImageDocker(object):
         )
 
         if base_image:
-            uncompressor = Compress(base_image)
-            uncompressor.uncompress(True)
-            self.uncompressed_image = uncompressor.uncompressed_filename
-
             Command.run([
                 'skopeo', 'copy',
-                'docker-archive:{0}'.format(self.uncompressed_image),
+                'docker-archive:{0}'.format(base_image),
                 'oci:{0}'.format(container_name)
             ])
         else:

--- a/kiwi/container/docker.py
+++ b/kiwi/container/docker.py
@@ -42,7 +42,6 @@ class ContainerImageDocker(object):
         self.root_dir = root_dir
         self.docker_dir = None
         self.docker_root_dir = None
-        self.uncompressed_image = None
 
         self.container_name = ''
         self.container_tag = 'latest'
@@ -189,5 +188,3 @@ class ContainerImageDocker(object):
             Path.wipe(self.docker_dir)
         if self.docker_root_dir:
             Path.wipe(self.docker_root_dir)
-        if self.uncompressed_image:
-            Path.wipe(self.uncompressed_image)

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -720,6 +720,21 @@ class Defaults(object):
         """
         return resource_filename('kiwi', filename)
 
+    @classmethod
+    def get_imported_root_image(self, root_dir):
+        """
+        Returns the path of the image used to import a root during
+        the prepare task. This is the filename expected to be
+        found during the create step if derived_from attribute is
+        present.
+
+        :param string root_dir: is the root directory of the current build
+
+        :return: file name of the image
+        :rtype: string
+        """
+        return os.sep.join([root_dir, 'image', 'imported_root'])
+
     def get(self, key):
         """
         Implements get method for profile elements

--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -752,3 +752,10 @@ class KiwiRootImportError(KiwiError):
     Exception is raised when something fails during the root import
     procedure.
     """
+
+
+class KiwiContainerBuilderError(KiwiError):
+    """
+    Exception is raised when something fails during a container image
+    build procedure.
+    """

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -73,7 +73,6 @@ class SystemPrepare(object):
                 root_dir, image_uri, xml_state.build_type.get_image()
             )
             root_import.sync_data()
-            root_import.copy_image_file()
         root_bind = RootBind(
             root
         )

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -67,7 +67,7 @@ class SystemPrepare(object):
             root_dir, allow_existing
         )
         root.create()
-        image_uri = xml_state.build_type.get_derived_from()
+        image_uri = xml_state.get_derived_from_image_uri()
         if image_uri:
             root_import = RootImport(
                 root_dir, image_uri, xml_state.build_type.get_image()

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -73,6 +73,7 @@ class SystemPrepare(object):
                 root_dir, image_uri, xml_state.build_type.get_image()
             )
             root_import.sync_data()
+            root_import.copy_image_file()
         root_bind = RootBind(
             root
         )

--- a/kiwi/system/root_import/base.py
+++ b/kiwi/system/root_import/base.py
@@ -21,6 +21,7 @@ import shutil
 # project
 from kiwi.system.uri import Uri
 from kiwi.path import Path
+from kiwi.utils.checksum import Checksum
 from kiwi.exceptions import KiwiRootImportError
 
 
@@ -69,11 +70,12 @@ class RootImportBase(object):
         """
         raise NotImplementedError
 
-    def copy_image_file(self):
-        """
-        Copies the original image file inside the image directory of the
-        root directory.
-        """
+    def _copy_image(self, image):
         image_path = os.sep.join([self.root_dir, 'image'])
         Path.create(image_path)
-        shutil.copy(self.image_file, image_path)
+        image_file = os.sep.join([image_path, 'image_file'])
+        shutil.copy(
+            image, image_file
+        )
+        checksum = Checksum(image_file)
+        checksum.md5(''.join([image_file, '.md5']))

--- a/kiwi/system/root_import/base.py
+++ b/kiwi/system/root_import/base.py
@@ -16,9 +16,11 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
+import shutil
 
 # project
 from kiwi.system.uri import Uri
+from kiwi.path import Path
 from kiwi.exceptions import KiwiRootImportError
 
 
@@ -66,3 +68,12 @@ class RootImportBase(object):
         Implementation in specialized root import class
         """
         raise NotImplementedError
+
+    def copy_image_file(self):
+        """
+        Copies the original image file inside the image directory of the
+        root directory.
+        """
+        image_path = os.sep.join([self.root_dir, 'image'])
+        Path.create(image_path)
+        shutil.copy(self.image_file, image_path)

--- a/kiwi/system/root_import/base.py
+++ b/kiwi/system/root_import/base.py
@@ -19,7 +19,6 @@ import os
 import shutil
 
 # project
-from kiwi.system.uri import Uri
 from kiwi.path import Path
 from kiwi.utils.checksum import Checksum
 from kiwi.exceptions import KiwiRootImportError
@@ -32,24 +31,21 @@ class RootImportBase(object):
     * :attr:`root_dir`
         root directory path name
 
-    * :attr:`image_file`
-        local image file to import
-
-    * :attr:`tmp_root_dir`
-        temporary directory where image_file is extracted
+    * :attr:`image_uri`
+        Uri object to store source location
     """
     def __init__(self, root_dir, image_uri):
-        uri = Uri(image_uri)
-        if uri.is_remote():
+        if image_uri.is_remote():
             raise KiwiRootImportError(
                 'Only local imports are supported'
             )
-        else:
-            self.image_file = uri.translate()
-            if not os.path.exists(self.image_file):
-                raise KiwiRootImportError(
-                    'Could not stat base image file: {0}'.format(self.image_file)
-                )
+
+        self.image_file = image_uri.translate()
+
+        if not os.path.exists(self.image_file):
+            raise KiwiRootImportError(
+                'Could not stat base image file: {0}'.format(self.image_file)
+            )
 
         self.root_dir = root_dir
         self.post_init()

--- a/kiwi/system/root_import/docker.py
+++ b/kiwi/system/root_import/docker.py
@@ -70,12 +70,9 @@ class RootImportDocker(RootImportBase):
         self._copy_image(self.uncompressed_image)
 
     def __del__(self):
-        try:
-            if self.oci_layout_dir:
-                Path.wipe(self.oci_layout_dir)
-            if self.oci_unpack_dir:
-                Path.wipe(self.oci_unpack_dir)
-            if self.uncompressed_image:
-                Path.wipe(self.uncompressed_image)
-        except Exception:
-            pass
+        if self.oci_layout_dir:
+            Path.wipe(self.oci_layout_dir)
+        if self.oci_unpack_dir:
+            Path.wipe(self.oci_unpack_dir)
+        if self.uncompressed_image:
+            Path.wipe(self.uncompressed_image)

--- a/kiwi/system/root_import/docker.py
+++ b/kiwi/system/root_import/docker.py
@@ -63,10 +63,19 @@ class RootImportDocker(RootImportBase):
         )
         synchronizer.sync_data(options=['-a', '-H', '-X', '-A'])
 
+        # A copy of the uncompressed image and its checksum are
+        # kept inside the root_dir in order to ensure the later steps
+        # i.e. system create are atomic and don't need any third
+        # party archive.
+        self._copy_image(self.uncompressed_image)
+
     def __del__(self):
-        if self.oci_layout_dir:
-            Path.wipe(self.oci_layout_dir)
-        if self.oci_unpack_dir:
-            Path.wipe(self.oci_unpack_dir)
-        if self.uncompressed_image:
-            Path.wipe(self.uncompressed_image)
+        try:
+            if self.oci_layout_dir:
+                Path.wipe(self.oci_layout_dir)
+            if self.oci_unpack_dir:
+                Path.wipe(self.oci_unpack_dir)
+            if self.uncompressed_image:
+                Path.wipe(self.uncompressed_image)
+        except Exception:
+            pass

--- a/kiwi/utils/checksum.py
+++ b/kiwi/utils/checksum.py
@@ -48,6 +48,27 @@ class Checksum(object):
         self.source_filename = source_filename
         self.checksum_filename = None
 
+    def matches(self, checksum, filename):
+        """
+        Compare given checksum with reference checksum stored
+        in the provided filename. If the checksum matches the
+        method returns True, or False in case it does not match
+
+        :param string checksum: checksum string to compare
+        :param string filename: filename containing checksum
+        """
+        if not os.path.exists(filename):
+            return False
+        with open(filename) as checksum_file:
+            checksum_from_file = checksum_file.read()
+            # checksum is expected to be stored in the first field
+            # separated by space, other information might contain
+            # the filename or blocklist data which is not of interest
+            # for the plain checksum match
+            if checksum_from_file.split(' ')[0] == checksum:
+                return True
+        return False
+
     def md5(self, filename=None):
         """
         Create md5 checksum

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -22,6 +22,7 @@ from collections import namedtuple
 
 # project
 from . import xml_parse
+from .system.uri import Uri
 from .defaults import Defaults
 
 from .exceptions import (
@@ -1473,6 +1474,21 @@ class XMLState(object):
             option_list = [mount_options]
 
         return option_list
+
+    def get_derived_from_image_uri(self):
+        """
+        Uri object of derived image if configured
+
+        Specific image types can be based on a master image.
+        This method returns the location of this image when
+        configured in the XML description
+
+        :return: Instance of Uri
+        :rtype: object
+        """
+        derived_image = self.build_type.get_derived_from()
+        if derived_image:
+            return Uri(derived_image)
 
     def _used_profiles(self, profiles=None):
         """

--- a/test/unit/builder_container_test.py
+++ b/test/unit/builder_container_test.py
@@ -50,7 +50,7 @@ class TestContainerBuilder(object):
         builder = ContainerBuilder(
             self.xml_state, 'target_dir', 'root_dir'
         )
-        assert builder.base_image == 'root_dir/image/image_file'
+        assert builder.base_image == 'root_dir/image/imported_root'
 
     @patch('os.path.exists')
     @raises(KiwiContainerBuilderError)
@@ -167,9 +167,9 @@ class TestContainerBuilder(object):
 
         container.create()
 
-        mock_checksum.assert_called_once_with('root_dir/image/image_file')
+        mock_checksum.assert_called_once_with('root_dir/image/imported_root')
         checksum.matches.assert_called_once_with(
-            'checksumvalue', 'root_dir/image/image_file.md5'
+            'checksumvalue', 'root_dir/image/imported_root.md5'
         )
 
         mock_image.assert_called_once_with(
@@ -177,7 +177,7 @@ class TestContainerBuilder(object):
         )
         container_image.create.assert_called_once_with(
             'target_dir/image_name.x86_64-1.2.3.docker.tar.xz',
-            'root_dir/image/image_file'
+            'root_dir/image/imported_root'
         )
         assert container.result.add.call_args_list == [
             call(

--- a/test/unit/container_image_docker_test.py
+++ b/test/unit/container_image_docker_test.py
@@ -51,12 +51,12 @@ class TestContainerImageDocker(object):
 
     @patch('kiwi.container.docker.Path.wipe')
     def test_del(self, mock_wipe):
-        docker = ContainerImageDocker('root_dir')
-        docker.docker_dir = 'dir_a'
-        docker.docker_root_dir = 'dir_b'
-        docker.__del__()
+        self.docker.docker_dir = 'dir_a'
+        self.docker.docker_root_dir = 'dir_b'
+        self.docker.uncompressed_image = 'uncompressed_image'
+        self.docker.__del__()
         assert mock_wipe.call_args_list == [
-            call('dir_a'), call('dir_b')
+            call('dir_a'), call('dir_b'), call('uncompressed_image')
         ]
 
     @patch('kiwi.container.docker.Compress')
@@ -78,7 +78,7 @@ class TestContainerImageDocker(object):
 
         mock_mkdtemp.side_effect = call_mkdtemp
 
-        self.docker.create('result.tar.xz')
+        self.docker.create('result.tar.xz', None)
 
         mock_wipe.assert_called_once_with('result.tar')
 
@@ -122,4 +122,70 @@ class TestContainerImageDocker(object):
             options=['-a', '-H', '-X', '-A']
         )
         mock_compress.assert_called_once_with('result.tar')
+        compressor.xz.assert_called_once_with()
+
+    @patch('kiwi.container.docker.Compress')
+    @patch('kiwi.container.docker.Command.run')
+    @patch('kiwi.container.docker.DataSync')
+    @patch('kiwi.container.docker.mkdtemp')
+    @patch('kiwi.container.docker.Path.wipe')
+    def test_create_derived(
+        self, mock_wipe, mock_mkdtemp, mock_sync, mock_command, mock_compress
+    ):
+        compressor = mock.Mock()
+        compressor.uncompressed_filename = 'tmp_uncompressed'
+        mock_compress.return_value = compressor
+        docker_root = mock.Mock()
+        mock_sync.return_value = docker_root
+        tmpdirs = ['kiwi_docker_root_dir', 'kiwi_docker_dir']
+
+        def call_mkdtemp(prefix):
+            return tmpdirs.pop()
+
+        mock_mkdtemp.side_effect = call_mkdtemp
+
+        self.docker.create('result.tar.xz', 'image.tar.xz')
+
+        mock_wipe.assert_called_once_with('result.tar')
+
+        assert mock_command.call_args_list == [
+            call([
+                'skopeo', 'copy', 'docker-archive:tmp_uncompressed',
+                'oci:kiwi_docker_dir/umoci_layout:latest'
+            ]),
+            call([
+                'umoci', 'unpack', '--image',
+                'kiwi_docker_dir/umoci_layout:latest', 'kiwi_docker_root_dir'
+            ]),
+            call([
+                'umoci', 'repack', '--image',
+                'kiwi_docker_dir/umoci_layout:latest', 'kiwi_docker_root_dir'
+            ]),
+            call([
+                'umoci', 'config', '--config.cmd=/bin/bash', '--image',
+                'kiwi_docker_dir/umoci_layout:latest', '--tag', 'latest'
+            ]),
+            call([
+                'umoci', 'gc', '--layout', 'kiwi_docker_dir/umoci_layout'
+            ]),
+            call([
+                'skopeo', 'copy', 'oci:kiwi_docker_dir/umoci_layout:latest',
+                'docker-archive:result.tar:foo/bar:latest'
+            ])
+        ]
+        mock_sync.assert_called_once_with(
+            'root_dir/', 'kiwi_docker_root_dir/rootfs'
+        )
+        docker_root.sync_data.assert_called_once_with(
+            exclude=[
+                'image', '.profile', '.kconfig', 'boot', 'dev', 'sys', 'proc',
+                'var/cache/kiwi'
+            ],
+            options=['-a', '-H', '-X', '-A']
+        )
+        assert mock_compress.call_args_list == [
+            call('image.tar.xz'), call('result.tar')
+        ]
+
+        compressor.uncompress.assert_called_once_with(True)
         compressor.xz.assert_called_once_with()

--- a/test/unit/container_image_docker_test.py
+++ b/test/unit/container_image_docker_test.py
@@ -53,10 +53,9 @@ class TestContainerImageDocker(object):
     def test_del(self, mock_wipe):
         self.docker.docker_dir = 'dir_a'
         self.docker.docker_root_dir = 'dir_b'
-        self.docker.uncompressed_image = 'uncompressed_image'
         self.docker.__del__()
         assert mock_wipe.call_args_list == [
-            call('dir_a'), call('dir_b'), call('uncompressed_image')
+            call('dir_a'), call('dir_b')
         ]
 
     @patch('kiwi.container.docker.Compress')
@@ -64,9 +63,12 @@ class TestContainerImageDocker(object):
     @patch('kiwi.container.docker.DataSync')
     @patch('kiwi.container.docker.mkdtemp')
     @patch('kiwi.container.docker.Path.wipe')
+    @patch('kiwi.container.docker.Defaults.get_shared_cache_location')
     def test_create(
-        self, mock_wipe, mock_mkdtemp, mock_sync, mock_command, mock_compress
+        self, mock_cache, mock_wipe, mock_mkdtemp,
+        mock_sync, mock_command, mock_compress
     ):
+        mock_cache.return_value = 'var/cache/kiwi'
         compressor = mock.Mock()
         mock_compress.return_value = compressor
         docker_root = mock.Mock()
@@ -129,9 +131,12 @@ class TestContainerImageDocker(object):
     @patch('kiwi.container.docker.DataSync')
     @patch('kiwi.container.docker.mkdtemp')
     @patch('kiwi.container.docker.Path.wipe')
+    @patch('kiwi.container.docker.Defaults.get_shared_cache_location')
     def test_create_derived(
-        self, mock_wipe, mock_mkdtemp, mock_sync, mock_command, mock_compress
+        self, mock_cache, mock_wipe, mock_mkdtemp,
+        mock_sync, mock_command, mock_compress
     ):
+        mock_cache.return_value = 'var/cache/kiwi'
         compressor = mock.Mock()
         mock_compress.return_value = compressor
         docker_root = mock.Mock()

--- a/test/unit/container_image_docker_test.py
+++ b/test/unit/container_image_docker_test.py
@@ -133,7 +133,6 @@ class TestContainerImageDocker(object):
         self, mock_wipe, mock_mkdtemp, mock_sync, mock_command, mock_compress
     ):
         compressor = mock.Mock()
-        compressor.uncompressed_filename = 'tmp_uncompressed'
         mock_compress.return_value = compressor
         docker_root = mock.Mock()
         mock_sync.return_value = docker_root
@@ -144,13 +143,13 @@ class TestContainerImageDocker(object):
 
         mock_mkdtemp.side_effect = call_mkdtemp
 
-        self.docker.create('result.tar.xz', 'image.tar.xz')
+        self.docker.create('result.tar.xz', 'root_dir/image/image_file')
 
         mock_wipe.assert_called_once_with('result.tar')
 
         assert mock_command.call_args_list == [
             call([
-                'skopeo', 'copy', 'docker-archive:tmp_uncompressed',
+                'skopeo', 'copy', 'docker-archive:root_dir/image/image_file',
                 'oci:kiwi_docker_dir/umoci_layout:latest'
             ]),
             call([
@@ -183,9 +182,5 @@ class TestContainerImageDocker(object):
             ],
             options=['-a', '-H', '-X', '-A']
         )
-        assert mock_compress.call_args_list == [
-            call('image.tar.xz'), call('result.tar')
-        ]
-
-        compressor.uncompress.assert_called_once_with(True)
+        mock_compress.assert_called_once_with('result.tar')
         compressor.xz.assert_called_once_with()

--- a/test/unit/system_prepare_test.py
+++ b/test/unit/system_prepare_test.py
@@ -79,6 +79,11 @@ class TestSystemPrepare(object):
         state = XMLState(
             xml, profiles=['vmxFlavour'], build_type='docker'
         )
+        uri = mock.Mock()
+        get_derived_from_image_uri = mock.Mock(
+            return_value=uri
+        )
+        state.get_derived_from_image_uri = get_derived_from_image_uri
         SystemPrepare(
             xml_state=state, root_dir='root_dir',
         )
@@ -87,7 +92,7 @@ class TestSystemPrepare(object):
         )
         root_init.create.assert_called_once_with()
         mock_root_import.assert_called_once_with(
-            'root_dir', 'file:///image.tar.xz',
+            'root_dir', uri,
             state.build_type.get_image()
         )
         root_import.sync_data.assert_called_once_with()

--- a/test/unit/system_root_import_base_test.py
+++ b/test/unit/system_root_import_base_test.py
@@ -30,13 +30,3 @@ class TestRootImportBase(object):
         mock_path.return_value = True
         root_import = RootImportBase('root_dir', 'file:///image.tar.xz')
         root_import.sync_data()
-
-    @patch('os.path.exists')
-    @patch('kiwi.path.Path.create')
-    @patch('shutil.copy')
-    def test_copy_image_file(self, mock_copy, mock_path, mock_exists):
-        mock_path.return_value = True
-        root_import = RootImportBase('root_dir', 'file:///image.tar.xz')
-        root_import.copy_image_file()
-        mock_path.assert_called_once_with('root_dir/image')
-        mock_copy.assert_called_once_with('/image.tar.xz', 'root_dir/image')

--- a/test/unit/system_root_import_base_test.py
+++ b/test/unit/system_root_import_base_test.py
@@ -30,3 +30,13 @@ class TestRootImportBase(object):
         mock_path.return_value = True
         root_import = RootImportBase('root_dir', 'file:///image.tar.xz')
         root_import.sync_data()
+
+    @patch('os.path.exists')
+    @patch('kiwi.path.Path.create')
+    @patch('shutil.copy')
+    def test_copy_image_file(self, mock_copy, mock_path, mock_exists):
+        mock_path.return_value = True
+        root_import = RootImportBase('root_dir', 'file:///image.tar.xz')
+        root_import.copy_image_file()
+        mock_path.assert_called_once_with('root_dir/image')
+        mock_copy.assert_called_once_with('/image.tar.xz', 'root_dir/image')

--- a/test/unit/system_root_import_base_test.py
+++ b/test/unit/system_root_import_base_test.py
@@ -2,6 +2,7 @@ from mock import patch
 
 from .test_helper import raises
 
+from kiwi.system.uri import Uri
 from kiwi.system.root_import.base import RootImportBase
 from kiwi.exceptions import KiwiRootImportError
 
@@ -10,23 +11,23 @@ class TestRootImportBase(object):
     @patch('os.path.exists')
     def test_init(self, mock_path):
         mock_path.return_value = True
-        RootImportBase('root_dir', 'file:///image.tar.xz')
+        RootImportBase('root_dir', Uri('file:///image.tar.xz'))
         mock_path.assert_called_once_with('/image.tar.xz')
 
     @raises(KiwiRootImportError)
     def test_init_remote_uri(self):
-        RootImportBase('root_dir', 'http://example.com/image.tar.xz')
+        RootImportBase('root_dir', Uri('http://example.com/image.tar.xz'))
 
     @patch('os.path.exists')
     @raises(KiwiRootImportError)
     def test_init_non_existing(self, mock_path):
         mock_path.return_value = False
-        RootImportBase('root_dir', 'file:///image.tar.xz')
+        RootImportBase('root_dir', Uri('file:///image.tar.xz'))
         mock_path.assert_called_once_with('/image.tar.xz')
 
     @raises(NotImplementedError)
     @patch('os.path.exists')
     def test_data_sync(self, mock_path):
         mock_path.return_value = True
-        root_import = RootImportBase('root_dir', 'file:///image.tar.xz')
+        root_import = RootImportBase('root_dir', Uri('file:///image.tar.xz'))
         root_import.sync_data()

--- a/test/unit/system_root_import_docker_test.py
+++ b/test/unit/system_root_import_docker_test.py
@@ -76,10 +76,10 @@ class TestRootImportDocker(object):
         sync.sync_data.assert_called_once_with(
             options=['-a', '-H', '-X', '-A']
         )
-        mock_md5.assert_called_once_with('root_dir/image/image_file')
-        md5.md5.called_once_with('root_dir/image/image_file.md5')
+        mock_md5.assert_called_once_with('root_dir/image/imported_root')
+        md5.md5.called_once_with('root_dir/image/imported_root.md5')
         mock_copy.assert_called_once_with(
-            'tmp_uncompressed', 'root_dir/image/image_file'
+            'tmp_uncompressed', 'root_dir/image/imported_root'
         )
         mock_path.assert_called_once_with('root_dir/image')
 

--- a/test/unit/system_root_import_docker_test.py
+++ b/test/unit/system_root_import_docker_test.py
@@ -4,6 +4,7 @@ from mock import call
 
 from .test_helper import raises
 
+from kiwi.system.uri import Uri
 from kiwi.system.root_import.docker import RootImportDocker
 from kiwi.exceptions import KiwiRootImportError
 
@@ -13,7 +14,7 @@ class TestRootImportDocker(object):
     def setup(self, mock_path):
         mock_path.return_value = True
         self.docker_import = RootImportDocker(
-            'root_dir', 'file:///image.tar.xz'
+            'root_dir', Uri('file:///image.tar.xz')
         )
         assert self.docker_import.image_file == '/image.tar.xz'
 
@@ -22,7 +23,7 @@ class TestRootImportDocker(object):
     def test_failed_init(self, mock_path):
         mock_path.return_value = False
         RootImportDocker(
-            'root_dir', 'file:///image.tar.xz'
+            'root_dir', Uri('file:///image.tar.xz')
         )
 
     @patch('kiwi.system.root_import.base.shutil.copy')

--- a/test/unit/utils_checksum_test.py
+++ b/test/unit/utils_checksum_test.py
@@ -35,6 +35,22 @@ class TestChecksum(object):
     def test_checksum_file_not_found(self):
         Checksum('some-file')
 
+    @patch('os.path.exists')
+    def test_matches_checksum_file_does_not_exist(self, mock_exists):
+        mock_exists.return_value = False
+        assert self.checksum.matches('sum', 'some-file') is False
+
+    @patch('os.path.exists')
+    @patch_open
+    def test_matches(self, mock_open, mock_exists):
+        mock_exists.return_value = True
+        mock_open.return_value = self.context_manager_mock
+        self.file_mock.read.side_effect = None
+        self.file_mock.read.return_value = 'sum'
+        assert self.checksum.matches('sum', 'some-file') is True
+        mock_open.assert_called_once_with('some-file')
+        assert self.checksum.matches('foo', 'some-file') is False
+
     @patch('kiwi.path.Path.which')
     @patch('kiwi.utils.checksum.Compress')
     @patch('hashlib.md5')

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -576,3 +576,9 @@ class TestXMLState(object):
 
     def test_get_spare_part(self):
         assert self.state.get_build_type_spare_part_size() == 200
+
+    def test_get_derived_from_image_uri(self):
+        description = XMLDescription('../data/example_config.xml')
+        xml_data = description.load()
+        state = XMLState(xml_data, ['vmxFlavour'], 'docker')
+        assert state.get_derived_from_image_uri().translate() == '/image.tar.xz'


### PR DESCRIPTION
This commit includes support for building layered docker. A new
layer is added on top of the base image referenced by `derived_from`
attribute.
