### PR TITLE
Fixup theme setup in boot

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -656,8 +656,8 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         boot_theme_dir = os.sep.join(
             [self.root_dir, 'boot', self.boot_directory_name, 'themes']
         )
-        if self.theme and not os.path.exists(boot_theme_dir):
-            Path.create(boot_theme_dir)
+        Path.create(boot_theme_dir)
+        if self.theme and not os.listdir(boot_theme_dir):
             theme_dir = self._find_grub_data(lookup_path + '/usr/share') + \
                 '/themes/' + self.theme
             if os.path.exists(theme_dir):

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -97,12 +97,14 @@ class TestBootLoaderConfigGrub2(object):
     @patch('kiwi.bootloader.config.grub2.DataSync')
     @patch('builtins.open')
     @patch('os.path.exists')
+    @patch('os.listdir')
     @patch('platform.machine')
     @raises(KiwiBootLoaderGrubSecureBootError)
     def test_setup_install_boot_images_raises_no_shim(
-        self, mock_machine, mock_exists, mock_open, mock_sync, mock_command,
-        mock_grub, mock_shim, mock_warn
+        self, mock_machine, mock_listdir, mock_exists, mock_open,
+        mock_sync, mock_command, mock_grub, mock_shim, mock_warn
     ):
+        mock_listdir.return_value = []
         self.firmware.efi_mode = mock.Mock(
             return_value='uefi'
         )
@@ -126,12 +128,14 @@ class TestBootLoaderConfigGrub2(object):
     @patch('kiwi.bootloader.config.grub2.DataSync')
     @patch('builtins.open')
     @patch('os.path.exists')
+    @patch('os.listdir')
     @patch('platform.machine')
     @raises(KiwiBootLoaderGrubSecureBootError)
     def test_setup_install_boot_images_raises_no_efigrub(
-        self, mock_machine, mock_exists, mock_open, mock_sync, mock_command,
-        mock_grub, mock_shim, mock_warn
+        self, mock_machine, mock_listdir, mock_exists, mock_open,
+        mock_sync, mock_command, mock_grub, mock_shim, mock_warn
     ):
+        mock_listdir.return_value = []
         self.firmware.efi_mode = mock.Mock(
             return_value='uefi'
         )
@@ -697,17 +701,18 @@ class TestBootLoaderConfigGrub2(object):
     @patch('kiwi.bootloader.config.grub2.DataSync')
     @patch_open
     @patch('os.path.exists')
+    @patch('os.listdir')
     @patch('kiwi.logger.log.warning')
     @patch('platform.machine')
     def test_setup_install_boot_images_with_theme(
-        self, mock_machine, mock_warn, mock_exists, mock_open,
+        self, mock_machine, mock_warn, mock_listdir, mock_exists, mock_open,
         mock_sync, mock_command
     ):
+        mock_listdir.return_value = []
         data = mock.Mock()
         mock_sync.return_value = data
         mock_machine.return_value = 'x86_64'
         self.bootloader.theme = 'some-theme'
-        self.os_exists['root_dir/boot/grub2/themes'] = False
         self.os_exists['root_dir/usr/share/grub2/themes/some-theme'] = True
         self.os_exists['root_dir/boot/grub2/themes/some-theme'] = True
 
@@ -761,12 +766,14 @@ class TestBootLoaderConfigGrub2(object):
     @patch('kiwi.bootloader.config.grub2.DataSync')
     @patch('builtins.open')
     @patch('os.path.exists')
+    @patch('os.listdir')
     @patch('kiwi.logger.log.warning')
     @patch('platform.machine')
     def test_setup_install_boot_images_with_theme_not_existing(
-        self, mock_machine, mock_warn, mock_exists, mock_open,
+        self, mock_machine, mock_warn, mock_listdir, mock_exists, mock_open,
         mock_sync, mock_command
     ):
+        mock_listdir.return_value = []
         mock_machine.return_value = 'x86_64'
         self.bootloader.theme = 'some-theme'
         self.os_exists['root_dir/usr/share/grub2/themes/some-theme'] = False


### PR DESCRIPTION
Make sure grub theme data is populated in the boot directory.
Checking only for the presence of the theme directory is not
enough. If the theme directory in boot does not contain the
requested theme it must be provided including a warning if
the theme data could not be found in the system


