### PR TITLE
Runtime xz options

### DIFF
--- a/kiwi/boot/image/__init__.py
+++ b/kiwi/boot/image/__init__.py
@@ -28,13 +28,16 @@ class BootImage(object):
     """
         BootImge factory
     """
-    def __new__(self, xml_state, target_dir, root_dir=None, signing_keys=None):
+    def __new__(
+        self, xml_state, target_dir, root_dir=None,
+        signing_keys=None, custom_args=None
+    ):
         initrd_system = xml_state.build_type.get_initrd_system()
         if not initrd_system:
             initrd_system = 'kiwi'
         if initrd_system == 'kiwi':
             return BootImageKiwi(
-                xml_state, target_dir, root_dir, signing_keys
+                xml_state, target_dir, root_dir, signing_keys, custom_args
             )
         elif initrd_system == 'dracut':
             return BootImageDracut(xml_state, target_dir, root_dir)

--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -50,9 +50,14 @@ class BootImageBase(object):
 
     * :attr:`signing_keys`
         list of package signing keys
+
+    * :attr:`custom_args`
+        Custom processing arguments defined as hash keys:
+        * xz_options: string of XZ compression parameters
     """
     def __init__(
-        self, xml_state, target_dir, root_dir=None, signing_keys=None
+        self, xml_state, target_dir, root_dir=None,
+        signing_keys=None, custom_args=None
     ):
         self.xml_state = xml_state
         self.target_dir = target_dir
@@ -63,6 +68,9 @@ class BootImageBase(object):
         self.call_destructor = True
         self.signing_keys = signing_keys
         self.boot_root_directory = root_dir
+
+        self.xz_options = custom_args['xz_options'] if custom_args \
+            and 'xz_options' in custom_args else None
 
         if not os.path.exists(target_dir):
             raise KiwiTargetDirectoryNotFound(

--- a/kiwi/boot/image/builtin_kiwi.py
+++ b/kiwi/boot/image/builtin_kiwi.py
@@ -167,5 +167,5 @@ class BootImageKiwi(BootImageBase):
             compress = Compress(
                 os.sep.join([self.target_dir, self.initrd_base_name])
             )
-            compress.xz()
+            compress.xz(self.xz_options)
             self.initrd_filename = compress.compressed_filename

--- a/kiwi/builder/__init__.py
+++ b/kiwi/builder/__init__.py
@@ -53,11 +53,11 @@ class ImageBuilder(object):
             )
         elif requested_image_type in Defaults.get_archive_image_types():
             return ArchiveBuilder(
-                xml_state, target_dir, root_dir
+                xml_state, target_dir, root_dir, custom_args
             )
         elif requested_image_type in Defaults.get_container_image_types():
             return ContainerBuilder(
-                xml_state, target_dir, root_dir
+                xml_state, target_dir, root_dir, custom_args
             )
         else:
             raise KiwiRequestedTypeError(

--- a/kiwi/builder/archive.py
+++ b/kiwi/builder/archive.py
@@ -44,8 +44,12 @@ class ArchiveBuilder(object):
 
     * :attr:`root_dir`
         root directory path name
+
+    * :attr:`custom_args`
+        Custom processing arguments defined as hash keys:
+        * xz_options: string of XZ compression parameters
     """
-    def __init__(self, xml_state, target_dir, root_dir):
+    def __init__(self, xml_state, target_dir, root_dir, custom_args=None):
         self.root_dir = root_dir
         self.target_dir = target_dir
         self.xml_state = xml_state
@@ -56,6 +60,8 @@ class ArchiveBuilder(object):
         )
         self.filename = self._target_file_for('tar.xz')
         self.checksum = self._target_file_for('md5')
+        self.xz_options = custom_args['xz_options'] if custom_args \
+            and 'xz_options' in custom_args else None
 
     def create(self):
         """
@@ -78,7 +84,9 @@ class ArchiveBuilder(object):
             archive = ArchiveTar(
                 self._target_file_for('tar')
             )
-            archive.create_xz_compressed(self.root_dir)
+            archive.create_xz_compressed(
+                self.root_dir, xz_options=self.xz_options
+            )
             checksum = Checksum(self.filename)
             log.info('--> Creating archive checksum')
             checksum.md5(self.checksum)

--- a/kiwi/builder/container.py
+++ b/kiwi/builder/container.py
@@ -43,14 +43,21 @@ class ContainerBuilder(object):
 
     * :attr:`root_dir`
         root directory path name
+
+    * :attr:`custom_args`
+        Custom processing arguments defined as hash keys:
+        * xz_options: string of XZ compression parameters
     """
-    def __init__(self, xml_state, target_dir, root_dir):
+    def __init__(self, xml_state, target_dir, root_dir, custom_args=None):
         self.root_dir = root_dir
         self.target_dir = target_dir
         self.container_config = xml_state.get_container_config()
         self.requested_container_type = xml_state.get_build_type_name()
         self.base_image = None
         self.base_image_md5 = None
+
+        self.container_config['xz_options'] = custom_args['xz_options'] \
+            if custom_args and 'xz_options' in custom_args else None
 
         if xml_state.get_derived_from_image_uri():
             # The base image is expected to be unpacked by the kiwi

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -73,6 +73,7 @@ class DiskBuilder(object):
     * :attr:`custom_args`
         Custom processing arguments defined as hash keys:
         * signing_keys: list of package signing keys
+        * xz_options: string of XZ compression parameters
     """
     def __init__(self, xml_state, target_dir, root_dir, custom_args=None):
         self.arch = platform.machine()
@@ -117,7 +118,7 @@ class DiskBuilder(object):
 
         self.boot_image = BootImage(
             xml_state, target_dir, root_dir,
-            signing_keys=self.signing_keys
+            signing_keys=self.signing_keys, custom_args=self.custom_args
         )
         self.firmware = FirmWare(
             xml_state
@@ -469,7 +470,7 @@ class DiskBuilder(object):
         if self.install_media:
             install_image = InstallImageBuilder(
                 self.xml_state, self.root_dir, self.target_dir,
-                self._load_boot_image_instance()
+                self._load_boot_image_instance(), self.custom_args
             )
 
             if self.install_iso or self.install_stick:

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -55,8 +55,15 @@ class InstallImageBuilder(object):
 
     * :attr:`boot_image_task`
         Instance of BootImage
+
+    * :attr:`custom_args`
+        Custom processing arguments defined as hash keys:
+        * xz_options: string of XZ compression parameters
     """
-    def __init__(self, xml_state, root_dir, target_dir, boot_image_task):
+    def __init__(
+        self, xml_state, root_dir, target_dir, boot_image_task,
+        custom_args=None
+    ):
         self.arch = platform.machine()
         if self.arch == 'i686' or self.arch == 'i586':
             self.arch = 'ix86'
@@ -98,6 +105,8 @@ class InstallImageBuilder(object):
         self.md5name = ''.join(
             [xml_state.xml_data.get_name(), '.md5']
         )
+        self.xz_options = custom_args['xz_options'] if custom_args \
+            and 'xz_options' in custom_args else None
 
         self.mbrid = SystemIdentifier()
         self.mbrid.calculate_id()
@@ -236,7 +245,7 @@ class InstallImageBuilder(object):
             source_filename=self.diskname,
             keep_source_on_compress=True
         )
-        compress.xz()
+        compress.xz(self.xz_options)
         Command.run(
             ['mv', compress.compressed_filename, pxe_image_filename]
         )
@@ -280,7 +289,7 @@ class InstallImageBuilder(object):
             self.pxename.replace('.xz', '')
         )
         archive.create_xz_compressed(
-            self.pxe_dir
+            self.pxe_dir, xz_options=self.xz_options
         )
 
     def _create_pxe_install_kernel_and_initrd(self):

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -58,6 +58,7 @@ class LiveImageBuilder(object):
     * :attr:`custom_args`
         Custom processing arguments defined as hash keys:
         * signing_keys: list of package signing keys
+        * xz_options: string of XZ compression parameters
     """
     def __init__(self, xml_state, target_dir, root_dir, custom_args=None):
         self.media_dir = None
@@ -86,7 +87,8 @@ class LiveImageBuilder(object):
             boot_signing_keys = custom_args['signing_keys']
 
         self.boot_image_task = BootImage(
-            xml_state, target_dir, signing_keys=boot_signing_keys
+            xml_state, target_dir,
+            signing_keys=boot_signing_keys, custom_args=custom_args
         )
         self.firmware = FirmWare(
             xml_state

--- a/kiwi/builder/pxe.py
+++ b/kiwi/builder/pxe.py
@@ -52,6 +52,7 @@ class PxeBuilder(object):
     * :attr:`custom_args`
         Custom processing arguments defined as hash keys:
         * signing_keys: list of package signing keys
+        * xz_options: string of XZ compression parameters
     """
     def __init__(self, xml_state, target_dir, root_dir, custom_args=None):
         self.target_dir = target_dir
@@ -65,12 +66,15 @@ class PxeBuilder(object):
             xml_state=xml_state, root_dir=root_dir
         )
 
-        boot_signing_keys = None
-        if custom_args and 'signing_keys' in custom_args:
-            boot_signing_keys = custom_args['signing_keys']
+        self.boot_signing_keys = custom_args['signing_keys'] if custom_args \
+            and 'signing_keys' in custom_args else None
+
+        self.xz_options = custom_args['xz_options'] if custom_args \
+            and 'xz_options' in custom_args else None
 
         self.boot_image_task = BootImage(
-            xml_state, target_dir, signing_keys=boot_signing_keys
+            xml_state, target_dir,
+            signing_keys=self.boot_signing_keys, custom_args=custom_args
         )
         self.image_name = ''.join(
             [
@@ -105,7 +109,7 @@ class PxeBuilder(object):
         if self.compressed:
             log.info('xz compressing root filesystem image')
             compress = Compress(self.image)
-            compress.xz()
+            compress.xz(self.xz_options)
             self.image = compress.compressed_filename
 
         log.info('Creating PXE root filesystem MD5 checksum')

--- a/kiwi/container/docker.py
+++ b/kiwi/container/docker.py
@@ -57,4 +57,4 @@ class ContainerImageDocker(ContainerImageOCI):
             ]
         )
         compressor = Compress(docker_tarfile)
-        compressor.xz()
+        compressor.xz(self.xz_options)

--- a/kiwi/container/oci.py
+++ b/kiwi/container/oci.py
@@ -49,12 +49,14 @@ class ContainerImageOCI(object):
         * volumes: storage volumes to attach to container
         * environment: environment variables
         * labels: container labels
+        * xz_options: string of XZ compression parameters
     """
     def __init__(self, root_dir, custom_args=None):
         self.root_dir = root_dir
         self.oci_dir = None
         self.oci_root_dir = None
 
+        self.xz_options = None
         self.container_name = ''
         self.container_tag = 'latest'
         self.entry_command = []
@@ -100,6 +102,9 @@ class ContainerImageOCI(object):
 
             if 'labels' in custom_args:
                 self.labels = custom_args['labels']
+
+            if 'xz_options' in custom_args:
+                self.xz_options = custom_args['xz_options']
 
         if not self.entry_command and not self.entry_subcommand:
             self.entry_subcommand = ['--config.cmd=/bin/bash']
@@ -190,7 +195,9 @@ class ContainerImageOCI(object):
         """
         image_dir = os.sep.join([self.oci_dir, 'umoci_layout'])
         oci_tarfile = ArchiveTar(filename.replace('.xz', ''))
-        oci_tarfile.create_xz_compressed(image_dir)
+        oci_tarfile.create_xz_compressed(
+            image_dir, xz_options=self.xz_options
+        )
 
     def __del__(self):
         if self.oci_dir:

--- a/kiwi/tasks/result_bundle.py
+++ b/kiwi/tasks/result_bundle.py
@@ -120,7 +120,7 @@ class ResultBundleTask(CliTask):
                 if result_file.compress:
                     log.info('--> XZ compressing')
                     compress = Compress(bundle_file)
-                    compress.xz()
+                    compress.xz(self.runtime_config.get_xz_options())
                     bundle_file = compress.compressed_filename
                     checksum_file = compress.compressed_filename + '.sha256'
                 if result_file.shasum:

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -252,7 +252,10 @@ class SystemBuildTask(CliTask):
             self.xml_state,
             abs_target_dir_path,
             image_root,
-            {'signing_keys': self.command_args['--signing-key']}
+            custom_args={
+                'signing_keys': self.command_args['--signing-key'],
+                'xz_options': self.runtime_config.get_xz_options()
+            }
         )
         result = image_builder.create()
         result.print_results()

--- a/kiwi/tasks/system_create.py
+++ b/kiwi/tasks/system_create.py
@@ -97,7 +97,10 @@ class SystemCreateTask(CliTask):
             self.xml_state,
             abs_target_dir_path,
             abs_root_path,
-            custom_args={'signing_keys': self.command_args['--signing-key']}
+            custom_args={
+                'signing_keys': self.command_args['--signing-key'],
+                'xz_options': self.runtime_config.get_xz_options()
+            }
         )
         result = image_builder.create()
         result.print_results()

--- a/test/unit/boot_image_builtin_kiwi_test.py
+++ b/test/unit/boot_image_builtin_kiwi_test.py
@@ -131,7 +131,7 @@ class TestBootImageKiwi(object):
                 '/usr/share/doc', '/usr/share/man', '/home', '/media', '/srv'
             ]
         )
-        compress.xz.assert_called_once_with()
+        compress.xz.assert_called_once_with(None)
 
     @patch('kiwi.boot.image.base.Path.wipe')
     @patch('os.path.exists')

--- a/test/unit/boot_image_test.py
+++ b/test/unit/boot_image_test.py
@@ -23,7 +23,7 @@ class TestBootImage(object):
         self.xml_state.build_type.get_initrd_system.return_value = None
         BootImage(self.xml_state, 'target_dir')
         mock_kiwi.assert_called_once_with(
-            self.xml_state, 'target_dir', None, None
+            self.xml_state, 'target_dir', None, None, None
         )
 
     @patch('kiwi.boot.image.BootImageKiwi')
@@ -31,7 +31,7 @@ class TestBootImage(object):
         self.xml_state.build_type.get_initrd_system.return_value = 'kiwi'
         BootImage(self.xml_state, 'target_dir')
         mock_kiwi.assert_called_once_with(
-            self.xml_state, 'target_dir', None, None
+            self.xml_state, 'target_dir', None, None, None
         )
 
     @patch('kiwi.boot.image.BootImageDracut')

--- a/test/unit/builder_archive_test.py
+++ b/test/unit/builder_archive_test.py
@@ -62,7 +62,7 @@ class TestArchiveBuilder(object):
             'target_dir/myimage.x86_64-1.2.3.tar'
         )
         archive.create_xz_compressed.assert_called_once_with(
-            'root_dir'
+            'root_dir', xz_options=None
         )
         mock_checksum.assert_called_once_with(
             'target_dir/myimage.x86_64-1.2.3.tar.xz'

--- a/test/unit/builder_install_test.py
+++ b/test/unit/builder_install_test.py
@@ -248,7 +248,7 @@ class TestInstallImageBuilder(object):
             keep_source_on_compress=True,
             source_filename='target_dir/result-image.x86_64-1.2.3.raw'
         )
-        compress.xz.assert_called_once_with()
+        compress.xz.assert_called_once_with(None)
         assert mock_command.call_args_list[0] == call(
             ['mv', compress.compressed_filename, 'tmpdir/result-image.xz']
         )
@@ -282,7 +282,7 @@ class TestInstallImageBuilder(object):
             'target_dir/result-image.x86_64-1.2.3.install.tar'
         )
         archive.create_xz_compressed.assert_called_once_with(
-            'tmpdir'
+            'tmpdir', xz_options=None
         )
 
     @patch('kiwi.builder.install.Path.wipe')

--- a/test/unit/builder_pxe_test.py
+++ b/test/unit/builder_pxe_test.py
@@ -82,7 +82,7 @@ class TestPxeBuilder(object):
         mock_rename.assert_called_once_with(
             'myimage.fs', 'myimage'
         )
-        compress.xz.assert_called_once_with()
+        compress.xz.assert_called_once_with(None)
         checksum.md5.assert_called_once_with('compressed-file-name.md5')
         self.boot_image_task.prepare.assert_called_once_with()
         self.setup.export_modprobe_setup.assert_called_once_with(

--- a/test/unit/builder_test.py
+++ b/test/unit/builder_test.py
@@ -62,7 +62,7 @@ class TestImageBuilder(object):
         )
         ImageBuilder(xml_state, 'target_dir', 'root_dir')
         mock_builder.assert_called_once_with(
-            xml_state, 'target_dir', 'root_dir'
+            xml_state, 'target_dir', 'root_dir', None
         )
 
     @patch('kiwi.builder.ContainerBuilder')
@@ -73,7 +73,7 @@ class TestImageBuilder(object):
         )
         ImageBuilder(xml_state, 'target_dir', 'root_dir')
         mock_builder.assert_called_once_with(
-            xml_state, 'target_dir', 'root_dir'
+            xml_state, 'target_dir', 'root_dir', None
         )
 
     @raises(KiwiRequestedTypeError)

--- a/test/unit/container_image_oci_test.py
+++ b/test/unit/container_image_oci_test.py
@@ -15,39 +15,53 @@ class TestContainerImageOCI(object):
         )
 
     def test_init_custom_args(self):
-        ContainerImageOCI(
-            'root_dir', {
-                'container_name': 'foo',
-                'container_tag': '1.0',
-                'entry_command': [
-                    "--config.entrypoint=/bin/bash",
-                    "--config.entrypoint=-x"
-                ],
-                'entry_subcommand': [
-                    "--config.cmd=ls",
-                    "--config.cmd=-l"
-                ],
-                'maintainer': ['--author=tux'],
-                'user': ['--config.user=root'],
-                'workingdir': ['--config.workingdir=/root'],
-                'expose_ports': [
-                    "--config.exposedports=80",
-                    "--config.exposedports=42"
-                ],
-                'volumes': [
-                    "--config.volume=/var/log",
-                    "--config.volume=/tmp"
-                ],
-                'environment': [
-                    "--config.env=PATH=/bin'",
-                    "--config.env=FOO=bar"
-                ],
-                'labels': [
-                    "--config.label=a=value",
-                    "--config.label=b=value"
-                ]
-            }
+        custom_args = {
+            'container_name': 'foo',
+            'container_tag': '1.0',
+            'entry_command': [
+                '--config.entrypoint=/bin/bash',
+                '--config.entrypoint=-x'
+            ],
+            'entry_subcommand': [
+                '--config.cmd=ls',
+                '--config.cmd=-l'
+            ],
+            'maintainer': ['--author=tux'],
+            'user': ['--config.user=root'],
+            'workingdir': ['--config.workingdir=/root'],
+            'expose_ports': [
+                '--config.exposedports=80',
+                '--config.exposedports=42'
+            ],
+            'volumes': [
+                '--config.volume=/var/log',
+                '--config.volume=/tmp'
+            ],
+            'environment': [
+                '--config.env=PATH=/bin',
+                '--config.env=FOO=bar'
+            ],
+            'labels': [
+                '--config.label=a=value',
+                '--config.label=b=value'
+            ],
+            'xz_options': ['-a', '-b']
+        }
+        container = ContainerImageOCI(
+            'root_dir', custom_args
         )
+        assert container.container_name == custom_args['container_name']
+        assert container.container_tag == custom_args['container_tag']
+        assert container.entry_command == custom_args['entry_command']
+        assert container.entry_subcommand == custom_args['entry_subcommand']
+        assert container.maintainer == custom_args['maintainer']
+        assert container.user == custom_args['user']
+        assert container.workingdir == custom_args['workingdir']
+        assert container.expose_ports == custom_args['expose_ports']
+        assert container.volumes == custom_args['volumes']
+        assert container.environment == custom_args['environment']
+        assert container.labels == custom_args['labels']
+        assert container.xz_options == custom_args['xz_options']
 
     @patch('kiwi.container.oci.Path.wipe')
     def test_del(self, mock_wipe):


### PR DESCRIPTION
Evaluate and hand over xz_options from the runtime configuration file to all classes which performs
xz compression tasks. This Fixes #373
