### PR TITLE
Fixup repository setup for yum

### DIFF
--- a/kiwi/repository/yum.py
+++ b/kiwi/repository/yum.py
@@ -153,6 +153,12 @@ class RepositoryYum(RepositoryBase):
         repo_config.set(
             name, 'baseurl', uri
         )
+        repo_config.set(
+            name, 'enabled', '1'
+        )
+        repo_config.set(
+            name, 'gpgcheck', self.gpg_check
+        )
         if prio:
             repo_config.set(
                 name, 'priority', format(prio)

--- a/test/unit/repository_yum_test.py
+++ b/test/unit/repository_yum_test.py
@@ -108,6 +108,8 @@ class TestRepositoryYum(object):
         assert repo_config.set.call_args_list == [
             call('foo', 'name', 'foo'),
             call('foo', 'baseurl', 'file://kiwi_iso_mount/uri'),
+            call('foo', 'enabled', '1'),
+            call('foo', 'gpgcheck', '0'),
             call('foo', 'priority', '42')
         ]
         mock_open.assert_called_once_with(


### PR DESCRIPTION
Yum cannot handle spaces between the key and the value.
This patch provides a method to tell ConfigParser to use
no spaces for the '=' delimiter and thus Fixes #357

