### PR TITLE
Allow https location as repository source

### DIFF
--- a/kiwi/system/uri.py
+++ b/kiwi/system/uri.py
@@ -113,7 +113,7 @@ class Uri(object):
             return self._suse_buildservice_path(
                 ''.join([uri.netloc, uri.path])
             )
-        elif uri.scheme == 'http' or uri.scheme == 'ftp':
+        elif uri.scheme == 'http' or uri.scheme == 'https' or uri.scheme == 'ftp':
             return ''.join([uri.scheme, '://', uri.netloc, uri.path])
         else:
             raise KiwiUriStyleUnknown(

--- a/test/unit/system_uri_test.py
+++ b/test/unit/system_uri_test.py
@@ -101,6 +101,10 @@ class TestUri(object):
         uri = Uri('http://example.com/foo', 'rpm-md')
         assert uri.translate() == 'http://example.com/foo'
 
+    def test_translate_https_path(self):
+        uri = Uri('https://example.com/foo', 'rpm-md')
+        assert uri.translate() == 'https://example.com/foo'
+
     def test_translate_ftp_path(self):
         uri = Uri('ftp://example.com/foo', 'rpm-md')
         assert uri.translate() == 'ftp://example.com/foo'


### PR DESCRIPTION
a repository of the form

```xml
<repository type="yast2" imageinclude="true">
    <source path="https://download.opensuse.org/distribution/leap/42.2/repo/oss"/>
</repository>
```

was not allowed because the https locator was not know to kiwi's uri style