### PR TITLE
Derived container source locators

### DIFF
--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -19,6 +19,7 @@ import re
 import copy
 import platform
 from collections import namedtuple
+from six.moves.urllib.parse import urlparse
 
 # project
 from . import xml_parse
@@ -1129,30 +1130,32 @@ class XMLState(object):
 
     def translate_obs_to_ibs_repositories(self):
         """
-        Change obs:// repotype to ibs:// type
+        Change obs repotype to ibs type
 
         This will result in pointing to build.suse.de instead of
         build.opensuse.org
         """
         for repository in self.get_repository_sections():
             source_path = repository.get_source()
-            if 'obs://' in source_path.get_path():
+            source_uri = urlparse(source_path.get_path())
+            if source_uri.scheme == 'obs':
                 source_path.set_path(
-                    source_path.get_path().replace('obs://', 'ibs://')
+                    source_path.get_path().replace('obs:', 'ibs:')
                 )
 
     def translate_obs_to_suse_repositories(self):
         """
-        Change obs:// repotype to suse:// type
+        Change obs: repotype to suse: type
 
         This will result in a local repo path suitable for a
         buildservice worker instance
         """
         for repository in self.get_repository_sections():
             source_path = repository.get_source()
-            if 'obs://' in source_path.get_path():
+            source_uri = urlparse(source_path.get_path())
+            if source_uri.scheme == 'obs':
                 source_path.set_path(
-                    source_path.get_path().replace('obs://', 'suse://')
+                    source_path.get_path().replace('obs:', 'suse:')
                 )
 
     def set_repository(self, repo_source, repo_type, repo_alias, repo_prio):
@@ -1504,7 +1507,7 @@ class XMLState(object):
         """
         derived_image = self.build_type.get_derived_from()
         if derived_image:
-            return Uri(derived_image)
+            return Uri(derived_image, repo_type='container')
 
     def _used_profiles(self, profiles=None):
         """

--- a/test/unit/system_uri_test.py
+++ b/test/unit/system_uri_test.py
@@ -131,6 +131,11 @@ class TestUri(object):
         assert uri.translate() == \
             '/usr/src/packages/SOURCES/repos/openSUSE:13.2/standard'
 
+    def test_translate_suse_buildservice_container_path(self):
+        uri = Uri('suse://project/repo/container#latest', 'container')
+        assert uri.translate() == \
+            '/usr/src/packages/SOURCES/containers/project/repo/container#latest'
+
     @patch('kiwi.system.uri.MountManager')
     @patch('kiwi.system.uri.mkdtemp')
     @patch('kiwi.system.uri.Path.wipe')

--- a/test/unit/system_uri_test.py
+++ b/test/unit/system_uri_test.py
@@ -136,6 +136,11 @@ class TestUri(object):
         assert uri.translate() == \
             '/usr/src/packages/SOURCES/containers/project/repo/container#latest'
 
+    def test_translate_buildservice_obsrepositories_container_path(self):
+        uri = Uri('obsrepositories:/container#latest', 'container')
+        assert uri.translate() == \
+            '/usr/src/packages/SOURCES/containers/_obsrepositories/container#latest'
+
     @patch('kiwi.system.uri.MountManager')
     @patch('kiwi.system.uri.mkdtemp')
     @patch('kiwi.system.uri.Path.wipe')


### PR DESCRIPTION
Regarding a discussion with the buildservice team we agreed on an uri schema to allow the use of obs:/ and obsrepositories:/ on the derived_from attribute in a docker type setup. This pull request implements the parts required for KIWI

There will be follow up pull requests which will allow to set the derived_from uri and the container tag also from the commandline 