### PR TITLE
Include --delete flag in DataSync for docker images

### DIFF
--- a/kiwi/container/docker.py
+++ b/kiwi/container/docker.py
@@ -140,7 +140,7 @@ class ContainerImageDocker(object):
             os.sep.join([self.docker_root_dir, 'rootfs'])
         )
         docker_root.sync_data(
-            options=['-a', '-H', '-X', '-A'], exclude=exclude_list
+            options=['-a', '-H', '-X', '-A', '--delete'], exclude=exclude_list
         )
         Command.run(
             ['umoci', 'repack', '--image', container_name, self.docker_root_dir]

--- a/test/unit/container_image_docker_test.py
+++ b/test/unit/container_image_docker_test.py
@@ -121,7 +121,7 @@ class TestContainerImageDocker(object):
                 'image', '.profile', '.kconfig', 'boot', 'dev', 'sys', 'proc',
                 'var/cache/kiwi'
             ],
-            options=['-a', '-H', '-X', '-A']
+            options=['-a', '-H', '-X', '-A', '--delete']
         )
         mock_compress.assert_called_once_with('result.tar')
         compressor.xz.assert_called_once_with()
@@ -189,7 +189,7 @@ class TestContainerImageDocker(object):
                 'image', '.profile', '.kconfig', 'boot', 'dev', 'sys', 'proc',
                 'var/cache/kiwi'
             ],
-            options=['-a', '-H', '-X', '-A']
+            options=['-a', '-H', '-X', '-A', '--delete']
         )
         mock_compress.assert_called_once_with('result.tar')
         compressor.xz.assert_called_once_with()


### PR DESCRIPTION
This commit includes the --delete flag in order to synchronize the
docker images. This is relevant for derived images where the new
layer might not only add files, but also remove something from the
base image.

Fixes #309
