### PR TITLE
Improve rpm-check-signatures support

### DIFF
--- a/kiwi/repository/dnf.py
+++ b/kiwi/repository/dnf.py
@@ -234,6 +234,9 @@ class RepositoryDnf(RepositoryBase):
         self.runtime_dnf_config.set(
             'main', 'gpgcheck', self.gpg_check
         )
+        self.runtime_dnf_config.set(
+            'main', 'repo_gpgcheck', self.gpg_check
+        )
         if self.exclude_docs:
             self.runtime_dnf_config.set(
                 'main', 'tsflags', 'nodocs'

--- a/kiwi/repository/yum.py
+++ b/kiwi/repository/yum.py
@@ -235,6 +235,9 @@ class RepositoryYum(RepositoryBase):
             'main', 'gpgcheck', self.gpg_check
         )
         self.runtime_yum_config.set(
+            'main', 'repo_gpgcheck', self.gpg_check
+        )
+        self.runtime_yum_config.set(
             'main', 'metadata_expire', '1800'
         )
         self.runtime_yum_config.set(

--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -64,6 +64,7 @@ class RepositoryZypper(RepositoryBase):
         """
         self.custom_args = custom_args
         self.exclude_docs = False
+        self.gpgcheck = False
         if not custom_args:
             self.custom_args = []
 
@@ -74,8 +75,7 @@ class RepositoryZypper(RepositoryBase):
 
         if 'check_signatures' in self.custom_args:
             self.custom_args.remove('check_signatures')
-        else:
-            self.custom_args.append('--no-gpg-checks')
+            self.gpgcheck = True
 
         self.repo_names = []
 
@@ -141,6 +141,18 @@ class RepositoryZypper(RepositoryBase):
         if self.exclude_docs:
             self.runtime_zypp_config.set(
                 'main', 'rpm.install.excludedocs', 'yes'
+            )
+
+        if self.gpgcheck:
+            self.runtime_zypp_config.set(
+                'main', 'pkg_gpgcheck', '1'
+            )
+            self.runtime_zypp_config.set(
+                'main', 'repo_gpgcheck', '1'
+            )
+        else:
+            self.runtime_zypp_config.set(
+                'main', 'gpgcheck', '0'
             )
 
         self._write_runtime_config()

--- a/test/unit/repository_dnf_test.py
+++ b/test/unit/repository_dnf_test.py
@@ -41,6 +41,7 @@ class TestRepositoryDnf(object):
             call('main', 'obsoletes', '1'),
             call('main', 'plugins', '1'),
             call('main', 'gpgcheck', '0'),
+            call('main', 'repo_gpgcheck', '0'),
             call('main', 'tsflags', 'nodocs'),
             call('main', 'enabled', '1')
         ]
@@ -80,6 +81,7 @@ class TestRepositoryDnf(object):
             call('main', 'obsoletes', '1'),
             call('main', 'plugins', '1'),
             call('main', 'gpgcheck', '0'),
+            call('main', 'repo_gpgcheck', '0'),
             call('main', 'tsflags', 'nodocs'),
             call('main', 'enabled', '1')
         ]

--- a/test/unit/repository_yum_test.py
+++ b/test/unit/repository_yum_test.py
@@ -40,6 +40,7 @@ class TestRepositoryYum(object):
             call('main', 'obsoletes', '1'),
             call('main', 'plugins', '1'),
             call('main', 'gpgcheck', '0'),
+            call('main', 'repo_gpgcheck', '0'),
             call('main', 'metadata_expire', '1800'),
             call('main', 'group_command', 'compat'),
             call('main', 'enabled', '1')
@@ -83,6 +84,7 @@ class TestRepositoryYum(object):
             call('main', 'obsoletes', '1'),
             call('main', 'plugins', '1'),
             call('main', 'gpgcheck', '0'),
+            call('main', 'repo_gpgcheck', '0'),
             call('main', 'metadata_expire', '1800'),
             call('main', 'group_command', 'compat'),
             call('main', 'enabled', '1')


### PR DESCRIPTION
This commit ensures the signatures are checked for both: the
repository and the rpm package. It applies for zypper, dnf and
yum package managers.
