### PR TITLE
Fix default reposdir path for Yum

### DIFF
--- a/kiwi/repository/yum.py
+++ b/kiwi/repository/yum.py
@@ -97,7 +97,7 @@ class RepositoryYum(RepositoryBase):
         in the default places
         """
         self.shared_yum_dir['reposd-dir'] = \
-            self.root_dir + '/etc/yum/repos.d'
+            self.root_dir + '/etc/yum.repos.d'
         self.shared_yum_dir['cache-dir'] = \
             self.root_dir + '/var/cache/yum'
         self.shared_yum_dir['pluginconf-dir'] = \

--- a/test/unit/repository_yum_test.py
+++ b/test/unit/repository_yum_test.py
@@ -64,7 +64,7 @@ class TestRepositoryYum(object):
 
         assert runtime_yum_config.set.call_args_list == [
             call('main', 'cachedir', '../data/var/cache/yum'),
-            call('main', 'reposdir', '../data/etc/yum/repos.d'),
+            call('main', 'reposdir', '../data/etc/yum.repos.d'),
             call('main', 'pluginconfpath', '../data/etc/yum/pluginconf.d'),
             call('main', 'keepcache', '1'),
             call('main', 'debuglevel', '2'),


### PR DESCRIPTION
The default reposdir path for Yum is wrong. While stock Yum does in fact use `/etc/yum/repos.d`, all distros that use Yum change this to `/etc/yum.repos.d`, in part so that the repository definition directory isn't owned by the `yum` package.

This issue was likely not caught because generally repositories for RHEL/CentOS/Fedora ship a `<reponame>-release` package that bundles the GPG key and the repo definition to be installed in `/etc/yum.repos.d` and these would just usually be installed via the KIWI definition. However, if you add an OBS repo (or some other repo that doesn't follow this convention), then the repository files do not get written to the right place, and thus do not get picked up by Yum.

Changes proposed in this pull request:
* `/etc/yum/repos.d` -> `/etc/yum.repos.d`
