### PR TITLE
Add clear attribute for entrypoint and subcommand sections

### DIFF
--- a/doc/source/schema.rst
+++ b/doc/source/schema.rst
@@ -369,6 +369,7 @@ Children:
 List of attributes for ``entrypoint``:
 
 * ``execute`` : Specifies the entry point program name to execute
+* ``clear`` : Specifies to clear or not some data or configurations
 
 .. _k.image.preferences.type.containerconfig.entrypoint.argument:
 
@@ -400,6 +401,7 @@ Children:
 List of attributes for ``subcommand``:
 
 * ``execute`` : Specifies the subcommand program name to execute
+* ``clear`` : Specifies to clear or not some data or configurations
 
 .. _k.image.preferences.type.containerconfig.subcommand.argument:
 

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -172,6 +172,9 @@ k.username.attribute    =
 k.imagename.attribute   =
     ## An image name without / and spaces
     attribute name { image-name }
+k.clear.attribute   =
+    ## Specifies to clear or not some data or configurations
+    attribute clear { xsd:boolean }
 
 div {
     k._any.attribute =
@@ -2516,7 +2519,7 @@ div {
         attribute execute { text }
 
     k.entrypoint.attlist =
-        k.entrypoint.execute.attribute
+        k.entrypoint.execute.attribute | k.clear.attribute
 
     k.entrypoint =
         ## Provides details for the entry point command. This
@@ -2537,7 +2540,7 @@ div {
         attribute execute { text }
 
     k.subcommand.attlist =
-        k.subcommand.execute.attribute
+        k.subcommand.execute.attribute | k.clear.attribute
 
     k.subcommand =
         ## Provides details for the subcommand command. This

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -299,6 +299,12 @@ file was fetched</a:documentation>
       <ref name="image-name"/>
     </attribute>
   </define>
+  <define name="k.clear.attribute">
+    <attribute name="clear">
+      <a:documentation>Specifies to clear or not some data or configurations</a:documentation>
+      <data type="boolean"/>
+    </attribute>
+  </define>
   <div>
     <define name="k._any.attribute">
       <attribute>
@@ -3507,7 +3513,10 @@ image is imported via the docker load command</a:documentation>
       </attribute>
     </define>
     <define name="k.entrypoint.attlist">
-      <ref name="k.entrypoint.execute.attribute"/>
+      <choice>
+        <ref name="k.entrypoint.execute.attribute"/>
+        <ref name="k.clear.attribute"/>
+      </choice>
     </define>
     <define name="k.entrypoint">
       <element name="entrypoint">
@@ -3535,7 +3544,10 @@ can be optionally specified</a:documentation>
       </attribute>
     </define>
     <define name="k.subcommand.attlist">
-      <ref name="k.subcommand.execute.attribute"/>
+      <choice>
+        <ref name="k.subcommand.execute.attribute"/>
+        <ref name="k.clear.attribute"/>
+      </choice>
     </define>
     <define name="k.subcommand">
       <element name="subcommand">

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Tue Mar 28 11:25:19 2017 by generateDS.py version 2.25a.
+# Generated Wed Apr 12 14:43:43 2017 by generateDS.py version 2.25a.
 #
 # Command line options:
 #   ('-f', '')
@@ -13,7 +13,7 @@
 #   kiwi/schema/kiwi.xsd
 #
 # Command line:
-#   /home/ms/Project/kiwi/.tox/2.7/bin/generateDS.py -f --external-encoding="utf-8" -o "kiwi/xml_parse.py" kiwi/schema/kiwi.xsd
+#   /home/david/workspaces/kiwi/.env2/bin/generateDS.py -f --external-encoding="utf-8" -o "kiwi/xml_parse.py" kiwi/schema/kiwi.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -4729,9 +4729,10 @@ class entrypoint(GeneratedsSuper):
     specified"""
     subclass = None
     superclass = None
-    def __init__(self, execute=None, argument=None):
+    def __init__(self, execute=None, clear=None, argument=None):
         self.original_tagname_ = None
         self.execute = _cast(None, execute)
+        self.clear = _cast(bool, clear)
         if argument is None:
             self.argument = []
         else:
@@ -4754,6 +4755,8 @@ class entrypoint(GeneratedsSuper):
     def replace_argument_at(self, index, value): self.argument[index] = value
     def get_execute(self): return self.execute
     def set_execute(self, execute): self.execute = execute
+    def get_clear(self): return self.clear
+    def set_clear(self, clear): self.clear = clear
     def hasContent_(self):
         if (
             self.argument
@@ -4783,6 +4786,9 @@ class entrypoint(GeneratedsSuper):
         if self.execute is not None and 'execute' not in already_processed:
             already_processed.add('execute')
             outfile.write(' execute=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.execute), input_name='execute')), ))
+        if self.clear is not None and 'clear' not in already_processed:
+            already_processed.add('clear')
+            outfile.write(' clear="%s"' % self.gds_format_boolean(self.clear, input_name='clear'))
     def exportChildren(self, outfile, level, namespace_='', name_='entrypoint', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -4802,6 +4808,15 @@ class entrypoint(GeneratedsSuper):
         if value is not None and 'execute' not in already_processed:
             already_processed.add('execute')
             self.execute = value
+        value = find_attr_value_('clear', node)
+        if value is not None and 'clear' not in already_processed:
+            already_processed.add('clear')
+            if value in ('true', '1'):
+                self.clear = True
+            elif value in ('false', '0'):
+                self.clear = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         if nodeName_ == 'argument':
             obj_ = argument.factory()
@@ -4820,9 +4835,10 @@ class subcommand(GeneratedsSuper):
     a valid execution command"""
     subclass = None
     superclass = None
-    def __init__(self, execute=None, argument=None):
+    def __init__(self, execute=None, clear=None, argument=None):
         self.original_tagname_ = None
         self.execute = _cast(None, execute)
+        self.clear = _cast(bool, clear)
         if argument is None:
             self.argument = []
         else:
@@ -4845,6 +4861,8 @@ class subcommand(GeneratedsSuper):
     def replace_argument_at(self, index, value): self.argument[index] = value
     def get_execute(self): return self.execute
     def set_execute(self, execute): self.execute = execute
+    def get_clear(self): return self.clear
+    def set_clear(self, clear): self.clear = clear
     def hasContent_(self):
         if (
             self.argument
@@ -4874,6 +4892,9 @@ class subcommand(GeneratedsSuper):
         if self.execute is not None and 'execute' not in already_processed:
             already_processed.add('execute')
             outfile.write(' execute=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.execute), input_name='execute')), ))
+        if self.clear is not None and 'clear' not in already_processed:
+            already_processed.add('clear')
+            outfile.write(' clear="%s"' % self.gds_format_boolean(self.clear, input_name='clear'))
     def exportChildren(self, outfile, level, namespace_='', name_='subcommand', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -4893,6 +4914,15 @@ class subcommand(GeneratedsSuper):
         if value is not None and 'execute' not in already_processed:
             already_processed.add('execute')
             self.execute = value
+        value = find_attr_value_('clear', node)
+        if value is not None and 'clear' not in already_processed:
+            already_processed.add('clear')
+            if value in ('true', '1'):
+                self.clear = True
+            elif value in ('false', '0'):
+                self.clear = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         if nodeName_ == 'argument':
             obj_ = argument.factory()

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -711,7 +711,7 @@ class XMLState(object):
         container_entry = {}
         if container_config_section:
             entrypoint = container_config_section.get_entrypoint()
-            if entrypoint:
+            if entrypoint and entrypoint[0].get_execute():
                 container_entry['entry_command'] = [
                     ''.join(
                         [
@@ -731,6 +731,14 @@ class XMLState(object):
                                 ]
                             )
                         )
+            elif entrypoint and entrypoint[0].get_clear():
+                container_entry['entry_command'] = [
+                    ''.join(
+                        [
+                            '--clear=config.entrypoint'
+                        ]
+                    )
+                ]
         return container_entry
 
     def _match_docker_subcommand(self):
@@ -741,7 +749,7 @@ class XMLState(object):
         container_subcommand = {}
         if container_config_section:
             subcommand = container_config_section.get_subcommand()
-            if subcommand:
+            if subcommand and subcommand[0].get_execute():
                 container_subcommand['entry_subcommand'] = [
                     ''.join(
                         [
@@ -761,6 +769,14 @@ class XMLState(object):
                                 ]
                             )
                         )
+            elif subcommand and subcommand[0].get_clear():
+                container_subcommand['entry_subcommand'] = [
+                    ''.join(
+                        [
+                            '--clear=config.cmd',
+                        ]
+                    )
+                ]
         return container_subcommand
 
     def _match_docker_expose_ports(self):

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -29,6 +29,7 @@
         <profile name="xenFlavour" description="VMX with Xen kernel"/>
         <profile name="ec2Flavour" description="VMX with EC2/Xen kernel"/>
         <profile name="vmxFlavour" description="VMX with default kernel" import="true"/>
+        <profile name="derivedContainer" description="Container built on top of a base issue"/>
     </profiles>
     <preferences>
         <locale>de_DE</locale>
@@ -99,7 +100,7 @@
                 <vmnic driver="e1000" interface="0" mode="bridged"/>
             </machine>
         </type>
-        <type image="docker" derived_from="file:///image.tar.xz">
+        <type image="docker">
             <containerconfig name="container_name" maintainer="tux" user="root" workingdir="/root" tag="container_tag">
                 <entrypoint execute="/bin/bash">
                     <argument name="-x"/>
@@ -123,6 +124,14 @@
                     <label name="somelabel" value="labelvalue"/>
                     <label name="someotherlabel" value="anotherlabelvalue"/>
                 </labels>
+            </containerconfig>
+        </type>
+    </preferences>
+    <preferences profiles="derivedContainer">
+        <type image="docker" derived_from="file:///image.tar.xz">
+            <containerconfig name="container_name" maintainer="tux" user="root" workingdir="/root" tag="container_tag">
+                <entrypoint clear="true"/>
+                <subcommand clear="true"/>
             </containerconfig>
         </type>
     </preferences>

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -574,11 +574,30 @@ class TestXMLState(object):
         state = XMLState(xml_data, ['vmxFlavour'], 'docker')
         assert state.get_container_config() == expected_config
 
+    def test_get_container_config_clear_commands(self):
+        expected_config = {
+            'maintainer': ['--author=tux'],
+            'entry_subcommand': [
+                '--clear=config.cmd'
+            ],
+            'container_name': 'container_name',
+            'container_tag': 'container_tag',
+            'workingdir': ['--config.workingdir=/root'],
+            'user': ['--config.user=root'],
+            'entry_command': [
+                '--clear=config.entrypoint',
+            ]
+        }
+        description = XMLDescription('../data/example_config.xml')
+        xml_data = description.load()
+        state = XMLState(xml_data, ['derivedContainer'], 'docker')
+        assert state.get_container_config() == expected_config
+
     def test_get_spare_part(self):
         assert self.state.get_build_type_spare_part_size() == 200
 
     def test_get_derived_from_image_uri(self):
         description = XMLDescription('../data/example_config.xml')
         xml_data = description.load()
-        state = XMLState(xml_data, ['vmxFlavour'], 'docker')
+        state = XMLState(xml_data, ['derivedContainer'], 'docker')
         assert state.get_derived_from_image_uri().translate() == '/image.tar.xz'


### PR DESCRIPTION
This commit adds the possibility of clearing any subcommand or
entrypoint. This is relevant for docker derived images, as they
inherit the configuration and it might lead to some bad behavior.

See how it is used [here](https://github.com/davidcassany/kiwi-derived-images)