### PR TITLE
Keep imported image in OCI format instead of docker

### DIFF
--- a/kiwi/container/docker.py
+++ b/kiwi/container/docker.py
@@ -24,6 +24,7 @@ from kiwi.path import Path
 from kiwi.command import Command
 from kiwi.utils.sync import DataSync
 from kiwi.utils.compress import Compress
+from kiwi.archive.tar import ArchiveTar
 
 
 class ContainerImageDocker(object):
@@ -116,10 +117,12 @@ class ContainerImageDocker(object):
         )
 
         if base_image:
+            Path.create(container_dir)
+            image_tar = ArchiveTar(base_image)
+            image_tar.extract(container_dir)
             Command.run([
-                'skopeo', 'copy',
-                'docker-archive:{0}'.format(base_image),
-                'oci:{0}'.format(container_name)
+                'umoci', 'config', '--image',
+                container_dir, '--tag', self.container_tag
             ])
         else:
             Command.run(
@@ -157,7 +160,6 @@ class ContainerImageDocker(object):
             self.labels +
             [
                 '--image', container_name,
-                '--tag', self.container_tag
             ]
         )
         Command.run(

--- a/kiwi/system/root_import/base.py
+++ b/kiwi/system/root_import/base.py
@@ -16,12 +16,9 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
-import shutil
 
 # project
-from kiwi.path import Path
 from kiwi.utils.checksum import Checksum
-from kiwi.defaults import Defaults
 from kiwi.exceptions import KiwiRootImportError
 
 
@@ -69,9 +66,6 @@ class RootImportBase(object):
         """
         raise NotImplementedError
 
-    def _copy_image(self, image):
-        image_copy = Defaults.get_imported_root_image(self.root_dir)
-        Path.create(os.path.dirname(image_copy))
-        shutil.copy(image, image_copy)
-        checksum = Checksum(image_copy)
-        checksum.md5(''.join([image_copy, '.md5']))
+    def _make_checksum(self, image):
+        checksum = Checksum(image)
+        checksum.md5(''.join([image, '.md5']))

--- a/kiwi/system/root_import/docker.py
+++ b/kiwi/system/root_import/docker.py
@@ -24,6 +24,8 @@ from kiwi.path import Path
 from kiwi.utils.sync import DataSync
 from kiwi.utils.compress import Compress
 from kiwi.command import Command
+from kiwi.archive.tar import ArchiveTar
+from kiwi.defaults import Defaults
 
 
 class RootImportDocker(RootImportBase):
@@ -67,7 +69,11 @@ class RootImportDocker(RootImportBase):
         # kept inside the root_dir in order to ensure the later steps
         # i.e. system create are atomic and don't need any third
         # party archive.
-        self._copy_image(self.uncompressed_image)
+        image_copy = Defaults.get_imported_root_image(self.root_dir)
+        Path.create(os.path.dirname(image_copy))
+        image_tar = ArchiveTar(image_copy)
+        image_tar.create(self.oci_layout_dir)
+        self._make_checksum(image_copy)
 
     def __del__(self):
         if self.oci_layout_dir:

--- a/test/unit/system_root_import_docker_test.py
+++ b/test/unit/system_root_import_docker_test.py
@@ -26,16 +26,16 @@ class TestRootImportDocker(object):
             'root_dir', Uri('file:///image.tar.xz')
         )
 
-    @patch('kiwi.system.root_import.base.shutil.copy')
+    @patch('kiwi.system.root_import.docker.ArchiveTar')
     @patch('kiwi.system.root_import.base.Checksum')
-    @patch('kiwi.system.root_import.base.Path.create')
+    @patch('kiwi.system.root_import.docker.Path.create')
     @patch('kiwi.system.root_import.docker.Compress')
     @patch('kiwi.system.root_import.docker.Command.run')
     @patch('kiwi.system.root_import.docker.DataSync')
     @patch('kiwi.system.root_import.docker.mkdtemp')
     def test_sync_data(
         self, mock_mkdtemp, mock_sync, mock_run,
-        mock_compress, mock_path, mock_md5, mock_copy
+        mock_compress, mock_path, mock_md5, mock_tar
     ):
         uncompress = mock.Mock()
         uncompress.uncompressed_filename = 'tmp_uncompressed'
@@ -78,8 +78,8 @@ class TestRootImportDocker(object):
         )
         mock_md5.assert_called_once_with('root_dir/image/imported_root')
         md5.md5.called_once_with('root_dir/image/imported_root.md5')
-        mock_copy.assert_called_once_with(
-            'tmp_uncompressed', 'root_dir/image/imported_root'
+        mock_tar.assert_called_once_with(
+            'root_dir/image/imported_root'
         )
         mock_path.assert_called_once_with('root_dir/image')
 


### PR DESCRIPTION
Kiwi always uses OCI format for container manipulations, so it is
easier to assume the image kept between prepare and create step
is also in OCI format, this way less format conversions are needed.
