### PR TITLE
Avoid GRUB_DISTRIBUTOR setup in etc/default/grub

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -452,13 +452,9 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         * GRUB_USE_LINUXEFI
         * GRUB_USE_INITRDEFI
         * GRUB_SERIAL_COMMAND
-        * GRUB_DISTRIBUTOR
         * GRUB_CMDLINE_LINUX
         """
         grub_default_entries = {
-            'GRUB_DISTRIBUTOR': '"{0}"'.format(
-                self.get_menu_entry_title(plain=True)
-            ),
             'GRUB_TIMEOUT': self.timeout
         }
         if self.cmdline:

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -257,7 +257,6 @@ class TestBootLoaderConfigGrub2(object):
         assert grub_default.__setitem__.call_args_list == [
             call('GRUB_BACKGROUND', '/boot/grub2/themes/openSUSE/background.png'),
             call('GRUB_CMDLINE_LINUX', '"some-cmdline"'),
-            call('GRUB_DISTRIBUTOR', '"Bob"'),
             call('GRUB_SERIAL_COMMAND', '"serial --speed=38400 --unit=0 --word=8 --parity=no --stop=1"'),
             call('GRUB_THEME', '/boot/grub2/themes/openSUSE/theme.txt'),
             call('GRUB_TIMEOUT', 10),


### PR DESCRIPTION
The GRUB_DISTRIBUTOR information can't be provided in a generic
way for all distributions. The information should be either placed
by a package post script (as done by most of the distributions)
or by a custom kiwi config.sh or images.sh script. Fixes #286
Fixes (bsc#1032119)

