### PR TITLE
Add support for excluding packages when using Yum or DNF

### DIFF
--- a/kiwi/package_manager/yum.py
+++ b/kiwi/package_manager/yum.py
@@ -18,7 +18,6 @@
 import re
 
 # project
-from kiwi.logger import log
 from kiwi.command import Command
 from kiwi.package_manager.base import PackageManagerBase
 from kiwi.exceptions import (
@@ -87,11 +86,9 @@ class PackageManagerYum(PackageManagerBase):
 
         Package exclusion for yum package manager not yet implemented
 
-        :param string name: unused
+        :param string name: package name
         """
-        log.warning(
-            'Package exclusion for (%s) not supported for yum', name
-        )
+        self.exclude_requests.append(name)
 
     def process_install_requests_bootstrap(self):
         """
@@ -120,6 +117,13 @@ class PackageManagerYum(PackageManagerBase):
         """
         Process package install requests for image phase (chroot)
         """
+        if self.exclude_requests:
+            # For Yum, excluding a package means removing it from
+            # the solver operation. This is done by adding --exclude
+            # to the command line. This means that if the package is
+            # hard required by another package, it will break the transaction.
+            for package in self.exclude_requests:
+                self.custom_args.append('--exclude=' + package)
         Command.run(
             ['chroot', self.root_dir, 'rpm', '--rebuilddb']
         )

--- a/test/unit/package_manager_dnf_test.py
+++ b/test/unit/package_manager_dnf_test.py
@@ -39,11 +39,9 @@ class TestPackageManagerDnf(object):
         self.manager.request_product('name')
         assert self.manager.product_requests == []
 
-    @patch('kiwi.logger.log.warning')
-    def test_request_package_exclusion(self, mock_log_warn):
+    def test_request_package_exclusion(self):
         self.manager.request_package_exclusion('name')
-        assert self.manager.exclude_requests == []
-        assert mock_log_warn.called
+        assert self.manager.exclude_requests == ['name']
 
     @patch('kiwi.command.Command.call')
     @patch('kiwi.command.Command.run')
@@ -68,6 +66,7 @@ class TestPackageManagerDnf(object):
     def test_process_install_requests(self, mock_run, mock_call):
         self.manager.request_package('vim')
         self.manager.request_collection('collection')
+        self.manager.request_package_exclusion('skipme')
         self.manager.process_install_requests()
         self.manager.root_bind.move_to_root(
             self.manager.dnf_args
@@ -78,8 +77,8 @@ class TestPackageManagerDnf(object):
         mock_call.assert_called_once_with(
             [
                 'bash', '-c',
-                'chroot root-dir dnf root-moved-arguments install vim && ' +
-                'chroot root-dir dnf root-moved-arguments group install ' +
+                'chroot root-dir dnf root-moved-arguments --exclude=skipme install vim && ' +
+                'chroot root-dir dnf root-moved-arguments --exclude=skipme group install ' +
                 '"collection"'
             ], ['env']
         )

--- a/test/unit/package_manager_yum_test.py
+++ b/test/unit/package_manager_yum_test.py
@@ -40,11 +40,9 @@ class TestPackageManagerYum(object):
         self.manager.request_product('name')
         assert self.manager.product_requests == []
 
-    @patch('kiwi.logger.log.warning')
-    def test_request_package_exclusion(self, mock_log_warn):
+    def test_request_package_exclusion(self):
         self.manager.request_package_exclusion('name')
-        assert self.manager.exclude_requests == []
-        assert mock_log_warn.called
+        assert self.manager.exclude_requests == ['name']
 
     @patch('kiwi.command.Command.call')
     @patch('kiwi.command.Command.run')
@@ -69,6 +67,7 @@ class TestPackageManagerYum(object):
     def test_process_install_requests(self, mock_run, mock_call):
         self.manager.request_package('vim')
         self.manager.request_collection('collection')
+        self.manager.request_package_exclusion('skipme')
         self.manager.process_install_requests()
         self.manager.root_bind.move_to_root(
             self.manager.yum_args
@@ -79,8 +78,8 @@ class TestPackageManagerYum(object):
         mock_call.assert_called_once_with(
             [
                 'bash', '-c',
-                'chroot root-dir yum root-moved-arguments install vim && ' +
-                'chroot root-dir yum root-moved-arguments groupinstall ' +
+                'chroot root-dir yum root-moved-arguments --exclude=skipme install vim && ' +
+                'chroot root-dir yum root-moved-arguments --exclude=skipme groupinstall ' +
                 '"collection"'
             ], ['env']
         )


### PR DESCRIPTION
This pull request implements support for excluding packages from installation onto the image being built when the selected package manager is Yum or DNF.

Fixes #282.

Changes proposed in this pull request:
* Add support for excluding packages when using Yum
* Add support for excluding packages when using DNF
