### PR TITLE
Delete obsolete ec2 disk format

### DIFF
--- a/doc/source/schema.rst
+++ b/doc/source/schema.rst
@@ -298,7 +298,7 @@ List of attributes for ``type``:
 * ``editbootinstall`` `[?]`_: Specifies the path to a script which is called right after the bootloader is installed. The script runs relative to the directory which contains the image structure
 * ``filesystem`` `[?]`_: Specifies the root filesystem type
 * ``flags`` `[?]`_: Specifies overlay filesystem flags for the iso image type. `clic` uses the fuse based clicfs as root overlay filesystem. When using clicfs make sure it is installed on your build host system and also put as bootincluded package in your XML description: `<package name="clicfs" bootinclude="true"/>`, `clic_udf` same as clicfs but allows creation if live images which exceeds the 4G boundary, `overlay` uses the kernel overlayfs as root overlay filesystem. This is the most stable and preferred method.
-* ``format`` `[?]`_: Specifies the format of the virtual disk. The ec2 value is deprecated and no longer supported It remains in the schema to allow us to print a better Error message than we receive from the parser. To be remove from here by the end of 2014
+* ``format`` `[?]`_: Specifies the format of the virtual disk.
 * ``formatoptions`` `[?]`_: Specifies additional format options passed on to qemu-img formatoptions is a comma separated list of format specific options in a name=value format like qemu-img expects it. kiwi will take the information and pass it as parameter to the -o option in the qemu-img call
 * ``fsnocheck`` `[?]`_: Turn off periodic filesystem checks on ext2/3/4. Obsolete attribute since KIWI v8
 * ``fsmountoptions`` `[?]`_: Specifies the filesystem mount options which also ends up in fstab The string given here is passed as value to the -o option of mount

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1719,8 +1719,7 @@ div {
         ## the disk layout and the partition table type. By default
         ## the standard x86 bios firmware setup is used
         attribute firmware {
-            "bios" | "ec2" | "ec2hvm" | "efi" |
-            "uefi" | "ofw" | "opal"
+            "bios" | "ec2" | "efi" | "uefi" | "ofw" | "opal"
         }
         >> sch:pattern [ id = "firmware" is-a = "image_type"
             sch:param [ name = "attr" value = "firmware" ]
@@ -1765,12 +1764,8 @@ div {
         ]
     k.type.format.attribute =
         ## Specifies the format of the virtual disk.
-        ## The ec2 value is deprecated and no longer supported
-        ## It remains in the schema to allow us to print a better
-        ## Error message than we receive from the parser.
-        ## To be remove from here by the end of 2014
         attribute format {
-            "ec2" | "gce" | "ovf" | "ova" | "qcow2" | "vagrant" | "vmdk" |
+            "gce" | "ovf" | "ova" | "qcow2" | "vagrant" | "vmdk" |
             "vdi" | "vhd" | "vhd-fixed"
         }
         >> sch:pattern [ id = "format" is-a = "image_type"

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2220,7 +2220,6 @@ the standard x86 bios firmware setup is used</a:documentation>
         <choice>
           <value>bios</value>
           <value>ec2</value>
-          <value>ec2hvm</value>
           <value>efi</value>
           <value>uefi</value>
           <value>ofw</value>
@@ -2286,13 +2285,8 @@ and preferred method.</a:documentation>
     </define>
     <define name="k.type.format.attribute">
       <attribute name="format">
-        <a:documentation>Specifies the format of the virtual disk.
-The ec2 value is deprecated and no longer supported
-It remains in the schema to allow us to print a better
-Error message than we receive from the parser.
-To be remove from here by the end of 2014</a:documentation>
+        <a:documentation>Specifies the format of the virtual disk.</a:documentation>
         <choice>
-          <value>ec2</value>
           <value>gce</value>
           <value>ovf</value>
           <value>ova</value>


### PR DESCRIPTION
The ec2 value in the format attribute is deprecated and no
longer supported It remained in the schema for a while and
has now reached EOL

