### PR TITLE
Fixup bootloader menu title setup

### DIFF
--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -337,6 +337,11 @@ class BootLoaderConfigBase(object):
         title = self.xml_state.xml_data.get_displayname()
         if not title:
             title = self.xml_state.xml_data.get_name()
+        else:
+            # if the is set via the displayname attribute no custom
+            # kiwi prefix or other style changes to that text should
+            # be made
+            plain = True
         type_name = self.xml_state.build_type.get_image()
         if plain:
             return title

--- a/test/unit/bootloader_config_base_test.py
+++ b/test/unit/bootloader_config_base_test.py
@@ -226,6 +226,12 @@ class TestBootLoaderConfigBase(object):
             'LimeJeOS-openSUSE-13.2'
 
     @patch('kiwi.xml_parse.image.get_displayname')
+    def test_get_menu_entry_title_by_displayname(self, mock_displayname):
+        mock_displayname.return_value = 'my_title'
+        assert self.bootloader.get_menu_entry_title() == \
+            'my_title'
+
+    @patch('kiwi.xml_parse.image.get_displayname')
     def test_get_menu_entry_install_title(self, mock_displayname):
         mock_displayname.return_value = None
         assert self.bootloader.get_menu_entry_install_title() == \


### PR DESCRIPTION
If the menu title is setup via the displayname attribute in
the XML configuration, kiwi should not change this text by
a prefix or any other style adaptions. Fixes #287


