### PR TITLE
Make sure CliTask instance reads the config file

### DIFF
--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -54,7 +54,7 @@ class CliTask(object):
         self.runtime_checker = None
 
         # initialize runtime configuration
-        self.runtime_config = None
+        self.runtime_config = RuntimeConfig()
 
         # help requested
         self.cli.show_and_exit_on_help_request()
@@ -142,7 +142,6 @@ class CliTask(object):
             )
 
         self.runtime_checker = RuntimeChecker(self.xml_state)
-        self.runtime_config = RuntimeConfig()
 
     def quadruple_token(self, option):
         """

--- a/test/unit/tasks_base_test.py
+++ b/test/unit/tasks_base_test.py
@@ -17,8 +17,9 @@ class TestCliTask(object):
     @patch('kiwi.cli.Cli.load_command')
     @patch('kiwi.cli.Cli.get_command_args')
     @patch('kiwi.cli.Cli.get_global_args')
+    @patch('kiwi.tasks.base.RuntimeConfig')
     def setup(
-        self, mock_global_args, mock_command_args,
+        self, mock_runtime_config, mock_global_args, mock_command_args,
         mock_load_command, mock_help_check, mock_color,
         mock_setlog, mock_setlevel
     ):
@@ -45,18 +46,15 @@ class TestCliTask(object):
         mock_setlevel.assert_called_once_with(logging.DEBUG)
         mock_setlog.assert_called_once_with('log')
         mock_color.assert_called_once_with()
+        mock_runtime_config.assert_called_once_with()
 
     def test_quadruple_token(self):
         assert self.task.quadruple_token('a,b') == ['a', 'b', None, None]
 
     @patch('kiwi.tasks.base.RuntimeChecker')
-    @patch('kiwi.tasks.base.RuntimeConfig')
-    def test_load_xml_description(
-        self, mock_runtime_config, mock_runtime_checker
-    ):
+    def test_load_xml_description(self, mock_runtime_checker):
         self.task.load_xml_description('../data/description')
         mock_runtime_checker.assert_called_once_with(self.task.xml_state)
-        mock_runtime_config.assert_called_once_with()
         assert self.task.config_file == '../data/description/config.xml'
         assert isinstance(self.task.xml_data, kiwi.xml_parse.image)
         assert self.task.xml_state.profiles == ['vmxFlavour']


### PR DESCRIPTION
Any instance of a CliTask has to read the runtime config file
if present

