### PR TITLE
Fixup check_target_directory_not_in_shared_cache

### DIFF
--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -94,10 +94,11 @@ class RuntimeChecker(object):
         ''')
 
         shared_cache_location = Defaults.get_shared_cache_location()
-        absolute_target_dir = os.path.abspath(
+
+        target_dir_stack = os.path.abspath(
             os.path.normpath(target_dir)
-        ).replace('//', '/')
-        if absolute_target_dir.startswith('/' + shared_cache_location):
+        ).replace(os.sep + os.sep, os.sep).split(os.sep)
+        if target_dir_stack[1:4] == shared_cache_location.split(os.sep):
             raise KiwiRuntimeError(
                 message % (target_dir, shared_cache_location)
             )

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -23,30 +23,40 @@ class TestRuntimeChecker(object):
         self.runtime_checker.check_image_include_repos_http_resolvable()
 
     @raises(KiwiRuntimeError)
-    def test_check_target_directory_not_in_shared_cache_1(self):
+    def test_invalid_target_dir_pointing_to_shared_cache_1(self):
         self.runtime_checker.check_target_directory_not_in_shared_cache(
             '/var/cache//kiwi/foo'
         )
 
     @raises(KiwiRuntimeError)
-    def test_check_target_directory_not_in_shared_cache_2(self):
+    def test_invalid_target_dir_pointing_to_shared_cache_2(self):
         self.runtime_checker.check_target_directory_not_in_shared_cache(
             '/var/cache/kiwi'
         )
 
     @raises(KiwiRuntimeError)
     @patch('os.getcwd')
-    def test_check_target_directory_not_in_shared_cache_3(self, mock_getcwd):
+    def test_invalid_target_dir_pointing_to_shared_cache_3(self, mock_getcwd):
         mock_getcwd.return_value = '/'
         self.runtime_checker.check_target_directory_not_in_shared_cache(
             'var/cache/kiwi'
         )
 
     @raises(KiwiRuntimeError)
-    def test_check_target_directory_not_in_shared_cache_4(self):
+    def test_invalid_target_dir_pointing_to_shared_cache_4(self):
         self.runtime_checker.check_target_directory_not_in_shared_cache(
             '//var/cache//kiwi/foo'
         )
+
+    def test_valid_target_dir_1(self):
+        assert self.runtime_checker.check_target_directory_not_in_shared_cache(
+            '/var/cache/kiwi-fast-tmpsystemdir'
+        ) is None
+
+    def test_valid_target_dir_2(self):
+        assert self.runtime_checker.check_target_directory_not_in_shared_cache(
+            '/foo/bar'
+        ) is None
 
     @raises(KiwiRuntimeError)
     def test_check_repositories_configured(self):


### PR DESCRIPTION
The runtime check compared the given target path if it starts
with the cache directory /var/cache/kiwi. This however also
matches for e.g /var/cache/kiwi-foo which would be a valid
target directory. This patch changes the matcher in a way to
really check if the target directory points to the same cache
directory structure.