### PR TITLE
Setup plymouth splash in the image prepare process

### DIFF
--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -353,6 +353,27 @@ class SystemSetup(object):
                         home_path
                     )
 
+    def setup_plymouth_splash(self):
+        """
+        Setup the KIWI configured splash theme as default
+
+        The method uses the plymouth-set-default-theme tool to setup the
+        theme for the plymouth splash system. Only in case the tool could
+        be found in the image root, it is assumed plymouth splash is in
+        use and the tool is called in a chroot operation
+        """
+        chroot_env = {
+            'PATH': os.sep.join([self.root_dir, 'usr', 'sbin'])
+        }
+        theme_setup = 'plymouth-set-default-theme'
+        if Path.which(filename=theme_setup, custom_env=chroot_env):
+            for preferences in self.xml_state.get_preferences_sections():
+                splash_theme = preferences.get_bootsplash_theme()
+                if splash_theme:
+                    Command.run(
+                        ['chroot', self.root_dir, theme_setup, splash_theme]
+                    )
+
     def import_image_identifier(self):
         """
         Create etc/ImageID identifier file

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -211,6 +211,7 @@ class SystemPrepareTask(CliTask):
         setup.setup_users()
         setup.setup_keyboard_map()
         setup.setup_locale()
+        setup.setup_plymouth_splash()
         setup.setup_timezone()
 
         system.pinch_system(

--- a/test/unit/system_setup_test.py
+++ b/test/unit/system_setup_test.py
@@ -405,6 +405,26 @@ class TestSystemSetup(object):
         ]
         users.user_modify.assert_has_calls(calls)
 
+    @patch('kiwi.system.setup.Path.which')
+    @patch('kiwi.system.setup.Command.run')
+    def test_setup_plymouth_splash(self, mock_command, mock_which):
+        mock_which.return_value = 'plymouth-set-default-theme'
+        preferences = mock.Mock()
+        preferences.get_bootsplash_theme = mock.Mock(
+            return_value='some-theme'
+        )
+        self.xml_state.get_preferences_sections = mock.Mock(
+            return_value=[preferences]
+        )
+        self.setup.setup_plymouth_splash()
+        mock_which.assert_called_once_with(
+            custom_env={'PATH': 'root_dir/usr/sbin'},
+            filename='plymouth-set-default-theme'
+        )
+        mock_command.assert_called_once_with(
+            ['chroot', 'root_dir', 'plymouth-set-default-theme', 'some-theme']
+        )
+
     @patch_open
     @patch('os.path.exists')
     def test_import_image_identifier(self, mock_os_path, mock_open):

--- a/test/unit/tasks_system_prepare_test.py
+++ b/test/unit/tasks_system_prepare_test.py
@@ -104,6 +104,7 @@ class TestSystemPrepareTask(object):
         self.setup.setup_users.assert_called_once_with()
         self.setup.setup_keyboard_map.assert_called_once_with()
         self.setup.setup_locale.assert_called_once_with()
+        self.setup.setup_plymouth_splash.assert_called_once_with()
         self.setup.setup_timezone.assert_called_once_with()
 
         self.system_prepare.pinch_system.assert_called_once_with(


### PR DESCRIPTION
Setup plymouth splash in the image prepare process
    
In case the plymouth-set-default-theme tool can be found in the
image root system and a bootsplash theme is configured in the
XML description, the tool is used to setup the theme configuration
This Fixes #366