### PR TITLE
Add method to setup installation of recommended packages

### DIFF
--- a/kiwi/package_manager/apt.py
+++ b/kiwi/package_manager/apt.py
@@ -214,7 +214,15 @@ class PackageManagerApt(PackageManagerBase):
         """
         Setup package processing only for required packages
 
-        There is no required/recommends information in the rhel repo data
+        Kiwi has no required/recommends support for apt manager yet
+        """
+        pass
+
+    def process_plus_recommended(self):
+        """
+        Setup package processing to also include recommended dependencies
+
+        Kiwi has no required/recommends support for apt manager yet
         """
         pass
 

--- a/kiwi/package_manager/base.py
+++ b/kiwi/package_manager/base.py
@@ -154,6 +154,14 @@ class PackageManagerBase(object):
         """
         raise NotImplementedError
 
+    def process_plus_recommended(self):
+        """
+        Setup package processing to also include recommended dependencies
+
+        Implementation in specialized package manager class
+        """
+        raise NotImplementedError
+
     def match_package_installed(self, package_list, log_line):
         """
         Match expression to indicate a package has been installed

--- a/kiwi/package_manager/dnf.py
+++ b/kiwi/package_manager/dnf.py
@@ -191,7 +191,15 @@ class PackageManagerDnf(PackageManagerBase):
         """
         Setup package processing only for required packages
 
-        There is no required/recommends information in the rhel repo data
+        Kiwi has no required/recommends support for dnf manager yet
+        """
+        pass
+
+    def process_plus_recommended(self):
+        """
+        Setup package processing to also include recommended dependencies
+
+        Kiwi has no required/recommends support for dnf manager yet
         """
         pass
 

--- a/kiwi/package_manager/yum.py
+++ b/kiwi/package_manager/yum.py
@@ -193,6 +193,14 @@ class PackageManagerYum(PackageManagerBase):
         """
         pass
 
+    def process_plus_recommended(self):
+        """
+        Setup package processing to also include recommended dependencies
+
+        There is no required/recommends information in the rhel repo data
+        """
+        pass
+
     def match_package_installed(self, package_name, yum_output):
         """
         Match expression to indicate a package has been installed

--- a/kiwi/package_manager/zypper.py
+++ b/kiwi/package_manager/zypper.py
@@ -194,6 +194,13 @@ class PackageManagerZypper(PackageManagerBase):
         if '--no-recommends' not in self.custom_args:
             self.custom_args.append('--no-recommends')
 
+    def process_plus_recommended(self):
+        """
+        Setup package processing to also include recommended dependencies.
+        """
+        if '--no-recommends' in self.custom_args:
+            self.custom_args.remove('--no-recommends')
+
     def match_package_installed(self, package_name, zypper_output):
         """
         Match expression to indicate a package has been installed

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -168,6 +168,8 @@ class SystemPrepare(object):
         # process package installations
         if collection_type == 'onlyRequired':
             manager.process_only_required()
+        else:
+            manager.process_plus_recommended()
         all_install_items = self._setup_requests(
             manager,
             bootstrap_packages,
@@ -222,6 +224,8 @@ class SystemPrepare(object):
         # process package installations
         if collection_type == 'onlyRequired':
             manager.process_only_required()
+        else:
+            manager.process_plus_recommended()
         all_install_items = self._setup_requests(
             manager,
             system_packages,

--- a/test/unit/package_manager_apt_test.py
+++ b/test/unit/package_manager_apt_test.py
@@ -153,6 +153,9 @@ class TestPackageManagerApt(object):
     def test_process_only_required(self):
         self.manager.process_only_required()
 
+    def test_process_plus_recommended(self):
+        self.manager.process_plus_recommended()
+
     def test_match_package_installed(self):
         assert self.manager.match_package_installed('foo', 'Unpacking foo')
 

--- a/test/unit/package_manager_base_test.py
+++ b/test/unit/package_manager_base_test.py
@@ -54,6 +54,10 @@ class TestPackageManagerBase(object):
         self.manager.process_only_required()
 
     @raises(NotImplementedError)
+    def test_process_plus_recommended(self):
+        self.manager.process_plus_recommended()
+
+    @raises(NotImplementedError)
     def test_match_package_installed(self):
         self.manager.match_package_installed('package_name', 'log')
 

--- a/test/unit/package_manager_dnf_test.py
+++ b/test/unit/package_manager_dnf_test.py
@@ -128,6 +128,9 @@ class TestPackageManagerDnf(object):
     def test_process_only_required(self):
         self.manager.process_only_required()
 
+    def test_process_plus_recommended(self):
+        self.manager.process_plus_recommended()
+
     def test_match_package_installed(self):
         assert self.manager.match_package_installed('foo', 'Installing  : foo')
 

--- a/test/unit/package_manager_yum_test.py
+++ b/test/unit/package_manager_yum_test.py
@@ -129,6 +129,9 @@ class TestPackageManagerYum(object):
     def test_process_only_required(self):
         self.manager.process_only_required()
 
+    def test_process_plus_recommended(self):
+        self.manager.process_plus_recommended()
+
     def test_match_package_installed(self):
         assert self.manager.match_package_installed('foo', 'Installing : foo')
 

--- a/test/unit/package_manager_zypper_test.py
+++ b/test/unit/package_manager_zypper_test.py
@@ -139,6 +139,12 @@ class TestPackageManagerZypper(object):
         self.manager.process_only_required()
         assert self.manager.custom_args == ['--no-recommends']
 
+    def test_process_plus_recommended(self):
+        self.manager.process_only_required()
+        assert self.manager.custom_args == ['--no-recommends']
+        self.manager.process_plus_recommended()
+        assert '--no-recommends' not in self.manager.custom_args
+
     def test_match_package_installed(self):
         assert self.manager.match_package_installed('foo', 'Installing: foo')
 


### PR DESCRIPTION
With this commit package manager are always set to include only
required packages or set to include required and recommended
packages.

This commit fixes #285
