### PR TITLE
Let dracut create a compressed initrd

### DIFF
--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -79,9 +79,8 @@ class BootImageBase(object):
                 'target directory %s not found' % target_dir
             )
 
-        self.initrd_file_name = ''.join(
+        self.initrd_base_name = ''.join(
             [
-                self.target_dir, '/',
                 self.xml_state.xml_data.get_name(),
                 '.' + platform.machine(),
                 '-' + self.xml_state.get_image_version(),

--- a/kiwi/boot/image/builtin_kiwi.py
+++ b/kiwi/boot/image/builtin_kiwi.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+import os
 from tempfile import mkdtemp
 
 from kiwi.defaults import Defaults
@@ -122,7 +123,9 @@ class BootImageKiwi(BootImageBase):
                 image_identifier = boot_directory + '/mbrid'
                 mbrid.write(image_identifier)
 
-            cpio = ArchiveCpio(self.initrd_file_name)
+            cpio = ArchiveCpio(
+                os.sep.join([self.target_dir, self.initrd_base_name])
+            )
             # the following is a list of directories which were needed
             # during the process of creating an image but not when the
             # image is actually booting with this initrd
@@ -142,6 +145,8 @@ class BootImageKiwi(BootImageBase):
             log.info(
                 '--> xz compressing archive'
             )
-            compress = Compress(self.initrd_file_name)
+            compress = Compress(
+                os.sep.join([self.target_dir, self.initrd_base_name])
+            )
             compress.xz()
             self.initrd_filename = compress.compressed_filename

--- a/test/unit/boot_image_dracut_test.py
+++ b/test/unit/boot_image_dracut_test.py
@@ -26,36 +26,28 @@ class TestBootImageKiwi(object):
         # just pass, there is nothing we need to do for dracut here
         self.boot_image.prepare()
 
-    @patch('kiwi.boot.image.dracut.Compress')
     @patch('kiwi.boot.image.dracut.Kernel')
     @patch('kiwi.boot.image.dracut.Command.run')
     @patch('kiwi.boot.image.base.BootImageBase.is_prepared')
     def test_create_initrd(
-        self, mock_prepared, mock_command, mock_kernel, mock_compress
+        self, mock_prepared, mock_command, mock_kernel
     ):
         kernel = mock.Mock()
         kernel_details = mock.Mock()
         kernel_details.version = '1.2.3'
         kernel.get_kernel = mock.Mock(return_value=kernel_details)
         mock_kernel.return_value = kernel
-        compress = mock.Mock()
-        mock_compress.return_value = compress
         self.boot_image.create_initrd()
         assert mock_command.call_args_list == [
             call([
                 'chroot', 'system-directory',
                 'dracut', '--force', '--no-hostonly',
-                '--no-hostonly-cmdline', '--no-compress',
-                'LimeJeOS-openSUSE-13.2.x86_64-1.13.2.initrd', '1.2.3'
+                '--no-hostonly-cmdline', '--xz',
+                'LimeJeOS-openSUSE-13.2.x86_64-1.13.2.initrd.xz', '1.2.3'
             ]),
             call([
                 'mv',
-                'system-directory/LimeJeOS-openSUSE-13.2.x86_64-1.13.2.initrd',
-                'some-target-dir/LimeJeOS-openSUSE-13.2.x86_64-1.13.2.initrd'
+                'system-directory/LimeJeOS-openSUSE-13.2.x86_64-1.13.2.initrd.xz',
+                'some-target-dir'
             ])
         ]
-        mock_compress.assert_called_once_with(
-            self.boot_image.target_dir +
-            '/LimeJeOS-openSUSE-13.2.x86_64-1.13.2.initrd'
-        )
-        compress.xz.assert_called_once_with()


### PR DESCRIPTION
dracut was called in a way to create an uncompressed initrd archive
and kiwi later runs the xz compression on it. That way the default
compression parameters used by dracut get lost. Fixes #335

