### PR TITLE
No automatic use of existing root

### DIFF
--- a/doc/source/commands/system_build.rst
+++ b/doc/source/commands/system_build.rst
@@ -10,6 +10,7 @@ SYNOPSIS
 
    kiwi system build -h | --help
    kiwi system build --description=<directory> --target-dir=<directory>
+       [--allow-existing-root]
        [--clear-cache]
        [--ignore-repos]
        [--set-repo=<source,type,alias,priority>]
@@ -41,6 +42,13 @@ OPTIONS
 
   Add a new repository to the existing repository setup in the XML
   description. This option can be specified multiple times
+
+--allow-existing-root
+
+  Allow to use an existing root directory from an earlier
+  build attempt. Use with caution this could cause an inconsistent
+  root tree if the existing contents does not fit to the
+  former image type setup
 
 --clear-cache
 

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -18,6 +18,7 @@
 """
 usage: kiwi system build -h | --help
        kiwi system build --description=<directory> --target-dir=<directory>
+           [--allow-existing-root]
            [--clear-cache]
            [--ignore-repos]
            [--set-repo=<source,type,alias,priority>]
@@ -40,7 +41,12 @@ options:
     --add-package=<name>
         install the given package name
     --add-repo=<source,type,alias,priority>
-        add repository with given source, type, alias and priority.
+        add repository with given source, type, alias and priority
+    --allow-existing-root
+        allow to use an existing root directory from an earlier
+        build attempt. Use with caution this could cause an inconsistent
+        root tree if the existing contents does not fit to the
+        former image type setup
     --clear-cache
         delete repository cache for each of the used repositories
         before installing any package
@@ -178,7 +184,9 @@ class SystemBuildTask(CliTask):
 
         log.info('Preparing new root system')
         system = SystemPrepare(
-            self.xml_state, image_root, True
+            self.xml_state,
+            image_root,
+            self.command_args['--allow-existing-root']
         )
         manager = system.setup_repositories(
             self.command_args['--clear-cache']

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -41,8 +41,6 @@ options:
         install the given package name
     --add-repo=<source,type,alias,priority>
         add repository with given source, type, alias and priority.
-    --delete-package=<name>
-        delete the given package name
     --allow-existing-root
         allow to use an existing root directory. Use with caution
         this could cause an inconsistent root tree if the existing
@@ -50,6 +48,8 @@ options:
     --clear-cache
         delete repository cache for each of the used repositories
         before installing any package
+    --delete-package=<name>
+        delete the given package name
     --description=<directory>
         the description must be a directory containing a kiwi XML
         description and optional metadata files

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -70,6 +70,7 @@ class TestSystemBuildTask(object):
         self.task.command_args = {}
         self.task.command_args['help'] = False
         self.task.command_args['build'] = False
+        self.task.command_args['--allow-existing-root'] = True
         self.task.command_args['--description'] = '../data/description'
         self.task.command_args['--target-dir'] = 'some-target'
         self.task.command_args['--obs-repo-internal'] = None


### PR DESCRIPTION
Fixup default behavior of build command
    
The build command automatically used an existing root tree from a former build attempt. However this could cause an inconsistent image if the former build root was not based on the same image type setup. Thus it is better to allow this only if the --allow-existing-root option is specified along with the build command call