### PR TITLE
Convert user input to absolute paths

### DIFF
--- a/kiwi/tasks/image_resize.py
+++ b/kiwi/tasks/image_resize.py
@@ -45,6 +45,7 @@ options:
 """
 import re
 import math
+import os
 
 # project
 from kiwi.tasks.base import CliTask
@@ -75,11 +76,17 @@ class ImageResizeTask(CliTask):
         if self.command_args.get('help') is True:
             return self.manual.show('kiwi::image::resize')
 
+        abs_target_dir_path = os.path.abspath(
+            self.command_args['--target-dir']
+        )
+
         if self.command_args['--root']:
-            image_root = self.command_args['--root']
+            image_root = os.path.abspath(
+                os.path.normpath(self.command_args['--root'])
+            )
         else:
-            image_root = ''.join(
-                [self.command_args['--target-dir'], '/build/image-root']
+            image_root = os.sep.join(
+                [abs_target_dir_path, 'build', 'image-root']
             )
 
         self.load_xml_description(
@@ -90,7 +97,7 @@ class ImageResizeTask(CliTask):
 
         image_format = DiskFormat(
             disk_format or 'raw', self.xml_state, image_root,
-            self.command_args['--target-dir']
+            abs_target_dir_path
         )
         if not image_format.has_raw_disk():
             raise KiwiImageResizeError(

--- a/kiwi/tasks/result_bundle.py
+++ b/kiwi/tasks/result_bundle.py
@@ -79,8 +79,8 @@ class ResultBundleTask(CliTask):
             return
 
         # load serialized result object from target directory
-        result_directory = os.path.normpath(self.command_args['--target-dir'])
-        bundle_directory = os.path.normpath(self.command_args['--bundle-dir'])
+        result_directory = os.path.abspath(self.command_args['--target-dir'])
+        bundle_directory = os.path.abspath(self.command_args['--bundle-dir'])
         if result_directory == bundle_directory:
             raise KiwiBundleError(
                 'Bundle directory must be different from target directory'

--- a/kiwi/tasks/result_list.py
+++ b/kiwi/tasks/result_list.py
@@ -54,7 +54,7 @@ class ResultListTask(CliTask):
         if self._help():
             return
 
-        result_directory = os.path.normpath(
+        result_directory = os.path.abspath(
             self.command_args['--target-dir']
         )
         log.info(

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -55,6 +55,8 @@ options:
     --target-dir=<directory>
         the target directory to store the system image file(s)
 """
+import os
+
 # project
 from kiwi.tasks.base import CliTask
 from kiwi.help import Help
@@ -88,12 +90,15 @@ class SystemBuildTask(CliTask):
 
         Privileges.check_for_root_permissions()
 
-        image_root = self.command_args['--target-dir'] + '/build/image-root'
+        abs_target_dir_path = os.path.abspath(
+            self.command_args['--target-dir']
+        )
+        image_root = os.sep.join([abs_target_dir_path, 'build', 'image-root'])
         Path.create(image_root)
 
         if not self.global_args['--logfile']:
             log.set_logfile(
-                self.command_args['--target-dir'] + '/build/image-root.log'
+                os.sep.join([abs_target_dir_path, 'build', 'image-root.log'])
             )
 
         self.load_xml_description(
@@ -105,7 +110,7 @@ class SystemBuildTask(CliTask):
         self.runtime_checker.check_volume_setup_has_no_root_definition()
         self.runtime_checker.check_image_include_repos_http_resolvable()
         self.runtime_checker.check_target_directory_not_in_shared_cache(
-            self.command_args['--target-dir']
+            abs_target_dir_path
         )
 
         if self.command_args['--ignore-repos']:
@@ -126,7 +131,7 @@ class SystemBuildTask(CliTask):
                     repo_source, repo_type, repo_alias, repo_prio
                 )
 
-                Path.create(self.command_args['--target-dir'])
+                Path.create(abs_target_dir_path)
 
         self.runtime_checker.check_repositories_configured()
 
@@ -206,13 +211,13 @@ class SystemBuildTask(CliTask):
         log.info('Creating system image')
         image_builder = ImageBuilder(
             self.xml_state,
-            self.command_args['--target-dir'],
+            abs_target_dir_path,
             image_root
         )
         result = image_builder.create()
         result.print_results()
         result.dump(
-            self.command_args['--target-dir'] + '/kiwi.result'
+            os.sep.join([abs_target_dir_path, 'kiwi.result'])
         )
 
     def _help(self):

--- a/kiwi/tasks/system_create.py
+++ b/kiwi/tasks/system_create.py
@@ -68,32 +68,37 @@ class SystemCreateTask(CliTask):
 
         Privileges.check_for_root_permissions()
 
+        abs_target_dir_path = os.path.abspath(
+            self.command_args['--target-dir']
+        )
+        abs_root_path = os.path.abspath(self.command_args['--root'])
+
         self.load_xml_description(
-            self.command_args['--root']
+            abs_root_path
         )
         self.runtime_checker.check_target_directory_not_in_shared_cache(
-            self.command_args['--target-dir']
+            abs_target_dir_path
         )
 
         log.info('Creating system image')
-        if not os.path.exists(self.command_args['--target-dir']):
-            Path.create(self.command_args['--target-dir'])
+        if not os.path.exists(abs_target_dir_path):
+            Path.create(abs_target_dir_path)
 
         setup = SystemSetup(
             xml_state=self.xml_state,
-            root_dir=self.command_args['--root']
+            root_dir=abs_root_path
         )
         setup.call_image_script()
 
         image_builder = ImageBuilder(
             self.xml_state,
-            self.command_args['--target-dir'],
-            self.command_args['--root']
+            abs_target_dir_path,
+            abs_root_path
         )
         result = image_builder.create()
         result.print_results()
         result.dump(
-            self.command_args['--target-dir'] + '/kiwi.result'
+            os.sep.join([abs_target_dir_path, 'kiwi.result'])
         )
 
     def _help(self):

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -59,6 +59,8 @@ options:
         overwrite the repo source, type, alias or priority for the first
         repository in the XML description
 """
+import os
+
 # project
 from kiwi.tasks.base import CliTask
 from kiwi.help import Help
@@ -92,13 +94,16 @@ class SystemPrepareTask(CliTask):
         self.load_xml_description(
             self.command_args['--description']
         )
+
+        abs_root_path = os.path.abspath(self.command_args['--root'])
+
         self.runtime_checker.check_consistent_kernel_in_boot_and_system_image()
         self.runtime_checker.check_boot_image_reference_correctly_setup()
         self.runtime_checker.check_docker_tool_chain_installed()
         self.runtime_checker.check_volume_setup_has_no_root_definition()
         self.runtime_checker.check_image_include_repos_http_resolvable()
         self.runtime_checker.check_target_directory_not_in_shared_cache(
-            self.command_args['--root']
+            abs_root_path
         )
 
         if self.command_args['--ignore-repos']:
@@ -140,7 +145,7 @@ class SystemPrepareTask(CliTask):
         log.info('Preparing system')
         system = SystemPrepare(
             self.xml_state,
-            self.command_args['--root'],
+            abs_root_path,
             self.command_args['--allow-existing-root']
         )
         manager = system.setup_repositories()
@@ -164,7 +169,7 @@ class SystemPrepareTask(CliTask):
         defaults.to_profile(profile)
 
         setup = SystemSetup(
-            self.xml_state, self.command_args['--root']
+            self.xml_state, abs_root_path
         )
         setup.import_shell_environment(profile)
 

--- a/kiwi/tasks/system_update.py
+++ b/kiwi/tasks/system_update.py
@@ -38,6 +38,8 @@ options:
     --root=<directory>
         path to the root directory of the image
 """
+import os
+
 # project
 from kiwi.tasks.base import CliTask
 from kiwi.privileges import Privileges
@@ -68,8 +70,10 @@ class SystemUpdateTask(CliTask):
 
         Privileges.check_for_root_permissions()
 
+        abs_root_path = os.path.abspath(self.command_args['--root'])
+
         self.load_xml_description(
-            self.command_args['--root']
+            abs_root_path
         )
 
         package_requests = False
@@ -81,7 +85,7 @@ class SystemUpdateTask(CliTask):
         log.info('Updating system')
         self.system = SystemPrepare(
             self.xml_state,
-            self.command_args['--root'],
+            abs_root_path,
             allow_existing=True
         )
         manager = self.system.setup_repositories()

--- a/test/unit/tasks_image_resize_test.py
+++ b/test/unit/tasks_image_resize_test.py
@@ -1,6 +1,7 @@
 import sys
 import mock
 from mock import call
+import os
 
 import kiwi
 
@@ -18,6 +19,8 @@ class TestImageResizeTask(object):
             '--target-dir', 'target_dir', '--size', '20g',
             '--root', '../data/root-dir'
         ]
+        self.abs_root_dir = os.path.abspath('../data/root-dir')
+
         kiwi.tasks.image_resize.Help = mock.Mock(
             return_value=mock.Mock()
         )
@@ -106,7 +109,10 @@ class TestImageResizeTask(object):
         )
         assert mock_log_info.call_args_list == [
             call('Loading XML description'),
-            call('--> loaded %s', '../data/root-dir/image/config.xml'),
+            call(
+                '--> loaded %s',
+                os.sep.join([self.abs_root_dir, 'image', 'config.xml'])
+            ),
             call('--> Selected build type: %s', 'vmx'),
             call('--> Selected profiles: %s', 'vmxFlavour'),
             call('Resizing raw disk to 42 bytes'),

--- a/test/unit/tasks_result_bundle_test.py
+++ b/test/unit/tasks_result_bundle_test.py
@@ -1,5 +1,6 @@
 import sys
 import mock
+import os
 
 from mock import patch
 
@@ -17,6 +18,8 @@ class TestResultBundleTask(object):
             sys.argv[0], 'result', 'bundle', '--target-dir', 'target_dir',
             '--bundle-dir', 'bundle_dir', '--id', 'Build_42'
         ]
+        self.abs_target_dir = os.path.abspath('target_dir')
+        self.abs_bundle_dir = os.path.abspath('bundle_dir')
         self.context_manager_mock = mock.Mock()
         self.file_mock = mock.Mock()
         self.enter_mock = mock.Mock()
@@ -86,16 +89,16 @@ class TestResultBundleTask(object):
 
         self.task.process()
 
-        mock_load.assert_called_once_with('target_dir/kiwi.result')
-        mock_path.assert_called_once_with('bundle_dir')
+        mock_load.assert_called_once_with(os.sep.join([self.abs_target_dir, 'kiwi.result']))
+        mock_path.assert_called_once_with(self.abs_bundle_dir)
         mock_command.assert_called_once_with(
             [
                 'cp', 'filename-1.2.3',
-                'bundle_dir/filename-1.2.3-Build_42'
+                os.sep.join([self.abs_bundle_dir, 'filename-1.2.3-Build_42'])
             ]
         )
         mock_compress.assert_called_once_with(
-            'bundle_dir/filename-1.2.3-Build_42'
+            os.sep.join([self.abs_bundle_dir, 'filename-1.2.3-Build_42'])
         )
         mock_checksum.assert_called_once_with(
             compress.compressed_filename

--- a/test/unit/tasks_result_list_test.py
+++ b/test/unit/tasks_result_list_test.py
@@ -1,5 +1,6 @@
 import sys
 import mock
+import os
 
 from mock import patch
 
@@ -14,6 +15,7 @@ class TestResultListTask(object):
         sys.argv = [
             sys.argv[0], 'result', 'list', '--target-dir', 'directory'
         ]
+        self.abs_target_dir = os.path.abspath('directory')
         self.result = mock.Mock()
         kiwi.tasks.result_list.Help = mock.Mock(
             return_value=mock.Mock()
@@ -35,7 +37,9 @@ class TestResultListTask(object):
         self._init_command_args()
         self.task.command_args['list'] = True
         self.task.process()
-        mock_load.assert_called_once_with('directory/kiwi.result')
+        mock_load.assert_called_once_with(
+            os.sep.join([self.abs_target_dir, 'kiwi.result'])
+        )
         self.result.print_results.assert_called_once_with()
 
     def test_process_result_list_help(self):

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -1,5 +1,6 @@
 import sys
 import mock
+import os
 
 from mock import patch
 
@@ -17,6 +18,8 @@ class TestSystemBuildTask(object):
             '--description', '../data/description',
             '--target-dir', 'some-target'
         ]
+        self.abs_target_dir = os.path.abspath('some-target')
+
         kiwi.tasks.system_build.Privileges = mock.Mock()
         kiwi.tasks.system_build.Path = mock.Mock()
 
@@ -83,7 +86,7 @@ class TestSystemBuildTask(object):
         self.task.process()
         self.runtime_checker.check_docker_tool_chain_installed.assert_called_once_with()
         self.runtime_checker.check_image_include_repos_http_resolvable.assert_called_once_with()
-        self.runtime_checker.check_target_directory_not_in_shared_cache.assert_called_once_with('some-target')
+        self.runtime_checker.check_target_directory_not_in_shared_cache.assert_called_once_with(self.abs_target_dir)
         self.runtime_checker.check_repositories_configured.assert_called_once_with()
         self.system_prepare.setup_repositories.assert_called_once_with()
         self.system_prepare.install_bootstrap.assert_called_once_with(
@@ -112,7 +115,7 @@ class TestSystemBuildTask(object):
         self.builder.create.assert_called_once_with()
         self.result.print_results.assert_called_once_with()
         self.result.dump.assert_called_once_with(
-            'some-target/kiwi.result'
+            os.sep.join([self.abs_target_dir, 'kiwi.result'])
         )
 
     @patch('kiwi.logger.Logger.set_logfile')

--- a/test/unit/tasks_system_create_test.py
+++ b/test/unit/tasks_system_create_test.py
@@ -1,5 +1,6 @@
 import sys
 import mock
+import os
 
 import kiwi
 
@@ -14,6 +15,11 @@ class TestSystemCreateTask(object):
             sys.argv[0], '--profile', 'vmxFlavour', 'system', 'create',
             '--root', '../data/root-dir', '--target-dir', 'some-target'
         ]
+
+        self.abs_root_dir = os.path.abspath('../data/root-dir')
+        self.abs_target_dir = os.path.abspath('some-target')
+
+        kiwi.tasks.system_create.Path = mock.Mock()
         kiwi.tasks.system_create.Privileges = mock.Mock()
         kiwi.tasks.system_create.Path = mock.Mock()
 
@@ -56,12 +62,14 @@ class TestSystemCreateTask(object):
         self._init_command_args()
         self.task.command_args['create'] = True
         self.task.process()
-        self.runtime_checker.check_target_directory_not_in_shared_cache.called_once_with('some-target')
+        self.runtime_checker.check_target_directory_not_in_shared_cache.called_once_with(
+            self.abs_target_dir
+        )
         self.setup.call_image_script.assert_called_once_with()
         self.builder.create.assert_called_once_with()
         self.result.print_results.assert_called_once_with()
         self.result.dump.assert_called_once_with(
-            'some-target/kiwi.result'
+            os.sep.join([self.abs_target_dir, 'kiwi.result'])
         )
 
     def test_process_system_create_help(self):

--- a/test/unit/tasks_system_prepare_test.py
+++ b/test/unit/tasks_system_prepare_test.py
@@ -1,5 +1,6 @@
 import sys
 import mock
+import os
 
 from mock import patch
 
@@ -17,6 +18,9 @@ class TestSystemPrepareTask(object):
             '--description', '../data/description',
             '--root', '../data/root-dir'
         ]
+
+        self.abs_root_dir = os.path.abspath('../data/root-dir')
+
         kiwi.tasks.system_prepare.Privileges = mock.Mock()
 
         self.runtime_checker = mock.Mock()
@@ -72,7 +76,9 @@ class TestSystemPrepareTask(object):
         self.task.process()
         self.runtime_checker.check_docker_tool_chain_installed.assert_called_once_with()
         self.runtime_checker.check_image_include_repos_http_resolvable.assert_called_once_with()
-        self.runtime_checker.check_target_directory_not_in_shared_cache.assert_called_once_with('../data/root-dir')
+        self.runtime_checker.check_target_directory_not_in_shared_cache.assert_called_once_with(
+            self.abs_root_dir
+        )
         self.runtime_checker.check_repositories_configured.assert_called_once_with()
         self.system_prepare.setup_repositories.assert_called_once_with()
         self.system_prepare.install_bootstrap.assert_called_once_with(


### PR DESCRIPTION
This commit converts the paths provided by the user with the
command line to absolute paths. The effected arguments are:
* --root
* --target-dir
* --bundle-dir

This supersedes and fixes #271