### PR TITLE
Make sure debian repositories database is populated before install

### DIFF
--- a/test/unit/package_manager_apt_test.py
+++ b/test/unit/package_manager_apt_test.py
@@ -101,11 +101,11 @@ class TestPackageManagerApt(object):
                 'debootstrap', '--no-check-gpg', 'xenial',
                 'root-dir.debootstrap', 'xenial_path'],
                 ['env']),
+            call(['rm', '-r', '-f', 'root-dir.debootstrap']),
             call([
-                'bash', '-c',
-                'rm -r -f root-dir.debootstrap &&' +
-                ' chroot root-dir apt-get root-moved-arguments update'],
-                ['env'])
+                'chroot', 'root-dir', 'apt-get',
+                'root-moved-arguments', 'update'
+            ], ['env'])
         ]
         mock_call.assert_called_once_with([
             'chroot', 'root-dir', 'apt-get',


### PR DESCRIPTION
This commit includes an `apt-get update` call before any 
`apt-get install` command. This way the packages database is
always ready, even if no bootstrap procedure has been executed.
