### PR TITLE
Additional container commandline options

### DIFF
--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -24,6 +24,8 @@ usage: kiwi system build -h | --help
            [--obs-repo-internal]
            [--add-package=<name>...]
            [--delete-package=<name>...]
+           [--set-container-derived-from=<uri>]
+           [--set-container-tag=<name>]
        kiwi system build help
 
 commands:
@@ -49,6 +51,15 @@ options:
         when using obs:// repos resolve them using the SUSE internal
         buildservice. This only works if access to SUSE's internal
         buildservice is granted
+    --set-container-derived-from=<uri>
+        overwrite the source location of the base container
+        for the selected image type. The setting is only effective
+        if the configured image type is setup with an initial
+        derived_from reference
+    --set-container-tag=<name>
+        overwrite the container tag in the container configuration.
+        The setting is only effective if the container configuraiton
+        provides an initial tag value
     --set-repo=<source,type,alias,priority>
         overwrite the repo source, type, alias or priority for the first
         repository in the XML description
@@ -132,6 +143,16 @@ class SystemBuildTask(CliTask):
                 )
 
                 Path.create(abs_target_dir_path)
+
+        if self.command_args['--set-container-tag']:
+            self.xml_state.set_container_config_tag(
+                self.command_args['--set-container-tag']
+            )
+
+        if self.command_args['--set-container-derived-from']:
+            self.xml_state.set_derived_from_image_uri(
+                self.command_args['--set-container-derived-from']
+            )
 
         self.runtime_checker.check_repositories_configured()
 

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -25,6 +25,8 @@ usage: kiwi system prepare -h | --help
            [--obs-repo-internal]
            [--add-package=<name>...]
            [--delete-package=<name>...]
+           [--set-container-derived-from=<uri>]
+           [--set-container-tag=<name>]
        kiwi system prepare help
 
 commands:
@@ -55,6 +57,15 @@ options:
         buildservice is granted
     --root=<directory>
         the path to the new root directory of the system
+    --set-container-derived-from=<uri>
+        overwrite the source location of the base container
+        for the selected image type. The setting is only effective
+        if the configured image type is setup with an initial
+        derived_from reference
+    --set-container-tag=<name>
+        overwrite the container tag in the container configuration.
+        The setting is only effective if the container configuraiton
+        provides an initial tag value
     --set-repo=<source,type,alias,priority>
         overwrite the repo source, type, alias or priority for the first
         repository in the XML description
@@ -123,6 +134,16 @@ class SystemPrepareTask(CliTask):
                 self.xml_state.add_repository(
                     repo_source, repo_type, repo_alias, repo_prio
                 )
+
+        if self.command_args['--set-container-tag']:
+            self.xml_state.set_container_config_tag(
+                self.command_args['--set-container-tag']
+            )
+
+        if self.command_args['--set-container-derived-from']:
+            self.xml_state.set_derived_from_image_uri(
+                self.command_args['--set-container-derived-from']
+            )
 
         self.runtime_checker.check_repositories_configured()
 

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -20,9 +20,11 @@ import copy
 import platform
 from collections import namedtuple
 from six.moves.urllib.parse import urlparse
+from textwrap import dedent
 
 # project
 from . import xml_parse
+from .logger import log
 from .system.uri import Uri
 from .defaults import Defaults
 
@@ -889,6 +891,28 @@ class XMLState(object):
         )
         return container_config
 
+    def set_container_config_tag(self, tag):
+        """
+        Set new tag name in containerconfig section
+
+        In order to set a new tag value an existing containerconfig and
+        tag setup is required
+
+        :param string tag: tag name
+        """
+        container_config_section = self.get_build_type_containerconfig_section()
+        if container_config_section and container_config_section.get_tag():
+            container_config_section.set_tag(tag)
+        else:
+            message = dedent('''\n
+                No <containerconfig> section and/or tag attribute configured
+
+                In order to set the tag {0} as new container tag,
+                an initial containerconfig section including a tag
+                setup is required
+            ''')
+            log.warning(message.format(tag))
+
     def get_volumes(self):
         """
         List of configured systemdisk volumes.
@@ -1508,6 +1532,27 @@ class XMLState(object):
         derived_image = self.build_type.get_derived_from()
         if derived_image:
             return Uri(derived_image, repo_type='container')
+
+    def set_derived_from_image_uri(self, uri):
+        """
+        Set derived_from attribute to a new value
+
+        In order to set a new value the derived_from attribute
+        must be already present in the image configuration
+
+        :param string uri: URI
+        """
+        if self.build_type.get_derived_from():
+            self.build_type.set_derived_from(uri)
+        else:
+            message = dedent('''\n
+                No derived_from attribute configured in image <type>
+
+                In order to set the uri {0} as base container reference
+                an initial derived_from attribute must be set in the
+                type section
+            ''')
+            log.warning(message.format(uri))
 
     def _used_profiles(self, profiles=None):
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ exclude=xml_parse.py
 # we allow long lines
 ignore = E501
 # we allow a custom complexity level
-max-complexity = 16
+max-complexity = 17
 
 [doc8]
 max-line-length = 90

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -43,6 +43,8 @@ class TestCli(object):
             '--set-repo': None,
             '--add-package': [],
             '--delete-package': [],
+            '--set-container-derived-from': None,
+            '--set-container-tag': None,
             '-h': False,
             'help': False,
             'prepare': True,

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -78,6 +78,8 @@ class TestSystemBuildTask(object):
         self.task.command_args['--add-package'] = []
         self.task.command_args['--delete-package'] = []
         self.task.command_args['--ignore-repos'] = False
+        self.task.command_args['--set-container-derived-from'] = None
+        self.task.command_args['--set-container-tag'] = None
 
     @patch('kiwi.logger.Logger.set_logfile')
     def test_process_system_build(self, mock_log):
@@ -136,6 +138,30 @@ class TestSystemBuildTask(object):
         self.system_prepare.setup_repositories.assert_called_once_with()
         self.system_prepare.delete_packages.assert_called_once_with(
             self.manager, ['vim']
+        )
+
+    @patch('kiwi.xml_state.XMLState.set_container_config_tag')
+    @patch('kiwi.logger.Logger.set_logfile')
+    def test_process_system_build_prepare_stage_set_container_tag(
+        self, mock_log, mock_set_container_tag
+    ):
+        self._init_command_args()
+        self.task.command_args['--set-container-tag'] = 'new_tag'
+        self.task.process()
+        mock_set_container_tag.assert_called_once_with(
+            'new_tag'
+        )
+
+    @patch('kiwi.xml_state.XMLState.set_derived_from_image_uri')
+    @patch('kiwi.logger.Logger.set_logfile')
+    def test_process_system_build_prepare_stage_set_derived_from_uri(
+        self, mock_log, mock_set_derived_from_uri
+    ):
+        self._init_command_args()
+        self.task.command_args['--set-container-derived-from'] = 'file:///new'
+        self.task.process()
+        mock_set_derived_from_uri.assert_called_once_with(
+            'file:///new'
         )
 
     @patch('kiwi.xml_state.XMLState.set_repository')

--- a/test/unit/tasks_system_prepare_test.py
+++ b/test/unit/tasks_system_prepare_test.py
@@ -69,6 +69,8 @@ class TestSystemPrepareTask(object):
         self.task.command_args['--add-package'] = []
         self.task.command_args['--delete-package'] = []
         self.task.command_args['--ignore-repos'] = False
+        self.task.command_args['--set-container-derived-from'] = None
+        self.task.command_args['--set-container-tag'] = None
 
     def test_process_system_prepare(self):
         self._init_command_args()
@@ -121,6 +123,28 @@ class TestSystemPrepareTask(object):
         self.system_prepare.setup_repositories.assert_called_once_with()
         self.system_prepare.delete_packages.assert_called_once_with(
             self.manager, ['vim']
+        )
+
+    @patch('kiwi.xml_state.XMLState.set_container_config_tag')
+    def test_process_system_prepare_set_container_tag(
+        self, mock_set_container_tag
+    ):
+        self._init_command_args()
+        self.task.command_args['--set-container-tag'] = 'new_tag'
+        self.task.process()
+        mock_set_container_tag.assert_called_once_with(
+            'new_tag'
+        )
+
+    @patch('kiwi.xml_state.XMLState.set_derived_from_image_uri')
+    def test_process_system_prepare_set_derived_from_uri(
+        self, mock_set_derived_from_uri
+    ):
+        self._init_command_args()
+        self.task.command_args['--set-container-derived-from'] = 'file:///new'
+        self.task.process()
+        mock_set_derived_from_uri.assert_called_once_with(
+            'file:///new'
         )
 
     @patch('kiwi.xml_state.XMLState.set_repository')

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -537,6 +537,19 @@ class TestXMLState(object):
         assert containerconfig.get_workingdir() == \
             '/root'
 
+    def test_set_container_tag(self):
+        description = XMLDescription('../data/example_config.xml')
+        xml_data = description.load()
+        state = XMLState(xml_data, ['vmxFlavour'], 'docker')
+        state.set_container_config_tag('new_tag')
+        config = state.get_container_config()
+        assert config['container_tag'] == 'new_tag'
+
+    @patch('kiwi.logger.log.warning')
+    def test_set_container_tag_not_applied(self, mock_log_warn):
+        self.state.set_container_config_tag('new_tag')
+        assert mock_log_warn.called
+
     def test_get_container_config(self):
         expected_config = {
             'labels': [
@@ -601,3 +614,15 @@ class TestXMLState(object):
         xml_data = description.load()
         state = XMLState(xml_data, ['derivedContainer'], 'docker')
         assert state.get_derived_from_image_uri().translate() == '/image.tar.xz'
+
+    def test_set_derived_from_image_uri(self):
+        description = XMLDescription('../data/example_config.xml')
+        xml_data = description.load()
+        state = XMLState(xml_data, ['derivedContainer'], 'docker')
+        state.set_derived_from_image_uri('file:///new_uri')
+        assert state.get_derived_from_image_uri().translate() == '/new_uri'
+
+    @patch('kiwi.logger.log.warning')
+    def test_set_derived_from_image_uri_not_applied(self, mock_log_warn):
+        self.state.set_derived_from_image_uri('file:///new_uri')
+        assert mock_log_warn.called


### PR DESCRIPTION
Added --set-container-derived-from and --set-container-tag
commandline options which allows to overwrite the data set
in the XML configuration

This completes the buildservice requirements for building docker images in OBS