### PR TITLE
Pass full path to initrd file for compressing

### DIFF
--- a/kiwi/boot/image/builtin_kiwi.py
+++ b/kiwi/boot/image/builtin_kiwi.py
@@ -142,6 +142,6 @@ class BootImageKiwi(BootImageBase):
             log.info(
                 '--> xz compressing archive'
             )
-            compress = Compress(self.initrd_file_name)
+            compress = Compress(temp_boot_root_directory + "/" + self.initrd_file_name)
             compress.xz()
             self.initrd_filename = compress.compressed_filename


### PR DESCRIPTION
At initrd compress time, host xz is being used, so the path expected is relative to the host filesystem structure. Thus, we pass the full path.

Changes proposed in this pull request:
* Use full path for initrd file path to pass to xz for compressing initrd
