### PR TITLE
Fix/workaround invalid xsd pattern translation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,12 +53,23 @@ kiwi/schema/kiwi.rng: kiwi/schema/kiwi.rnc
 	# the short form of the RelaxNG schema to the format used
 	# in code and auto generates the python data structures
 	trang -I rnc -O rng kiwi/schema/kiwi.rnc kiwi/schema/kiwi.rng
-	trang -I rnc -O xsd kiwi/schema/kiwi.rnc kiwi/schema/kiwi.xsd
 	# XML parser code is auto generated from schema using generateDS
 	# http://pythonhosted.org/generateDS
-	generateDS.py -f --external-encoding='utf-8' \
-		-o kiwi/xml_parse.py kiwi/schema/kiwi.xsd
-	rm kiwi/schema/kiwi.xsd
+	# ---
+	# a) modify arch-name xsd:token pattern to be generic because
+	#    generateDS translates the regular expression into another
+	#    expression which is different and wrong compared to the
+	#    expression in the schema
+	cat kiwi/schema/kiwi.rnc | sed -e \
+		s'@arch-name = xsd:token.*@arch-name = xsd:token {pattern = ".*"}@' >\
+		kiwi/schema/kiwi_modified_for_generateDS.rnc
+	# convert schema rnc format into xsd format and call generateDS
+	trang -I rnc -O xsd kiwi/schema/kiwi_modified_for_generateDS.rnc \
+		kiwi/schema/kiwi_for_generateDS.xsd
+	generateDS.py -f --external-encoding='utf-8' --no-dates --no-warnings \
+		-o kiwi/xml_parse.py kiwi/schema/kiwi_for_generateDS.xsd
+	rm kiwi/schema/kiwi_for_generateDS.xsd
+	rm kiwi/schema/kiwi_modified_for_generateDS.rnc
 
 po:
 	./.locale

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2,18 +2,20 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated Wed Apr 12 14:43:43 2017 by generateDS.py version 2.25a.
+# Generated  by generateDS.py version 2.26a.
 #
 # Command line options:
 #   ('-f', '')
 #   ('--external-encoding', 'utf-8')
+#   ('--no-dates', '')
+#   ('--no-warnings', '')
 #   ('-o', 'kiwi/xml_parse.py')
 #
 # Command line arguments:
-#   kiwi/schema/kiwi.xsd
+#   kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Command line:
-#   /home/david/workspaces/kiwi/.env2/bin/generateDS.py -f --external-encoding="utf-8" -o "kiwi/xml_parse.py" kiwi/schema/kiwi.xsd
+#   /home/ms/Project/kiwi/.tox/2.7/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -1210,7 +1212,7 @@ class configuration(GeneratedsSuper):
             if not self.gds_validate_simple_patterns(
                     self.validate_arch_name_patterns_, value):
                 warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_arch_name_patterns_, ))
-    validate_arch_name_patterns_ = [['^(x86_64$|^i586$|^i686$|^ix86$|^aarch64$|^arm64$|^armv5el$|^armv5tel$|^armv6hl$|^armv6l$|^armv7hl$|^armv7l$|^ppc$|^ppc64$|^ppc64le$|^s390$|^s390x)(,(x86_64$|^i586$|^i686$|^ix86$|^aarch64$|^arm64$|^armv5el$|^armv5tel$|^armv6hl$|^armv6l$|^armv7hl$|^armv7l$|^ppc$|^ppc64$|^ppc64le$|^s390$|^s390x))*$']]
+    validate_arch_name_patterns_ = [['^.*$']]
     def hasContent_(self):
         if (
 
@@ -1303,7 +1305,7 @@ class file(GeneratedsSuper):
             if not self.gds_validate_simple_patterns(
                     self.validate_arch_name_patterns_, value):
                 warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_arch_name_patterns_, ))
-    validate_arch_name_patterns_ = [['^(x86_64$|^i586$|^i686$|^ix86$|^aarch64$|^arm64$|^armv5el$|^armv5tel$|^armv6hl$|^armv6l$|^armv7hl$|^armv7l$|^ppc$|^ppc64$|^ppc64le$|^s390$|^s390x)(,(x86_64$|^i586$|^i686$|^ix86$|^aarch64$|^arm64$|^armv5el$|^armv5tel$|^armv6hl$|^armv6l$|^armv7hl$|^armv7l$|^ppc$|^ppc64$|^ppc64le$|^s390$|^s390x))*$']]
+    validate_arch_name_patterns_ = [['^.*$']]
     def hasContent_(self):
         if (
 
@@ -1389,7 +1391,7 @@ class ignore(GeneratedsSuper):
             if not self.gds_validate_simple_patterns(
                     self.validate_arch_name_patterns_, value):
                 warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_arch_name_patterns_, ))
-    validate_arch_name_patterns_ = [['^(x86_64$|^i586$|^i686$|^ix86$|^aarch64$|^arm64$|^armv5el$|^armv5tel$|^armv6hl$|^armv6l$|^armv7hl$|^armv7l$|^ppc$|^ppc64$|^ppc64le$|^s390$|^s390x)(,(x86_64$|^i586$|^i686$|^ix86$|^aarch64$|^arm64$|^armv5el$|^armv5tel$|^armv6hl$|^armv6l$|^armv7hl$|^armv7l$|^ppc$|^ppc64$|^ppc64le$|^s390$|^s390x))*$']]
+    validate_arch_name_patterns_ = [['^.*$']]
     def hasContent_(self):
         if (
 
@@ -1475,7 +1477,7 @@ class namedCollection(GeneratedsSuper):
             if not self.gds_validate_simple_patterns(
                     self.validate_arch_name_patterns_, value):
                 warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_arch_name_patterns_, ))
-    validate_arch_name_patterns_ = [['^(x86_64$|^i586$|^i686$|^ix86$|^aarch64$|^arm64$|^armv5el$|^armv5tel$|^armv6hl$|^armv6l$|^armv7hl$|^armv7l$|^ppc$|^ppc64$|^ppc64le$|^s390$|^s390x)(,(x86_64$|^i586$|^i686$|^ix86$|^aarch64$|^arm64$|^armv5el$|^armv5tel$|^armv6hl$|^armv6l$|^armv7hl$|^armv7l$|^ppc$|^ppc64$|^ppc64le$|^s390$|^s390x))*$']]
+    validate_arch_name_patterns_ = [['^.*$']]
     def hasContent_(self):
         if (
 
@@ -1561,7 +1563,7 @@ class product(GeneratedsSuper):
             if not self.gds_validate_simple_patterns(
                     self.validate_arch_name_patterns_, value):
                 warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_arch_name_patterns_, ))
-    validate_arch_name_patterns_ = [['^(x86_64$|^i586$|^i686$|^ix86$|^aarch64$|^arm64$|^armv5el$|^armv5tel$|^armv6hl$|^armv6l$|^armv7hl$|^armv7l$|^ppc$|^ppc64$|^ppc64le$|^s390$|^s390x)(,(x86_64$|^i586$|^i686$|^ix86$|^aarch64$|^arm64$|^armv5el$|^armv5tel$|^armv6hl$|^armv6l$|^armv7hl$|^armv7l$|^ppc$|^ppc64$|^ppc64le$|^s390$|^s390x))*$']]
+    validate_arch_name_patterns_ = [['^.*$']]
     def hasContent_(self):
         if (
 
@@ -1656,7 +1658,7 @@ class package(GeneratedsSuper):
             if not self.gds_validate_simple_patterns(
                     self.validate_arch_name_patterns_, value):
                 warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_arch_name_patterns_, ))
-    validate_arch_name_patterns_ = [['^(x86_64$|^i586$|^i686$|^ix86$|^aarch64$|^arm64$|^armv5el$|^armv5tel$|^armv6hl$|^armv6l$|^armv7hl$|^armv7l$|^ppc$|^ppc64$|^ppc64le$|^s390$|^s390x)(,(x86_64$|^i586$|^i686$|^ix86$|^aarch64$|^arm64$|^armv5el$|^armv5tel$|^armv6hl$|^armv6l$|^armv7hl$|^armv7l$|^ppc$|^ppc64$|^ppc64le$|^s390$|^s390x))*$']]
+    validate_arch_name_patterns_ = [['^.*$']]
     def hasContent_(self):
         if (
 

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ deps =
     -r.virtualenv.dev-requirements.txt
 changedir=test/unit
 commands =
-    py.test {posargs:-W ignore --no-cov-on-fail --cov=kiwi --cov-report=term-missing --cov-fail-under=100 --cov-config .coveragerc}
+    py.test {posargs:--no-cov-on-fail --cov=kiwi --cov-report=term-missing --cov-fail-under=100 --cov-config .coveragerc}
 
 
 [testenv:doc]


### PR DESCRIPTION
The data structures are auto generated by the generateDS
tool which works nicely except for the arch-name xsd pattern
used in the RelaxNG schema. For some reason the used regular
expression is translated by generateDS into a python
expression not matching the original expression from the
schema. The result is an invalid python warning message after
the schema has successfully validated the arch string.
The problem has been reported to the generateDS developer.

As long as their is no fix available in generateDS the
following workaround in kiwi applies: The original xs:token
pattern validation will be disabled on the generateDS
level and applies only to the schema. This Fixes #347

