### PR TITLE
Define correct default locations for sources-dir and preferences-dir

### DIFF
--- a/kiwi/repository/apt.py
+++ b/kiwi/repository/apt.py
@@ -99,6 +99,10 @@ class RepositoryApt(RepositoryBase):
         Setup apt-get repository operations to store all data
         in the default places
         """
+        self.shared_apt_get_dir['sources-dir'] = \
+            self.root_dir + '/etc/apt/sources.list.d'
+        self.shared_apt_get_dir['preferences-dir'] = \
+            self.root_dir + '/etc/apt/preferences.d'
         self._write_runtime_config(system_default=True)
 
     def runtime_config(self):


### PR DESCRIPTION
In order to ensure that the defined repositories in the KIWI configuration are set to the correct places for installing into the image, the `sources-dir` and `preferences-dir` need to be redefined to point to the in-image location, as it is done for the other package managers.

Fixes #306.

Changes proposed in this pull request:
* Set `shared_apt_get_dir['sources-dir']` and `shared_apt_get_dir['preferences-dir']` correctly in `use_default_location()` in `RepositoryApt()` class.