### PR TITLE
Added fallback setup for grub secure boot

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -116,6 +116,11 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 'host architecture %s not supported for grub2 setup' % arch
             )
 
+        if self.custom_args and 'grub_directory_name' in self.custom_args:
+            self.boot_directory_name = self.custom_args['grub_directory_name']
+        else:
+            self.boot_directory_name = 'grub'
+
         self.terminal = self.xml_state.build_type.get_bootloader_console() \
             or 'gfxterm'
         self.gfxmode = self.get_gfxmode('grub2')
@@ -144,7 +149,6 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         self.grub2 = BootLoaderTemplateGrub2()
         self.config = None
         self.efi_boot_path = None
-        self.boot_directory_name = self._get_grub2_boot_directory_name()
         self.cmdline_failsafe = None
         self.cmdline = None
         self.iso_boot = False
@@ -752,27 +756,6 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         raise KiwiBootLoaderGrubDataError(
             'No grub2 installation found in %s' % lookup_path
         )
-
-    def _get_grub2_boot_directory_name(self):
-        """
-        Get grub2 data directory name in boot/ directory
-
-        Depending on the distribution the grub2 boot path could be
-        either boot/grub2 or boot/grub. The method will decide for
-        the correct base directory name according to the name pattern
-        of the installed grub2 tools
-        """
-        chroot_env = {
-            'PATH': os.sep.join([self.root_dir, 'usr', 'sbin'])
-        }
-        if Path.which(filename='grub2-install', custom_env=chroot_env):
-            # the presence of grub2-install is an indicator to put all
-            # grub2 data below boot/grub2
-            return 'grub2'
-        else:
-            # in any other case the assumption is made that all grub
-            # boot data should live below boot/grub
-            return 'grub'
 
     def _get_shim_install(self):
         chroot_env = {

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -320,8 +320,12 @@ class DiskBuilder(object):
 
         # create the bootloader instance
         self.bootloader_config = BootLoaderConfig(
-            self.bootloader, self.xml_state, self.root_dir,
-            {'targetbase': loop_provider.get_device()}
+            self.bootloader, self.xml_state, self.root_dir, {
+                'targetbase':
+                    loop_provider.get_device(),
+                'grub_directory_name':
+                    Defaults.get_grub_boot_directory_name(self.root_dir)
+            }
         )
 
         # create disk partitions and instance device map
@@ -561,7 +565,7 @@ class DiskBuilder(object):
         """
         if self.install_media:
             install_image = InstallImageBuilder(
-                self.xml_state, self.target_dir,
+                self.xml_state, self.root_dir, self.target_dir,
                 self._load_boot_image_instance()
             )
 

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -25,6 +25,7 @@ from kiwi.filesystem.squashfs import FileSystemSquashFs
 from kiwi.filesystem.isofs import FileSystemIsoFs
 from kiwi.system.identifier import SystemIdentifier
 from kiwi.path import Path
+from kiwi.defaults import Defaults
 from kiwi.utils.checksum import Checksum
 from kiwi.logger import log
 from kiwi.system.kernel import Kernel
@@ -90,10 +91,11 @@ class InstallImageBuilder(object):
     * :attr:`custom_iso_args`
         Additional custom ISO creation arguments
     """
-    def __init__(self, xml_state, target_dir, boot_image_task):
+    def __init__(self, xml_state, root_dir, target_dir, boot_image_task):
         self.arch = platform.machine()
         if self.arch == 'i686' or self.arch == 'i586':
             self.arch = 'ix86'
+        self.root_dir = root_dir
         self.target_dir = target_dir
         self.machine = xml_state.get_build_type_machine_section()
         self.boot_image_task = boot_image_task
@@ -209,7 +211,10 @@ class InstallImageBuilder(object):
 
         # setup bootloader config to boot the ISO via EFI
         bootloader_config_grub = BootLoaderConfig(
-            'grub2', self.xml_state, self.media_dir
+            'grub2', self.xml_state, self.media_dir, {
+                'grub_directory_name':
+                    Defaults.get_grub_boot_directory_name(self.root_dir)
+            }
         )
         bootloader_config_grub.setup_install_boot_images(
             mbrid=self.mbrid,

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -17,9 +17,6 @@
 #
 from tempfile import mkdtemp
 import platform
-import shutil
-import glob
-import os
 
 # project
 from kiwi.bootloader.config import BootLoaderConfig
@@ -244,14 +241,6 @@ class LiveImageBuilder(object):
                 mbrid=self.mbrid
             )
             bootloader_config_grub.write()
-            if self.firmware.efi_mode() == 'uefi':
-                # write bootloader config to EFI directory in order to allow
-                # grub loaded by shim to find the config file
-                grubconf_glob = os.sep.join(
-                    [self.media_dir, 'boot/grub*/grub.cfg']
-                )
-                for grubconf in glob.glob(grubconf_glob):
-                    shutil.copy(grubconf, self.media_dir + '/EFI/BOOT')
 
         # create initrd for live image
         log.info('Creating live ISO boot image')

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -231,7 +231,10 @@ class LiveImageBuilder(object):
         if self.firmware.efi_mode():
             log.info('Setting up EFI grub bootloader configuration')
             bootloader_config_grub = BootLoaderConfig(
-                'grub2', self.xml_state, self.media_dir
+                'grub2', self.xml_state, self.media_dir, {
+                    'grub_directory_name':
+                        Defaults.get_grub_boot_directory_name(self.root_dir)
+                }
             )
             bootloader_config_grub.setup_live_boot_images(
                 mbrid=self.mbrid,

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -339,6 +339,20 @@ class Defaults(object):
                 return signed_grub
 
     @classmethod
+    def get_shim_vendor_directory(self, root_path):
+        """
+        Return shim vendor directory or None
+
+        :param string root_path: image root path
+        """
+        shim_vendor_patterns = [
+            '/boot/efi/EFI/*/shim.efi'
+        ]
+        for shim_vendor_pattern in shim_vendor_patterns:
+            for shim_file in glob.iglob(root_path + shim_vendor_pattern):
+                return os.path.dirname(shim_file)
+
+    @classmethod
     def get_default_volume_group_name(self):
         """
         Implements default LVM volume group name

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -308,12 +308,34 @@ class Defaults(object):
         return 'SUSE LINUX GmbH'
 
     @classmethod
-    def get_shim_name(self):
-        return 'shim.efi'
+    def get_shim_loader(self, root_path):
+        """
+        Return shim loader file path or None if not found
+
+        :param string root_path: image root path
+        """
+        shim_files = [
+            '/usr/lib64/efi/shim.efi',
+            '/boot/efi/EFI/fedora/shim.efi'
+        ]
+        for shim_file in shim_files:
+            if os.path.exists(root_path + shim_file):
+                return root_path + shim_file
 
     @classmethod
-    def get_signed_grub_name(self):
-        return 'grub.efi'
+    def get_signed_grub_loader(self, root_path):
+        """
+        Return shim signed grub loader file path or None
+
+        :param string root_path: image root path
+        """
+        signed_grub_files = [
+            '/usr/lib64/efi/grub.efi',
+            '/boot/efi/EFI/fedora/grubx64.efi'
+        ]
+        for signed_grub_file in signed_grub_files:
+            if os.path.exists(root_path + signed_grub_file):
+                return root_path + signed_grub_file
 
     @classmethod
     def get_default_volume_group_name(self):

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -346,7 +346,8 @@ class Defaults(object):
         :param string root_path: image root path
         """
         shim_vendor_patterns = [
-            '/boot/efi/EFI/*/shim.efi'
+            '/boot/efi/EFI/*/shim.efi',
+            '/EFI/*/shim.efi'
         ]
         for shim_vendor_pattern in shim_vendor_patterns:
             for shim_file in glob.iglob(root_path + shim_vendor_pattern):

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -22,6 +22,7 @@ import platform
 from pkg_resources import resource_filename
 
 # project
+from .path import Path
 from .version import __githash__
 
 
@@ -170,6 +171,28 @@ class Defaults(object):
         :rtype: string
         """
         return '0x303'
+
+    @classmethod
+    def get_grub_boot_directory_name(self, lookup_path):
+        """
+        Get grub2 data directory name in boot/ directory
+
+        Depending on the distribution the grub2 boot path could be
+        either boot/grub2 or boot/grub. The method will decide for
+        the correct base directory name according to the name pattern
+        of the installed grub2 tools
+        """
+        chroot_env = {
+            'PATH': os.sep.join([lookup_path, 'usr', 'sbin'])
+        }
+        if Path.which(filename='grub2-install', custom_env=chroot_env):
+            # the presence of grub2-install is an indicator to put all
+            # grub2 data below boot/grub2
+            return 'grub2'
+        else:
+            # in any other case the assumption is made that all grub
+            # boot data should live below boot/grub
+            return 'grub'
 
     @classmethod
     def get_grub_basic_modules(self, multiboot):

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -16,6 +16,7 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
+import glob
 from collections import namedtuple
 import platform
 from pkg_resources import resource_filename
@@ -314,13 +315,13 @@ class Defaults(object):
 
         :param string root_path: image root path
         """
-        shim_files = [
+        shim_file_patterns = [
             '/usr/lib64/efi/shim.efi',
-            '/boot/efi/EFI/fedora/shim.efi'
+            '/boot/efi/EFI/*/shim.efi'
         ]
-        for shim_file in shim_files:
-            if os.path.exists(root_path + shim_file):
-                return root_path + shim_file
+        for shim_file_pattern in shim_file_patterns:
+            for shim_file in glob.iglob(root_path + shim_file_pattern):
+                return shim_file
 
     @classmethod
     def get_signed_grub_loader(self, root_path):
@@ -329,13 +330,13 @@ class Defaults(object):
 
         :param string root_path: image root path
         """
-        signed_grub_files = [
+        signed_grub_file_patterns = [
             '/usr/lib64/efi/grub.efi',
-            '/boot/efi/EFI/fedora/grubx64.efi'
+            '/boot/efi/EFI/*/grub*.efi'
         ]
-        for signed_grub_file in signed_grub_files:
-            if os.path.exists(root_path + signed_grub_file):
-                return root_path + signed_grub_file
+        for signed_grub_pattern in signed_grub_file_patterns:
+            for signed_grub in glob.iglob(root_path + signed_grub_pattern):
+                return signed_grub
 
     @classmethod
     def get_default_volume_group_name(self):

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -27,13 +27,10 @@ class TestBootLoaderConfigGrub2(object):
     @patch('kiwi.bootloader.config.grub2.FirmWare')
     @patch('kiwi.bootloader.config.base.BootLoaderConfigBase.get_boot_theme')
     @patch('kiwi.bootloader.config.base.BootLoaderConfigBase.get_hypervisor_domain')
-    @patch.object(BootLoaderConfigGrub2, '_get_grub2_boot_directory_name')
     @patch('platform.machine')
     def setup(
-        self, mock_machine, mock_grub2_boot_directory_name,
-        mock_domain, mock_theme, mock_firmware
+        self, mock_machine, mock_domain, mock_theme, mock_firmware
     ):
-        mock_grub2_boot_directory_name.return_value = 'grub2'
         self.context_manager_mock = mock.Mock()
         self.file_mock = mock.Mock()
         self.enter_mock = mock.Mock()
@@ -91,7 +88,7 @@ class TestBootLoaderConfigGrub2(object):
             XMLDescription('../data/example_config.xml').load()
         )
         self.bootloader = BootLoaderConfigGrub2(
-            self.state, 'root_dir'
+            self.state, 'root_dir', {'grub_directory_name': 'grub2'}
         )
 
     @patch('platform.machine')
@@ -105,18 +102,6 @@ class TestBootLoaderConfigGrub2(object):
         mock_which.return_value = None
         bootloader = BootLoaderConfigGrub2(xml_state, 'root_dir')
         assert bootloader.boot_directory_name == 'grub'
-
-    @patch('platform.machine')
-    @patch('kiwi.bootloader.config.grub2.Path.which')
-    def test_post_init_grub_boot_directory(self, mock_which, mock_machine):
-        xml_state = mock.MagicMock()
-        xml_state.build_type.get_firmware = mock.Mock(
-            return_value=None
-        )
-        mock_machine.return_value = 'i686'
-        mock_which.return_value = 'root_dir/usr/sbin/grub2-install'
-        bootloader = BootLoaderConfigGrub2(xml_state, 'root_dir')
-        assert bootloader.boot_directory_name == 'grub2'
 
     @raises(KiwiBootLoaderGrubPlatformError)
     @patch('platform.machine')

--- a/test/unit/bootloader_install_grub2_test.py
+++ b/test/unit/bootloader_install_grub2_test.py
@@ -325,10 +325,59 @@ class TestBootLoaderInstallGrub2(object):
         self.sysfs_mount.bind_mount.assert_called_once_with()
         self.efi_mount.mount.assert_called_once_with()
 
+    @patch('kiwi.bootloader.install.grub2.Path.wipe')
+    @patch('kiwi.bootloader.install.grub2.Path.which')
     @patch('kiwi.bootloader.install.grub2.Command.run')
     @patch('kiwi.bootloader.install.grub2.MountManager')
     @patch('kiwi.bootloader.install.grub2.Defaults.get_grub_path')
-    def test_destructor(self, mock_grub_path, mock_mount_manager, mock_command):
+    @patch('kiwi.bootloader.install.grub2.glob.glob')
+    @patch('os.path.exists')
+    def test_install_secure_boot_no_shim_install(
+        self, mock_exists, mock_glob, mock_grub_path, mock_mount_manager,
+        mock_command, mock_which, mock_wipe
+    ):
+        mock_which.return_value = None
+        mock_exists.return_value = True
+        mock_glob.return_value = ['tmp_root/boot/grub2/grubenv']
+        mock_grub_path.return_value = \
+            self.root_mount.mountpoint + '/usr/lib/grub2'
+        self.firmware.efi_mode.return_value = 'uefi'
+        self.boot_mount.device = self.root_mount.device
+
+        def side_effect(device, mountpoint=None):
+            return self.mount_managers.pop()
+
+        mock_mount_manager.side_effect = side_effect
+
+        self.bootloader.install()
+
+        mock_wipe.assert_called_once_with(
+            'tmp_root/boot/grub2/grubenv'
+        )
+        assert mock_command.call_args_list == [
+            call([
+                'chroot', 'tmp_root', 'grub2-install', '--skip-fs-probe',
+                '--directory', '/usr/lib/grub2/i386-pc',
+                '--boot-directory', '/boot',
+                '--target', 'i386-pc',
+                '--modules', ' '.join(
+                    Defaults.get_grub_bios_modules(multiboot=True)
+                ),
+                '/dev/some-device'
+            ])
+        ]
+        self.device_mount.bind_mount.assert_called_once_with()
+        self.proc_mount.bind_mount.assert_called_once_with()
+        self.sysfs_mount.bind_mount.assert_called_once_with()
+
+    @patch('kiwi.bootloader.install.grub2.Command.run')
+    @patch('kiwi.bootloader.install.grub2.MountManager')
+    @patch('kiwi.bootloader.install.grub2.Defaults.get_grub_path')
+    @patch('os.path.exists')
+    def test_destructor(
+        self, mock_exists, mock_grub_path, mock_mount_manager, mock_command
+    ):
+        mock_exists.return_value = True
         self.firmware.efi_mode.return_value = 'uefi'
 
         def side_effect(device, mountpoint=None):

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -241,9 +241,11 @@ class TestDiskBuilder(object):
     @patch_open
     @patch('random.randrange')
     @patch('kiwi.builder.disk.Command.run')
+    @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
     @patch('os.path.exists')
     def test_create_disk_standard_root_with_kiwi_initrd(
-        self, mock_path, mock_command, mock_rand, mock_open, mock_fs
+        self, mock_path, mock_grub_dir, mock_command, mock_rand,
+        mock_open, mock_fs
     ):
         mock_path.return_value = True
         mock_rand.return_value = 15
@@ -356,9 +358,11 @@ class TestDiskBuilder(object):
     @patch_open
     @patch('random.randrange')
     @patch('kiwi.builder.disk.Command.run')
+    @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
     @patch('os.path.exists')
     def test_create_disk_standard_root_with_dracut_initrd(
-        self, mock_path, mock_command, mock_rand, mock_open, mock_fs
+        self, mock_path, mock_grub_dir, mock_command, mock_rand,
+        mock_open, mock_fs
     ):
         mock_path.return_value = True
         mock_rand.return_value = 15
@@ -474,10 +478,12 @@ class TestDiskBuilder(object):
     @patch('kiwi.builder.disk.FileSystem')
     @patch_open
     @patch('kiwi.builder.disk.Command.run')
+    @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
     @patch('kiwi.builder.disk.Path.which')
     @patch('kiwi.builder.disk.re.findall')
     def test_create_disk_standard_root_dracut_initrd_system(
-        self, mock_re_findall, mock_which, mock_command, mock_open, mock_fs
+        self, mock_re_findall, mock_which, mock_grub_dir, mock_command,
+        mock_open, mock_fs
     ):
         mock_re_findall.return_value = ['initrd-$kernel']
         mock_which.return_value = 'dracut_found'
@@ -496,8 +502,9 @@ class TestDiskBuilder(object):
     @patch('kiwi.builder.disk.FileSystem')
     @patch_open
     @patch('kiwi.builder.disk.Command.run')
+    @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
     def test_create_disk_standard_root_dracut_initramfs_system(
-        self, mock_command, mock_open, mock_fs
+        self, mock_grub_dir, mock_command, mock_open, mock_fs
     ):
         self.disk_builder.initrd_system = 'dracut'
         self.disk_builder.volume_manager_name = None
@@ -515,11 +522,12 @@ class TestDiskBuilder(object):
     @patch('kiwi.builder.disk.FileSystemSquashFs')
     @patch_open
     @patch('kiwi.builder.disk.Command.run')
+    @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
     @patch('os.path.exists')
     @patch('os.path.getsize')
     @patch('kiwi.builder.disk.NamedTemporaryFile')
     def test_create_disk_standard_root_is_overlay(
-        self, mock_temp, mock_getsize, mock_exists, mock_command,
+        self, mock_temp, mock_getsize, mock_exists, mock_grub_dir, mock_command,
         mock_open, mock_squashfs, mock_fs
     ):
         self.disk_builder.root_filesystem_is_overlay = True
@@ -551,8 +559,9 @@ class TestDiskBuilder(object):
     @patch('kiwi.builder.disk.FileSystem')
     @patch_open
     @patch('kiwi.builder.disk.Command.run')
+    @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
     def test_create_disk_standard_root_dracut_initrd_system_on_arm(
-        self, mock_command, mock_open, mock_fs
+        self, mock_grub_dir, mock_command, mock_open, mock_fs
     ):
         self.disk_builder.initrd_system = 'dracut'
         self.disk_builder.arch = 'aarch64'
@@ -592,8 +601,9 @@ class TestDiskBuilder(object):
     @patch('kiwi.builder.disk.FileSystem')
     @patch_open
     @patch('kiwi.builder.disk.Command.run')
+    @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
     def test_create_disk_standard_root_s390_boot(
-        self, mock_command, mock_open, mock_fs
+        self, mock_grub_dir, mock_command, mock_open, mock_fs
     ):
         filesystem = mock.Mock()
         mock_fs.return_value = filesystem
@@ -610,8 +620,9 @@ class TestDiskBuilder(object):
     @patch('kiwi.builder.disk.FileSystem')
     @patch_open
     @patch('kiwi.builder.disk.Command.run')
+    @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
     def test_create_disk_standard_root_secure_boot(
-        self, mock_command, mock_open, mock_fs
+        self, mock_grub_dir, mock_command, mock_open, mock_fs
     ):
         filesystem = mock.Mock()
         mock_fs.return_value = filesystem
@@ -626,7 +637,10 @@ class TestDiskBuilder(object):
     @patch('kiwi.builder.disk.FileSystem')
     @patch_open
     @patch('kiwi.builder.disk.Command.run')
-    def test_create_disk_mdraid_root(self, mock_command, mock_open, mock_fs):
+    @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
+    def test_create_disk_mdraid_root(
+        self, mock_grub_dir, mock_command, mock_open, mock_fs
+    ):
         filesystem = mock.Mock()
         mock_fs.return_value = filesystem
         self.disk_builder.volume_manager_name = None
@@ -645,7 +659,10 @@ class TestDiskBuilder(object):
     @patch('kiwi.builder.disk.FileSystem')
     @patch_open
     @patch('kiwi.builder.disk.Command.run')
-    def test_create_disk_luks_root(self, mock_command, mock_open, mock_fs):
+    @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
+    def test_create_disk_luks_root(
+        self, mock_grub_dir, mock_command, mock_open, mock_fs
+    ):
         filesystem = mock.Mock()
         mock_fs.return_value = filesystem
         self.disk_builder.volume_manager_name = None
@@ -662,9 +679,11 @@ class TestDiskBuilder(object):
     @patch('kiwi.builder.disk.VolumeManager')
     @patch_open
     @patch('kiwi.builder.disk.Command.run')
+    @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
     @patch('os.path.exists')
     def test_create_disk_volume_managed_root(
-        self, mock_exists, mock_command, mock_open, mock_volume_manager, mock_fs
+        self, mock_exists, mock_grub_dir, mock_command,
+        mock_open, mock_volume_manager, mock_fs
     ):
         mock_exists.return_value = True
         volume_manager = mock.Mock()
@@ -713,8 +732,9 @@ class TestDiskBuilder(object):
     @patch('kiwi.builder.disk.FileSystem')
     @patch_open
     @patch('kiwi.builder.disk.Command.run')
+    @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
     def test_create_disk_hybrid_gpt_requested(
-        self, mock_command, mock_open, mock_fs
+        self, mock_grub_dir, mock_command, mock_open, mock_fs
     ):
         filesystem = mock.Mock()
         mock_fs.return_value = filesystem
@@ -727,8 +747,9 @@ class TestDiskBuilder(object):
     @patch('kiwi.builder.disk.FileSystem')
     @patch_open
     @patch('kiwi.builder.disk.Command.run')
+    @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
     def test_create_disk_force_mbr_requested(
-        self, mock_command, mock_open, mock_fs
+        self, mock_grub_dir, mock_command, mock_open, mock_fs
     ):
         filesystem = mock.Mock()
         mock_fs.return_value = filesystem
@@ -757,8 +778,9 @@ class TestDiskBuilder(object):
     @patch('kiwi.builder.disk.FileSystem')
     @patch_open
     @patch('kiwi.builder.disk.Command.run')
+    @patch('kiwi.builder.disk.Defaults.get_grub_boot_directory_name')
     def test_create_disk_spare_part_requested(
-        self, mock_command, mock_open, mock_fs
+        self, mock_grub_dir, mock_command, mock_open, mock_fs
     ):
         filesystem = mock.Mock()
         mock_fs.return_value = filesystem

--- a/test/unit/builder_install_test.py
+++ b/test/unit/builder_install_test.py
@@ -62,7 +62,7 @@ class TestInstallImageBuilder(object):
         self.boot_image_task.boot_root_directory = 'initrd_dir'
         self.boot_image_task.initrd_filename = 'initrd'
         self.install_image = InstallImageBuilder(
-            self.xml_state, 'target_dir', self.boot_image_task
+            self.xml_state, 'root_dir', 'target_dir', self.boot_image_task
         )
         self.install_image.machine = mock.Mock()
         self.install_image.machine.get_domain = mock.Mock(
@@ -83,7 +83,7 @@ class TestInstallImageBuilder(object):
             return_value='custom_kernel_options'
         )
         install_image = InstallImageBuilder(
-            xml_state, 'target_dir', mock.Mock()
+            xml_state, 'root_dir', 'target_dir', mock.Mock()
         )
         assert install_image.arch == 'ix86'
 
@@ -91,8 +91,9 @@ class TestInstallImageBuilder(object):
     @patch_open
     @patch('kiwi.builder.install.Command.run')
     @patch('kiwi.builder.install.Iso.create_hybrid')
+    @patch('kiwi.builder.install.Defaults.get_grub_boot_directory_name')
     def test_create_install_iso(
-        self, mock_hybrid, mock_command, mock_open, mock_dtemp
+        self, mock_grub_dir, mock_hybrid, mock_command, mock_open, mock_dtemp
     ):
         tmpdir_name = ['temp-squashfs', 'temp_media_dir']
 

--- a/test/unit/builder_live_test.py
+++ b/test/unit/builder_live_test.py
@@ -100,11 +100,13 @@ class TestLiveImageBuilder(object):
     @patch('kiwi.builder.live.FileSystemIsoFs')
     @patch('kiwi.builder.live.BootLoaderConfig')
     @patch('kiwi.builder.live.SystemSize')
+    @patch('kiwi.builder.live.Defaults.get_grub_boot_directory_name')
     @patch_open
     def test_create_overlay_structure(
-        self, mock_open, mock_size, mock_bootloader, mock_isofs, mock_fs,
-        mock_hybrid, mock_command, mock_dtemp
+        self, mock_open, mock_grub_dir, mock_size, mock_bootloader,
+        mock_isofs, mock_fs, mock_hybrid, mock_command, mock_dtemp
     ):
+        mock_grub_dir.return_value = 'grub2'
         tmpdir_name = ['temp-squashfs', 'temp_media_dir']
 
         def side_effect(prefix, dir):
@@ -179,7 +181,8 @@ class TestLiveImageBuilder(object):
         assert bootloader.write.call_args_list[0] == call()
 
         assert mock_bootloader.call_args_list[1] == call(
-            'grub2', self.xml_state, 'temp_media_dir'
+            'grub2', self.xml_state, 'temp_media_dir',
+            {'grub_directory_name': 'grub2'}
         )
         assert bootloader.setup_live_boot_images.call_args_list[1] == call(
             lookup_path=self.live_image.boot_image_task.boot_root_directory,

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -1,3 +1,5 @@
+from mock import patch
+
 import sys
 
 import mock
@@ -50,3 +52,14 @@ class TestDefaults(object):
             '--description', 'description', '--root', 'directory'
         ]
         assert Defaults.get_shared_cache_location() == 'my/cachedir'
+
+    @patch('kiwi.defaults.Path.which')
+    def test_get_grub_boot_directory_name(self, mock_which):
+        mock_which.return_value = 'grub2-install-was-found'
+        assert Defaults.get_grub_boot_directory_name(
+            lookup_path='lookup_path'
+        ) == 'grub2'
+        mock_which.return_value = None
+        assert Defaults.get_grub_boot_directory_name(
+            lookup_path='lookup_path'
+        ) == 'grub'

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -2,8 +2,6 @@ import sys
 
 import mock
 
-from mock import patch
-
 from .test_helper import argv_kiwi_tests
 
 from kiwi.defaults import Defaults
@@ -52,15 +50,3 @@ class TestDefaults(object):
             '--description', 'description', '--root', 'directory'
         ]
         assert Defaults.get_shared_cache_location() == 'my/cachedir'
-
-    @patch('os.path.exists')
-    def test_get_shim_loader(self, mock_exists):
-        mock_exists.return_value = True
-        assert Defaults.get_shim_loader('some-root') == \
-            'some-root/usr/lib64/efi/shim.efi'
-
-    @patch('os.path.exists')
-    def test_get_signed_grub_loader(self, mock_exists):
-        mock_exists.return_value = True
-        assert Defaults.get_signed_grub_loader('some-root') == \
-            'some-root/usr/lib64/efi/grub.efi'

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -2,6 +2,8 @@ import sys
 
 import mock
 
+from mock import patch
+
 from .test_helper import argv_kiwi_tests
 
 from kiwi.defaults import Defaults
@@ -50,3 +52,15 @@ class TestDefaults(object):
             '--description', 'description', '--root', 'directory'
         ]
         assert Defaults.get_shared_cache_location() == 'my/cachedir'
+
+    @patch('os.path.exists')
+    def test_get_shim_loader(self, mock_exists):
+        mock_exists.return_value = True
+        assert Defaults.get_shim_loader('some-root') == \
+            'some-root/usr/lib64/efi/shim.efi'
+
+    @patch('os.path.exists')
+    def test_get_signed_grub_loader(self, mock_exists):
+        mock_exists.return_value = True
+        assert Defaults.get_signed_grub_loader('some-root') == \
+            'some-root/usr/lib64/efi/grub.efi'


### PR DESCRIPTION
The current implementation is based on the presence of the
shim-install tool. This tool does not exist on all distributions.
In case shim-install is not present a kiwi fallback solution
applies. Fixes #337

