### PR TITLE
Include patternType information to resolv packages in image info task

### DIFF
--- a/kiwi/solver/sat.py
+++ b/kiwi/solver/sat.py
@@ -69,7 +69,7 @@ class Sat(object):
 
     def solve(self, job_names, skip_missing=False, ignore_recommended=True):
         """
-        Solve dependencies for the given job list. The list is allowd
+        Solve dependencies for the given job list. The list is allowed
         to contain element names of the following format:
 
         * name

--- a/kiwi/solver/sat.py
+++ b/kiwi/solver/sat.py
@@ -67,7 +67,7 @@ class Sat(object):
         self.pool.addfileprovides()
         self.pool.createwhatprovides()
 
-    def solve(self, job_names, skip_missing=False):
+    def solve(self, job_names, skip_missing=False, ignore_recommended=True):
         """
         Solve dependencies for the given job list. The list is allowd
         to contain element names of the following format:
@@ -87,11 +87,15 @@ class Sat(object):
 
         :param list job_names: list of strings
         :param bool skip_missing: skip job if not found
+        :param bool ignore_recommended: do not include recommended packages
 
         :rtype: dict
         :return: Transaction result information
         """
         solver = self.pool.Solver()
+        if ignore_recommended:
+            solver.set_flag(self.solv.Solver.SOLVER_FLAG_IGNORE_RECOMMENDED, 1)
+
         solver_problems = solver.solve(
             self._setup_jobs(job_names, skip_missing)
         )

--- a/kiwi/tasks/image_info.py
+++ b/kiwi/tasks/image_info.py
@@ -99,10 +99,12 @@ class ImageInfoTask(CliTask):
 
         if self.command_args['--resolve-package-list']:
             solver = self._setup_solver()
-            package_list = self.xml_state.get_bootstrap_packages() + \
+            boostrap_package_list = self.xml_state.get_bootstrap_packages() + \
+                [self.xml_state.get_package_manager()]
+            package_list = boostrap_package_list + \
                 self.xml_state.get_system_packages()
             bootstrap_packages = solver.solve(
-                self.xml_state.get_bootstrap_packages(), False,
+                boostrap_package_list, False,
                 True if self.xml_state.get_bootstrap_collection_type() is
                 'onlyRequired' else False
             )

--- a/kiwi/tasks/image_info.py
+++ b/kiwi/tasks/image_info.py
@@ -101,7 +101,17 @@ class ImageInfoTask(CliTask):
             solver = self._setup_solver()
             package_list = self.xml_state.get_bootstrap_packages() + \
                 self.xml_state.get_system_packages()
-            solved_packages = solver.solve(package_list)
+            bootstrap_packages = solver.solve(
+                self.xml_state.get_bootstrap_packages(), False,
+                True if self.xml_state.get_bootstrap_collection_type() is
+                'onlyRequired' else False
+            )
+            solved_packages = solver.solve(
+                self.xml_state.get_system_packages(), False,
+                True if self.xml_state.get_system_collection_type() is
+                'onlyRequired' else False
+            )
+            solved_packages.update(bootstrap_packages)
             package_info = {}
             for package, metadata in sorted(list(solved_packages.items())):
                 if package in package_list:


### PR DESCRIPTION
This commit includes ingore_recommended flag in the Sat.solve method.
This way if the description file states to include only required
packages (without recommendations) it is respected and taken into
account to resolv the packages list.

Fixes #381
