### PR TITLE
Refactor method name of package manager interface

### DIFF
--- a/kiwi/package_manager/apt.py
+++ b/kiwi/package_manager/apt.py
@@ -93,16 +93,16 @@ class PackageManagerApt(PackageManagerBase):
             'Product(%s) handling not supported for apt-get', name
         )
 
-    def request_package_lock(self, name):
+    def request_package_exclusion(self, name):
         """
-        Queue a package lock(ignore) request
+        Queue a package exclusion(skip) request
 
-        There is no locking mechanism for the apt package manager
+        Package exclusion for apt package manager not yet implemented
 
         :param string name: unused
         """
         log.warning(
-            'Package locking for (%s) not supported for apt-get', name
+            'Package exclusion for (%s) not supported for apt-get', name
         )
 
     def process_install_requests_bootstrap(self):

--- a/kiwi/package_manager/base.py
+++ b/kiwi/package_manager/base.py
@@ -93,6 +93,15 @@ class PackageManagerBase(object):
         """
         raise NotImplementedError
 
+    def request_package_lock(self, name):
+        """
+        Queue a package exclusion(skip) request
+
+        Obsolete method, only kept for API compatbility
+        Method calls: request_package_exclusion
+        """
+        return self.request_package_exclusion(name)
+
     def request_package_exclusion(self, name):
         """
         Queue a package exclusion(skip) request

--- a/kiwi/package_manager/base.py
+++ b/kiwi/package_manager/base.py
@@ -49,7 +49,7 @@ class PackageManagerBase(object):
         self.package_requests = []
         self.collection_requests = []
         self.product_requests = []
-        self.lock_requests = []
+        self.exclude_requests = []
 
         self.post_init(custom_args)
 
@@ -93,9 +93,9 @@ class PackageManagerBase(object):
         """
         raise NotImplementedError
 
-    def request_package_lock(self, name):
+    def request_package_exclusion(self, name):
         """
-        Queue a package lock(ignore) request
+        Queue a package exclusion(skip) request
 
         Implementation in specialized package manager class
 
@@ -193,4 +193,4 @@ class PackageManagerBase(object):
         del self.package_requests[:]
         del self.collection_requests[:]
         del self.product_requests[:]
-        del self.lock_requests[:]
+        del self.exclude_requests[:]

--- a/kiwi/package_manager/dnf.py
+++ b/kiwi/package_manager/dnf.py
@@ -81,16 +81,16 @@ class PackageManagerDnf(PackageManagerBase):
         """
         pass
 
-    def request_package_lock(self, name):
+    def request_package_exclusion(self, name):
         """
-        Queue a package lock(ignore) request
+        Queue a package exclusion(skip) request
 
-        There is no locking mechanism for the dnf package manager
+        Package exclusion for dnf package manager not yet implemented
 
         :param string name: unused
         """
         log.warning(
-            'Package locking for (%s) not supported for dnf', name
+            'Package exclusion for (%s) not supported for dnf', name
         )
 
     def process_install_requests_bootstrap(self):

--- a/kiwi/package_manager/yum.py
+++ b/kiwi/package_manager/yum.py
@@ -81,16 +81,16 @@ class PackageManagerYum(PackageManagerBase):
         """
         pass
 
-    def request_package_lock(self, name):
+    def request_package_exclusion(self, name):
         """
-        Queue a package lock(ignore) request
+        Queue a package exclusion(skip) request
 
-        There is no locking mechanism for the yum package manager
+        Package exclusion for yum package manager not yet implemented
 
         :param string name: unused
         """
         log.warning(
-            'Package locking for (%s) not supported for yum', name
+            'Package exclusion for (%s) not supported for yum', name
         )
 
     def process_install_requests_bootstrap(self):

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -388,13 +388,13 @@ class SystemPrepare(object):
                 manager.request_product(product)
         if ignored:
             for package in sorted(ignored):
-                log.info('--> package locked(ignored): {0}'.format(package))
-                manager.request_package_lock(package)
+                log.info('--> package excluded: {0}'.format(package))
+                manager.request_package_exclusion(package)
         return \
             manager.package_requests + \
             manager.collection_requests + \
             manager.product_requests + \
-            manager.lock_requests
+            manager.exclude_requests
 
     def __del__(self):
         log.info('Cleaning up %s instance', type(self).__name__)

--- a/test/unit/package_manager_apt_test.py
+++ b/test/unit/package_manager_apt_test.py
@@ -46,9 +46,9 @@ class TestPackageManagerApt(object):
         assert mock_log_warn.called
 
     @patch('kiwi.logger.log.warning')
-    def test_request_package_lock(self, mock_log_warn):
-        self.manager.request_package_lock('name')
-        assert self.manager.lock_requests == []
+    def test_request_package_exclusion(self, mock_log_warn):
+        self.manager.request_package_exclusion('name')
+        assert self.manager.exclude_requests == []
         assert mock_log_warn.called
 
     @raises(KiwiDebootstrapError)

--- a/test/unit/package_manager_base_test.py
+++ b/test/unit/package_manager_base_test.py
@@ -1,4 +1,5 @@
 import mock
+from mock import patch
 
 from .test_helper import raises
 
@@ -22,6 +23,11 @@ class TestPackageManagerBase(object):
     @raises(NotImplementedError)
     def test_request_product(self):
         self.manager.request_product('name')
+
+    @patch.object(PackageManagerBase, 'request_package_exclusion')
+    def test_request_package_lock(self, mock_exclude):
+        self.manager.request_package_lock('name')
+        mock_exclude.assert_called_once_with('name')
 
     @raises(NotImplementedError)
     def test_request_package_exclusion(self):

--- a/test/unit/package_manager_base_test.py
+++ b/test/unit/package_manager_base_test.py
@@ -24,8 +24,8 @@ class TestPackageManagerBase(object):
         self.manager.request_product('name')
 
     @raises(NotImplementedError)
-    def test_request_package_lock(self):
-        self.manager.request_package_lock('name')
+    def test_request_package_exclusion(self):
+        self.manager.request_package_exclusion('name')
 
     @raises(NotImplementedError)
     def test_process_install_requests_bootstrap(self):
@@ -68,4 +68,4 @@ class TestPackageManagerBase(object):
         assert self.manager.package_requests == []
         assert self.manager.product_requests == []
         assert self.manager.collection_requests == []
-        assert self.manager.lock_requests == []
+        assert self.manager.exclude_requests == []

--- a/test/unit/package_manager_dnf_test.py
+++ b/test/unit/package_manager_dnf_test.py
@@ -40,9 +40,9 @@ class TestPackageManagerDnf(object):
         assert self.manager.product_requests == []
 
     @patch('kiwi.logger.log.warning')
-    def test_request_package_lock(self, mock_log_warn):
-        self.manager.request_package_lock('name')
-        assert self.manager.lock_requests == []
+    def test_request_package_exclusion(self, mock_log_warn):
+        self.manager.request_package_exclusion('name')
+        assert self.manager.exclude_requests == []
         assert mock_log_warn.called
 
     @patch('kiwi.command.Command.call')

--- a/test/unit/package_manager_yum_test.py
+++ b/test/unit/package_manager_yum_test.py
@@ -41,9 +41,9 @@ class TestPackageManagerYum(object):
         assert self.manager.product_requests == []
 
     @patch('kiwi.logger.log.warning')
-    def test_request_package_lock(self, mock_log_warn):
-        self.manager.request_package_lock('name')
-        assert self.manager.lock_requests == []
+    def test_request_package_exclusion(self, mock_log_warn):
+        self.manager.request_package_exclusion('name')
+        assert self.manager.exclude_requests == []
         assert mock_log_warn.called
 
     @patch('kiwi.command.Command.call')

--- a/test/unit/package_manager_zypper_test.py
+++ b/test/unit/package_manager_zypper_test.py
@@ -53,9 +53,9 @@ class TestPackageManagerZypper(object):
         self.manager.request_product('name')
         assert self.manager.product_requests == ['product:name']
 
-    def test_request_package_lock(self):
-        self.manager.request_package_lock('name')
-        assert self.manager.lock_requests == ['name']
+    def test_request_package_exclusion(self):
+        self.manager.request_package_exclusion('name')
+        assert self.manager.exclude_requests == ['name']
 
     @patch('kiwi.command.Command.call')
     def test_process_install_requests_bootstrap(self, mock_call):
@@ -78,13 +78,13 @@ class TestPackageManagerZypper(object):
     ):
         mock_exists.return_value = False
         self.manager.request_package('vim')
-        self.manager.request_package_lock('lockme')
+        self.manager.request_package_exclusion('skipme')
         self.manager.process_install_requests()
         mock_path.assert_called_once_with('root-dir/etc/zypp')
         mock_run.assert_called_once_with(
             ['chroot', 'root-dir', 'zypper'] + self.chroot_zypper_args + [
                 'al'
-            ] + self.manager.custom_args + ['lockme'], self.chroot_command_env
+            ] + self.manager.custom_args + ['skipme'], self.chroot_command_env
         )
         mock_call.assert_called_once_with(
             ['chroot', 'root-dir', 'zypper'] + self.chroot_zypper_args + [

--- a/test/unit/system_prepare_test.py
+++ b/test/unit/system_prepare_test.py
@@ -303,7 +303,7 @@ class TestSystemPrepare(object):
         self.manager.request_product.assert_any_call(
             'openSUSE'
         )
-        self.manager.request_package_lock.assert_any_call(
+        self.manager.request_package_exclusion.assert_any_call(
             'foo'
         )
         self.manager.process_install_requests.assert_called_once_with()


### PR DESCRIPTION
The request_package_lock was renamed into request_package_exclusion
because that is the goal, to actually exclude(skip) a package. From
an implementation point of view this is done to set a lock in the
zypper case. However other package managers might do it differently.
The interface should stay consistent with regards to the user goal
and not with the package manager specific implementation. This
Fixes #248


