### PR TITLE
Refactoring quote_xml_aux, quote_attrib, quote_python

### DIFF
--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -28,6 +28,7 @@ try:
     from lxml import etree as etree_
 except ImportError:
     from xml.etree import ElementTree as etree_
+from xml.sax.saxutils import escape, quoteattr
 
 
 Validate_simpletypes_ = True
@@ -441,42 +442,15 @@ def quote_xml(inStr):
     return s2
 
 
-def quote_xml_aux(inStr):
-    s1 = inStr.replace('&', '&amp;')
-    s1 = s1.replace('<', '&lt;')
-    s1 = s1.replace('>', '&gt;')
-    return s1
+quote_xml_aux = escape
 
 
 def quote_attrib(inStr):
     s1 = (isinstance(inStr, BaseStrType_) and inStr or '%s' % inStr)
-    s1 = s1.replace('&', '&amp;')
-    s1 = s1.replace('<', '&lt;')
-    s1 = s1.replace('>', '&gt;')
-    if '"' in s1:
-        if "'" in s1:
-            s1 = '"%s"' % s1.replace('"', "&quot;")
-        else:
-            s1 = "'%s'" % s1
-    else:
-        s1 = '"%s"' % s1
-    return s1
+    return quoteattr(inStr)
 
 
-def quote_python(inStr):
-    s1 = inStr
-    if s1.find("'") == -1:
-        if s1.find('\n') == -1:
-            return "'%s'" % s1
-        else:
-            return "'''%s'''" % s1
-    else:
-        if s1.find('"') != -1:
-            s1 = s1.replace('"', '\\"')
-        if s1.find('\n') == -1:
-            return '"%s"' % s1
-        else:
-            return '"""%s"""' % s1
+quote_python = repr
 
 
 def get_all_text_(node):

--- a/test/unit/xml_parse_test.py
+++ b/test/unit/xml_parse_test.py
@@ -1,0 +1,44 @@
+import pytest
+from kiwi.xml_parse import quote_xml_aux, quote_attrib, quote_python
+
+
+@pytest.mark.parametrize("string,result", [
+    ("hallo", "hallo"),
+    ("a & b", "a &amp; b"),
+    ("a < b", "a &lt; b"),
+    ("a > b", "a &gt; b"),
+    ("a ' b", "a ' b"),
+    ('a " b', 'a " b'),
+    ('a < b > c == "abc" + \'edf\'',
+     'a &lt; b &gt; c == "abc" + \'edf\''),
+    ("a < b > c == 'abc' + \"edf\"",
+     'a &lt; b &gt; c == \'abc\' + "edf"')
+])
+def test_quote_xml_aux(string, result):
+    assert quote_xml_aux(string) == result
+
+
+@pytest.mark.parametrize("string,result", [
+    ("hallo", '"hallo"'),
+    ("a & b", '"a &amp; b"'),
+    ("a < b", '"a &lt; b"'),
+    ("a > b", '"a &gt; b"'),
+    ("a ' b", '"a \' b"'),
+    ('a "b" c', '\'a "b" c\''),
+    ('a < b > c == "abc" + \'edf\'',
+     '"a &lt; b &gt; c == &quot;abc&quot; + \'edf\'"'),
+])
+def test_quote_attrib(string, result):
+    assert quote_attrib(string) == result
+
+
+@pytest.mark.parametrize("string,result", [
+    ("a 'b' c", '"a \'b\' c"'),
+    ("""a "b" c""", '\'a "b" c\''),
+    ('''a 'b' c''', '"a \'b\' c"'),
+    # ('''a 'b' "c" d''',
+    #  '\'a \\\'b\\\' "c" d\'' # the new implementation
+    #  '"a \'b\' \\"c\\" d"'), # the old implementation
+])
+def test_quote_python(string, result):
+    assert quote_python(string) == result


### PR DESCRIPTION
This fixes no special issues, but I just came across. It's a minor change in this pull request:

* Add test case for `quote_xml_aux`, `quote_attrib`, `quote_python`
* Basically, the original functions are refactored as this:
  * `quote_xml_aux()` is equally to `xml.sax.saxutils.escape`
  * `quote_attrib()` is almost the same as `xml.sax.saxutils.quoteattr`

**Question:**

* `quote_python()` is tricky; it is almost(!) equal to `repr()`. As `quote_python()` is never used, it is probably safer to remove it...?

