### PR TITLE
Bypass bootstrap procedure if no bootstrap packages section

### DIFF
--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -155,6 +155,11 @@ class SystemPrepare(object):
         Install system software using the package manager
         from the host, also known as bootstrapping
         """
+        if not self.xml_state.get_bootstrap_packages_sections():
+            log.warning('No <packages> sections marked as "bootstrap" found')
+            log.info('Processing of bootstrap stage skipped')
+            return
+
         log.info('Installing bootstrap packages')
         bootstrap_packages = self.xml_state.get_bootstrap_packages()
         bootstrap_packages.append(

--- a/kiwi/system/root_bind.py
+++ b/kiwi/system/root_bind.py
@@ -88,9 +88,14 @@ class RootBind(object):
         """
         try:
             for location in self.bind_locations:
-                if os.path.exists(location):
+                location_mount_target = os.path.normpath(os.sep.join([
+                    self.root_dir, location
+                ]))
+                if os.path.exists(location) and os.path.exists(
+                    location_mount_target
+                ):
                     shared_mount = MountManager(
-                        device=location, mountpoint=self.root_dir + location
+                        device=location, mountpoint=location_mount_target
                     )
                     shared_mount.bind_mount()
                     self.mount_stack.append(shared_mount)

--- a/test/unit/system_prepare_test.py
+++ b/test/unit/system_prepare_test.py
@@ -267,6 +267,16 @@ class TestSystemPrepare(object):
         mock_tar.assert_called_once_with('../data/bootstrap.tgz')
         tar.extract.assert_called_once_with('root_dir')
 
+    @patch('kiwi.logger.log.warning')
+    @patch('kiwi.xml_state.XMLState.get_bootstrap_packages_sections')
+    def test_install_bootstrap_skipped(
+        self, mock_bootstrap_section, mock_log_warning
+    ):
+        mock_bootstrap_section.return_value = []
+        self.system.install_bootstrap(self.manager)
+        mock_bootstrap_section.assert_called_once_with()
+        assert mock_log_warning.called
+
     @patch('kiwi.xml_state.XMLState.get_bootstrap_collection_type')
     @patch('kiwi.system.prepare.CommandProcess.poll_show_progress')
     @patch('kiwi.system.prepare.ArchiveTar')

--- a/test/unit/system_root_bind_test.py
+++ b/test/unit/system_root_bind_test.py
@@ -70,8 +70,10 @@ class TestRootBind(object):
         self.bind_root.setup_intermediate_config()
         mock.cleanup.assert_called_once_with()
 
+    @patch('kiwi.system.root_bind.os.path.exists')
     @patch('kiwi.system.root_bind.MountManager')
-    def test_mount_kernel_file_systems(self, mock_mount):
+    def test_mount_kernel_file_systems(self, mock_mount, mock_exists):
+        mock_exists.return_value = True
         shared_mount = mock.Mock()
         mock_mount.return_value = shared_mount
         self.bind_root.mount_kernel_file_systems()


### PR DESCRIPTION
This commit updates kiwi to bypass bootstrap procedure in case
there is no bootstrap packages section.

It also fixes little related issues in root_bind and apt manager.
