### PR TITLE
Remove erroneous statement in request_package_exclusion() for Yum+DNF

### DIFF
--- a/kiwi/package_manager/dnf.py
+++ b/kiwi/package_manager/dnf.py
@@ -84,8 +84,6 @@ class PackageManagerDnf(PackageManagerBase):
         """
         Queue a package exclusion(skip) request
 
-        Package exclusion for dnf package manager not yet implemented
-
         :param string name: package name
         """
         self.exclude_requests.append(name)

--- a/kiwi/package_manager/yum.py
+++ b/kiwi/package_manager/yum.py
@@ -84,8 +84,6 @@ class PackageManagerYum(PackageManagerBase):
         """
         Queue a package exclusion(skip) request
 
-        Package exclusion for yum package manager not yet implemented
-
         :param string name: package name
         """
         self.exclude_requests.append(name)


### PR DESCRIPTION
Remove a statement that is now erroneous after merging #315.

Changes proposed in this pull request:
* Remove erroneous doc string statement in `request_package_exclusion()` in Yum/DNF classes
* No code changes
