### PR TITLE
Throw a proper exception on missing boot reference

### DIFF
--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -143,6 +143,10 @@ class BootImageBase(object):
         """
         log.info('Loading Boot XML description')
         boot_description_directory = self.get_boot_description_directory()
+        if not boot_description_directory:
+            raise KiwiConfigFileNotFound(
+                'no boot reference specified in XML description'
+            )
         boot_config_file = boot_description_directory + '/config.xml'
         if not os.path.exists(boot_config_file):
             raise KiwiConfigFileNotFound(

--- a/test/unit/boot_image_base_test.py
+++ b/test/unit/boot_image_base_test.py
@@ -6,7 +6,8 @@ from .test_helper import raises, patch_open
 
 from kiwi.exceptions import (
     KiwiTargetDirectoryNotFound,
-    KiwiBootImageDumpError
+    KiwiBootImageDumpError,
+    KiwiConfigFileNotFound
 )
 
 from kiwi.boot.image.base import BootImageBase
@@ -111,6 +112,12 @@ class TestBootImageBase(object):
         boot_path.return_value = 'boot_path'
         assert self.boot_image.get_boot_description_directory() == \
             'boot_path/oemboot/suse-13.2'
+
+    @raises(KiwiConfigFileNotFound)
+    @patch('kiwi.boot.image.base.BootImageBase.get_boot_description_directory')
+    def test_load_boot_xml_description(self, mock_boot_dir):
+        mock_boot_dir.return_value = None
+        self.boot_image.load_boot_xml_description()
 
     @patch('kiwi.boot.image.base.Path.wipe')
     @patch('os.path.exists')


### PR DESCRIPTION
If not boot attribute was set but required for the build a proper error message should be shown