### PR TITLE
Fixup boot-load-size for efi loader in iso

### DIFF
--- a/kiwi/iso.py
+++ b/kiwi/iso.py
@@ -272,11 +272,23 @@ class Iso(object):
         bootloader/config/grub2.py
         """
         loader_file = self.boot_path + '/efi'
-        if os.path.exists(self.source_dir + '/' + loader_file):
+        if os.path.exists(os.sep.join([self.source_dir, loader_file])):
             self.iso_loaders += [
                 '-eltorito-alt-boot', '-b', loader_file,
                 '-no-emul-boot', '-joliet-long'
             ]
+            loader_file_512_byte_blocks = os.path.getsize(
+                os.sep.join([self.source_dir, loader_file])
+            ) / 512
+            # boot-load-size is stored in a 16bit range, thus we only
+            # set the value if it fits into that range
+            if loader_file_512_byte_blocks <= 0xffff:
+                self.iso_loaders.append(
+                    '-boot-load-size'
+                )
+                self.iso_loaders.append(
+                    format(int(loader_file_512_byte_blocks))
+                )
 
     def get_iso_creation_parameters(self):
         """

--- a/test/unit/iso_test.py
+++ b/test/unit/iso_test.py
@@ -134,7 +134,22 @@ class TestIso(object):
         )
 
     @patch('os.path.exists')
-    def test_add_efi_loader_parameters(self, mock_exists):
+    @patch('os.path.getsize')
+    def test_add_efi_loader_parameters(self, mock_getsize, mock_exists):
+        mock_getsize.return_value = 4096
+        mock_exists.return_value = True
+        self.iso.add_efi_loader_parameters()
+        assert self.iso.iso_loaders == [
+            '-eltorito-alt-boot', '-b', 'boot/x86_64/efi',
+            '-no-emul-boot', '-joliet-long', '-boot-load-size', '8'
+        ]
+
+    @patch('os.path.exists')
+    @patch('os.path.getsize')
+    def test_add_efi_loader_parameters_big_loader(
+        self, mock_getsize, mock_exists
+    ):
+        mock_getsize.return_value = 33554432
         mock_exists.return_value = True
         self.iso.add_efi_loader_parameters()
         assert self.iso.iso_loaders == [


### PR DESCRIPTION
Pass the real boot-load-size of the used loader as number
of 512byte blocks to the iso creation call. Related to
(bsc#939456)