### PR TITLE
Idea: Test Function Docstrings

### DIFF
--- a/kiwi/kiwi.py
+++ b/kiwi/kiwi.py
@@ -85,6 +85,8 @@ def usage(command_usage):
        short form by default, long form with -h | --help
 
     3. the global options
+
+    :param command_usage: the usage string
     """
     with open(Defaults.project_file('cli.py'), 'r') as cli:
         program_code = cli.readlines()

--- a/kiwi/kiwi_compat.py
+++ b/kiwi/kiwi_compat.py
@@ -214,6 +214,7 @@ class Command(object):
 
 
 def main():
+    """Entry point for :command:`kiwicompat`"""
     logging.basicConfig(format='%(message)s', level=logging.INFO)
 
     try:

--- a/kiwi/kiwi_compat.py
+++ b/kiwi/kiwi_compat.py
@@ -214,7 +214,6 @@ class Command(object):
 
 
 def main():
-    """Entry point for :command:`kiwicompat`"""
     logging.basicConfig(format='%(message)s', level=logging.INFO)
 
     try:

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -488,12 +488,6 @@ def quote_python(inStr):
 
 
 def get_all_text_(node):
-    """Get all texts from a node and their child nodes
-
-    :param node: element node
-    :return: the combined string of the node and all their child nodes
-    :rtype: str
-    """
     if node.text is not None:
         text = node.text
     else:
@@ -505,12 +499,6 @@ def get_all_text_(node):
 
 
 def find_attr_value_(attr_name, node):
-    """Find attribute value from node
-
-    :param attr_name: name of the attribute
-    :param node: element node
-    :return: attribute value
-    """
     attrs = node.attrib
     attr_parts = attr_name.split(':')
     value = None

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -38,6 +38,7 @@ else:
 
 
 def parsexml_(infile, parser=None, **kwargs):
+    """ TBD """
     if parser is None:
         # Use the lxml ElementTree compatible parser so that, e.g.,
         #   we ignore comments.
@@ -418,6 +419,13 @@ CurrentSubclassModule_ = None
 
 
 def showIndent(outfile, level, pretty_print=True):
+    """Indent code
+
+    :param outfile: file like object
+    :param level: integer level of spaces (multiplied with 4)
+    :param pretty_print: boolean to real pretty print (True)
+                         or not (False)
+    """
     if pretty_print:
         for idx in range(level):
             outfile.write('    ')
@@ -7292,11 +7300,13 @@ Usage: python <Parser>.py [ -s ] <in_xml_file>
 
 
 def usage():
+    """Output usage and exit code 1"""
     print(USAGE_TEXT)
     sys.exit(1)
 
 
 def get_root_tag(node):
+    """TBD"""
     tag = Tag_pattern_.match(node.tag).groups()[-1]
     rootClass = GDSClassesMapping.get(tag)
     if rootClass is None:
@@ -7305,6 +7315,7 @@ def get_root_tag(node):
 
 
 def parse(inFileName, silence=False):
+    """TBD"""
     parser = None
     doc = parsexml_(inFileName, parser)
     rootNode = doc.getroot()
@@ -7326,6 +7337,7 @@ def parse(inFileName, silence=False):
 
 
 def parseEtree(inFileName, silence=False):
+    """TBD"""
     parser = None
     doc = parsexml_(inFileName, parser)
     rootNode = doc.getroot()
@@ -7350,6 +7362,7 @@ def parseEtree(inFileName, silence=False):
 
 
 def parseString(inString, silence=False):
+    """TBD"""
     if sys.version_info.major == 2:
         from StringIO import StringIO as IOBuffer
     else:
@@ -7374,6 +7387,7 @@ def parseString(inString, silence=False):
 
 
 def parseLiteral(inFileName, silence=False):
+    """TBD"""
     parser = None
     doc = parsexml_(inFileName, parser)
     rootNode = doc.getroot()
@@ -7395,6 +7409,7 @@ def parseLiteral(inFileName, silence=False):
 
 
 def main():
+    """Parse XML file"""
     args = sys.argv[1:]
     if len(args) == 1:
         parse(args[0])

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -480,6 +480,12 @@ def quote_python(inStr):
 
 
 def get_all_text_(node):
+    """Get all texts from a node and their child nodes
+
+    :param node: element node
+    :return: the combined string of the node and all their child nodes
+    :rtype: str
+    """
     if node.text is not None:
         text = node.text
     else:
@@ -491,6 +497,12 @@ def get_all_text_(node):
 
 
 def find_attr_value_(attr_name, node):
+    """Find attribute value from node
+
+    :param attr_name: name of the attribute
+    :param node: element node
+    :return: attribute value
+    """
     attrs = node.attrib
     attr_parts = attr_name.split(':')
     value = None

--- a/test/unit/docstrings_test.py
+++ b/test/unit/docstrings_test.py
@@ -1,0 +1,79 @@
+import inspect
+import pkgutil
+import pytest
+import re
+
+import kiwi
+
+
+def members(module, predicate=None):
+    """Yields all functions of a module if predicate=None
+
+    :param module: the given module to search for members
+    :type module: :class:`module`
+    :param predicate: a function with expects an object and returns True or False
+                      see :func:`inspect.isfunction` as an example
+    :type prediate: :class:`function`
+    """
+    predicate = inspect.isfunction if predicate is None else predicate
+    for _, func, in inspect.getmembers(module, predicate):
+        if func.__module__ == module.__name__:
+            yield func
+
+
+def getmodules(module, predicate=None):
+    """Yields recursively sub module names from a given module
+
+    :param module: the given module to search for members
+    :type module: :class:`module`
+    :param predicate: a function with expects an object and returns True or False
+                      see :func:`inspect.isfunction` as an example
+    :type prediate: :class:`function`
+    """
+    prefix = module.__name__ + "."
+    for importer, modname, ispkg in pkgutil.iter_modules(module.__path__, prefix):
+        module = importer.find_module(modname).load_module(modname)
+        yield from members(module, predicate)
+        if ispkg:
+            getmodules(module, predicate)
+        del module
+
+
+def getallfunctions(module):
+    yield from getmodules(module)
+
+
+# Only add modules/functions starting not with "_"; this would indicate a private
+# member.
+modfuncs = [ff for ff in getallfunctions(kiwi) if not ff.__name__.startswith("_")]
+modfuncsnames = ["%s.%s" % (ff.__module__, ff.__name__) for ff in modfuncs]
+
+
+@pytest.mark.parametrize("func",
+                         modfuncs,
+                         ids=modfuncsnames
+                         )
+def test_docstrings_nonempty(func):
+    """Test if docstring is not empty"""
+    fname = func.__name__
+    doc = func.__doc__
+
+    assert doc is not None, "Need an non-empty docstring for %r" % fname
+
+
+@pytest.mark.parametrize("func",
+                         modfuncs,
+                         ids=modfuncsnames
+                         )
+def test_docstrings_args(func):
+    """Test if docstring contains description of all parameters"""
+    fname = ".".join([func.__module__, func.__name__])
+    doc = func.__doc__
+
+    assert doc is not None
+    if func.__code__.co_argcount:
+        for arg in inspect.getargspec(func).args:
+            m = re.search(":param\s+\w*\s*%s:" % arg, doc)
+            assert m, "Func argument %r " \
+                "not explained in docstring " \
+                "of function %r" % (arg, fname)

--- a/test/unit/docstrings_test.py
+++ b/test/unit/docstrings_test.py
@@ -42,10 +42,30 @@ def getmodules(module, predicate=None):
 def getallfunctions(module):
     yield from getmodules(module)
 
+# List of qualified function names as regex to ignore
+IGNORELIST=(r"kiwi\.xml_parse\.(.*)",
+            )
+IGNORELIST = tuple(re.compile(p) for p in IGNORELIST)
+
+def ignore(func):
+    """Check if function should be ignored
+
+    :param func: function
+    :return: True (=ignore) or False (=don't ignore)
+    """
+    fname = func.__name__
+    if fname.startswith("_"):
+        # Ignore any private functions
+        return False
+    # Use now the complete qualified function name:
+    fname = "%s.%s" % (func.__module__, func.__name__)
+    print(">>>", fname)
+    return not any(pattern.search(fname) for pattern in IGNORELIST)
 
 # Only add modules/functions starting not with "_"; this would indicate a private
 # member.
-modfuncs = [ff for ff in getallfunctions(kiwi) if not ff.__name__.startswith("_")]
+modfuncs = [ff for ff in getallfunctions(kiwi) if ignore(ff)]
+# modfuncs = [ff for ff in modfuncs if ff.__name__ not in IGNORELIST]
 modfuncsnames = ["%s.%s" % (ff.__module__, ff.__name__) for ff in modfuncs]
 
 


### PR DESCRIPTION
This fixes no particular issue. It's up to you if you think it is useful or not. 😉 I don't mind if you close it without merging.

Yes, the testcases **fail** for the time being, but this has to be: not all functions contains a description of the function parameters. I would have documented them, but I wasn't sure on some, so it's "work in progress".

Changes proposed in this pull request:
* Add two new testcases for docstrings (file `docstrings_test.py`):
  * `test_docstrings_nonempty()`
    just tests for an non-empty docstring for each functions in the KIWI code.
  * `test_docstrings_args()`
    tests , if a docstring contains descriptions of all parameters of a function
 
As you can see, the second one is more strict than the first. This was done on purpose as you can choose one or the other. 

Both tests skip private functions starting with "_" in the function name. Also classes. If you want them to be checked as well, additional code needs to be added (I wanted to start with something simple, I leave it as an exercise. 😉 )

An example output:
```
test/unit/docstrings_test.py::test_docstrings_nonempty[kiwi.xml_parse.quote_attrib] FAILED
[...]
==== 17 failed, 25 passed in 0.42 seconds ====
```

Some benefits:

* Improve code hygiene
* Improves API documentation
* New functions are not only checked for their functionality, but for their documentation (=docstring) too
* Adheres to a "definition of done" check (if you consider docstrings as valueable 😉 )
* Test can be as strict or as loose as you want it

Let me know what you think.
