### PR TITLE
Include imageonly attribute for repositories

### DIFF
--- a/doc/source/development/schema.rst
+++ b/doc/source/development/schema.rst
@@ -1274,6 +1274,7 @@ List of attributes for ``repository``:
 * ``components`` `[?]`_: Distribution components, used for deb repositories. If not set it defaults to main
 * ``distribution`` `[?]`_: Distribution name information, used for deb repositories
 * ``imageinclude`` `[?]`_: Specify whether or not this repository should be configured in the resulting image. Boolean value true or false, the default is false.
+* ``imageonly`` `[?]`_: Specify whether or not this repository should be configured in the resulting image without using it at build time. Boolean value true or false, the default is false.
 * ``repository_gpgcheck`` `[?]`_: Specify whether or not this specific repository is configured to to run repository signature validation. If not set, no value is appended into the repository configuration file.
 * ``package_gpgcheck`` `[?]`_: Specify whether or not this specific repository is configured to to run package signature validation. If not set, no value is appended into the repository configuration file.
 * ``prefer-license`` `[?]`_: Use the license found in this repository, if any, as the license installed in the image

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1254,6 +1254,11 @@ div {
         ## Specify whether or not this repository should be configured in the
         ## resulting image. Boolean value true or false, the default is false.
         attribute imageinclude { xsd:boolean }
+    k.repository.imageonly.attribute =
+        ## Specify whether or not this repository should be configured in the
+        ## resulting image without using it at build time. Boolean value true
+        ## or false, the default is false.
+        attribute imageonly { xsd:boolean }
     k.repository.repository_gpgcheck.attribute =
         ## Specify whether or not this specific repository is configured to
         ## to run repository signature validation. If not set, no value is
@@ -1289,7 +1294,10 @@ div {
         k.repository.alias.attribute? &
         k.repository.components.attribute? &
         k.repository.distribution.attribute? &
-        k.repository.imageinclude.attribute? &
+        (
+            k.repository.imageinclude.attribute |
+            k.repository.imageonly.attribute
+        )? &
         k.repository.repository_gpgcheck.attribute? &
         k.repository.package_gpgcheck.attribute? &
         k.repository.prefer-license.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -1606,6 +1606,14 @@ resulting image. Boolean value true or false, the default is false.</a:documenta
         <data type="boolean"/>
       </attribute>
     </define>
+    <define name="k.repository.imageonly.attribute">
+      <attribute name="imageonly">
+        <a:documentation>Specify whether or not this repository should be configured in the
+resulting image without using it at build time. Boolean value true
+or false, the default is false.</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+    </define>
     <define name="k.repository.repository_gpgcheck.attribute">
       <attribute name="repository_gpgcheck">
         <a:documentation>Specify whether or not this specific repository is configured to
@@ -1671,7 +1679,10 @@ whether and how this information is passed</a:documentation>
           <ref name="k.repository.distribution.attribute"/>
         </optional>
         <optional>
-          <ref name="k.repository.imageinclude.attribute"/>
+          <choice>
+            <ref name="k.repository.imageinclude.attribute"/>
+            <ref name="k.repository.imageonly.attribute"/>
+          </choice>
         </optional>
         <optional>
           <ref name="k.repository.repository_gpgcheck.attribute"/>

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -99,7 +99,8 @@ class SystemPrepare(object):
         :rtype: PackageManager
         """
         repository_options = []
-        repository_sections = self.xml_state.get_build_repository_sections()
+        repository_sections = \
+            self.xml_state.get_repository_sections_used_for_build()
         package_manager = self.xml_state.get_package_manager()
         if self.xml_state.get_rpm_check_signatures():
             repository_options.append('check_signatures')

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -99,7 +99,7 @@ class SystemPrepare(object):
         :rtype: PackageManager
         """
         repository_options = []
-        repository_sections = self.xml_state.get_repository_sections()
+        repository_sections = self.xml_state.get_build_repository_sections()
         package_manager = self.xml_state.get_package_manager()
         if self.xml_state.get_rpm_check_signatures():
             repository_options.append('check_signatures')

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -115,7 +115,7 @@ class SystemSetup(object):
         imageinclude attribute should be permanently added to
         the image repository configuration
         """
-        repository_sections = self.xml_state.get_repository_sections()
+        repository_sections = self.xml_state.get_image_repository_sections()
         root = RootInit(
             root_dir=self.root_dir, allow_existing=True
         )
@@ -124,33 +124,30 @@ class SystemSetup(object):
         )
         repo.use_default_location()
         for xml_repo in repository_sections:
-            repo_marked_for_image_include = xml_repo.get_imageinclude()
-
-            if repo_marked_for_image_include:
-                repo_type = xml_repo.get_type()
-                repo_source = xml_repo.get_source().get_path()
-                repo_user = xml_repo.get_username()
-                repo_secret = xml_repo.get_password()
-                repo_alias = xml_repo.get_alias()
-                repo_priority = xml_repo.get_priority()
-                repo_dist = xml_repo.get_distribution()
-                repo_components = xml_repo.get_components()
-                repo_repository_gpgcheck = xml_repo.get_repository_gpgcheck()
-                repo_package_gpgcheck = xml_repo.get_package_gpgcheck()
-                uri = Uri(repo_source, repo_type)
-                repo_source_translated = uri.translate()
-                if not repo_alias:
-                    repo_alias = uri.alias()
-                log.info('Setting up image repository %s', repo_source)
-                log.info('--> Type: %s', repo_type)
-                log.info('--> Translated: %s', repo_source_translated)
-                log.info('--> Alias: %s', repo_alias)
-                repo.add_repo(
-                    repo_alias, repo_source_translated,
-                    repo_type, repo_priority, repo_dist, repo_components,
-                    repo_user, repo_secret, uri.credentials_file_name(),
-                    repo_repository_gpgcheck, repo_package_gpgcheck
-                )
+            repo_type = xml_repo.get_type()
+            repo_source = xml_repo.get_source().get_path()
+            repo_user = xml_repo.get_username()
+            repo_secret = xml_repo.get_password()
+            repo_alias = xml_repo.get_alias()
+            repo_priority = xml_repo.get_priority()
+            repo_dist = xml_repo.get_distribution()
+            repo_components = xml_repo.get_components()
+            repo_repository_gpgcheck = xml_repo.get_repository_gpgcheck()
+            repo_package_gpgcheck = xml_repo.get_package_gpgcheck()
+            uri = Uri(repo_source, repo_type)
+            repo_source_translated = uri.translate()
+            if not repo_alias:
+                repo_alias = uri.alias()
+            log.info('Setting up image repository %s', repo_source)
+            log.info('--> Type: %s', repo_type)
+            log.info('--> Translated: %s', repo_source_translated)
+            log.info('--> Alias: %s', repo_alias)
+            repo.add_repo(
+                repo_alias, repo_source_translated,
+                repo_type, repo_priority, repo_dist, repo_components,
+                repo_user, repo_secret, uri.credentials_file_name(),
+                repo_repository_gpgcheck, repo_package_gpgcheck
+            )
 
     def import_shell_environment(self, profile):
         """

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -115,7 +115,8 @@ class SystemSetup(object):
         imageinclude attribute should be permanently added to
         the image repository configuration
         """
-        repository_sections = self.xml_state.get_image_repository_sections()
+        repository_sections = \
+            self.xml_state.get_repository_sections_used_in_image()
         root = RootInit(
             root_dir=self.root_dir, allow_existing=True
         )

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -15,7 +15,7 @@
 #   kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Command line:
-#   /home/david/workspaces/kiwi/.env2.7/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
+#   /home/david/workspaces/kiwi/.env3/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -2114,7 +2114,7 @@ class repository(k_source):
     """The Name of the Repository"""
     subclass = None
     superclass = k_source
-    def __init__(self, source=None, type_=None, profiles=None, status=None, alias=None, components=None, distribution=None, imageinclude=None, repository_gpgcheck=None, package_gpgcheck=None, prefer_license=None, priority=None, password=None, username=None):
+    def __init__(self, source=None, type_=None, profiles=None, status=None, alias=None, components=None, distribution=None, imageinclude=None, imageonly=None, repository_gpgcheck=None, package_gpgcheck=None, prefer_license=None, priority=None, password=None, username=None):
         self.original_tagname_ = None
         super(repository, self).__init__(source, )
         self.type_ = _cast(None, type_)
@@ -2124,6 +2124,7 @@ class repository(k_source):
         self.components = _cast(None, components)
         self.distribution = _cast(None, distribution)
         self.imageinclude = _cast(bool, imageinclude)
+        self.imageonly = _cast(bool, imageonly)
         self.repository_gpgcheck = _cast(bool, repository_gpgcheck)
         self.package_gpgcheck = _cast(bool, package_gpgcheck)
         self.prefer_license = _cast(bool, prefer_license)
@@ -2155,6 +2156,8 @@ class repository(k_source):
     def set_distribution(self, distribution): self.distribution = distribution
     def get_imageinclude(self): return self.imageinclude
     def set_imageinclude(self, imageinclude): self.imageinclude = imageinclude
+    def get_imageonly(self): return self.imageonly
+    def set_imageonly(self, imageonly): self.imageonly = imageonly
     def get_repository_gpgcheck(self): return self.repository_gpgcheck
     def set_repository_gpgcheck(self, repository_gpgcheck): self.repository_gpgcheck = repository_gpgcheck
     def get_package_gpgcheck(self): return self.package_gpgcheck
@@ -2218,6 +2221,9 @@ class repository(k_source):
         if self.imageinclude is not None and 'imageinclude' not in already_processed:
             already_processed.add('imageinclude')
             outfile.write(' imageinclude="%s"' % self.gds_format_boolean(self.imageinclude, input_name='imageinclude'))
+        if self.imageonly is not None and 'imageonly' not in already_processed:
+            already_processed.add('imageonly')
+            outfile.write(' imageonly="%s"' % self.gds_format_boolean(self.imageonly, input_name='imageonly'))
         if self.repository_gpgcheck is not None and 'repository_gpgcheck' not in already_processed:
             already_processed.add('repository_gpgcheck')
             outfile.write(' repository_gpgcheck="%s"' % self.gds_format_boolean(self.repository_gpgcheck, input_name='repository_gpgcheck'))
@@ -2279,6 +2285,15 @@ class repository(k_source):
                 self.imageinclude = True
             elif value in ('false', '0'):
                 self.imageinclude = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
+        value = find_attr_value_('imageonly', node)
+        if value is not None and 'imageonly' not in already_processed:
+            already_processed.add('imageonly')
+            if value in ('true', '1'):
+                self.imageonly = True
+            elif value in ('false', '0'):
+                self.imageonly = False
             else:
                 raise_parse_error(node, 'Bad boolean attribute')
         value = find_attr_value_('repository_gpgcheck', node)

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1163,7 +1163,7 @@ class XMLState(object):
             repo.get_imageonly()
         ))
 
-    def get_build_repository_sections(self):
+    def get_repository_sections_used_for_build(self):
         """
         List the repositorys sections used to build the image matching
         configured profiles.
@@ -1176,7 +1176,7 @@ class XMLState(object):
             repo for repo in repos if not repo.get_imageonly()
         )
 
-    def get_image_repository_sections(self):
+    def get_repository_sections_used_in_image(self):
         """
         List the repositorys sections to be configured in the resulting
         image matching configured profiles.

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1158,7 +1158,37 @@ class XMLState(object):
         :rtype: bool
         """
         repos = self.get_repository_sections()
-        return bool(list(repo for repo in repos if repo.get_imageinclude()))
+        return bool(list(
+            repo for repo in repos if repo.get_imageinclude() or
+            repo.get_imageonly()
+        ))
+
+    def get_build_repository_sections(self):
+        """
+        List the repositorys sections used to build the image matching
+        configured profiles.
+
+        :return: <repository>
+        :rtype: list
+        """
+        repos = self.get_repository_sections()
+        return list(
+            repo for repo in repos if not repo.get_imageonly()
+        )
+
+    def get_image_repository_sections(self):
+        """
+        List the repositorys sections to be configured in the resulting
+        image matching configured profiles.
+
+        :return: <repository>
+        :rtype: list
+        """
+        repos = self.get_repository_sections()
+        return list(
+            repo for repo in repos if repo.get_imageinclude() or
+            repo.get_imageonly()
+        )
 
     def delete_repository_sections(self):
         """


### PR DESCRIPTION
This commit adds imageonly attribute support for the repository
element. imageonly is a boolean attribute that if true indicates
that the repository is not used for the build but needs to be
configured for the resulting image.

Fixes #362
