### PR TITLE
Revert "Refactor detection code for grub directory name"

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -22,6 +22,7 @@ import platform
 from pkg_resources import resource_filename
 
 # project
+from .path import Path
 from .version import __githash__
 
 
@@ -178,12 +179,19 @@ class Defaults(object):
 
         Depending on the distribution the grub2 boot path could be
         either boot/grub2 or boot/grub. The method will decide for
-        the correct base directory name according to the installation
-        directory of the grub2 package
+        the correct base directory name according to the name pattern
+        of the installed grub2 tools
         """
-        if os.path.exists(os.sep.join([lookup_path, 'usr', 'lib', 'grub2'])):
+        chroot_env = {
+            'PATH': os.sep.join([lookup_path, 'usr', 'sbin'])
+        }
+        if Path.which(filename='grub2-install', custom_env=chroot_env):
+            # the presence of grub2-install is an indicator to put all
+            # grub2 data below boot/grub2
             return 'grub2'
         else:
+            # in any other case the assumption is made that all grub
+            # boot data should live below boot/grub
             return 'grub'
 
     @classmethod

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -53,13 +53,13 @@ class TestDefaults(object):
         ]
         assert Defaults.get_shared_cache_location() == 'my/cachedir'
 
-    @patch('kiwi.defaults.os.path.exists')
-    def test_get_grub_boot_directory_name(self, mock_exists):
-        mock_exists.return_value = True
+    @patch('kiwi.defaults.Path.which')
+    def test_get_grub_boot_directory_name(self, mock_which):
+        mock_which.return_value = 'grub2-install-was-found'
         assert Defaults.get_grub_boot_directory_name(
             lookup_path='lookup_path'
         ) == 'grub2'
-        mock_exists.return_value = False
+        mock_which.return_value = None
         assert Defaults.get_grub_boot_directory_name(
             lookup_path='lookup_path'
         ) == 'grub'


### PR DESCRIPTION
The former detection of the grub directory name in boot was
correct whereas the new code introduced a problem.
This reverts commit b3e4b871d52da2b5ab579d592ccc7ae39de75339.
This Fixes #371

