### PR TITLE
Removing has_repositories_marked_as_imageinclude method

### DIFF
--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -236,8 +236,7 @@ class SystemBuildTask(CliTask):
         del manager
 
         # setup permanent image repositories after cleanup
-        if self.xml_state.has_repositories_marked_as_imageinclude():
-            setup.import_repositories_marked_as_imageinclude()
+        setup.import_repositories_marked_as_imageinclude()
         setup.call_config_script()
 
         # make sure system instance is cleaned up now

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -221,8 +221,7 @@ class SystemPrepareTask(CliTask):
         del manager
 
         # setup permanent image repositories after cleanup
-        if self.xml_state.has_repositories_marked_as_imageinclude():
-            setup.import_repositories_marked_as_imageinclude()
+        setup.import_repositories_marked_as_imageinclude()
         setup.call_config_script()
 
         # make sure system instance is cleaned up now

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1150,19 +1150,6 @@ class XMLState(object):
             self.xml_data.get_repository()
         )
 
-    def has_repositories_marked_as_imageinclude(self):
-        """
-        Return true if has one or more repository section
-        marked as imageinclude.
-
-        :rtype: bool
-        """
-        repos = self.get_repository_sections()
-        return bool(list(
-            repo for repo in repos if repo.get_imageinclude() or
-            repo.get_imageonly()
-        ))
-
     def get_repository_sections_used_for_build(self):
         """
         List the repositorys sections used to build the image matching

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -503,19 +503,6 @@ class TestXMLState(object):
         self.state.delete_repository_sections()
         assert self.state.get_repository_sections() == []
 
-    def test_has_repositories_marked_as_imageinclude(self):
-        assert self.state.has_repositories_marked_as_imageinclude()
-
-    def test_has_repositories_marked_as_imageinclude_without_any_imageinclude(
-        self
-    ):
-        description = XMLDescription(
-            '../data/example_no_imageinclude_config.xml'
-        )
-        xml_data = description.load()
-        state = XMLState(xml_data)
-        assert not state.has_repositories_marked_as_imageinclude()
-
     def test_get_build_type_vmconfig_entries(self):
         assert self.state.get_build_type_vmconfig_entries() == []
 


### PR DESCRIPTION
With the current repository management this method is not required anymore, since the setup repositories method does not modify the image if no repositories are defined to be configured in the image.

It is related to #305 and #191. `has_repositories_marked_as_imageinclude` was included in #191 in order to avoid purging any repository if no repositories were configured to be included in the image. Since #305 including repositories in the image does not purge any already present repository.