### PR TITLE
Fixup grub2 setup and tool calls

### DIFF
--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -298,12 +298,15 @@ class BootLoaderConfigBase(object):
                 filesystem = self.xml_state.build_type.get_filesystem()
                 volumes = self.xml_state.get_volumes()
                 if filesystem == 'btrfs' and volumes:
-                    # boot or boot/grub2 on a subvolume prevents grub from
-                    # finding its config file
+                    # grub boot data paths must not be in a subvolume
+                    # otherwise grub won't be able to find its config file
+                    grub2_boot_data_paths = ['boot', 'boot/grub', 'boot/grub2']
                     for volume in volumes:
-                        if volume.name == 'boot' or volume.name == 'boot/grub2':
+                        if volume.name in grub2_boot_data_paths:
                             raise KiwiBootLoaderTargetError(
-                                'boot or boot/grub2 must not be a subvolume'
+                                '{0} must not be a subvolume'.format(
+                                    volume.name
+                                )
                             )
 
         return bootpath

--- a/kiwi/bootloader/template/grub2.py
+++ b/kiwi/bootloader/template/grub2.py
@@ -73,10 +73,10 @@ class BootLoaderTemplateGrub2(object):
 
         self.fonts = dedent('''
             set font=($$root)${bootpath}/unicode.pf2
-            set ascii_font=grub2/themes/${theme}/ascii.pf2
-            set sans_bold_14_font=grub2/themes/${theme}/DejaVuSans-Bold14.pf2
-            set sans_10_font=grub2/themes/${theme}/DejaVuSans10.pf2
-            set sans_12_font=grub2/themes/${theme}/DejaVuSans12.pf2
+            set ascii_font=${boot_directory_name}/themes/${theme}/ascii.pf2
+            set sans_bold_14_font=${boot_directory_name}/themes/${theme}/DejaVuSans-Bold14.pf2
+            set sans_10_font=${boot_directory_name}/themes/${theme}/DejaVuSans10.pf2
+            set sans_12_font=${boot_directory_name}/themes/${theme}/DejaVuSans12.pf2
         ''').strip() + os.linesep
 
         self.header_theme = self.fonts + dedent('''
@@ -95,8 +95,8 @@ class BootLoaderTemplateGrub2(object):
             if [ -f ($$root)${bootpath}/$${sans_12_font} ];then
                 loadfont ($$root)${bootpath}/$${sans_12_font}
             fi
-            if [ -f ($$root)${bootpath}/grub2/themes/${theme}/theme.txt ];then
-                set theme=($$root)${bootpath}/grub2/themes/${theme}/theme.txt
+            if [ -f ($$root)${bootpath}/${boot_directory_name}/themes/${theme}/theme.txt ];then
+                set theme=($$root)${bootpath}/${boot_directory_name}/themes/${theme}/theme.txt
                 export theme
             fi
         ''').strip() + os.linesep
@@ -117,8 +117,8 @@ class BootLoaderTemplateGrub2(object):
             if [ -f ($$root)/boot/$${sans_12_font} ];then
                 loadfont ($$root)/boot/$${sans_12_font}
             fi
-            if [ -f ($$root)/boot/grub2/themes/${theme}/theme.txt ];then
-                set theme=($$root)/boot/grub2/themes/${theme}/theme.txt
+            if [ -f ($$root)/boot/${boot_directory_name}/themes/${theme}/theme.txt ];then
+                set theme=($$root)/boot/${boot_directory_name}/themes/${theme}/theme.txt
             fi
         ''').strip() + os.linesep
 

--- a/test/unit/bootloader_install_grub2_test.py
+++ b/test/unit/bootloader_install_grub2_test.py
@@ -141,12 +141,16 @@ class TestBootLoaderInstallGrub2(object):
         assert self.bootloader.install_required() is False
 
     @patch('kiwi.bootloader.install.grub2.Path.wipe')
+    @patch('kiwi.bootloader.install.grub2.Path.which')
     @patch('kiwi.bootloader.install.grub2.Command.run')
     @patch('kiwi.bootloader.install.grub2.MountManager')
     @patch('kiwi.bootloader.install.grub2.Defaults.get_grub_path')
+    @patch('kiwi.bootloader.install.grub2.glob.glob')
     def test_install_with_extra_boot_partition(
-        self, mock_grub_path, mock_mount_manager, mock_command, mock_wipe
+        self, mock_glob, mock_grub_path, mock_mount_manager,
+        mock_command, mock_which, mock_wipe
     ):
+        mock_glob.return_value = ['tmp_root/boot/grub2/grubenv']
         mock_grub_path.return_value = \
             self.root_mount.mountpoint + '/usr/lib/grub2'
 
@@ -158,8 +162,14 @@ class TestBootLoaderInstallGrub2(object):
         self.bootloader.install()
         self.bootloader.root_mount.mount.assert_called_once_with()
         self.bootloader.boot_mount.mount.assert_called_once_with()
+        mock_glob.assert_called_once_with(
+            'tmp_root/boot/*/grubenv'
+        )
         mock_wipe.assert_called_once_with(
             'tmp_root/boot/grub2/grubenv'
+        )
+        mock_which.assert_called_once_with(
+            custom_env={'PATH': 'tmp_root/usr/sbin'}, filename='grub2-install'
         )
         mock_command.assert_called_once_with(
             [
@@ -175,12 +185,16 @@ class TestBootLoaderInstallGrub2(object):
         )
 
     @patch('kiwi.bootloader.install.grub2.Path.wipe')
+    @patch('kiwi.bootloader.install.grub2.Path.which')
     @patch('kiwi.bootloader.install.grub2.Command.run')
     @patch('kiwi.bootloader.install.grub2.MountManager')
     @patch('kiwi.bootloader.install.grub2.Defaults.get_grub_path')
+    @patch('kiwi.bootloader.install.grub2.glob.glob')
     def test_install_ppc_ieee1275(
-        self, mock_grub_path, mock_mount_manager, mock_command, mock_wipe
+        self, mock_glob, mock_grub_path, mock_mount_manager,
+        mock_command, mock_which, mock_wipe
     ):
+        mock_glob.return_value = ['tmp_root/boot/grub2/grubenv']
         mock_grub_path.return_value = \
             self.root_mount.mountpoint + '/usr/lib/grub2'
         self.bootloader.arch = 'ppc64'
@@ -210,12 +224,16 @@ class TestBootLoaderInstallGrub2(object):
         )
 
     @patch('kiwi.bootloader.install.grub2.Path.wipe')
+    @patch('kiwi.bootloader.install.grub2.Path.which')
     @patch('kiwi.bootloader.install.grub2.Command.run')
     @patch('kiwi.bootloader.install.grub2.MountManager')
     @patch('kiwi.bootloader.install.grub2.Defaults.get_grub_path')
+    @patch('kiwi.bootloader.install.grub2.glob.glob')
     def test_install(
-        self, mock_grub_path, mock_mount_manager, mock_command, mock_wipe
+        self, mock_glob, mock_grub_path, mock_mount_manager,
+        mock_command, mock_which, mock_wipe
     ):
+        mock_glob.return_value = ['tmp_root/boot/grub2/grubenv']
         mock_grub_path.return_value = \
             self.root_mount.mountpoint + '/usr/lib/grub2'
         self.boot_mount.device = self.root_mount.device
@@ -248,15 +266,18 @@ class TestBootLoaderInstallGrub2(object):
             ])
 
     @patch('kiwi.bootloader.install.grub2.Path.wipe')
+    @patch('kiwi.bootloader.install.grub2.Path.which')
     @patch('kiwi.bootloader.install.grub2.Command.run')
     @patch('kiwi.bootloader.install.grub2.MountManager')
     @patch('kiwi.bootloader.install.grub2.Defaults.get_grub_path')
+    @patch('kiwi.bootloader.install.grub2.glob.glob')
     @patch('os.path.exists')
     def test_install_secure_boot(
-        self, mock_exists, mock_grub_path, mock_mount_manager,
-        mock_command, mock_wipe
+        self, mock_exists, mock_glob, mock_grub_path, mock_mount_manager,
+        mock_command, mock_which, mock_wipe
     ):
         mock_exists.return_value = True
+        mock_glob.return_value = ['tmp_root/boot/grub2/grubenv']
         mock_grub_path.return_value = \
             self.root_mount.mountpoint + '/usr/lib/grub2'
         self.firmware.efi_mode.return_value = 'uefi'

--- a/test/unit/bootloader_template_grub2_test.py
+++ b/test/unit/bootloader_template_grub2_test.py
@@ -17,7 +17,8 @@ class TestBootLoaderTemplateGrub2(object):
             theme='SLE',
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community [ VMX ]',
-            bootpath='/boot'
+            bootpath='/boot',
+            boot_directory_name='grub2'
         )
 
     def test_get_disk_template_console(self):
@@ -64,6 +65,7 @@ class TestBootLoaderTemplateGrub2(object):
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community [ VMX ]',
             bootpath='/boot',
+            boot_directory_name='grub2',
             hypervisor='xen.gz'
         )
 
@@ -112,6 +114,7 @@ class TestBootLoaderTemplateGrub2(object):
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community [ VMX ]',
             bootpath='/boot',
+            boot_directory_name='grub2',
             hypervisor='xen.gz'
         )
 
@@ -159,7 +162,8 @@ class TestBootLoaderTemplateGrub2(object):
             theme='SLE',
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community [ VMX ]',
-            bootpath='/boot'
+            bootpath='/boot',
+            boot_directory_name='grub2'
         )
 
     def test_get_install_template_console_no_hybrid(self):
@@ -206,7 +210,8 @@ class TestBootLoaderTemplateGrub2(object):
             theme='SLE',
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community',
-            bootpath='/boot'
+            bootpath='/boot',
+            boot_directory_name='grub2'
         )
 
     def test_get_iso_template_console_no_hybrid(self):
@@ -254,6 +259,7 @@ class TestBootLoaderTemplateGrub2(object):
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community',
             bootpath='/boot',
+            boot_directory_name='grub2',
             hypervisor='xen.gz'
         )
 


### PR DESCRIPTION
Depending on the distribution the grub tools are either named
grub2-tool or grub-tool. Additionally the grub configuration
data is expected to live in boot/grub2 or boot/grub. This commit
handles the tool calls and also the grub boot directory setup
in a generic way

