### PR TITLE
Evaluate UNIONFS_CONFIG filesystem

### DIFF
--- a/kiwi/boot/arch/ppc/netboot/linuxrc
+++ b/kiwi/boot/arch/ppc/netboot/linuxrc
@@ -604,8 +604,9 @@ then
         done
         imageRootDevice=$imageDevice
         if [ ! -z "$UNIONFS_CONFIG" ];then
-            imageRWDevice=`echo $UNIONFS_CONFIG | cut -d , -f 1`
-            imageRODevice=`echo $UNIONFS_CONFIG | cut -d , -f 2`
+            imageRWDevice=$(echo $UNIONFS_CONFIG | cut -d , -f 1)
+            imageRODevice=$(echo $UNIONFS_CONFIG | cut -d , -f 2)
+            unionFST=$(echo $UNIONFS_CONFIG | cut -d , -f 3)
         fi
         rm -f /etc/ireal.md5
         rm -f /etc/image.md5

--- a/kiwi/boot/arch/s390/netboot/linuxrc
+++ b/kiwi/boot/arch/s390/netboot/linuxrc
@@ -621,8 +621,9 @@ then
         done
         imageRootDevice=$imageDevice
         if [ ! -z "$UNIONFS_CONFIG" ];then
-            imageRWDevice=`echo $UNIONFS_CONFIG | cut -d , -f 1`
-            imageRODevice=`echo $UNIONFS_CONFIG | cut -d , -f 2`
+            imageRWDevice=$(echo $UNIONFS_CONFIG | cut -d , -f 1)
+            imageRODevice=$(echo $UNIONFS_CONFIG | cut -d , -f 2)
+            unionFST=$(echo $UNIONFS_CONFIG | cut -d , -f 3)
         fi
         rm -f /etc/ireal.md5
         rm -f /etc/image.md5

--- a/kiwi/boot/arch/x86_64/netboot/linuxrc
+++ b/kiwi/boot/arch/x86_64/netboot/linuxrc
@@ -604,8 +604,9 @@ then
         done
         imageRootDevice=$imageDevice
         if [ ! -z "$UNIONFS_CONFIG" ];then
-            imageRWDevice=`echo $UNIONFS_CONFIG | cut -d , -f 1`
-            imageRODevice=`echo $UNIONFS_CONFIG | cut -d , -f 2`
+            imageRWDevice=$(echo $UNIONFS_CONFIG | cut -d , -f 1)
+            imageRODevice=$(echo $UNIONFS_CONFIG | cut -d , -f 2)
+            unionFST=$(echo $UNIONFS_CONFIG | cut -d , -f 3)
         fi
         rm -f /etc/ireal.md5
         rm -f /etc/image.md5


### PR DESCRIPTION
This commit makes sure the filesystem is parsed from the
UNIONFS_CONFIG configuration variable when the PXE image is
loaded to a block device.

This commit fixes #316
