### PR TITLE
Fix existing root check, fixes #349

### DIFF
--- a/kiwi/system/root_init.py
+++ b/kiwi/system/root_init.py
@@ -74,6 +74,7 @@ class RootInit(object):
         initial setup
         """
         root = mkdtemp(prefix='kiwi_root.')
+        Path.create(self.root_dir)
         try:
             self._create_base_directories(root)
             self._create_device_nodes(root)
@@ -83,12 +84,13 @@ class RootInit(object):
             data.sync_data(
                 options=['-a', '--ignore-existing']
             )
-            rmtree(root, ignore_errors=True)
         except Exception as e:
-            rmtree(root, ignore_errors=True)
+            self.delete()
             raise KiwiRootInitCreationError(
                 '%s: %s' % (type(e).__name__, format(e))
             )
+        finally:
+            rmtree(root, ignore_errors=True)
 
     def _setup_config_templates(self, root):
         group_template = '/var/adm/fillup-templates/group.aaa_base'

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -114,8 +114,9 @@ class SystemBuildTask(CliTask):
         abs_target_dir_path = os.path.abspath(
             self.command_args['--target-dir']
         )
-        image_root = os.sep.join([abs_target_dir_path, 'build', 'image-root'])
-        Path.create(image_root)
+        build_dir = os.sep.join([abs_target_dir_path, 'build'])
+        image_root = os.sep.join([build_dir, 'image-root'])
+        Path.create(build_dir)
 
         if not self.global_args['--logfile']:
             log.set_logfile(

--- a/test/unit/system_root_init_test.py
+++ b/test/unit/system_root_init_test.py
@@ -28,9 +28,10 @@ class TestRootInit(object):
     @patch('shutil.rmtree')
     @patch('kiwi.system.root_init.DataSync')
     @patch('kiwi.system.root_init.mkdtemp')
+    @patch('kiwi.system.root_init.Command.run')
     def test_create_raises_error(
-        self, mock_temp, mock_data_sync, mock_rmtree, mock_symlink,
-        mock_mknod, mock_chwon, mock_makedirs, mock_path
+        self, mock_command, mock_temp, mock_data_sync, mock_rmtree,
+        mock_symlink, mock_mknod, mock_chwon, mock_makedirs, mock_path
     ):
         mock_path.return_value = False
         mock_temp.return_value = 'tmpdir'
@@ -109,6 +110,7 @@ class TestRootInit(object):
             call('/run', 'tmpdir/var/run')
         ]
         assert mock_command.call_args_list == [
+            call(['mkdir', '-p', 'root_dir']),
             call([
                 'cp',
                 '/var/adm/fillup-templates/group.aaa_base',


### PR DESCRIPTION
This commit fixes the validation of an existing root directory
for the command  `system build`. System build used to create the root
directory before performing the root existance check, thus the
check was always failing in any case. The root directory is created
inside the RootInit class within the `create` method.

Fixes #349