### PR TITLE
Fixup working dir for editboot scripts

### DIFF
--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -222,7 +222,8 @@ class LiveImageBuilder(object):
         )
         bootloader_config_isolinux.write()
         self.system_setup.call_edit_boot_config_script(
-            filesystem=self.types[self.live_type], boot_part_id=1
+            filesystem=self.types[self.live_type], boot_part_id=1,
+            working_directory=self.media_dir
         )
 
         # setup bootloader config to boot the ISO via EFI

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -466,7 +466,9 @@ class SystemSetup(object):
         """
         self._call_script('images.sh')
 
-    def call_edit_boot_config_script(self, filesystem, boot_part_id):
+    def call_edit_boot_config_script(
+        self, filesystem, boot_part_id, working_directory=None
+    ):
         """
         Call configured editbootconfig script _NON_ chrooted
 
@@ -475,12 +477,17 @@ class SystemSetup(object):
 
         :param string filesystem: boot filesystem name
         :param int boot_part_id: boot partition number
+        :param string working_directory: directory name
         """
         self._call_script_no_chroot(
-            'edit_boot_config.sh', [filesystem, format(boot_part_id)]
+            name='edit_boot_config.sh',
+            option_list=[filesystem, format(boot_part_id)],
+            working_directory=working_directory
         )
 
-    def call_edit_boot_install_script(self, diskname, boot_device_node):
+    def call_edit_boot_install_script(
+        self, diskname, boot_device_node, working_directory=None
+    ):
         """
         Call configured editbootinstall script _NON_ chrooted
 
@@ -489,9 +496,12 @@ class SystemSetup(object):
 
         :param string diskname: file path name
         :param string boot_device_node: boot device node name
+        :param string working_directory: directory name
         """
         self._call_script_no_chroot(
-            'edit_boot_install.sh', [diskname, boot_device_node]
+            name='edit_boot_install.sh',
+            option_list=[diskname, boot_device_node],
+            working_directory=working_directory
         )
 
     def create_fstab(self, entries):
@@ -739,11 +749,18 @@ class SystemSetup(object):
                     '%s failed: %s' % (name, format(result.stderr))
                 )
 
-    def _call_script_no_chroot(self, name, option_list):
-        if os.path.exists(self.root_dir + '/image/' + name):
+    def _call_script_no_chroot(
+        self, name, option_list, working_directory
+    ):
+        if not working_directory:
+            working_directory = self.root_dir
+        script_path = os.path.abspath(
+            os.sep.join([self.root_dir, 'image', name])
+        )
+        if os.path.exists(script_path):
             bash_command = [
-                'cd', self.root_dir, '&&',
-                'bash', '--norc', 'image/' + name, ' '.join(option_list)
+                'cd', working_directory, '&&',
+                'bash', '--norc', script_path, ' '.join(option_list)
             ]
             config_script = Command.call(
                 ['bash', '-c', ' '.join(bash_command)]

--- a/test/unit/builder_live_test.py
+++ b/test/unit/builder_live_test.py
@@ -144,7 +144,8 @@ class TestLiveImageBuilder(object):
             'initrd_dir'
         )
         self.setup.call_edit_boot_config_script.assert_called_once_with(
-            boot_part_id=1, filesystem='squashfs'
+            boot_part_id=1, filesystem='squashfs',
+            working_directory='temp_media_dir'
         )
         mock_fs.assert_called_once_with(
             custom_args={'mount_options': 'async'},

--- a/test/unit/system_setup_test.py
+++ b/test/unit/system_setup_test.py
@@ -450,39 +450,49 @@ class TestSystemSetup(object):
     @patch('kiwi.command.Command.call')
     @patch('kiwi.command_process.CommandProcess.poll_and_watch')
     @patch('os.path.exists')
+    @patch('os.path.abspath')
     def test_call_edit_boot_config_script(
-        self, mock_os_path, mock_watch, mock_command
+        self, mock_abspath, mock_exists, mock_watch, mock_command
     ):
         result_type = namedtuple(
             'result_type', ['stderr', 'returncode']
         )
         mock_result = result_type(stderr='stderr', returncode=0)
-        mock_os_path.return_value = True
+        mock_exists.return_value = True
+        mock_abspath.return_value = '/root_dir/image/edit_boot_config.sh'
         mock_watch.return_value = mock_result
         self.setup.call_edit_boot_config_script('ext4', 1)
+        mock_abspath.assert_called_once_with(
+            'root_dir/image/edit_boot_config.sh'
+        )
         mock_command.assert_called_once_with([
             'bash', '-c',
-            'cd root_dir && bash --norc image/edit_boot_config.sh ext4 1'
+            'cd root_dir && bash --norc /root_dir/image/edit_boot_config.sh ext4 1'
         ])
 
     @patch('kiwi.command.Command.call')
     @patch('kiwi.command_process.CommandProcess.poll_and_watch')
     @patch('os.path.exists')
+    @patch('os.path.abspath')
     def test_call_edit_boot_install_script(
-        self, mock_os_path, mock_watch, mock_command
+        self, mock_abspath, mock_exists, mock_watch, mock_command
     ):
         result_type = namedtuple(
             'result_type', ['stderr', 'returncode']
         )
         mock_result = result_type(stderr='stderr', returncode=0)
-        mock_os_path.return_value = True
+        mock_exists.return_value = True
+        mock_abspath.return_value = '/root_dir/image/edit_boot_install.sh'
         mock_watch.return_value = mock_result
         self.setup.call_edit_boot_install_script(
             'my_image.raw', '/dev/mapper/loop0p1'
         )
+        mock_abspath.assert_called_once_with(
+            'root_dir/image/edit_boot_install.sh'
+        )
         mock_command.assert_called_once_with([
             'bash', '-c',
-            'cd root_dir && bash --norc image/edit_boot_install.sh my_image.raw /dev/mapper/loop0p1'
+            'cd root_dir && bash --norc /root_dir/image/edit_boot_install.sh my_image.raw /dev/mapper/loop0p1'
         ])
 
     @raises(KiwiScriptFailed)


### PR DESCRIPTION
editbootconfig and editbootinstall scripts needs to be
called from within the correct directory to allow access
to the written bootloader config files. For live images
the working directory was set to the wrong place. This
Fixes #353

