### PR TITLE
Build schema documentation with Oxygen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ completion/kiwi-ng.sh
 kiwi/schema/kiwi.xsd
 kiwi/schema/xsi.xsd
 kiwi/schema/kiwi.revision
+doc/source/development/schema/xsdDocHtml.css
 
 # C tool binaries
 tools/dcounter

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -54,7 +54,7 @@ clean:
 
 .PHONY: html
 html:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html && cp -a source/development/schema/images $(BUILDDIR)/html/development || true
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/doc/source/.static/css/custom.css
+++ b/doc/source/.static/css/custom.css
@@ -1,0 +1,447 @@
+/*----------------------------------------
+    Global 
+-----------------------------------------*/
+table {
+    font-family:arial, helvetica, sans-serif;
+    font-size:12px;
+}
+
+/*--------------------------------------------
+    Source code in the instance, source or 
+    annotations.
+--------------------------------------------*/
+span.tokenElement {
+    color: #000096;
+    background-color:inherit;
+}
+span.tokenAttrName {
+    color: #F5844C;
+    background-color:inherit;
+}
+span.tokenAttrValue {
+    color: #993300;
+    background-color:inherit;
+}
+span.tokenIndent {
+    color: #000000;
+    background-color:inherit;
+}
+span.tokenText {
+    color: #000000;
+    background-color:inherit;
+    white-space: normal;
+}
+span.tokenComment {
+    color: #006400;
+    background-color:inherit;
+}
+span.tokenCDATA {
+    color: #008C00;
+    background-color:inherit;
+}
+span.tokenPI {
+    color: #8B26C9;
+    background-color:inherit;
+}
+span.tokenEntity {
+    color: #969600;
+    background-color:inherit;
+}
+span.qname{
+    color:#000096;
+    background-color:inherit;
+}
+
+/*-----------------------------------------
+    Documentation sections.
+------------------------------------------*/
+
+div.componentTitle {
+    font-size:1.4em;
+    font-weight:bold;
+    text-align:left;
+    margin-top:1.4em;
+    margin-bottom:0.7em;
+}
+div.componentTitle{
+/*    color:rgb(255, 160, 100);*/
+    color:#333333;
+    background-color:inherit;
+}
+
+
+/* Tables. */
+
+td, th {
+    padding:2px 2px 2px 5px;
+    text-align:left;
+    vertical-align:top;
+}
+
+tr > th {
+    background-color:#C4DAF4;
+    color:inherit;
+}
+
+/* Contrast for the titles*/
+table.component {
+    width:100%;
+    border-spacing:1px;
+}
+
+@media print{
+    table.component{
+        border:1px solid gray;
+        border-collapse:collapse;
+    }
+    
+    table.component td{
+        border:1px solid gray;
+    }
+}
+
+table.component td.firstColumn{
+    background-color:#C4DAF4;
+    color:black;
+    width:12%;
+}
+
+table.component table td.firstColumn{
+    border:none;
+    background-color:#EAF1FB;
+    color: inherit;
+}
+
+td.firstColumn b{
+    font-weight:normal;
+}
+
+
+/* The Name and Expand/Collapse control are on the same line
+ but at different ends.*/
+td.firstColumn div.floatLeft{
+    float:left;
+}
+td.firstColumn div.floatRight{
+    float:right;
+}
+
+/* Subtables */
+table.component table{
+    width:100%;
+}
+table.component table,
+table.component table td,
+table.component table th{
+    border:0;
+}
+
+
+/* Properties table */
+table.propertiesTable {
+    border-spacing:1px;
+}
+table.propertiesTable td.firstColumn{
+    width:140px;
+    text-transform:capitalize;        
+}
+/* Used by table */
+table.usedByTable {
+    border-spacing:1px;
+}
+table.usedByTable td.firstColumn{
+    width:140px;
+    text-transform:capitalize;        
+}
+
+/* Facets table*/
+table.facetsTable {
+    border-spacing:1px;
+}
+table.facetsTable td.firstColumn{
+    width:140px;
+    text-transform:capitalize;        
+}
+
+/* Attributes table */
+table.attributesTable {
+    border-spacing:1px;
+}
+table.attributesTable th{
+    font-weight:normal;
+}
+table.attributesTable tr:hover{
+    color:inherit;
+    background-color:#EAF1FB;
+}
+
+
+/* Identity constraints table */
+table.identityConstraintsTable {
+    border-spacing:1px;
+}
+table.identityConstraintsTable th{
+    font-weight:normal;
+}
+table.identityConstraintsTable tr:hover{
+    color:inherit;
+    background-color:#EAF1FB;
+}
+
+
+
+/*---------------------------------------
+    The diagram.    
+----------------------------------------*/
+table.component td.diagram {
+    background-color:white;
+    color:inherit;
+}
+
+/* This table is a workaround for an IE bug regarding pre-wrap */
+table.preWrapContainer,
+table.preWrapContainer td{
+    border:0;
+    margin:0;
+    padding:0;
+}
+
+
+/* Annotations. */
+div.annotation{    
+}
+div.annotation pre{
+    font-family:arial, helvetica, sans-serif;
+    margin:0;
+}
+div.annotation,
+div.annotation table,
+div.annotation table td{
+    margin:0;
+    padding:0;
+}
+
+/*  Hierarchy */
+ul > li{
+    list-style:none;
+}
+
+ul {
+    margin:2px;
+    padding:0;
+}
+
+ul ul li {
+    padding-left:10px;
+    
+    list-style-image:url('images/hierarchy_arrow.gif');
+    list-style-position:inside;
+}
+
+/*-------------------------------------
+    Rounded tables.
+---------------------------------------*/
+table.rt,
+table.rt_with_bg{
+    border-collapse:collapse;
+    border-spacing:0;
+    width:100%;
+} 
+table.rt_with_bg{
+    /*background-color:#C0F0A0;*/
+    background-color:white;
+    color:inherit;
+}
+
+
+.rt_cornerTopLeft{
+    background-color:transparent;
+    background-repeat:no-repeat;
+    background-position:right;    
+    width:8px;
+    height:8px;
+    margin:0;
+    padding:0;
+}
+.rt_cornerTopLeft{
+    background-image:url('images/corner_top_left.gif');
+}
+
+
+.rt_cornerBottomLeft{
+    background-color:transparent;
+    background-repeat:no-repeat;
+    background-position:right;    
+    width:8px;
+    height:8px;
+    margin:0;
+    padding:0;
+}
+.rt_cornerBottomLeft{
+    background-image:url('images/corner_bottom_left.gif');
+}
+
+
+.rt_cornerTopRight{
+    background-color:transparent;
+    background-repeat:no-repeat;
+    width:8px;
+    height:8px;
+    margin:0;
+    padding:0;
+
+}
+.rt_cornerTopRight{
+    background-image:url('images/corner_top_right.gif');
+}
+
+
+.rt_cornerBottomRight{
+    background-color:transparent;
+    background-repeat:no-repeat;
+    width:8px;
+    height:8px;
+    margin:0;
+    padding:0;
+
+}
+.rt_cornerBottomRight{
+    background-image:url('images/corner_bottom_right.gif');    
+}
+
+
+.rt_content{
+    background-color:white;
+    color:inherit;
+    width:auto;
+    margin:0;
+    padding:0;
+}
+
+
+.rt_lineLeft{
+    background-color:transparent;
+    background-repeat:repeat-y;
+    background-position:right;    
+    width:8px;
+    margin:0;
+    padding:0;
+
+}
+.rt_lineLeft{
+    background-image:url('images/line_left.gif');
+}
+
+
+.rt_lineRight{
+    background-repeat:repeat-y;
+    width:8px;
+    margin:0;
+    padding:0;
+}
+.rt_lineRight{
+    background-image:url('images/line_right.gif');
+}
+
+
+.rt_lineTop{
+    background-color:transparent;
+    background-repeat:repeat-x;
+    height:8px;
+    width:auto;
+    margin:0;
+    padding:0;
+}
+.rt_lineTop{
+    background-image:url('images/line_top.gif');        
+}
+
+.rt_lineBottom{
+    background-color:transparent;
+    background-repeat:repeat-x;
+    height:8px;
+    width:auto;
+    margin:0;
+    padding:0;
+}
+.rt_lineBottom{
+    background-image:url('images/line_bottom.gif');
+}
+
+
+/* -------------------------------------- 
+    Controls for bulk showing/hidding sections 
+    from the documentation.
+----------------------------------------*/
+.globalControls h3{
+    margin:0.1em;
+    font-size:1.2em;
+}
+
+.globalControls table td{
+    padding:0;
+    margin:0;
+}
+
+.globalControls{
+    position:fixed;
+    left:0;
+    background-color:transparent;
+    padding-left:0.5em;
+    padding-right:0.5em;
+    padding-bottom:0.5em;
+    width:190px;
+}
+
+@media print{
+    .globalControls{
+        display:none;
+    }
+}
+
+/* Expand/collapse of a single section. */
+input.control {
+    text-align:center;
+    vertical-align:middle;
+    padding:0;
+    padding-right:3px;
+    padding-bottom:2px;
+    
+}
+
+
+/* close button */
+td.rt_content div span input{
+    font-size:0.8em;
+}
+
+@media print{
+    input.control{
+        display:none;
+    }
+}
+
+/*------------------------------------------
+  The second level of index. Floating DIVs
+-------------------------------------------*/
+.toc {
+}
+.toc div.verticalLayout, div.horizontalLayout{
+    float:left;
+    display:block;
+
+    background-color:white;
+    color:inherit;
+
+    min-width:130px;
+    min-height:50px;
+    
+    padding:0.5em;
+}
+
+.toc div.componentGroupTitle{
+    font-weight:bold;
+    margin-bottom:0.5em;
+    color:black;
+    background-color:inherit;
+}

--- a/doc/source/building/build_docker_container.rst
+++ b/doc/source/building/build_docker_container.rst
@@ -17,8 +17,7 @@ container configurations.
 The Docker configuration metadata is provided to KIWI as part of the
 :ref:`XML description file <decription_components>` using the
 ``<containerconfig>`` tag. The following configuration metadata can be
-specified (detailed XML schema documentation
-:ref:`here <k.image.preferences.type.containerconfig>`).
+specified:
 
 `containerconfig` attributes:
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -57,6 +57,7 @@ def remove_module_docstring(app, what, name, obj, options, lines):
 
 def setup(app):
     app.connect("autodoc-process-docstring", remove_module_docstring)
+    app.add_stylesheet('css/custom.css')
 
 spelling_lang = 'en_US'
 spelling_show_suggestions = True
@@ -156,6 +157,8 @@ html_sidebars = {
 html_theme = "sphinx_rtd_theme"
 
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
+html_static_path = ['.static']
 
 html_theme_options = {
     'collapse_navigation': False,

--- a/helper/schema_docs.conf
+++ b/helper/schema_docs.conf
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serialized>
+  <map>
+    <entry>
+      <String xml:space="preserve">xsd.documentation.options</String>
+      <xsdDocumentationOptions>
+        <field name="unexpandedOutputFile">
+          <String xml:space="preserve">../../kiwi/doc/source/development/schema/schema.html</String>
+        </field>
+        <field name="splitMethod">
+          <Integer xml:space="preserve">1</Integer>
+        </field>
+        <field name="openOutputInBrowser">
+          <Boolean xml:space="preserve">false</Boolean>
+        </field>
+        <field name="format">
+          <Integer xml:space="preserve">1</Integer>
+        </field>
+        <field name="customXSL">
+          <null></null>
+        </field>
+        <field name="deleteXMLFiles">
+          <Boolean xml:space="preserve">true</Boolean>
+        </field>
+        <field name="includeIndex">
+          <Boolean xml:space="preserve">true</Boolean>
+        </field>
+        <field name="includeGlobalElements">
+          <Boolean xml:space="preserve">true</Boolean>
+        </field>
+        <field name="includeGlobalAttributes">
+          <Boolean xml:space="preserve">true</Boolean>
+        </field>
+        <field name="includeLocalElements">
+          <Boolean xml:space="preserve">false</Boolean>
+        </field>
+        <field name="includeLocalAttributes">
+          <Boolean xml:space="preserve">true</Boolean>
+        </field>
+        <field name="includeSimpleTypes">
+          <Boolean xml:space="preserve">true</Boolean>
+        </field>
+        <field name="includeComplexTypes">
+          <Boolean xml:space="preserve">false</Boolean>
+        </field>
+        <field name="includeGroups">
+          <Boolean xml:space="preserve">false</Boolean>
+        </field>
+        <field name="includeAttributesGroups">
+          <Boolean xml:space="preserve">true</Boolean>
+        </field>
+        <field name="includeRedefines">
+          <Boolean xml:space="preserve">false</Boolean>
+        </field>
+        <field name="includeReferencedSchemas">
+          <Boolean xml:space="preserve">false</Boolean>
+        </field>
+        <field name="detailsDiagram">
+          <Boolean xml:space="preserve">true</Boolean>
+        </field>
+        <field name="detailsNamespace">
+          <Boolean xml:space="preserve">false</Boolean>
+        </field>
+        <field name="detailsLocation">
+          <Boolean xml:space="preserve">false</Boolean>
+        </field>
+        <field name="detailsType">
+          <Boolean xml:space="preserve">true</Boolean>
+        </field>
+        <field name="detailsTypeHierarchy">
+          <Boolean xml:space="preserve">false</Boolean>
+        </field>
+        <field name="detailsModel">
+          <Boolean xml:space="preserve">true</Boolean>
+        </field>
+        <field name="detailsChildren">
+          <Boolean xml:space="preserve">true</Boolean>
+        </field>
+        <field name="detailsInstance">
+          <Boolean xml:space="preserve">true</Boolean>
+        </field>
+        <field name="detailsUsedby">
+          <Boolean xml:space="preserve">true</Boolean>
+        </field>
+        <field name="detailsProperties">
+          <Boolean xml:space="preserve">false</Boolean>
+        </field>
+        <field name="detailsFacets">
+          <Boolean xml:space="preserve">true</Boolean>
+        </field>
+        <field name="detailsAttributes">
+          <Boolean xml:space="preserve">true</Boolean>
+        </field>
+        <field name="detailsIdentityConstr">
+          <Boolean xml:space="preserve">false</Boolean>
+        </field>
+        <field name="detailsEscapeAnn">
+          <Boolean xml:space="preserve">true</Boolean>
+        </field>
+        <field name="detailsSource">
+          <Boolean xml:space="preserve">false</Boolean>
+        </field>
+        <field name="detailsAnnotations">
+          <Boolean xml:space="preserve">false</Boolean>
+        </field>
+        <field name="includeIndexLocalComponents">
+          <Boolean xml:space="preserve">false</Boolean>
+        </field>
+        <field name="imageType">
+          <String xml:space="preserve">jpeg</String>
+        </field>
+        <field name="showAnnotationsInDiagram">
+          <Boolean xml:space="preserve">true</Boolean>
+        </field>
+      </xsdDocumentationOptions>
+    </entry>
+  </map>
+</serialized>

--- a/helper/schema_docs.sh
+++ b/helper/schema_docs.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+if [ -z "$oxygen_tool" ];then
+    echo "Oxygen schema tool not found"
+    echo "Please make sure you have a valid Oxygen license and call:"
+    echo
+    echo "export oxygen_tool=/path/to/Oxygen/schemaDocumentation.sh"
+    echo
+    echo "Switching to fallback schema documentation creator"
+    echo
+    ./schema_parser.py ../kiwi/schema/kiwi.rng \
+        --output ../doc/source/development/schema.rst
+else
+    cat > ../doc/source/development/schema.rst <<- EOF
+	.. _schema-docs:
+
+	Schema Documentation 6.5
+	========================
+
+	.. raw:: html
+	    :file: schema/schema.html
+	EOF
+    trang -I rnc -O xsd ../kiwi/schema/kiwi.rnc kiwi.xsd && \
+        bash $oxygen_tool kiwi.xsd -cfg:schema_docs.conf
+    rm -f kiwi.xsd xsi.xsd
+fi

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -24,15 +24,6 @@ namespace db  = "http://docbook.org/ns/docbook"
 namespace sch = "http://purl.oclc.org/dsdl/schematron"
 namespace nul = ""
 
-db:info [
-    db:releaseinfo [
-        "$Id: $"
-    ]
-    db:releaseinfo [ "RNC Schema Version 6.4" ]
-    db:pubdate [ "START" ]
-    db:pubdate [ "2016-03-18" ]
-]
-
 image-name = xsd:token {pattern = "[a-zA-Z0-9_\-\.]+"}
 locale-name = xsd:token {pattern = "[a-z]{2}_[A-Z]{2}(,[a-z]{2}_[A-Z]{2})*"}
 mac-address-type = xsd:token {pattern = "([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}"}
@@ -87,12 +78,6 @@ div {
 
     k.image =
         ## The root element of the configuration file   
-        [
-        db:para [
-            "Each KIWI configuration file consists of a root element\x{a}" ~
-            "image."
-        ]
-        ]
         element image {
             k.image.attlist &
             k.description &
@@ -235,11 +220,6 @@ div {
     k.bootloader-theme.attlist = empty
     k.bootloader-theme =
         ## Image bootloader theme setup.
-        [
-        db:para [
-            "The value will be used in KIWIConfig.sh::suseGFXBoot"
-        ]
-        ]
         element bootloader-theme {
             k.bootloader-theme.attlist,
             text
@@ -253,11 +233,6 @@ div {
     k.bootsplash-theme.attlist = empty
     k.bootsplash-theme =
         ## Image bootsplash theme setup.
-        [
-        db:para [
-            "The value will be used in KIWIConfig.sh::suseGFXBoot"
-        ]
-        ]
         element bootsplash-theme {
             k.bootsplash-theme.attlist,
             text
@@ -277,14 +252,9 @@ div {
         k.configuration.arch.attribute?
 
     k.configuration =
-        ## Specifies Configuration files
-        [
-        db:para [
-            "As part of the network deploy configuration this section\x{a}" ~
-            "specifies the configuration files which should be included\x{a}"~
-            "into the image after deployment."
-        ]
-        ]
+        ## As part of the network deploy configuration this section
+        ## specifies the configuration files which should be included
+        ## into the image after deployment
         element configuration {
             k.configuration.attlist,
             empty
@@ -369,12 +339,6 @@ div {
     k.hwclock.attlist = empty
     k.hwclock =
         ## Setup Image harware clock setup, either utc or localtime
-        [
-        db:para [
-            "Image hardware clock setup. The value can be either\x{a}"~
-            "set to utc or localtime."
-        ]
-        ]
         element hwclock {
             k.hwclock.attlist,
             k.hwclock.content
@@ -404,13 +368,8 @@ div {
 div {
     k.initrd.attlist = empty
     k.initrd =
-        ## Specifies where the Boot Image can be Found
-        [
-        db:para [
-            "As part of the network deploy configuration this element\x{a}"~
-            "specifies where the boot image (initrd) can be found."
-        ]
-        ]
+        ## As part of the network deploy configuration this element
+        ## specifies where the boot image (initrd) can be found
         element initrd {
             k.initrd.attlist,
             text
@@ -423,13 +382,8 @@ div {
 div {
     k.kernel.attlist = empty
     k.kernel =
-        ## Specifies Where to Find the Boot Kernel
-        [
-        db:para [
-            "As part of the network deploy configuration this section\x{a}" ~
-            "specifies the where to find the boot kernel."
-        ]
-        ]
+        ## As part of the network deploy configuration this section
+        ## specifies the where to find the boot kernel
         element kernel {
             k.kernel.attlist,
             text
@@ -443,11 +397,6 @@ div {
     k.keytable.attlist = empty
     k.keytable =
         ## Image keytable setup.
-        [
-        db:para [
-            "The value will be part of /etc/sysconfig/keyboard"
-        ]
-        ]
         element keytable {
             k.keytable.attlist,
             text
@@ -461,11 +410,6 @@ div { # locale
     k.locale.attlist = empty
     k.locale =
         ## Image locale setup.
-        [
-        db:para [
-            "The value will be part of /etc/sysconfig/keyboard"
-        ]
-        ]
         element locale {
             k.locale.attlist,
             locale-name
@@ -498,13 +442,6 @@ div {
         ## For oemboot driven images: setup of the boot menu text
         ## displayed within the square brackets after first reboot
         ## of the OEM image
-        [
-        db:para [
-            "For oemboot driven images: setup of the boot menu text\x{a}"~
-            "displayed within the square brackets after first reboot\x{a}"~
-            "of the OEM image."
-        ]
-        ]
         element oem-boot-title {
             k.oem-boot-title.attlist,
             text
@@ -519,15 +456,6 @@ div {
     k.oem-bootwait.attlist = empty
     k.oem-bootwait =
         ## For oemboot driven images: halt system after image dump true/false
-        [
-        db:para [
-            "For oemboot driven images: wait for user acknowledgement "~
-            "after first deployment true/false. A message to be "~
-            "acknowledged by the user is posted after the image has been "~
-            "dumped (installed) on the target disk. After user interaction "~
-            "the system reboots (softboot)."
-        ]
-        ]
         element oem-bootwait {
             k.oem-bootwait.attlist,
             k.oem-bootwait.content
@@ -544,13 +472,6 @@ div {
         ## For oemboot driven images: filter install devices by given
         ## regular expression. The expression is handled by the bash regexp
         ## operator
-        [
-        db:para [
-            "For oemboot driven images: filter install devices by given"~
-            "regular expression. The expression is handled by the bash"~
-            "regexp operator"
-        ]
-        ]
         element oem-device-filter {
             k.oem-device-filter.attlist,
             k.oem-device-filter.content
@@ -570,16 +491,6 @@ div {
         ## other interface names stay in the list. It is also possible to
         ## pass the variable kiwi_oemnicfilter as kernel command
         ## line in a PXE deployment
-        [
-        db:para [
-            "For oemboot driven images: filter network interface names by given"
-            "regular expression. The expression is handled by the bash regexp"
-            "operator. Interface names matching the rule will be skipped. All"
-            "other interface names stay in the list. It is also possible to"
-            "pass the variable kiwi_oemnicfilter as kernel command"
-            "line in a PXE deployment"
-        ]
-        ]
         element oem-nic-filter {
             k.oem-nic-filter.attlist,
             k.oem-nic-filter.content
@@ -597,14 +508,6 @@ div {
         ## recovery archive should be stored as part of the image
         ## or not. If it's not stored it's created during install
         ## of the oem image
-        [
-        db:para [
-            "For oemboot driven images: Specify whether the\x{a}"~
-            "recovery archive should be stored as part of the image\x{a}"~
-            "or not. If it's not stored it's created during install\x{a}"~
-            "of the oem image"
-        ]
-        ]
         element oem-inplace-recovery {
             k.oem-inplace-recovery.attlist,
             k.oem-inplace-recovery.content
@@ -620,12 +523,6 @@ div {
     k.oem-kiwi-initrd =
         ## For oemboot driven images: use kiwi initrd in any case
         ## and don't replace it with mkinitrd created initrd
-        [
-        db:para [
-            "For oemboot driven images: use kiwi initrd in any case\x{a}"~
-            "and don't replace it with mkinitrd created initrd"
-        ]
-        ]
         element oem-kiwi-initrd {
             k.oem-kiwi-initrd.attlist,
             k.oem-kiwi-initrd.content
@@ -643,14 +540,6 @@ div {
         ## disk but into a free partition. If this option is set
         ## all other oem-* options concerning the partition table
         ## will not have any effect
-        [
-        db:para [
-            "For oemboot driven images: install the system not as\x{a}"~
-            "disk but into a free partition. If this option is set\x{a}"~
-            "all other oem-* options concerning the partition table\x{a}"~
-            "will not have any effect"
-        ]
-        ]
         element oem-partition-install {
             k.oem-partition-install.attlist,
             k.oem-partition-install.content
@@ -665,14 +554,6 @@ div {
     k.oem-reboot.attlist = empty
     k.oem-reboot =
         ## For oemboot driven images: reboot after first deployment true/false
-        [
-        db:para [
-            "For oemboot driven images: reboot after first deployment "~
-            "true/false. The system is rebooted in similar fashion to "~
-            "shutdown -r after the image has been dumped (installed) "~
-            "and expanded on the target disk."
-        ]
-        ]
         element oem-reboot {
             k.oem-reboot.attlist,
             k.oem-reboot.content
@@ -686,16 +567,8 @@ div {
     k.oem-reboot-interactive.content = xsd:boolean
     k.oem-reboot-interactive.attlist = empty
     k.oem-reboot-interactive =
-        ## For oemboot driven images: reboot after first deployment true/false
-        [
-        db:para [
-            "For oemboot driven images: reboot after first deployment "~
-            "true/false. A message to be acknowledged by the user is "~
-            "posted after the image has been dumped (installed) and "~
-            "expanded on the target disk. After user interaction the "~
-            "system is rebooted in similar fashion to shutdown -r."
-        ]
-        ]
+        ## For oemboot driven images: reboot after first deployment
+        ## with an interactive dialog true/false
         element oem-reboot-interactive {
             k.oem-reboot-interactive.attlist,
             k.oem-reboot-interactive.content
@@ -710,11 +583,6 @@ div {
     k.oem-recovery.attlist = empty
     k.oem-recovery =
         ## For oemboot driven images: create a recovery archive yes/no
-        [
-        db:para [
-            "For oemboot driven images: create a recovery archive yes/no"
-        ]
-        ]
         element oem-recovery {
             k.oem-recovery.attlist,
             k.oem-recovery.content
@@ -729,12 +597,6 @@ div {
     k.oem-recoveryID =
         ## For oemboot driven images: Set the partition ID of
         ## recovery partition. Default value is 83 (Linux)
-        [
-        db:para [
-            "For oemboot driven images: Set the partition ID of\x{a}"~
-            "recovery partition. Default value is 83 (Linux)"
-        ]
-        ]
         element oem-recoveryID {
             k.oem-recoveryID.attlist,
             xsd:nonNegativeInteger
@@ -749,12 +611,6 @@ div {
     k.oem-recovery-part-size =
         ## For oemboot driven images: Set the size of the
         ## recovery partition. Value is interpreted as MB
-        [
-        db:para [
-            "For oemboot driven images: Set the size of\x{a}"~
-            "the recovery partition in MBytes."
-        ]
-        ]
         element oem-recovery-part-size {
             k.oem-recovery-part-size.attlist,
             xsd:nonNegativeInteger
@@ -770,13 +626,6 @@ div {
     k.oem-shutdown =
         ## For oemboot driven images: shutdown after first deployment 
         ## true/false
-        [
-        db:para [
-            "For oemboot driven images: shutdown after first deployment "~
-            "true/false. The system is powered down after the image has "~
-            "been dumped (installed) and expanded on the target disk. "
-        ]
-        ]
         element oem-shutdown {
             k.oem-shutdown.attlist,
             k.oem-shutdown.content
@@ -792,14 +641,6 @@ div {
     k.oem-shutdown-interactive =
         ## For oemboot driven images: shutdown after first deployment 
         ## true/false
-        [
-        db:para [
-            "For oemboot driven images: shutdown after first deployment "~
-            "true/false. A message to be acknowledged by the user is posted "~
-            "after the image has been dumped (installed) and expanded on "~
-            "the target disk. After user interaction the system is shutdown."
-        ]
-        ]
         element oem-shutdown-interactive {
             k.oem-shutdown-interactive.attlist,
             k.oem-shutdown-interactive.content
@@ -815,12 +656,6 @@ div {
     k.oem-silent-boot =
         ## For oemboot driven images: boot silently during the initial boot
         ## true/false
-        [
-        db:para [
-            "For oemboot driven images: complete the initial boot of the "~
-            "system in silent mode, true/false. "
-        ]
-        ]
         element oem-silent-boot {
             k.oem-silent-boot.attlist,
             k.oem-silent-boot.content
@@ -835,15 +670,9 @@ div {
     k.oem-silent-install.attlist = empty
     k.oem-silent-install =
         ## For oemboot driven images: do not show progress of the image
-                ## dump process, true/false
-        [
-        db:para [
-            "For oemboot driven images: do not show progress of the image "~
-                        "dump process, true/false (default is false.) "
-        ]
-        ]
+        ## dump process, true/false
         element oem-silent-install {
-                        k.oem-silent-install.attlist,
+            k.oem-silent-install.attlist,
             k.oem-silent-install.content
         }
 }
@@ -857,12 +686,6 @@ div {
     k.oem-skip-verify =
         ## For oemboot driven images: do not perform the md5
         ## verification process, true/false
-        [
-        db:para [
-            "For oemboot driven images: do not perform the md5 "~
-            "verification process, true/false (default is false.) "
-        ]
-        ]
         element oem-skip-verify {
             k.oem-skip-verify.attlist,
             k.oem-skip-verify.content
@@ -879,13 +702,6 @@ div {
         ## For oemboot driven images: turn on or off the search
         ## for ata raid devices (aka fake raid controllers)
         ## true/false (default is true)
-        [
-        db:para [
-            "For oemboot driven images: turn on or off the search "~
-            "for ata raid devices (aka fake raid controllers) "
-            "true/false (default is true) "
-        ]
-        ]
         element oem-ataraid-scan {
             k.oem-ataraid-scan.attlist,
             k.oem-ataraid-scan.content
@@ -902,13 +718,6 @@ div {
         ## For oemboot driven images: provide the name of a parmfile
         ## which is loaded via cmsfscat on s390 systems. Default value
         ## is set to: PARM-S11
-        [
-        db:para [
-            "For oemboot driven images: provide the name of a parmfile "~
-            "which is loaded via cmsfscat on s390 systems. Default value "~
-            "is set to: PARM-S11"
-        ]
-        ]
         element oem-vmcp-parmfile {
             k.oem-vmcp-parmfile.attlist,
             k.oem-vmcp-parmfile.content
@@ -924,12 +733,6 @@ div {
     k.oem-multipath-scan =
         ## For oemboot driven images: turn on or off the search
         ## for multipath devices: true/false (default is true)
-        [
-        db:para [
-            "For oemboot driven images: turn on or off the search "~
-            "for multipath devices: true/false (default is true) "
-        ]
-        ]
         element oem-multipath-scan {
             k.oem-multipath-scan.attlist,
             k.oem-multipath-scan.content
@@ -944,15 +747,9 @@ div {
     k.oem-silent-verify.attlist = empty
     k.oem-silent-verify =
         ## For oemboot driven images: do not show progress of the image
-                ## verification process, true/false
-        [
-        db:para [
-            "For oemboot driven images: do not show progress of the image "~
-                        "verification process, true/false (default is false.) "
-        ]
-        ]
+        ## verification process, true/false
         element oem-silent-verify {
-                        k.oem-silent-verify.attlist,
+            k.oem-silent-verify.attlist,
             k.oem-silent-verify.content
         }
 }
@@ -965,11 +762,6 @@ div {
     k.oem-swap.attlist = empty
     k.oem-swap =
         ## For oemboot driven images: use a swap partition yes/no
-        [
-        db:para [
-            "For oemboot driven images: use a swap partition yes/no."
-        ]
-        ]
         element oem-swap {
             k.oem-swap.attlist,
             k.oem-swap.content
@@ -984,12 +776,6 @@ div {
     k.oem-swapsize =
         ## For oemboot driven images: Set the size of the swap
         ## partition in MB
-        [
-        db:para [
-            "For oemboot driven images: Set the size of the swap\x{a}"~
-            "partition in MB. No swapspace with oem-swap set to false."
-        ]
-        ]
         element oem-swapsize {
             k.oem-swapsize.attlist,
             xsd:nonNegativeInteger
@@ -1020,12 +806,6 @@ div {
     k.oem-unattended =
         ## For oemboot driven images: don't ask questions if possible
         ## true/false
-        [
-        db:para [
-            "For oemboot driven images: don't ask questions if"~
-            "possible true/false"
-        ]
-        ]
         element oem-unattended {
             k.oem-unattended.attlist,
             k.oem-unattended.content
@@ -1040,12 +820,6 @@ div {
     k.oem-unattended-id =
         ## For oemboot driven images: use the specified disk id
         ## the device is looked up in /dev/disk/by-* and /dev/mapper/*
-        [
-        db:para [
-            "For oemboot driven images: use the specified disk id"
-            "the device is looked up in /dev/disk/by-* and /dev/mapper/*"
-        ]
-        ]
         element oem-unattended-id {
             k.oem-unattended-id.attlist,
             text
@@ -1101,12 +875,6 @@ div {
     k.packagemanager.attlist = empty
     k.packagemanager =
         ## Name of the Package Manager
-        [
-        db:para [
-            "The package manager used for package installation\x{a}"~
-            "could be either zypper or smart"
-        ]
-        ]
         element packagemanager {
             k.packagemanager.attlist,
             k.packagemanager.content
@@ -1121,12 +889,6 @@ div {
     k.partitioner.attlist = empty
     k.partitioner =
         ## Name of the Partitioner used for any disk partition tasks
-        [
-        db:para [
-            "The partitioner used for creating disk partitions\x{a}"~
-            "could be either parted or fdasd"
-        ]
-        ]
         element partitioner {
             k.partitioner.attlist,
             k.partitioner.content
@@ -1199,15 +961,10 @@ div {
         k.profile.description.attribute &
         k.profile.import.attribute?
     k.profile =
-        ## Creates Profiles
-        [
-        db:para [
-            "Profiles creates a namespace on an image description and\x{a}"~
-            "thus can be used to have one description with different\x{a}"~
-            "profiles for example KDE and GNOME including different\x{a}"~
-            "packages."
-        ]
-        ]
+        ## Profiles creates a namespace on an image description and
+        ## thus can be used to have one description with different
+        ## profiles for example KDE and GNOME including different
+        ## packages.
         element profile {
             k.profile.attlist,
             empty
@@ -1348,14 +1105,9 @@ div {
     k.rpm-excludedocs.content = xsd:boolean
     k.rpm-excludedocs.attlist = empty
     k.rpm-excludedocs =
-        ## Do not install files marked as documentation in the package
-        [
-        db:para [
-            "Setup if the package manager should exclude docs files\x{a}"~
-            "during package installation. This option could be ignored\x{a}"~
-            "according to the used package manager."
-        ]
-        ]
+        ## Setup if the package manager should exclude docs files
+        ## during package installation. This option could be ignored
+        ## according to the used package manager.
         element rpm-excludedocs {
             k.rpm-excludedocs.attlist,
             k.rpm-excludedocs.content
@@ -1370,13 +1122,6 @@ div {
     k.rpm-force.attlist = empty
     k.rpm-force =
         ## Force the Installation of a Package
-        [
-        db:para [
-        "Setup if the package manager should force the install\x{a}"~
-        "of the package or not. This option could be ignored\x{a}"~
-        "according to the used package manager."
-        ]
-        ]
         element rpm-force {
             k.rpm-force.attlist,
             k.rpm-force.content
@@ -1389,13 +1134,8 @@ div {
 div {
     k.showlicense.attlist = empty
     k.showlicense =
-        ## Setup showlicense
-        [
-        db:para [
-            "Image license setup. The specfied license name\x{a}"~
-            "will be displayed in a dialog window on boot."
-        ]
-        ]
+        ## Image license setup. The specfied license name
+        ## will be displayed in a dialog window on boot.
         element showlicense {
             k.showlicense.attlist,
             text
@@ -1432,13 +1172,8 @@ div {
 div {
     k.specification.attlist = empty
     k.specification =
-        ## A Detailed Description
-        [
-        db:para [
-            "A detailed description of this image and what it can be\x{a}"~
-            "used for."
-        ]
-        ]
+        ## A detailed description of this image and what it
+        ## can be used for.
         element specification {
             k.specification.attlist,
             text
@@ -1463,11 +1198,6 @@ div {
         k.systemdisk.preferlvm.attribute?
     k.systemdisk =
         ## Specify volumes and size attributes
-        [
-        db:para [
-            "Specify volumes and size attributes"
-        ]
-        ]
         element systemdisk {
             k.systemdisk.attlist &
             k.volume*
@@ -1481,12 +1211,6 @@ div {
     k.timeout.attlist = empty
     k.timeout = 
         ## Specifies an ATFTP Download Timeout
-        [
-        db:para [
-            "As part of the network deploy configuration this section\x{a}"~
-            "specifies an ATFTP download timeout"
-        ]
-        ]
         element timeout {
             k.timeout.attlist,
             text
@@ -1500,12 +1224,6 @@ div {
     k.timezone.attlist = empty
     k.timezone =  
         ## Setup Image Timezone setup
-        [
-        db:para [
-            "Image timezone setup. The value will be used to search\x{a}"~
-            "the correct timezone and copy it to /etc/localtime."
-        ]
-        ]
         element timezone {
             k.timezone.attlist,
             text
@@ -2113,16 +1831,11 @@ div {
         k.union.type.attribute
     
     k.union =  
-        ## Specifies the Overlay Filesystem
-        [
-        db:para [
-            "As part of the network deploy configuration this section\x{a}"~
-            "specifies the overlay filesystem setup if required by the\x{a}"~
-            "filesystem type of the system image.An overlay setup is\x{a}"~
-            "only required if the system image uses a squashfs\x{a}"~
-            "compressed filesystem."
-        ]
-        ]
+        ## As part of the network deploy configuration this section
+        ## specifies the overlay filesystem setup if required by the
+        ## filesystem type of the system image.An overlay setup is
+        ## only required if the system image uses a squashfs
+        ## compressed filesystem.
         element union {
             k.union.attlist,
             empty
@@ -2333,12 +2046,6 @@ div {
     k.volume =
         ## Specify which parts of the filesystem should be
         ## on an extra volume.
-        [
-        db:para [
-            "Specify which parts of the filesystem should be on\x{a}"
-            "an extra volume."
-        ]
-        ]
         element volume {
             k.volume.attlist,
             empty
@@ -2360,13 +2067,6 @@ div {
         k.pxedeploy.blocksize.attribute?
     k.pxedeploy =
         ## Controls the Image Deploy Process
-        [
-        db:para [
-            "The deploy section is used to allow kiwi to create the\x{a}"~
-            "config.<MAC> file required by PXE based network images.\x{a}"~
-            "the contents of this file controls the image deploy process."
-        ]
-        ]
         element pxedeploy {
             k.pxedeploy.attlist &
             k.timeout? &
@@ -2502,16 +2202,11 @@ div {
         k.containerconfig.workingdir.attribute?
 
     k.containerconfig =
-        ## Provides metadata information for containers
-        [
-        db:para [
-            "The containerconfig element provides metadata information"
-            "to setup a container in order to be prepared for use with"
-            "the container engine tool chain. container specific data"
-            "should be provided in an additional subsection whereas this"
-            "section provides globally useful container information"
-        ]
-        ]
+        ## The containerconfig element provides metadata information
+        ## to setup a container in order to be prepared for use with
+        ## the container engine tool chain. container specific data
+        ## should be provided in an additional subsection whereas this
+        ## section provides globally useful container information.
         element containerconfig {
             k.containerconfig.attlist &
             k.entrypoint? &
@@ -2718,14 +2413,9 @@ div {
 div {
     k.oemconfig.attlist = empty
     k.oemconfig =
-        ## Specifies the OEM configuration section
-        [
-        db:para [
-            "The oemconfig element specifies the OEM image\x{a}"~
-            "configuration options which are used to repartition\x{a}"~
-            "and setup the system disk"
-        ]
-        ]
+        ## The oemconfig element specifies the OEM image
+        ## configuration options which are used to repartition
+        ## and setup the system disk.
         element oemconfig {
             k.oemconfig.attlist &
             k.oem-ataraid-scan? &
@@ -2765,42 +2455,23 @@ div {
         ## The vagrant provider for this box
         attribute provider { "libvirt" }
     k.vagrantconfig.virtualsize.attribute =
-        ## The vagrant virtual image size in GB
-        [
-        db:para [
-            "virtualsize provides the value of the virtual_size key"
-            "which is embedded in the metadata.json hash inside the"
-            ".box file, as described here:"
-            ""
-            "http://docs.vagrantup.com/v2/boxes/format.html"
-            ""
-            "This tells the Vagrant provider how big to make the"
-            "virtual disk when it creates the VM."
-        ]
-        ]
+        ## virtualsize provides the value of the virtual_size key which
+        ## is embedded in the metadata.json hash inside the box file, as
+        ## described in http://docs.vagrantup.com/v2/boxes/format.html
+        ## This tells the Vagrant provider how big to make the
+        ## virtual disk when it creates the VM.
         attribute virtualsize { xsd:nonNegativeInteger }
     k.vagrantconfig.boxname.attribute =
         ## The boxname as it's written into the json file
         ## If not specified the image name is used
-        [
-        db:para [
-            "The boxname as it's written into the json file."
-            "If not specified the image name is used."
-        ]
-        ]
         attribute boxname { text }
     k.vagrantconfig.attlist =
         k.vagrantconfig.provider.attribute &
         k.vagrantconfig.virtualsize.attribute &
         k.vagrantconfig.boxname.attribute?
     k.vagrantconfig =
-        ## Specifies the Vagrant configuration section
-        [
-        db:para [
-            "The vagrantconfig element specifies the Vagrant meta"
-            "configuration options which are used inside a vagrant box"
-        ]
-        ]
+        ## The vagrantconfig element specifies the Vagrant meta
+        ## configuration options which are used inside a vagrant box
         element vagrantconfig {
             k.vagrantconfig.attlist
         }
@@ -2859,14 +2530,9 @@ div {
         k.machine.memory.attribute? &
         k.machine.ncpus.attribute?
     k.machine =
-        ## specifies the VM configuration sections
-        [
-        db:para [
-            "The machine element specifies the VM guest\x{a}"~
-            "configuration options which are used by the\x{a}"~
-            "virtual machine when running the image."
-        ]
-        ]
+        ## The machine element specifies the VM guest
+        ## configuration options which are used by the
+        ## virtual machine when running the image.
         element machine {
             k.machine.attlist &
             k.vmconfig-entry * &
@@ -2905,14 +2571,6 @@ div {
         k.packages.patternType.attribute?
     k.packages =
         ## Specifies Packages/Patterns Used in Different Stages
-        [
-        db:para [
-            "The packages elements specifies a set of packages\x{a}"~
-            "and/or patterns which are used in different stages of the\x{a}"~
-            "image building process\x{a}"~
-            "and also depends of the selected image output type."
-        ]
-        ]
         element packages {
             k.packages.attlist &
             k.archive* &
@@ -2963,13 +2621,8 @@ div {
 div {
     k.profiles.attlist = empty
     k.profiles =  
-        ## Creates Namespace Section for Drivers
-        [
-        db:para [
-            "Namespace section which creates a namespace and the\x{a}"~
-            "drivers can bind itself to one of the listed namespaces."
-        ]
-        ]
+        ## Namespace section which creates a namespace and the
+        ## drivers can bind itself to one of the listed namespaces.
         element profiles {
             k.profiles.attlist &
             k.profile+

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -21,12 +21,6 @@
   ****************
 -->
 <grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:db="http://docbook.org/ns/docbook" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
-  <db:info>
-    <db:releaseinfo>$Id: $</db:releaseinfo>
-    <db:releaseinfo>RNC Schema Version 6.4</db:releaseinfo>
-    <db:pubdate>START</db:pubdate>
-    <db:pubdate>2016-03-18</db:pubdate>
-  </db:info>
   <define name="image-name">
     <data type="token">
       <param name="pattern">[a-zA-Z0-9_\-\.]+</param>
@@ -159,8 +153,6 @@ named /etc/ImageID</a:documentation>
     <define name="k.image">
       <element name="image">
         <a:documentation>The root element of the configuration file   </a:documentation>
-        <db:para>Each KIWI configuration file consists of a root element
-image.</db:para>
         <interleave>
           <ref name="k.image.attlist"/>
           <ref name="k.description"/>
@@ -406,7 +398,6 @@ file was fetched</a:documentation>
     <define name="k.bootloader-theme">
       <element name="bootloader-theme">
         <a:documentation>Image bootloader theme setup.</a:documentation>
-        <db:para>The value will be used in KIWIConfig.sh::suseGFXBoot</db:para>
         <ref name="k.bootloader-theme.attlist"/>
         <text/>
       </element>
@@ -424,7 +415,6 @@ file was fetched</a:documentation>
     <define name="k.bootsplash-theme">
       <element name="bootsplash-theme">
         <a:documentation>Image bootsplash theme setup.</a:documentation>
-        <db:para>The value will be used in KIWIConfig.sh::suseGFXBoot</db:para>
         <ref name="k.bootsplash-theme.attlist"/>
         <text/>
       </element>
@@ -456,10 +446,9 @@ file was fetched</a:documentation>
     </define>
     <define name="k.configuration">
       <element name="configuration">
-        <a:documentation>Specifies Configuration files</a:documentation>
-        <db:para>As part of the network deploy configuration this section
+        <a:documentation>As part of the network deploy configuration this section
 specifies the configuration files which should be included
-into the image after deployment.</db:para>
+into the image after deployment</a:documentation>
         <ref name="k.configuration.attlist"/>
         <empty/>
       </element>
@@ -580,8 +569,6 @@ the directory is not specified on the command line</a:documentation>
     <define name="k.hwclock">
       <element name="hwclock">
         <a:documentation>Setup Image harware clock setup, either utc or localtime</a:documentation>
-        <db:para>Image hardware clock setup. The value can be either
-set to utc or localtime.</db:para>
         <ref name="k.hwclock.attlist"/>
         <ref name="k.hwclock.content"/>
       </element>
@@ -626,9 +613,8 @@ set to utc or localtime.</db:para>
     </define>
     <define name="k.initrd">
       <element name="initrd">
-        <a:documentation>Specifies where the Boot Image can be Found</a:documentation>
-        <db:para>As part of the network deploy configuration this element
-specifies where the boot image (initrd) can be found.</db:para>
+        <a:documentation>As part of the network deploy configuration this element
+specifies where the boot image (initrd) can be found</a:documentation>
         <ref name="k.initrd.attlist"/>
         <text/>
       </element>
@@ -645,9 +631,8 @@ specifies where the boot image (initrd) can be found.</db:para>
     </define>
     <define name="k.kernel">
       <element name="kernel">
-        <a:documentation>Specifies Where to Find the Boot Kernel</a:documentation>
-        <db:para>As part of the network deploy configuration this section
-specifies the where to find the boot kernel.</db:para>
+        <a:documentation>As part of the network deploy configuration this section
+specifies the where to find the boot kernel</a:documentation>
         <ref name="k.kernel.attlist"/>
         <text/>
       </element>
@@ -665,7 +650,6 @@ specifies the where to find the boot kernel.</db:para>
     <define name="k.keytable">
       <element name="keytable">
         <a:documentation>Image keytable setup.</a:documentation>
-        <db:para>The value will be part of /etc/sysconfig/keyboard</db:para>
         <ref name="k.keytable.attlist"/>
         <text/>
       </element>
@@ -684,7 +668,6 @@ specifies the where to find the boot kernel.</db:para>
     <define name="k.locale">
       <element name="locale">
         <a:documentation>Image locale setup.</a:documentation>
-        <db:para>The value will be part of /etc/sysconfig/keyboard</db:para>
         <ref name="k.locale.attlist"/>
         <ref name="locale-name"/>
       </element>
@@ -732,9 +715,6 @@ specifies the where to find the boot kernel.</db:para>
         <a:documentation>For oemboot driven images: setup of the boot menu text
 displayed within the square brackets after first reboot
 of the OEM image</a:documentation>
-        <db:para>For oemboot driven images: setup of the boot menu text
-displayed within the square brackets after first reboot
-of the OEM image.</db:para>
         <ref name="k.oem-boot-title.attlist"/>
         <text/>
       </element>
@@ -755,7 +735,6 @@ of the OEM image.</db:para>
     <define name="k.oem-bootwait">
       <element name="oem-bootwait">
         <a:documentation>For oemboot driven images: halt system after image dump true/false</a:documentation>
-        <db:para>For oemboot driven images: wait for user acknowledgement after first deployment true/false. A message to be acknowledged by the user is posted after the image has been dumped (installed) on the target disk. After user interaction the system reboots (softboot).</db:para>
         <ref name="k.oem-bootwait.attlist"/>
         <ref name="k.oem-bootwait.content"/>
       </element>
@@ -778,7 +757,6 @@ of the OEM image.</db:para>
         <a:documentation>For oemboot driven images: filter install devices by given
 regular expression. The expression is handled by the bash regexp
 operator</a:documentation>
-        <db:para>For oemboot driven images: filter install devices by givenregular expression. The expression is handled by the bashregexp operator</db:para>
         <ref name="k.oem-device-filter.attlist"/>
         <ref name="k.oem-device-filter.content"/>
       </element>
@@ -804,7 +782,6 @@ operator. Interface names matching the rule will be skipped. All
 other interface names stay in the list. It is also possible to
 pass the variable kiwi_oemnicfilter as kernel command
 line in a PXE deployment</a:documentation>
-        <db:para>For oemboot driven images: filter network interface names by givenregular expression. The expression is handled by the bash regexpoperator. Interface names matching the rule will be skipped. Allother interface names stay in the list. It is also possible topass the variable kiwi_oemnicfilter as kernel commandline in a PXE deployment</db:para>
         <ref name="k.oem-nic-filter.attlist"/>
         <ref name="k.oem-nic-filter.content"/>
       </element>
@@ -828,10 +805,6 @@ line in a PXE deployment</a:documentation>
 recovery archive should be stored as part of the image
 or not. If it's not stored it's created during install
 of the oem image</a:documentation>
-        <db:para>For oemboot driven images: Specify whether the
-recovery archive should be stored as part of the image
-or not. If it's not stored it's created during install
-of the oem image</db:para>
         <ref name="k.oem-inplace-recovery.attlist"/>
         <ref name="k.oem-inplace-recovery.content"/>
       </element>
@@ -853,8 +826,6 @@ of the oem image</db:para>
       <element name="oem-kiwi-initrd">
         <a:documentation>For oemboot driven images: use kiwi initrd in any case
 and don't replace it with mkinitrd created initrd</a:documentation>
-        <db:para>For oemboot driven images: use kiwi initrd in any case
-and don't replace it with mkinitrd created initrd</db:para>
         <ref name="k.oem-kiwi-initrd.attlist"/>
         <ref name="k.oem-kiwi-initrd.content"/>
       </element>
@@ -878,10 +849,6 @@ and don't replace it with mkinitrd created initrd</db:para>
 disk but into a free partition. If this option is set
 all other oem-* options concerning the partition table
 will not have any effect</a:documentation>
-        <db:para>For oemboot driven images: install the system not as
-disk but into a free partition. If this option is set
-all other oem-* options concerning the partition table
-will not have any effect</db:para>
         <ref name="k.oem-partition-install.attlist"/>
         <ref name="k.oem-partition-install.content"/>
       </element>
@@ -902,7 +869,6 @@ will not have any effect</db:para>
     <define name="k.oem-reboot">
       <element name="oem-reboot">
         <a:documentation>For oemboot driven images: reboot after first deployment true/false</a:documentation>
-        <db:para>For oemboot driven images: reboot after first deployment true/false. The system is rebooted in similar fashion to shutdown -r after the image has been dumped (installed) and expanded on the target disk.</db:para>
         <ref name="k.oem-reboot.attlist"/>
         <ref name="k.oem-reboot.content"/>
       </element>
@@ -922,8 +888,8 @@ will not have any effect</db:para>
     </define>
     <define name="k.oem-reboot-interactive">
       <element name="oem-reboot-interactive">
-        <a:documentation>For oemboot driven images: reboot after first deployment true/false</a:documentation>
-        <db:para>For oemboot driven images: reboot after first deployment true/false. A message to be acknowledged by the user is posted after the image has been dumped (installed) and expanded on the target disk. After user interaction the system is rebooted in similar fashion to shutdown -r.</db:para>
+        <a:documentation>For oemboot driven images: reboot after first deployment
+with an interactive dialog true/false</a:documentation>
         <ref name="k.oem-reboot-interactive.attlist"/>
         <ref name="k.oem-reboot-interactive.content"/>
       </element>
@@ -944,7 +910,6 @@ will not have any effect</db:para>
     <define name="k.oem-recovery">
       <element name="oem-recovery">
         <a:documentation>For oemboot driven images: create a recovery archive yes/no</a:documentation>
-        <db:para>For oemboot driven images: create a recovery archive yes/no</db:para>
         <ref name="k.oem-recovery.attlist"/>
         <ref name="k.oem-recovery.content"/>
       </element>
@@ -963,8 +928,6 @@ will not have any effect</db:para>
       <element name="oem-recoveryID">
         <a:documentation>For oemboot driven images: Set the partition ID of
 recovery partition. Default value is 83 (Linux)</a:documentation>
-        <db:para>For oemboot driven images: Set the partition ID of
-recovery partition. Default value is 83 (Linux)</db:para>
         <ref name="k.oem-recoveryID.attlist"/>
         <data type="nonNegativeInteger"/>
       </element>
@@ -983,8 +946,6 @@ recovery partition. Default value is 83 (Linux)</db:para>
       <element name="oem-recovery-part-size">
         <a:documentation>For oemboot driven images: Set the size of the
 recovery partition. Value is interpreted as MB</a:documentation>
-        <db:para>For oemboot driven images: Set the size of
-the recovery partition in MBytes.</db:para>
         <ref name="k.oem-recovery-part-size.attlist"/>
         <data type="nonNegativeInteger"/>
       </element>
@@ -1006,7 +967,6 @@ the recovery partition in MBytes.</db:para>
       <element name="oem-shutdown">
         <a:documentation>For oemboot driven images: shutdown after first deployment 
 true/false</a:documentation>
-        <db:para>For oemboot driven images: shutdown after first deployment true/false. The system is powered down after the image has been dumped (installed) and expanded on the target disk. </db:para>
         <ref name="k.oem-shutdown.attlist"/>
         <ref name="k.oem-shutdown.content"/>
       </element>
@@ -1028,7 +988,6 @@ true/false</a:documentation>
       <element name="oem-shutdown-interactive">
         <a:documentation>For oemboot driven images: shutdown after first deployment 
 true/false</a:documentation>
-        <db:para>For oemboot driven images: shutdown after first deployment true/false. A message to be acknowledged by the user is posted after the image has been dumped (installed) and expanded on the target disk. After user interaction the system is shutdown.</db:para>
         <ref name="k.oem-shutdown-interactive.attlist"/>
         <ref name="k.oem-shutdown-interactive.content"/>
       </element>
@@ -1050,7 +1009,6 @@ true/false</a:documentation>
       <element name="oem-silent-boot">
         <a:documentation>For oemboot driven images: boot silently during the initial boot
 true/false</a:documentation>
-        <db:para>For oemboot driven images: complete the initial boot of the system in silent mode, true/false. </db:para>
         <ref name="k.oem-silent-boot.attlist"/>
         <ref name="k.oem-silent-boot.content"/>
       </element>
@@ -1072,7 +1030,6 @@ true/false</a:documentation>
       <element name="oem-silent-install">
         <a:documentation>For oemboot driven images: do not show progress of the image
 dump process, true/false</a:documentation>
-        <db:para>For oemboot driven images: do not show progress of the image dump process, true/false (default is false.) </db:para>
         <ref name="k.oem-silent-install.attlist"/>
         <ref name="k.oem-silent-install.content"/>
       </element>
@@ -1094,7 +1051,6 @@ dump process, true/false</a:documentation>
       <element name="oem-skip-verify">
         <a:documentation>For oemboot driven images: do not perform the md5
 verification process, true/false</a:documentation>
-        <db:para>For oemboot driven images: do not perform the md5 verification process, true/false (default is false.) </db:para>
         <ref name="k.oem-skip-verify.attlist"/>
         <ref name="k.oem-skip-verify.content"/>
       </element>
@@ -1117,7 +1073,6 @@ verification process, true/false</a:documentation>
         <a:documentation>For oemboot driven images: turn on or off the search
 for ata raid devices (aka fake raid controllers)
 true/false (default is true)</a:documentation>
-        <db:para>For oemboot driven images: turn on or off the search for ata raid devices (aka fake raid controllers) true/false (default is true) </db:para>
         <ref name="k.oem-ataraid-scan.attlist"/>
         <ref name="k.oem-ataraid-scan.content"/>
       </element>
@@ -1140,7 +1095,6 @@ true/false (default is true)</a:documentation>
         <a:documentation>For oemboot driven images: provide the name of a parmfile
 which is loaded via cmsfscat on s390 systems. Default value
 is set to: PARM-S11</a:documentation>
-        <db:para>For oemboot driven images: provide the name of a parmfile which is loaded via cmsfscat on s390 systems. Default value is set to: PARM-S11</db:para>
         <ref name="k.oem-vmcp-parmfile.attlist"/>
         <ref name="k.oem-vmcp-parmfile.content"/>
       </element>
@@ -1162,7 +1116,6 @@ is set to: PARM-S11</a:documentation>
       <element name="oem-multipath-scan">
         <a:documentation>For oemboot driven images: turn on or off the search
 for multipath devices: true/false (default is true)</a:documentation>
-        <db:para>For oemboot driven images: turn on or off the search for multipath devices: true/false (default is true) </db:para>
         <ref name="k.oem-multipath-scan.attlist"/>
         <ref name="k.oem-multipath-scan.content"/>
       </element>
@@ -1184,7 +1137,6 @@ for multipath devices: true/false (default is true)</a:documentation>
       <element name="oem-silent-verify">
         <a:documentation>For oemboot driven images: do not show progress of the image
 verification process, true/false</a:documentation>
-        <db:para>For oemboot driven images: do not show progress of the image verification process, true/false (default is false.) </db:para>
         <ref name="k.oem-silent-verify.attlist"/>
         <ref name="k.oem-silent-verify.content"/>
       </element>
@@ -1205,7 +1157,6 @@ verification process, true/false</a:documentation>
     <define name="k.oem-swap">
       <element name="oem-swap">
         <a:documentation>For oemboot driven images: use a swap partition yes/no</a:documentation>
-        <db:para>For oemboot driven images: use a swap partition yes/no.</db:para>
         <ref name="k.oem-swap.attlist"/>
         <ref name="k.oem-swap.content"/>
       </element>
@@ -1224,8 +1175,6 @@ verification process, true/false</a:documentation>
       <element name="oem-swapsize">
         <a:documentation>For oemboot driven images: Set the size of the swap
 partition in MB</a:documentation>
-        <db:para>For oemboot driven images: Set the size of the swap
-partition in MB. No swapspace with oem-swap set to false.</db:para>
         <ref name="k.oem-swapsize.attlist"/>
         <data type="nonNegativeInteger"/>
       </element>
@@ -1266,7 +1215,6 @@ will grow to the maximum available free space on the disk</a:documentation>
       <element name="oem-unattended">
         <a:documentation>For oemboot driven images: don't ask questions if possible
 true/false</a:documentation>
-        <db:para>For oemboot driven images: don't ask questions ifpossible true/false</db:para>
         <ref name="k.oem-unattended.attlist"/>
         <ref name="k.oem-unattended.content"/>
       </element>
@@ -1285,7 +1233,6 @@ true/false</a:documentation>
       <element name="oem-unattended-id">
         <a:documentation>For oemboot driven images: use the specified disk id
 the device is looked up in /dev/disk/by-* and /dev/mapper/*</a:documentation>
-        <db:para>For oemboot driven images: use the specified disk idthe device is looked up in /dev/disk/by-* and /dev/mapper/*</db:para>
         <ref name="k.oem-unattended-id.attlist"/>
         <text/>
       </element>
@@ -1385,8 +1332,6 @@ the device is looked up in /dev/disk/by-* and /dev/mapper/*</a:documentation>
     <define name="k.packagemanager">
       <element name="packagemanager">
         <a:documentation>Name of the Package Manager</a:documentation>
-        <db:para>The package manager used for package installation
-could be either zypper or smart</db:para>
         <ref name="k.packagemanager.attlist"/>
         <ref name="k.packagemanager.content"/>
       </element>
@@ -1410,8 +1355,6 @@ could be either zypper or smart</db:para>
     <define name="k.partitioner">
       <element name="partitioner">
         <a:documentation>Name of the Partitioner used for any disk partition tasks</a:documentation>
-        <db:para>The partitioner used for creating disk partitions
-could be either parted or fdasd</db:para>
         <ref name="k.partitioner.attlist"/>
         <ref name="k.partitioner.content"/>
       </element>
@@ -1530,11 +1473,10 @@ the command line</a:documentation>
     </define>
     <define name="k.profile">
       <element name="profile">
-        <a:documentation>Creates Profiles</a:documentation>
-        <db:para>Profiles creates a namespace on an image description and
+        <a:documentation>Profiles creates a namespace on an image description and
 thus can be used to have one description with different
 profiles for example KDE and GNOME including different
-packages.</db:para>
+packages.</a:documentation>
         <ref name="k.profile.attlist"/>
         <empty/>
       </element>
@@ -1771,10 +1713,9 @@ The default value is false.</a:documentation>
     </define>
     <define name="k.rpm-excludedocs">
       <element name="rpm-excludedocs">
-        <a:documentation>Do not install files marked as documentation in the package</a:documentation>
-        <db:para>Setup if the package manager should exclude docs files
+        <a:documentation>Setup if the package manager should exclude docs files
 during package installation. This option could be ignored
-according to the used package manager.</db:para>
+according to the used package manager.</a:documentation>
         <ref name="k.rpm-excludedocs.attlist"/>
         <ref name="k.rpm-excludedocs.content"/>
       </element>
@@ -1795,9 +1736,6 @@ according to the used package manager.</db:para>
     <define name="k.rpm-force">
       <element name="rpm-force">
         <a:documentation>Force the Installation of a Package</a:documentation>
-        <db:para>Setup if the package manager should force the install
-of the package or not. This option could be ignored
-according to the used package manager.</db:para>
         <ref name="k.rpm-force.attlist"/>
         <ref name="k.rpm-force.content"/>
       </element>
@@ -1814,9 +1752,8 @@ according to the used package manager.</db:para>
     </define>
     <define name="k.showlicense">
       <element name="showlicense">
-        <a:documentation>Setup showlicense</a:documentation>
-        <db:para>Image license setup. The specfied license name
-will be displayed in a dialog window on boot.</db:para>
+        <a:documentation>Image license setup. The specfied license name
+will be displayed in a dialog window on boot.</a:documentation>
         <ref name="k.showlicense.attlist"/>
         <text/>
       </element>
@@ -1875,9 +1812,8 @@ to the required size of the image</a:documentation>
     </define>
     <define name="k.specification">
       <element name="specification">
-        <a:documentation>A Detailed Description</a:documentation>
-        <db:para>A detailed description of this image and what it can be
-used for.</db:para>
+        <a:documentation>A detailed description of this image and what it
+can be used for.</a:documentation>
         <ref name="k.specification.attlist"/>
         <text/>
       </element>
@@ -1916,7 +1852,6 @@ volume management system</a:documentation>
     <define name="k.systemdisk">
       <element name="systemdisk">
         <a:documentation>Specify volumes and size attributes</a:documentation>
-        <db:para>Specify volumes and size attributes</db:para>
         <interleave>
           <ref name="k.systemdisk.attlist"/>
           <zeroOrMore>
@@ -1938,8 +1873,6 @@ volume management system</a:documentation>
     <define name="k.timeout">
       <element name="timeout">
         <a:documentation>Specifies an ATFTP Download Timeout</a:documentation>
-        <db:para>As part of the network deploy configuration this section
-specifies an ATFTP download timeout</db:para>
         <ref name="k.timeout.attlist"/>
         <text/>
       </element>
@@ -1957,8 +1890,6 @@ specifies an ATFTP download timeout</db:para>
     <define name="k.timezone">
       <element name="timezone">
         <a:documentation>Setup Image Timezone setup</a:documentation>
-        <db:para>Image timezone setup. The value will be used to search
-the correct timezone and copy it to /etc/localtime.</db:para>
         <ref name="k.timezone.attlist"/>
         <text/>
       </element>
@@ -2899,12 +2830,11 @@ to work on.</a:documentation>
     </define>
     <define name="k.union">
       <element name="union">
-        <a:documentation>Specifies the Overlay Filesystem</a:documentation>
-        <db:para>As part of the network deploy configuration this section
+        <a:documentation>As part of the network deploy configuration this section
 specifies the overlay filesystem setup if required by the
 filesystem type of the system image.An overlay setup is
 only required if the system image uses a squashfs
-compressed filesystem.</db:para>
+compressed filesystem.</a:documentation>
         <ref name="k.union.attlist"/>
         <empty/>
       </element>
@@ -3262,8 +3192,6 @@ add "M" and/or "G" as postfix</a:documentation>
       <element name="volume">
         <a:documentation>Specify which parts of the filesystem should be
 on an extra volume.</a:documentation>
-        <db:para>Specify which parts of the filesystem should be on
-an extra volume.</db:para>
         <ref name="k.volume.attlist"/>
         <empty/>
       </element>
@@ -3299,9 +3227,6 @@ an extra volume.</db:para>
     <define name="k.pxedeploy">
       <element name="pxedeploy">
         <a:documentation>Controls the Image Deploy Process</a:documentation>
-        <db:para>The deploy section is used to allow kiwi to create the
-config.&lt;MAC&gt; file required by PXE based network images.
-the contents of this file controls the image deploy process.</db:para>
         <interleave>
           <ref name="k.pxedeploy.attlist"/>
           <optional>
@@ -3510,8 +3435,11 @@ image is imported via the docker load command</a:documentation>
     </define>
     <define name="k.containerconfig">
       <element name="containerconfig">
-        <a:documentation>Provides metadata information for containers</a:documentation>
-        <db:para>The containerconfig element provides metadata informationto setup a container in order to be prepared for use withthe container engine tool chain. container specific datashould be provided in an additional subsection whereas thissection provides globally useful container information</db:para>
+        <a:documentation>The containerconfig element provides metadata information
+to setup a container in order to be prepared for use with
+the container engine tool chain. container specific data
+should be provided in an additional subsection whereas this
+section provides globally useful container information.</a:documentation>
         <interleave>
           <ref name="k.containerconfig.attlist"/>
           <optional>
@@ -3815,10 +3743,9 @@ At least one label must be configured</a:documentation>
     </define>
     <define name="k.oemconfig">
       <element name="oemconfig">
-        <a:documentation>Specifies the OEM configuration section</a:documentation>
-        <db:para>The oemconfig element specifies the OEM image
+        <a:documentation>The oemconfig element specifies the OEM image
 configuration options which are used to repartition
-and setup the system disk</db:para>
+and setup the system disk.</a:documentation>
         <interleave>
           <ref name="k.oemconfig.attlist"/>
           <optional>
@@ -3917,8 +3844,11 @@ and setup the system disk</db:para>
     </define>
     <define name="k.vagrantconfig.virtualsize.attribute">
       <attribute name="virtualsize">
-        <a:documentation>The vagrant virtual image size in GB</a:documentation>
-        <db:para>virtualsize provides the value of the virtual_size keywhich is embedded in the metadata.json hash inside the.box file, as described here:http://docs.vagrantup.com/v2/boxes/format.htmlThis tells the Vagrant provider how big to make thevirtual disk when it creates the VM.</db:para>
+        <a:documentation>virtualsize provides the value of the virtual_size key which
+is embedded in the metadata.json hash inside the box file, as
+described in http://docs.vagrantup.com/v2/boxes/format.html
+This tells the Vagrant provider how big to make the
+virtual disk when it creates the VM.</a:documentation>
         <data type="nonNegativeInteger"/>
       </attribute>
     </define>
@@ -3926,7 +3856,6 @@ and setup the system disk</db:para>
       <attribute name="boxname">
         <a:documentation>The boxname as it's written into the json file
 If not specified the image name is used</a:documentation>
-        <db:para>The boxname as it's written into the json file.If not specified the image name is used.</db:para>
       </attribute>
     </define>
     <define name="k.vagrantconfig.attlist">
@@ -3940,8 +3869,8 @@ If not specified the image name is used</a:documentation>
     </define>
     <define name="k.vagrantconfig">
       <element name="vagrantconfig">
-        <a:documentation>Specifies the Vagrant configuration section</a:documentation>
-        <db:para>The vagrantconfig element specifies the Vagrant metaconfiguration options which are used inside a vagrant box</db:para>
+        <a:documentation>The vagrantconfig element specifies the Vagrant meta
+configuration options which are used inside a vagrant box</a:documentation>
         <ref name="k.vagrantconfig.attlist"/>
       </element>
     </define>
@@ -4070,10 +3999,9 @@ formats)</a:documentation>
     </define>
     <define name="k.machine">
       <element name="machine">
-        <a:documentation>specifies the VM configuration sections</a:documentation>
-        <db:para>The machine element specifies the VM guest
+        <a:documentation>The machine element specifies the VM guest
 configuration options which are used by the
-virtual machine when running the image.</db:para>
+virtual machine when running the image.</a:documentation>
         <interleave>
           <ref name="k.machine.attlist"/>
           <zeroOrMore>
@@ -4145,10 +4073,6 @@ or plusRecommended</a:documentation>
     <define name="k.packages">
       <element name="packages">
         <a:documentation>Specifies Packages/Patterns Used in Different Stages</a:documentation>
-        <db:para>The packages elements specifies a set of packages
-and/or patterns which are used in different stages of the
-image building process
-and also depends of the selected image output type.</db:para>
         <interleave>
           <ref name="k.packages.attlist"/>
           <zeroOrMore>
@@ -4258,9 +4182,8 @@ definition</a:documentation>
     </define>
     <define name="k.profiles">
       <element name="profiles">
-        <a:documentation>Creates Namespace Section for Drivers</a:documentation>
-        <db:para>Namespace section which creates a namespace and the
-drivers can bind itself to one of the listed namespaces.</db:para>
+        <a:documentation>Namespace section which creates a namespace and the
+drivers can bind itself to one of the listed namespaces.</a:documentation>
         <interleave>
           <ref name="k.profiles.attlist"/>
           <oneOrMore>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -15,7 +15,7 @@
 #   kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Command line:
-#   /home/david/workspaces/kiwi/.env3/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
+#   /home/ms/Project/kiwi/.tox/2.7/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -1219,7 +1219,9 @@ class archive(GeneratedsSuper):
 
 
 class configuration(GeneratedsSuper):
-    """Specifies Configuration files"""
+    """As part of the network deploy configuration this section specifies
+    the configuration files which should be included into the image
+    after deployment"""
     subclass = None
     superclass = None
     def __init__(self, source=None, dest=None, arch=None):
@@ -2016,7 +2018,9 @@ class partitions(GeneratedsSuper):
 
 
 class profile(GeneratedsSuper):
-    """Creates Profiles"""
+    """Profiles creates a namespace on an image description and thus can be
+    used to have one description with different profiles for example
+    KDE and GNOME including different packages."""
     subclass = None
     superclass = None
     def __init__(self, name=None, description=None, import_=None):
@@ -3483,7 +3487,10 @@ class type_(GeneratedsSuper):
 
 
 class union(GeneratedsSuper):
-    """Specifies the Overlay Filesystem"""
+    """As part of the network deploy configuration this section specifies
+    the overlay filesystem setup if required by the filesystem type
+    of the system image.An overlay setup is only required if the
+    system image uses a squashfs compressed filesystem."""
     subclass = None
     superclass = None
     def __init__(self, ro=None, rw=None, type_=None):
@@ -4670,7 +4677,11 @@ class strip(GeneratedsSuper):
 
 
 class containerconfig(GeneratedsSuper):
-    """Provides metadata information for containers"""
+    """The containerconfig element provides metadata information to setup a
+    container in order to be prepared for use with the container
+    engine tool chain. container specific data should be provided in
+    an additional subsection whereas this section provides globally
+    useful container information."""
     subclass = None
     superclass = None
     def __init__(self, name=None, tag=None, maintainer=None, user=None, workingdir=None, entrypoint=None, subcommand=None, expose=None, volumes=None, environment=None, labels=None):
@@ -5732,7 +5743,8 @@ class label(GeneratedsSuper):
 
 
 class oemconfig(GeneratedsSuper):
-    """Specifies the OEM configuration section"""
+    """The oemconfig element specifies the OEM image configuration options
+    which are used to repartition and setup the system disk."""
     subclass = None
     superclass = None
     def __init__(self, oem_ataraid_scan=None, oem_boot_title=None, oem_bootwait=None, oem_device_filter=None, oem_nic_filter=None, oem_inplace_recovery=None, oem_kiwi_initrd=None, oem_multipath_scan=None, oem_vmcp_parmfile=None, oem_partition_install=None, oem_reboot=None, oem_reboot_interactive=None, oem_recovery=None, oem_recoveryID=None, oem_recovery_part_size=None, oem_shutdown=None, oem_shutdown_interactive=None, oem_silent_boot=None, oem_silent_install=None, oem_silent_verify=None, oem_skip_verify=None, oem_swap=None, oem_swapsize=None, oem_systemsize=None, oem_unattended=None, oem_unattended_id=None):
@@ -6364,7 +6376,8 @@ class oemconfig(GeneratedsSuper):
 
 
 class vagrantconfig(GeneratedsSuper):
-    """Specifies the Vagrant configuration section"""
+    """The vagrantconfig element specifies the Vagrant meta configuration
+    options which are used inside a vagrant box"""
     subclass = None
     superclass = None
     def __init__(self, provider=None, virtualsize=None, boxname=None):
@@ -6460,7 +6473,8 @@ class vagrantconfig(GeneratedsSuper):
 
 
 class machine(GeneratedsSuper):
-    """specifies the VM configuration sections"""
+    """The machine element specifies the VM guest configuration options
+    which are used by the virtual machine when running the image."""
     subclass = None
     superclass = None
     def __init__(self, min_memory=None, max_memory=None, min_cpu=None, max_cpu=None, ovftype=None, HWversion=None, arch=None, domain=None, guestOS=None, memory=None, ncpus=None, vmconfig_entry=None, vmdisk=None, vmdvd=None, vmnic=None):
@@ -7312,7 +7326,8 @@ class preferences(GeneratedsSuper):
 
 
 class profiles(GeneratedsSuper):
-    """Creates Namespace Section for Drivers"""
+    """Namespace section which creates a namespace and the drivers can bind
+    itself to one of the listed namespaces."""
     subclass = None
     superclass = None
     def __init__(self, profile=None):

--- a/tox.ini
+++ b/tox.ini
@@ -26,13 +26,13 @@ whitelist_externals =
     /usr/bin/make
     /bin/bash
 basepython =
-    {check,doc,doc_travis,doc_travis_deploy}: python3.4
+    {check,doc,doc_travis,doc_travis_deploy,schema}: python3.4
     3.4: python3.4
     3.5: python3.5
     2.7: python2.7
 # {toxworkdir} defaults to .tox
 envdir =
-    {3.4,check,doc,doc_travis,doc_travis_deploy}: {toxworkdir}/3.4
+    {3.4,check,doc,doc_travis,doc_travis_deploy,schema}: {toxworkdir}/3.4
     3.5: {toxworkdir}/3.5
     2.7: {toxworkdir}/2.7
 setenv =
@@ -57,11 +57,19 @@ deps =
 changedir=doc
 commands =
     make clean
-    {[testenv:doc.schema]commands}
     {[testenv:doc.linkcheck]commands}
 #    {[testenv:doc.spell]commands}
     {[testenv:doc.html]commands}
     {[testenv:doc.man]commands}
+
+
+[testenv:schema]
+skip_install = True
+usedevelop = True
+deps =
+    -r.virtualenv.dev-requirements.txt
+commands =
+    {[testenv:doc.schema]commands}
 
 
 [testenv:doc_travis]
@@ -127,8 +135,7 @@ skip_install = True
 deps =
     {[testenv:doc]deps}
 commands =
-    {toxinidir}/helper/schema_parser.py {toxinidir}/kiwi/schema/kiwi.rng --output source/development/schema.rst
-
+    bash -c 'cd {toxinidir}/helper && ./schema_docs.sh'
 
 [testenv:check]
 deps =


### PR DESCRIPTION
Given there is a valid Oxygen license owned by the company
as described in https://www.oxygenxml.com/oxygen_scripting.html
the schema documentation can be created using Oxygen. This
commit changes the way the schema docs are generated in the
following way:

1. Install Oxygen and setup the license to activate the tool

2. Setup the KIWI development shell environment to export
   the schema_tool variable to point to the schemaDocumentation.sh
   script provided by the Oxygen installation

   export schema_tool=/path/to/Oxygen/schemaDocumentation.sh

3. In any case of a schema change manually call:
    
    tox -e schema
    
    This step was done before as part of the tox doc target
    but can't be done automatically because it would require
    a correctly licensed Oxygen installation in the travis
    environment. Thus the result data has to be part of the
    pull request

4. Build the documentation and review the result

    tox -e doc

5. Create the pull request