### PR TITLE
Added --clear-cache option

### DIFF
--- a/doc/source/commands/system_build.rst
+++ b/doc/source/commands/system_build.rst
@@ -10,6 +10,7 @@ SYNOPSIS
 
    kiwi system build -h | --help
    kiwi system build --description=<directory> --target-dir=<directory>
+       [--clear-cache]
        [--ignore-repos]
        [--set-repo=<source,type,alias,priority>]
        [--add-repo=<source,type,alias,priority>...]
@@ -40,6 +41,17 @@ OPTIONS
 
   Add a new repository to the existing repository setup in the XML
   description. This option can be specified multiple times
+
+--clear-cache
+
+  delete repository cache for each of the used repositories
+  before installing any package. This is useful if an image build
+  should take and validate the signature of the package from the
+  original repository source for any build. Some package managers
+  unconditionally trust the contents of the cache, which is ok for
+  cache data dedicated to one build but in case of kiwi the cache
+  is shared between multiple image builds on that host for performance
+  reasons.
 
 --delete-package=<name>
 

--- a/doc/source/commands/system_prepare.rst
+++ b/doc/source/commands/system_prepare.rst
@@ -11,6 +11,7 @@ SYNOPSIS
    kiwi system prepare -h | --help
    kiwi system prepare --description=<directory> --root=<directory>
        [--allow-existing-root]
+       [--clear-cache]
        [--ignore-repos]
        [--set-repo=<source,type,alias,priority>]
        [--add-repo=<source,type,alias,priority>...]
@@ -46,6 +47,17 @@ OPTIONS
 --allow-existing-root
 
   allow to re-use an existing image root directory
+
+--clear-cache
+
+  delete repository cache for each of the used repositories
+  before installing any package. This is useful if an image build
+  should take and validate the signature of the package from the
+  original repository source for any build. Some package managers
+  unconditionally trust the contents of the cache, which is ok for
+  cache data dedicated to one build but in case of kiwi the cache
+  is shared between multiple image builds on that host for performance
+  reasons.
 
 --delete-package=<name>
 

--- a/kiwi/repository/apt.py
+++ b/kiwi/repository/apt.py
@@ -184,6 +184,21 @@ class RepositoryApt(RepositoryBase):
         Path.wipe(self.shared_apt_get_dir['sources-dir'])
         Path.create(self.shared_apt_get_dir['sources-dir'])
 
+    def delete_repo_cache(self, name):
+        """
+        Delete apt-get repository cache
+
+        Apt stores the package cache in a collection of binary files
+        and deb archives. As of now I couldn't came across a solution
+        which allows for deleting only the cache data for a specific
+        repository. Thus the repo cache cleanup affects all cache
+        data
+
+        :param string name: unused
+        """
+        for cache_file in ['archives', 'pkgcache.bin', 'srcpkgcache.bin']:
+            Path.wipe(os.sep.join([self.manager_base, cache_file]))
+
     def cleanup_unused_repos(self):
         """
         Delete unused apt_get repositories

--- a/kiwi/repository/base.py
+++ b/kiwi/repository/base.py
@@ -114,3 +114,13 @@ class RepositoryBase(object):
         Implementation in specialized repository class
         """
         raise NotImplementedError
+
+    def delete_repo_cache(self, name):
+        """
+        Delete repository cache
+
+        Implementation in specialized repository class
+
+        :param string name: unused
+        """
+        raise NotImplementedError

--- a/kiwi/repository/dnf.py
+++ b/kiwi/repository/dnf.py
@@ -16,6 +16,7 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
+import glob
 from six.moves.configparser import ConfigParser
 from tempfile import NamedTemporaryFile
 
@@ -175,6 +176,24 @@ class RepositoryDnf(RepositoryBase):
         """
         Path.wipe(self.shared_dnf_dir['reposd-dir'])
         Path.create(self.shared_dnf_dir['reposd-dir'])
+
+    def delete_repo_cache(self, name):
+        """
+        Delete dnf repository cache
+
+        The cache data for each repository is stored in a directory
+        and additional files all starting with the repository name.
+        The method glob deletes all files and directories matching
+        the repository name followed by any characters to cleanup
+        the cache information
+
+        :param string name: repository name
+        """
+        dnf_cache_glob_pattern = ''.join(
+            [self.shared_dnf_dir['cache-dir'], os.sep, name, '*']
+        )
+        for dnf_cache_file in glob.iglob(dnf_cache_glob_pattern):
+            Path.wipe(dnf_cache_file)
 
     def cleanup_unused_repos(self):
         """

--- a/kiwi/repository/yum.py
+++ b/kiwi/repository/yum.py
@@ -176,6 +176,20 @@ class RepositoryYum(RepositoryBase):
         Path.wipe(self.shared_yum_dir['reposd-dir'])
         Path.create(self.shared_yum_dir['reposd-dir'])
 
+    def delete_repo_cache(self, name):
+        """
+        Delete yum repository cache
+
+        The cache data for each repository is stored in a directory
+        of the same name as the repository name. The method deletes
+        this directory to cleanup the cache information
+
+        :param string name: repository name
+        """
+        Path.wipe(
+            os.sep.join([self.shared_yum_dir['cache-dir'], name])
+        )
+
     def cleanup_unused_repos(self):
         """
         Delete unused yum repositories

--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -267,14 +267,20 @@ class RepositoryZypper(RepositoryBase):
         """
         Delete zypper repository cache
 
-        The cache data for each repository is stored in a directory
-        of the same name as the repository name. The method deletes
-        this directory to cleanup the cache information
+        The cache data for each repository is stored in a list of
+        directories of the same name as the repository name. The method
+        deletes these directories to cleanup the cache information
 
         :param string name: repository name
         """
         Path.wipe(
             os.sep.join([self.shared_zypper_dir['pkg-cache-dir'], name])
+        )
+        Path.wipe(
+            os.sep.join([self.shared_zypper_dir['solv-cache-dir'], name])
+        )
+        Path.wipe(
+            os.sep.join([self.shared_zypper_dir['raw-cache-dir'], name])
         )
 
     def cleanup_unused_repos(self):

--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -263,6 +263,20 @@ class RepositoryZypper(RepositoryBase):
         Path.wipe(self.shared_zypper_dir['reposd-dir'])
         Path.create(self.shared_zypper_dir['reposd-dir'])
 
+    def delete_repo_cache(self, name):
+        """
+        Delete zypper repository cache
+
+        The cache data for each repository is stored in a directory
+        of the same name as the repository name. The method deletes
+        this directory to cleanup the cache information
+
+        :param string name: repository name
+        """
+        Path.wipe(
+            os.sep.join([self.shared_zypper_dir['pkg-cache-dir'], name])
+        )
+
     def cleanup_unused_repos(self):
         """
         Delete unused zypper repositories

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -90,7 +90,7 @@ class SystemPrepare(object):
         # for System operations
         self.uri_list = []
 
-    def setup_repositories(self):
+    def setup_repositories(self, clear_cache=False):
         """
         Set up repositories for software installation and return a
         package manager for performing software installation tasks
@@ -146,6 +146,8 @@ class SystemPrepare(object):
                 repo_type, repo_priority, repo_dist, repo_components,
                 repo_user, repo_secret, uri.credentials_file_name()
             )
+            if clear_cache:
+                repo.delete_repo_cache(repo_alias)
             self.uri_list.append(uri)
         repo.cleanup_unused_repos()
         return PackageManager(

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -18,6 +18,7 @@
 """
 usage: kiwi system build -h | --help
        kiwi system build --description=<directory> --target-dir=<directory>
+           [--clear-cache]
            [--ignore-repos]
            [--set-repo=<source,type,alias,priority>]
            [--add-repo=<source,type,alias,priority>...]
@@ -40,6 +41,9 @@ options:
         install the given package name
     --add-repo=<source,type,alias,priority>
         add repository with given source, type, alias and priority.
+    --clear-cache
+        delete repository cache for each of the used repositories
+        before installing any package
     --delete-package=<name>
         delete the given package name
     --description=<directory>
@@ -176,7 +180,9 @@ class SystemBuildTask(CliTask):
         system = SystemPrepare(
             self.xml_state, image_root, True
         )
-        manager = system.setup_repositories()
+        manager = system.setup_repositories(
+            self.command_args['--clear-cache']
+        )
         system.install_bootstrap(manager)
         system.install_system(
             manager

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -19,6 +19,7 @@
 usage: kiwi system prepare -h | --help
        kiwi system prepare --description=<directory> --root=<directory>
            [--allow-existing-root]
+           [--clear-cache]
            [--ignore-repos]
            [--set-repo=<source,type,alias,priority>]
            [--add-repo=<source,type,alias,priority>...]
@@ -46,6 +47,9 @@ options:
         allow to use an existing root directory. Use with caution
         this could cause an inconsistent root tree if the existing
         contents does not fit to the additional installation
+    --clear-cache
+        delete repository cache for each of the used repositories
+        before installing any package
     --description=<directory>
         the description must be a directory containing a kiwi XML
         description and optional metadata files
@@ -169,7 +173,9 @@ class SystemPrepareTask(CliTask):
             abs_root_path,
             self.command_args['--allow-existing-root']
         )
-        manager = system.setup_repositories()
+        manager = system.setup_repositories(
+            self.command_args['--clear-cache']
+        )
         system.install_bootstrap(manager)
         system.install_system(
             manager

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -38,6 +38,7 @@ class TestCli(object):
             '--description': 'description',
             '--help': False,
             '--ignore-repos': False,
+            '--clear-cache': False,
             '--obs-repo-internal': False,
             '--root': 'directory',
             '--set-repo': None,

--- a/test/unit/repository_apt_test.py
+++ b/test/unit/repository_apt_test.py
@@ -1,4 +1,4 @@
-from mock import patch
+from mock import patch, call
 
 import mock
 
@@ -157,3 +157,12 @@ class TestRepositoryApt(object):
         mock_create.assert_called_once_with(
             '/shared-dir/apt-get/sources.list.d'
         )
+
+    @patch('kiwi.path.Path.wipe')
+    def test_delete_repo_cache(self, mock_wipe):
+        self.repo.delete_repo_cache('foo')
+        assert mock_wipe.call_args_list == [
+            call('/shared-dir/apt-get/archives'),
+            call('/shared-dir/apt-get/pkgcache.bin'),
+            call('/shared-dir/apt-get/srcpkgcache.bin')
+        ]

--- a/test/unit/repository_base_test.py
+++ b/test/unit/repository_base_test.py
@@ -38,3 +38,7 @@ class TestRepositoryBase(object):
     @raises(NotImplementedError)
     def test_cleanup_unused_repos(self):
         self.repo.cleanup_unused_repos()
+
+    @raises(NotImplementedError)
+    def test_delete_repo_cache(self):
+        self.repo.delete_repo_cache('foo')

--- a/test/unit/repository_dnf_test.py
+++ b/test/unit/repository_dnf_test.py
@@ -141,3 +141,15 @@ class TestRepositoryDnf(object):
         mock_create.assert_called_once_with(
             '/shared-dir/dnf/repos'
         )
+
+    @patch('kiwi.path.Path.wipe')
+    @patch('kiwi.repository.dnf.glob.iglob')
+    def test_delete_repo_cache(self, mock_glob, mock_wipe):
+        mock_glob.return_value = ['foo_cache']
+        self.repo.delete_repo_cache('foo')
+        mock_glob.assert_called_once_with(
+            '/shared-dir/dnf/cache/foo*'
+        )
+        mock_wipe.assert_called_once_with(
+            'foo_cache'
+        )

--- a/test/unit/repository_yum_test.py
+++ b/test/unit/repository_yum_test.py
@@ -145,3 +145,10 @@ class TestRepositoryYum(object):
         mock_create.assert_called_once_with(
             '/shared-dir/yum/repos'
         )
+
+    @patch('kiwi.path.Path.wipe')
+    def test_delete_repo_cache(self, mock_wipe):
+        self.repo.delete_repo_cache('foo')
+        mock_wipe.assert_called_once_with(
+            '/shared-dir/yum/cache/foo'
+        )

--- a/test/unit/repository_zypper_test.py
+++ b/test/unit/repository_zypper_test.py
@@ -205,9 +205,11 @@ class TestRepositoryZypper(object):
     @patch('kiwi.path.Path.wipe')
     def test_delete_repo_cache(self, mock_wipe):
         self.repo.delete_repo_cache('foo')
-        mock_wipe.assert_called_once_with(
-            '../data/shared-dir/packages/foo'
-        )
+        assert mock_wipe.call_args_list == [
+            call('../data/shared-dir/packages/foo'),
+            call('../data/shared-dir/zypper/solv/foo'),
+            call('../data/shared-dir/zypper/raw/foo')
+        ]
 
     @patch('kiwi.command.Command.run')
     @patch('os.path.exists')

--- a/test/unit/repository_zypper_test.py
+++ b/test/unit/repository_zypper_test.py
@@ -202,6 +202,13 @@ class TestRepositoryZypper(object):
                 'mkdir', '-p', '../data/shared-dir/zypper/repos'
             ])
 
+    @patch('kiwi.path.Path.wipe')
+    def test_delete_repo_cache(self, mock_wipe):
+        self.repo.delete_repo_cache('foo')
+        mock_wipe.assert_called_once_with(
+            '../data/shared-dir/packages/foo'
+        )
+
     @patch('kiwi.command.Command.run')
     @patch('os.path.exists')
     def test_destructor(self, mock_exists, mock_command):

--- a/test/unit/system_prepare_test.py
+++ b/test/unit/system_prepare_test.py
@@ -181,7 +181,7 @@ class TestSystemPrepare(object):
         repo = mock.Mock()
         mock_repo.return_value = repo
 
-        self.system.setup_repositories()
+        self.system.setup_repositories(clear_cache=True)
 
         mock_repo.assert_called_once_with(
             self.system.root_bind, 'package-manager-name',
@@ -206,6 +206,10 @@ class TestSystemPrepare(object):
                 'uri-alias', 'uri', 'rpm-md', None,
                 None, None, None, None, 'credentials-file'
             )
+        ]
+        assert repo.delete_repo_cache.call_args_list == [
+            call('uri-alias'),
+            call('uri-alias')
         ]
 
     @patch('kiwi.system.prepare.Repository')

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -80,6 +80,7 @@ class TestSystemBuildTask(object):
         self.task.command_args['--ignore-repos'] = False
         self.task.command_args['--set-container-derived-from'] = None
         self.task.command_args['--set-container-tag'] = None
+        self.task.command_args['--clear-cache'] = False
 
     @patch('kiwi.logger.Logger.set_logfile')
     def test_process_system_build(self, mock_log):
@@ -90,7 +91,7 @@ class TestSystemBuildTask(object):
         self.runtime_checker.check_image_include_repos_http_resolvable.assert_called_once_with()
         self.runtime_checker.check_target_directory_not_in_shared_cache.assert_called_once_with(self.abs_target_dir)
         self.runtime_checker.check_repositories_configured.assert_called_once_with()
-        self.system_prepare.setup_repositories.assert_called_once_with()
+        self.system_prepare.setup_repositories.assert_called_once_with(False)
         self.system_prepare.install_bootstrap.assert_called_once_with(
             self.manager
         )
@@ -125,7 +126,7 @@ class TestSystemBuildTask(object):
         self._init_command_args()
         self.task.command_args['--add-package'] = ['vim']
         self.task.process()
-        self.system_prepare.setup_repositories.assert_called_once_with()
+        self.system_prepare.setup_repositories.assert_called_once_with(False)
         self.system_prepare.install_packages.assert_called_once_with(
             self.manager, ['vim']
         )
@@ -135,7 +136,7 @@ class TestSystemBuildTask(object):
         self._init_command_args()
         self.task.command_args['--delete-package'] = ['vim']
         self.task.process()
-        self.system_prepare.setup_repositories.assert_called_once_with()
+        self.system_prepare.setup_repositories.assert_called_once_with(False)
         self.system_prepare.delete_packages.assert_called_once_with(
             self.manager, ['vim']
         )

--- a/test/unit/tasks_system_prepare_test.py
+++ b/test/unit/tasks_system_prepare_test.py
@@ -69,12 +69,14 @@ class TestSystemPrepareTask(object):
         self.task.command_args['--add-package'] = []
         self.task.command_args['--delete-package'] = []
         self.task.command_args['--ignore-repos'] = False
+        self.task.command_args['--clear-cache'] = False
         self.task.command_args['--set-container-derived-from'] = None
         self.task.command_args['--set-container-tag'] = None
 
     def test_process_system_prepare(self):
         self._init_command_args()
         self.task.command_args['prepare'] = True
+        self.task.command_args['--clear-cache'] = True
         self.task.process()
         self.runtime_checker.check_docker_tool_chain_installed.assert_called_once_with()
         self.runtime_checker.check_image_include_repos_http_resolvable.assert_called_once_with()
@@ -82,7 +84,7 @@ class TestSystemPrepareTask(object):
             self.abs_root_dir
         )
         self.runtime_checker.check_repositories_configured.assert_called_once_with()
-        self.system_prepare.setup_repositories.assert_called_once_with()
+        self.system_prepare.setup_repositories.assert_called_once_with(True)
         self.system_prepare.install_bootstrap.assert_called_once_with(
             self.manager
         )
@@ -111,7 +113,7 @@ class TestSystemPrepareTask(object):
         self._init_command_args()
         self.task.command_args['--add-package'] = ['vim']
         self.task.process()
-        self.system_prepare.setup_repositories.assert_called_once_with()
+        self.system_prepare.setup_repositories.assert_called_once_with(False)
         self.system_prepare.install_packages.assert_called_once_with(
             self.manager, ['vim']
         )
@@ -120,7 +122,7 @@ class TestSystemPrepareTask(object):
         self._init_command_args()
         self.task.command_args['--delete-package'] = ['vim']
         self.task.process()
-        self.system_prepare.setup_repositories.assert_called_once_with()
+        self.system_prepare.setup_repositories.assert_called_once_with(False)
         self.system_prepare.delete_packages.assert_called_once_with(
             self.manager, ['vim']
         )


### PR DESCRIPTION
The system prepare and build commands now provides the option --clear-cache which deletes all cache data associated with the repositories to build the image. This Fixes #341