### PR TITLE
Added dracut output file format detection

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -1009,7 +1009,7 @@ class DiskBuilder(object):
         all over the place in order to stay compatible with what the
         distribution does
         """
-        default_outfile_format = 'initrd-{kernel_version}'
+        default_outfile_format = 'initramfs-{kernel_version}.img'
         dracut_search_env = {
             'PATH': os.sep.join([self.root_dir, 'usr', 'bin'])
         }

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -16,6 +16,7 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
+import re
 import platform
 import pickle
 from collections import namedtuple
@@ -986,12 +987,44 @@ class DiskBuilder(object):
                 self.boot_image.boot_root_directory
             )
         if self.initrd_system and self.initrd_system == 'dracut':
+            dracut_output_format = self._get_dracut_output_file_format()
             return boot_names_type(
                 kernel_name=kernel_info.name,
-                initrd_name='initrd-' + kernel_info.version
+                initrd_name=dracut_output_format.format(
+                    kernel_version=kernel_info.version
+                )
             )
         else:
             return boot_names_type(
                 kernel_name='linux.vmx',
                 initrd_name='initrd.vmx'
             )
+
+    def _get_dracut_output_file_format(self):
+        """
+        Unfortunately the dracut initrd output file format varies between
+        the different Linux distributions. Tools like lsinitrd, and also
+        grub2 rely on the initrd output file to be in that format.
+        Thus when kiwi uses dracut the same file format should be used
+        all over the place in order to stay compatible with what the
+        distribution does
+        """
+        default_outfile_format = 'initrd-{kernel_version}'
+        dracut_search_env = {
+            'PATH': os.sep.join([self.root_dir, 'usr', 'bin'])
+        }
+        dracut_tool = Path.which(
+            'dracut', custom_env=dracut_search_env, access_mode=os.X_OK
+        )
+        if dracut_tool:
+            outfile_expression = r'outfile="/boot/(init.*\$kernel.*)"'
+            with open(dracut_tool) as dracut:
+                outfile = re.findall(outfile_expression, dracut.read())[0]
+                if outfile:
+                    return outfile.replace('$kernel', '{kernel_version}')
+
+        log.warning('Could not detect dracut output file format')
+        log.warning('Using default initrd file name format {0}'.format(
+            default_outfile_format
+        ))
+        return default_outfile_format

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -410,7 +410,7 @@ class TestDiskBuilder(object):
             '0815'
         )
         self.bootloader_config.setup_disk_image_config.assert_called_once_with(
-            initrd='initrd-1.2.3', kernel='vmlinuz-1.2.3-default',
+            initrd='initramfs-1.2.3.img', kernel='vmlinuz-1.2.3-default',
             boot_uuid='0815', root_uuid='0815'
         )
         self.setup.call_edit_boot_config_script.assert_called_once_with(
@@ -460,7 +460,7 @@ class TestDiskBuilder(object):
         ]
         assert mock_command.call_args_list == [
             call(['cp', 'root_dir/recovery.partition.size', 'boot_dir']),
-            call(['mv', 'initrd', 'root_dir/boot/initrd-1.2.3']),
+            call(['mv', 'initrd', 'root_dir/boot/initramfs-1.2.3.img']),
             call(['cp', 'root_dir/recovery.partition.size', 'boot_dir_kiwi'])
         ]
         self.setup.export_rpm_package_list.assert_called_once_with(
@@ -473,9 +473,13 @@ class TestDiskBuilder(object):
     @patch('kiwi.builder.disk.FileSystem')
     @patch_open
     @patch('kiwi.builder.disk.Command.run')
+    @patch('kiwi.builder.disk.Path.which')
+    @patch('kiwi.builder.disk.re.findall')
     def test_create_disk_standard_root_dracut_initrd_system(
-        self, mock_command, mock_open, mock_fs
+        self, mock_re_findall, mock_which, mock_command, mock_open, mock_fs
     ):
+        mock_re_findall.return_value = ['initrd-$kernel']
+        mock_which.return_value = 'dracut_found'
         self.disk_builder.initrd_system = 'dracut'
         self.disk_builder.volume_manager_name = None
         kernel = mock.Mock()
@@ -491,13 +495,9 @@ class TestDiskBuilder(object):
     @patch('kiwi.builder.disk.FileSystem')
     @patch_open
     @patch('kiwi.builder.disk.Command.run')
-    @patch('kiwi.builder.disk.Path.which')
-    @patch('kiwi.builder.disk.re.findall')
     def test_create_disk_standard_root_dracut_initramfs_system(
-        self, mock_re_findall, mock_which, mock_command, mock_open, mock_fs
+        self, mock_command, mock_open, mock_fs
     ):
-        mock_re_findall.return_value = ['initramfs-$kernel.img']
-        mock_which.return_value = 'dracut_found'
         self.disk_builder.initrd_system = 'dracut'
         self.disk_builder.volume_manager_name = None
         kernel = mock.Mock()
@@ -562,7 +562,7 @@ class TestDiskBuilder(object):
         self.kernel.get_kernel.return_value = kernel
         self.disk_builder.create_disk()
         self.bootloader_config.setup_disk_image_config.assert_called_once_with(
-            initrd='initrd-1.2.3', kernel=kernel.name,
+            initrd='initramfs-1.2.3.img', kernel=kernel.name,
             boot_uuid='0815', root_uuid='0815'
         )
 

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -489,6 +489,28 @@ class TestDiskBuilder(object):
         )
 
     @patch('kiwi.builder.disk.FileSystem')
+    @patch_open
+    @patch('kiwi.builder.disk.Command.run')
+    @patch('kiwi.builder.disk.Path.which')
+    @patch('kiwi.builder.disk.re.findall')
+    def test_create_disk_standard_root_dracut_initramfs_system(
+        self, mock_re_findall, mock_which, mock_command, mock_open, mock_fs
+    ):
+        mock_re_findall.return_value = ['initramfs-$kernel.img']
+        mock_which.return_value = 'dracut_found'
+        self.disk_builder.initrd_system = 'dracut'
+        self.disk_builder.volume_manager_name = None
+        kernel = mock.Mock()
+        kernel.version = '1.2.3'
+        kernel.name = 'vmlinuz-1.2.3'
+        self.kernel.get_kernel.return_value = kernel
+        self.disk_builder.create_disk()
+        self.bootloader_config.setup_disk_image_config.assert_called_once_with(
+            initrd='initramfs-1.2.3.img', kernel=kernel.name,
+            boot_uuid='0815', root_uuid='0815'
+        )
+
+    @patch('kiwi.builder.disk.FileSystem')
     @patch('kiwi.builder.disk.FileSystemSquashFs')
     @patch_open
     @patch('kiwi.builder.disk.Command.run')


### PR DESCRIPTION
Unfortunately the dracut initrd output file format varies between
the different Linux distributions. Tools like lsinitrd, and also
grub2 rely on the initrd output file to be in that format.
Thus when kiwi uses dracut the same file format should be used
all over the place in order to stay compatible with what the
distribution does. Fixes #325

