### PR TITLE
Added support for unknown uri types for base image references

### DIFF
--- a/kiwi/system/root_import/base.py
+++ b/kiwi/system/root_import/base.py
@@ -19,7 +19,10 @@ import os
 
 # project
 from kiwi.utils.checksum import Checksum
-from kiwi.exceptions import KiwiRootImportError
+from kiwi.exceptions import (
+    KiwiRootImportError,
+    KiwiUriTypeUnknown
+)
 
 
 class RootImportBase(object):
@@ -33,6 +36,8 @@ class RootImportBase(object):
         Uri object to store source location
     """
     def __init__(self, root_dir, image_uri):
+        self.unknown_uri = None
+        self.root_dir = root_dir
         try:
             if image_uri.is_remote():
                 raise KiwiRootImportError(
@@ -45,8 +50,9 @@ class RootImportBase(object):
                 raise KiwiRootImportError(
                     'Could not stat base image file: {0}'.format(self.image_file)
                 )
-
-            self.root_dir = root_dir
+        except KiwiUriTypeUnknown:
+            # Let specialized class handle unknown uri schemes
+            self.unknown_uri = image_uri.uri
         finally:
             self.post_init()
 

--- a/kiwi/system/root_import/base.py
+++ b/kiwi/system/root_import/base.py
@@ -19,6 +19,7 @@ import os
 
 # project
 from kiwi.utils.checksum import Checksum
+from kiwi.logger import log
 from kiwi.exceptions import (
     KiwiRootImportError,
     KiwiUriTypeUnknown
@@ -48,10 +49,15 @@ class RootImportBase(object):
 
             if not os.path.exists(self.image_file):
                 raise KiwiRootImportError(
-                    'Could not stat base image file: {0}'.format(self.image_file)
+                    'Could not stat base image file: {0}'.format(
+                        self.image_file
+                    )
                 )
         except KiwiUriTypeUnknown:
             # Let specialized class handle unknown uri schemes
+            log.warning(
+                'Unkown URI type for the base image: %s', image_uri.uri
+            )
             self.unknown_uri = image_uri.uri
         finally:
             self.post_init()

--- a/kiwi/system/root_import/docker.py
+++ b/kiwi/system/root_import/docker.py
@@ -42,17 +42,23 @@ class RootImportDocker(RootImportBase):
         self.oci_layout_dir = None
 
     def sync_data(self):
-        compressor = Compress(self.image_file)
-        compressor.uncompress(True)
-        self.uncompressed_image = compressor.uncompressed_filename
+        """
+        Synchronize data from the given base image to the target root
+        directory.
+        """
+        if not self.unknown_uri:
+            compressor = Compress(self.image_file)
+            compressor.uncompress(True)
+            self.uncompressed_image = compressor.uncompressed_filename
+            skopeo_uri = 'docker-archive:{0}'.format(self.uncompressed_image)
+        else:
+            skopeo_uri = self.unknown_uri
 
         self.oci_layout_dir = mkdtemp(prefix='kiwi_layout_dir.')
         self.oci_unpack_dir = mkdtemp(prefix='kiwi_unpack_dir.')
 
         Command.run([
-            'skopeo', 'copy',
-            'docker-archive:{0}'.format(self.uncompressed_image),
-            'oci:{0}'.format(self.oci_layout_dir)
+            'skopeo', 'copy', skopeo_uri, 'oci:{0}'.format(self.oci_layout_dir)
         ])
         Command.run([
             'umoci', 'unpack', '--image',

--- a/kiwi/system/root_import/docker.py
+++ b/kiwi/system/root_import/docker.py
@@ -20,6 +20,7 @@ import os
 
 # project
 from kiwi.system.root_import.base import RootImportBase
+from kiwi.logger import log
 from kiwi.path import Path
 from kiwi.utils.sync import DataSync
 from kiwi.utils.compress import Compress
@@ -52,6 +53,7 @@ class RootImportDocker(RootImportBase):
             self.uncompressed_image = compressor.uncompressed_filename
             skopeo_uri = 'docker-archive:{0}'.format(self.uncompressed_image)
         else:
+            log.warning('Bypassing base image URI to skopeo tool')
             skopeo_uri = self.unknown_uri
 
         self.oci_layout_dir = mkdtemp(prefix='kiwi_layout_dir.')

--- a/test/unit/system_root_import_base_test.py
+++ b/test/unit/system_root_import_base_test.py
@@ -18,9 +18,11 @@ class TestRootImportBase(object):
     def test_init_remote_uri(self):
         RootImportBase('root_dir', Uri('http://example.com/image.tar.xz'))
 
-    def test_init_unknown_uri(self):
+    @patch('kiwi.system.root_import.base.log.warning')
+    def test_init_unknown_uri(self, mock_log_warn):
         root = RootImportBase('root_dir', Uri('docker://opensuse:leap'))
         assert root.unknown_uri == 'docker://opensuse:leap'
+        assert mock_log_warn.called
 
     @patch('os.path.exists')
     @raises(KiwiRootImportError)

--- a/test/unit/system_root_import_base_test.py
+++ b/test/unit/system_root_import_base_test.py
@@ -18,6 +18,10 @@ class TestRootImportBase(object):
     def test_init_remote_uri(self):
         RootImportBase('root_dir', Uri('http://example.com/image.tar.xz'))
 
+    def test_init_unknown_uri(self):
+        root = RootImportBase('root_dir', Uri('docker://opensuse:leap'))
+        assert root.unknown_uri == 'docker://opensuse:leap'
+
     @patch('os.path.exists')
     @raises(KiwiRootImportError)
     def test_init_non_existing(self, mock_path):

--- a/test/unit/system_root_import_docker_test.py
+++ b/test/unit/system_root_import_docker_test.py
@@ -83,6 +83,7 @@ class TestRootImportDocker(object):
         )
         mock_path.assert_called_once_with('root_dir/image')
 
+    @patch('kiwi.system.root_import.base.log.warning')
     @patch('os.path.exists')
     @patch('kiwi.system.root_import.docker.ArchiveTar')
     @patch('kiwi.system.root_import.base.Checksum')
@@ -92,7 +93,7 @@ class TestRootImportDocker(object):
     @patch('kiwi.system.root_import.docker.mkdtemp')
     def test_sync_data_unknown_uri(
         self, mock_mkdtemp, mock_sync, mock_run,
-        mock_create, mock_md5, mock_tar, mock_exists
+        mock_create, mock_md5, mock_tar, mock_exists, mock_log_warn
     ):
         mock_exists.return_value = True
         docker_import = RootImportDocker(
@@ -113,6 +114,7 @@ class TestRootImportDocker(object):
 
         docker_import.sync_data()
 
+        assert mock_log_warn.called
         assert mock_run.call_args_list == [
             call([
                 'skopeo', 'copy', 'docker://opensuse:leap',


### PR DESCRIPTION
This commits bypasses any URI check if the uri schema is unknown in
RootImport class. This way the URI is bypassed to skopeo if it couldn't
be translated to any known type. That enables referencing images with
any URI supported by skopeo, i.e. DockerHub images.
