### PR TITLE
Use correct service name variable

### DIFF
--- a/kiwi/config/functions.sh
+++ b/kiwi/config/functions.sh
@@ -73,7 +73,7 @@ function baseSystemdCall {
     local service_name=$1; shift
     local service=$(baseSystemdServiceInstalled "$service_name")
     if [ ! -z "$service" ];then
-        systemctl "$@" "$service"
+        systemctl "$@" "$service_name"
     else
         local legacy_service=$(baseSysVServiceInstalled "$service_name")
         if [ ! -z "$legacy_service" ];then


### PR DESCRIPTION
The `$service` variable contains a path to the service file, this does only seems to work with "enable" in systemctl, by switching to using the service-name only, other commands now work properly.

Test setup:
```bash
baseInsertService sshd
baseRemoveService sshd

baseSystemdCall sshd mask
baseSystemdCall sshd unmask
```
Current code:
```bash
Created symlink from /etc/systemd/system/multi-user.target.wants/sshd.service to /usr/lib/systemd/system/sshd.service.
Failed to execute operation: Invalid argument
Failed to execute operation: Invalid argument
Failed to execute operation: Invalid argument
```
This is due to the command executing is looking like this: `systemctl disable /usr/lib/systemd/system/sshd.service`


By switching to using the `$service_name` variable everything works now as intended:
```bash
Created symlink from /etc/systemd/system/multi-user.target.wants/sshd.service to /usr/lib/systemd/system/sshd.service.
Removed symlink /etc/systemd/system/multi-user.target.wants/sshd.service.
Created symlink from /etc/systemd/system/sshd.service to /dev/null.
Removed symlink /etc/systemd/system/sshd.service.

```