### PR TITLE
Do not purge the repositories before inserting them

### DIFF
--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -123,7 +123,6 @@ class SystemSetup(object):
             RootBind(root), self.xml_state.get_package_manager()
         )
         repo.use_default_location()
-        repo.delete_all_repos()
         for xml_repo in repository_sections:
             repo_marked_for_image_include = xml_repo.get_imageinclude()
 

--- a/test/unit/system_setup_test.py
+++ b/test/unit/system_setup_test.py
@@ -686,7 +686,6 @@ class TestSystemSetup(object):
         repo = mock.Mock()
         mock_repo.return_value = repo
         self.setup_with_real_xml.import_repositories_marked_as_imageinclude()
-        repo.delete_all_repos.assert_called_once_with()
         repo.add_repo.assert_called_once_with(
             '95811799a6d1889c5b2363d3886986de',
             'http://download.opensuse.org/repositories/Devel:PubCloud:AmazonEC2/SLE_12_GA',


### PR DESCRIPTION
There are no good reasons to be purging the repo directories, especially when it is common for some distributions (Red Hat/CentOS/Fedora, for example) to ship repository configuration as packages. Deleting them puts the package manager in the system into a weird state, so we want to avoid this.

Fixes #304.

Changes proposed in this pull request:
* Remove `repo.delete_all_repos()` call in `import_repositories_marked_as_imageinclude()` in `SystemSetup()` class.
