### PR TITLE
Handle rpm-check-signatures flag for each package manager

### DIFF
--- a/kiwi/repository/apt.py
+++ b/kiwi/repository/apt.py
@@ -64,6 +64,12 @@ class RepositoryApt(RepositoryBase):
             self.custom_args.remove('exclude_docs')
             self.exclude_docs = True
 
+        if 'check_signatures' in self.custom_args:
+            self.custom_args.remove('check_signatures')
+            self.unauthenticated = 'false'
+        else:
+            self.unauthenticated = 'true'
+
         self.distribution = None
         self.distribution_path = None
         self.repo_names = []
@@ -202,7 +208,8 @@ class RepositoryApt(RepositoryBase):
     def _write_runtime_config(self, system_default=False):
         if not system_default:
             parameters = {
-                'apt_shared_base': self.manager_base
+                'apt_shared_base': self.manager_base,
+                'unauthenticated': self.unauthenticated
             }
             template = self.apt_conf.get_host_template(self.exclude_docs)
             apt_conf_data = template.substitute(parameters)

--- a/kiwi/repository/dnf.py
+++ b/kiwi/repository/dnf.py
@@ -61,6 +61,12 @@ class RepositoryDnf(RepositoryBase):
             self.custom_args.remove('exclude_docs')
             self.exclude_docs = True
 
+        if 'check_signatures' in self.custom_args:
+            self.custom_args.remove('check_signatures')
+            self.gpg_check = '1'
+        else:
+            self.gpg_check = '0'
+
         self.repo_names = []
 
         # dnf support is based on creating repo files which contains
@@ -224,6 +230,9 @@ class RepositoryDnf(RepositoryBase):
         )
         self.runtime_dnf_config.set(
             'main', 'plugins', '1'
+        )
+        self.runtime_dnf_config.set(
+            'main', 'gpgcheck', self.gpg_check
         )
         if self.exclude_docs:
             self.runtime_dnf_config.set(

--- a/kiwi/repository/template/apt.py
+++ b/kiwi/repository/template/apt.py
@@ -46,7 +46,7 @@ class PackageManagerTemplateAptGet(object):
                     AllowDowngrades "true";
                     AllowRemoveEssential "true";
                     AllowChangeHeldPackages "true";
-                    AllowUnauthenticated "true";
+                    AllowUnauthenticated "${unauthenticated}";
                 }
             };
         ''').strip() + os.linesep

--- a/kiwi/repository/yum.py
+++ b/kiwi/repository/yum.py
@@ -61,6 +61,12 @@ class RepositoryYum(RepositoryBase):
             self.custom_args.remove('exclude_docs')
             log.warning('rpm-excludedocs not supported for yum: ignoring')
 
+        if 'check_signatures' in self.custom_args:
+            self.custom_args.remove('check_signatures')
+            self.gpg_check = '1'
+        else:
+            self.gpg_check = '0'
+
         self.repo_names = []
 
         # yum support is based on creating repo files which contains
@@ -224,6 +230,9 @@ class RepositoryYum(RepositoryBase):
         )
         self.runtime_yum_config.set(
             'main', 'plugins', '1'
+        )
+        self.runtime_yum_config.set(
+            'main', 'gpgcheck', self.gpg_check
         )
         self.runtime_yum_config.set(
             'main', 'metadata_expire', '1800'

--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -72,6 +72,11 @@ class RepositoryZypper(RepositoryBase):
             self.custom_args.remove('exclude_docs')
             self.exclude_docs = True
 
+        if 'check_signatures' in self.custom_args:
+            self.custom_args.remove('check_signatures')
+        else:
+            self.custom_args.append('--no-gpg-checks')
+
         self.repo_names = []
 
         # zypper support by default point all actions into the root
@@ -111,7 +116,7 @@ class RepositoryZypper(RepositoryBase):
         )
 
         self.zypper_args = [
-            '--non-interactive', '--no-gpg-checks',
+            '--non-interactive',
             '--pkg-cache-dir', self.shared_zypper_dir['pkg-cache-dir'],
             '--reposd-dir', self.shared_zypper_dir['reposd-dir'],
             '--solv-cache-dir', self.shared_zypper_dir['solv-cache-dir'],
@@ -150,7 +155,7 @@ class RepositoryZypper(RepositoryBase):
         self.shared_zypper_dir['credentials-dir'] = \
             self.root_dir + '/etc/zypp/credentials.d'
         self.zypper_args = [
-            '--non-interactive', '--no-gpg-checks'
+            '--non-interactive',
         ] + self.custom_args
         self.command_env = dict(os.environ, LANG='C')
 

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -101,6 +101,8 @@ class SystemPrepare(object):
         repository_options = []
         repository_sections = self.xml_state.get_repository_sections()
         package_manager = self.xml_state.get_package_manager()
+        if self.xml_state.get_rpm_check_signatures():
+            repository_options.append('check_signatures')
         if self.xml_state.get_rpm_excludedocs():
             repository_options.append('exclude_docs')
         repo = Repository(

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -124,6 +124,20 @@ class XMLState(object):
                 return exclude_docs[0]
         return False
 
+    def get_rpm_check_signatures(self):
+        """
+        Gets the rpm-check-signatures configuration flag. Returns
+        False if not present.
+
+        :return: check-signatures flag
+        :rtype: bool
+        """
+        for preferences in self.get_preferences_sections():
+            check_signatures = preferences.get_rpm_check_signatures()
+            if check_signatures:
+                return check_signatures[0]
+        return False
+
     def get_package_manager(self):
         """
         Configured package manager

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -57,6 +57,7 @@
         <timezone>Europe/Berlin</timezone>
         <hwclock>utc</hwclock>
         <rpm-excludedocs>true</rpm-excludedocs>
+        <rpm-check-signatures>true</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
     </preferences>

--- a/test/unit/repository_apt_test.py
+++ b/test/unit/repository_apt_test.py
@@ -44,7 +44,10 @@ class TestRepositoryApt(object):
             self.exclude_docs
         )
         template.substitute.assert_called_once_with(
-            {'apt_shared_base': '/shared-dir/apt-get'}
+            {
+                'apt_shared_base': '/shared-dir/apt-get',
+                'unauthenticated': 'true'
+            }
         )
 
     @patch_open
@@ -53,6 +56,14 @@ class TestRepositoryApt(object):
     def test_post_init_no_custom_args(self, mock_open, mock_path, mock_temp):
         self.repo.post_init()
         assert self.repo.custom_args == []
+
+    @patch_open
+    @patch('kiwi.repository.apt.NamedTemporaryFile')
+    @patch('kiwi.repository.apt.Path.create')
+    def test_post_init_with_custom_args(self, mock_open, mock_path, mock_temp):
+        self.repo.post_init(['check_signatures'])
+        assert self.repo.custom_args == []
+        assert self.repo.unauthenticated == 'false'
 
     @patch_open
     def test_use_default_location(self, mock_open):

--- a/test/unit/repository_dnf_test.py
+++ b/test/unit/repository_dnf_test.py
@@ -40,6 +40,7 @@ class TestRepositoryDnf(object):
             call('main', 'exactarch', '1'),
             call('main', 'obsoletes', '1'),
             call('main', 'plugins', '1'),
+            call('main', 'gpgcheck', '0'),
             call('main', 'tsflags', 'nodocs'),
             call('main', 'enabled', '1')
         ]
@@ -50,6 +51,14 @@ class TestRepositoryDnf(object):
     def test_post_init_no_custom_args(self, mock_path, mock_temp, mock_open):
         self.repo.post_init()
         assert self.repo.custom_args == []
+
+    @patch_open
+    @patch('kiwi.repository.dnf.NamedTemporaryFile')
+    @patch('kiwi.repository.dnf.Path.create')
+    def test_post_init_with_custom_args(self, mock_path, mock_temp, mock_open):
+        self.repo.post_init(['check_signatures'])
+        assert self.repo.custom_args == []
+        assert self.repo.gpg_check == '1'
 
     @patch_open
     @patch('kiwi.repository.dnf.ConfigParser')
@@ -70,6 +79,7 @@ class TestRepositoryDnf(object):
             call('main', 'exactarch', '1'),
             call('main', 'obsoletes', '1'),
             call('main', 'plugins', '1'),
+            call('main', 'gpgcheck', '0'),
             call('main', 'tsflags', 'nodocs'),
             call('main', 'enabled', '1')
         ]

--- a/test/unit/repository_template_apt_test.py
+++ b/test/unit/repository_template_apt_test.py
@@ -7,16 +7,22 @@ class TestPackageManagerTemplateAptGet(object):
 
     def test_get_host_template(self):
         assert self.apt.get_host_template().substitute(
-            apt_shared_base='/var/cache/kiwi/apt-get'
+            apt_shared_base='/var/cache/kiwi/apt-get',
+            unauthenticated='true'
         )
 
     def test_get_image_template(self):
-        assert self.apt.get_image_template().substitute()
+        assert self.apt.get_image_template().substitute(
+            unauthenticated='true'
+        )
 
     def test_get_host_template_with_exclude_docs(self):
         assert self.apt.get_host_template(exclude_docs=True).substitute(
-            apt_shared_base='/var/cache/kiwi/apt-get'
+            apt_shared_base='/var/cache/kiwi/apt-get',
+            unauthenticated='true'
         )
 
     def test_get_image_template_with_exclude_docs(self):
-        assert self.apt.get_image_template(exclude_docs=True).substitute()
+        assert self.apt.get_image_template(exclude_docs=True).substitute(
+            unauthenticated='true'
+        )

--- a/test/unit/repository_yum_test.py
+++ b/test/unit/repository_yum_test.py
@@ -39,6 +39,7 @@ class TestRepositoryYum(object):
             call('main', 'exactarch', '1'),
             call('main', 'obsoletes', '1'),
             call('main', 'plugins', '1'),
+            call('main', 'gpgcheck', '0'),
             call('main', 'metadata_expire', '1800'),
             call('main', 'group_command', 'compat'),
             call('main', 'enabled', '1')
@@ -53,6 +54,14 @@ class TestRepositoryYum(object):
     def test_post_init_no_custom_args(self, mock_path, mock_temp, mock_open):
         self.repo.post_init()
         assert self.repo.custom_args == []
+
+    @patch_open
+    @patch('kiwi.repository.yum.NamedTemporaryFile')
+    @patch('kiwi.repository.yum.Path.create')
+    def test_post_init_with_custom_args(self, mock_path, mock_temp, mock_open):
+        self.repo.post_init(['check_signatures'])
+        assert self.repo.custom_args == []
+        assert self.repo.gpg_check == '1'
 
     @patch_open
     @patch('kiwi.repository.yum.ConfigParser')
@@ -73,6 +82,7 @@ class TestRepositoryYum(object):
             call('main', 'exactarch', '1'),
             call('main', 'obsoletes', '1'),
             call('main', 'plugins', '1'),
+            call('main', 'gpgcheck', '0'),
             call('main', 'metadata_expire', '1800'),
             call('main', 'group_command', 'compat'),
             call('main', 'enabled', '1')

--- a/test/unit/repository_zypper_test.py
+++ b/test/unit/repository_zypper_test.py
@@ -42,6 +42,15 @@ class TestRepositoryZypper(object):
     @patch_open
     def test_custom_args_init(self, mock_open, mock_temp, mock_command):
         self.repo = RepositoryZypper(self.root_bind)
+        assert self.repo.custom_args == ['--no-gpg-checks']
+
+    @patch('kiwi.command.Command.run')
+    @patch('kiwi.repository.zypper.NamedTemporaryFile')
+    @patch_open
+    def test_custom_args_init_check_signatures(
+        self, mock_open, mock_temp, mock_command
+    ):
+        self.repo = RepositoryZypper(self.root_bind, ['check_signatures'])
         assert self.repo.custom_args == []
 
     @raises(KiwiRepoTypeUnknown)

--- a/test/unit/system_prepare_test.py
+++ b/test/unit/system_prepare_test.py
@@ -184,7 +184,8 @@ class TestSystemPrepare(object):
         self.system.setup_repositories()
 
         mock_repo.assert_called_once_with(
-            self.system.root_bind, 'package-manager-name', ['exclude_docs']
+            self.system.root_bind, 'package-manager-name',
+            ['check_signatures', 'exclude_docs']
         )
         # mock local repos will be translated and bind mounted
         assert uri.translate.call_args_list == [

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -46,6 +46,14 @@ class TestXMLState(object):
     def test_get_rpm_excludedocs(self):
         assert self.state.get_rpm_excludedocs() is True
 
+    @patch('kiwi.xml_state.XMLState.get_preferences_sections')
+    def test_get_rpm_check_signatures_without_entry(self, mock_preferences):
+        mock_preferences.return_value = []
+        assert self.state.get_rpm_check_signatures() is False
+
+    def test_get_rpm_check_signatures(self):
+        assert self.state.get_rpm_check_signatures() is True
+
     def test_get_package_manager(self):
         assert self.state.get_package_manager() == 'zypper'
 


### PR DESCRIPTION
This commit adds support for the rpm-check-signatures flag, which
sets the package manager to verify or not each package signature.
By default KIWI assumes no gpg checks are done.
