### PR TITLE
Fixup repository setup with no type declaration

### DIFF
--- a/kiwi/repository/apt.py
+++ b/kiwi/repository/apt.py
@@ -125,7 +125,7 @@ class RepositoryApt(RepositoryBase):
         }
 
     def add_repo(
-        self, name, uri, repo_type='deb',
+        self, name, uri, repo_type=None,
         prio=None, dist=None, components=None,
         user=None, secret=None, credentials_file=None,
         repo_gpgcheck=None, pkg_gpgcheck=None

--- a/kiwi/repository/dnf.py
+++ b/kiwi/repository/dnf.py
@@ -124,7 +124,7 @@ class RepositoryDnf(RepositoryBase):
         }
 
     def add_repo(
-        self, name, uri, repo_type='rpm-md',
+        self, name, uri, repo_type=None,
         prio=None, dist=None, components=None,
         user=None, secret=None, credentials_file=None,
         repo_gpgcheck=None, pkg_gpgcheck=None
@@ -134,7 +134,7 @@ class RepositoryDnf(RepositoryBase):
 
         :param string name: repository base file name
         :param string uri: repository URI
-        :param repo_type: repostory type name
+        :param repo_type: unused
         :param int prio: dnf repostory priority
         :param dist: unused
         :param components: unused

--- a/kiwi/repository/yum.py
+++ b/kiwi/repository/yum.py
@@ -123,7 +123,7 @@ class RepositoryYum(RepositoryBase):
         }
 
     def add_repo(
-        self, name, uri, repo_type='rpm-md',
+        self, name, uri, repo_type=None,
         prio=None, dist=None, components=None,
         user=None, secret=None, credentials_file=None,
         repo_gpgcheck=None, pkg_gpgcheck=None
@@ -133,7 +133,7 @@ class RepositoryYum(RepositoryBase):
 
         :param string name: repository base file name
         :param string uri: repository URI
-        :param repo_type: repostory type name
+        :param repo_type: unused
         :param int prio: yum repostory priority
         :param dist: unused
         :param components: unused

--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -178,7 +178,7 @@ class RepositoryZypper(RepositoryBase):
         }
 
     def add_repo(
-        self, name, uri, repo_type='rpm-md',
+        self, name, uri, repo_type=None,
         prio=None, dist=None, components=None,
         user=None, secret=None, credentials_file=None,
         repo_gpgcheck=None, pkg_gpgcheck=None
@@ -220,16 +220,17 @@ class RepositoryZypper(RepositoryBase):
             Path.wipe(repo_file)
 
         self._backup_package_cache()
+        repo_setup_options = [
+            '--refresh', '--keep-packages', '--no-check'
+        ]
+        if repo_type:
+            repo_setup_options.append('--type')
+            repo_setup_options.append(self._translate_repo_type(repo_type))
         Command.run(
             ['zypper'] + self.zypper_args + [
-                '--root', self.root_dir,
-                'addrepo',
-                '--refresh',
-                '--type', self._translate_repo_type(repo_type),
-                '--keep-packages',
-                '-C',
-                uri,
-                name
+                '--root', self.root_dir, 'addrepo'
+            ] + repo_setup_options + [
+                uri, name
             ],
             self.command_env
         )

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -123,7 +123,8 @@ class SystemPrepare(object):
             repo_repository_gpgcheck = xml_repo.get_repository_gpgcheck()
             repo_package_gpgcheck = xml_repo.get_package_gpgcheck()
             log.info('Setting up repository %s', repo_source)
-            log.info('--> Type: %s', repo_type)
+            if repo_type:
+                log.info('--> Type: %s', repo_type)
             if repo_priority:
                 log.info('--> Priority: %s', repo_priority)
 

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -140,7 +140,8 @@ class SystemSetup(object):
             if not repo_alias:
                 repo_alias = uri.alias()
             log.info('Setting up image repository %s', repo_source)
-            log.info('--> Type: %s', repo_type)
+            if repo_type:
+                log.info('--> Type: %s', repo_type)
             log.info('--> Translated: %s', repo_source_translated)
             log.info('--> Alias: %s', repo_alias)
             repo.add_repo(

--- a/test/unit/repository_zypper_test.py
+++ b/test/unit/repository_zypper_test.py
@@ -112,9 +112,9 @@ class TestRepositoryZypper(object):
                 ['zypper'] + self.repo.zypper_args + [
                     '--root', '../data',
                     'addrepo', '--refresh',
-                    '--type', 'YUM',
                     '--keep-packages',
-                    '-C',
+                    '--no-check',
+                    '--type', 'YUM',
                     'kiwi_iso_mount/uri',
                     'foo'
                 ], self.repo.command_env
@@ -161,9 +161,9 @@ class TestRepositoryZypper(object):
                 ['zypper'] + self.repo.zypper_args + [
                     '--root', '../data',
                     'addrepo', '--refresh',
-                    '--type', 'YUM',
                     '--keep-packages',
-                    '-C',
+                    '--no-check',
+                    '--type', 'YUM',
                     'kiwi_iso_mount/uri',
                     'foo'
                 ], self.repo.command_env
@@ -225,9 +225,8 @@ class TestRepositoryZypper(object):
             ['zypper'] + self.repo.zypper_args + [
                 '--root', '../data',
                 'addrepo', '--refresh',
-                '--type', 'YUM',
                 '--keep-packages',
-                '-C',
+                '--no-check',
                 'http://some/repo?credentials=credentials_file',
                 'foo'
             ], self.repo.command_env


### PR DESCRIPTION
The type attribute in a repository section is optional, if not
specified the zypper add_repo code throws a KiwiRepoTypeUnknown
exception. However this is not needed because the repository
could be added without a type declaration in order to let zypper
auto detect the repository type


