### PR TITLE
Refactor Uri constructor

### DIFF
--- a/kiwi/system/root_import/base.py
+++ b/kiwi/system/root_import/base.py
@@ -36,7 +36,7 @@ class RootImportBase(object):
         temporary directory where image_file is extracted
     """
     def __init__(self, root_dir, image_uri):
-        uri = Uri(image_uri, 'images')
+        uri = Uri(image_uri)
         if uri.is_remote():
             raise KiwiRootImportError(
                 'Only local imports are supported'

--- a/kiwi/system/uri.py
+++ b/kiwi/system/uri.py
@@ -38,7 +38,9 @@ class Uri(object):
     Attributes
 
     * :attr:`repo_type`
-        Repository type name
+        Repository type name. Only needed if the uri
+        is not enough to determine the repository type
+        e.g for yast2 vs. rpm-md obs repositories
 
     * :attr:`uri`
         URI, repository location, file
@@ -55,10 +57,9 @@ class Uri(object):
     * :attr:`local_uri_type`
         dictionary of local uri type names
     """
-    def __init__(self, uri, repo_type):
+    def __init__(self, uri, repo_type=None):
         self.repo_type = repo_type
         self.uri = uri
-        self.repo_type = repo_type
         self.mount_stack = []
 
         self.remote_uri_types = {


### PR DESCRIPTION
Make repo_type an optional parameter, which is only
required if the specified uri leaves a type choice

