### PR TITLE
Convert root_dir passed to zypper/rpm --root to absolute path

### DIFF
--- a/kiwi/package_manager/zypper.py
+++ b/kiwi/package_manager/zypper.py
@@ -104,7 +104,7 @@ class PackageManagerZypper(PackageManagerBase):
         Process package install requests for bootstrap phase (no chroot)
         """
         command = ['zypper'] + self.zypper_args + [
-            '--root', self.root_dir,
+            '--root', os.path.abspath(self.root_dir),
             'install', '--auto-agree-with-licenses'
         ] + self.custom_args + self._install_items()
         return Command.call(

--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -205,7 +205,7 @@ class RepositoryZypper(RepositoryBase):
         self._backup_package_cache()
         Command.run(
             ['zypper'] + self.zypper_args + [
-                '--root', self.root_dir,
+                '--root', os.path.abspath(self.root_dir),
                 'addrepo',
                 '--refresh',
                 '--type', self._translate_repo_type(repo_type),
@@ -219,7 +219,7 @@ class RepositoryZypper(RepositoryBase):
         if prio:
             Command.run(
                 ['zypper'] + self.zypper_args + [
-                    '--root', self.root_dir,
+                    '--root', os.path.abspath(self.root_dir),
                     'modifyrepo', '--priority', format(prio), name
                 ],
                 self.command_env
@@ -234,7 +234,7 @@ class RepositoryZypper(RepositoryBase):
         """
         Command.run(
             ['zypper'] + self.zypper_args + [
-                '--root', self.root_dir, 'removerepo', name
+                '--root', os.path.abspath(self.root_dir), 'removerepo', name
             ],
             self.command_env
         )

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -416,7 +416,7 @@ class SystemSetup(object):
             )
             query_call = Command.run(
                 [
-                    'rpm', '--root', self.root_dir, '-qa', '--qf',
+                    'rpm', '--root', os.path.abspath(self.root_dir), '-qa', '--qf',
                     '|'.join(
                         [
                             '%{NAME}', '%{EPOCH}', '%{VERSION}', '%{RELEASE}',
@@ -448,7 +448,7 @@ class SystemSetup(object):
                 ]
             )
             query_call = Command.run(
-                command=['rpm', '--root', self.root_dir, '-Va'],
+                command=['rpm', '--root', os.path.abspath(self.root_dir), '-Va'],
                 raise_on_error=False
             )
             with open(filename, 'w') as verified:


### PR DESCRIPTION
Zypper on openSUSE 42.2 barfs when passed in root_dir as an argument for `--root` because it is always a relative path and Zypper doesn't like that. So, we convert it to an absolute path.

RPM also requires a similar change.

P.S.: @msrex sends his regards (we spent some time tracking this down while building images on openSUSE Leap 42.2)

Changes proposed in this pull request:
* Use `os.path.abspath()` on `root_dir` being passed to `zypper --root`
* Use `os.path.abspath()` on `root_dir` being passed to `rpm --root`
