### PR TITLE
Flag --ignore-repos do not ignore imageonly repos

### DIFF
--- a/kiwi/tasks/image_info.py
+++ b/kiwi/tasks/image_info.py
@@ -76,7 +76,7 @@ class ImageInfoTask(CliTask):
         )
 
         if self.command_args['--ignore-repos']:
-            self.xml_state.delete_repository_sections()
+            self.xml_state.delete_repository_sections_used_for_build()
 
         if self.command_args['--add-repo']:
             for add_repo in self.command_args['--add-repo']:

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -139,7 +139,7 @@ class SystemBuildTask(CliTask):
         )
 
         if self.command_args['--ignore-repos']:
-            self.xml_state.delete_repository_sections()
+            self.xml_state.delete_repository_sections_used_for_build()
 
         if self.command_args['--set-repo']:
             (repo_source, repo_type, repo_alias, repo_prio) = \

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -125,7 +125,7 @@ class SystemPrepareTask(CliTask):
         )
 
         if self.command_args['--ignore-repos']:
-            self.xml_state.delete_repository_sections()
+            self.xml_state.delete_repository_sections_used_for_build()
 
         if self.command_args['--set-repo']:
             (repo_source, repo_type, repo_alias, repo_prio) = \

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1183,6 +1183,17 @@ class XMLState(object):
         """
         self.xml_data.set_repository([])
 
+    def delete_repository_sections_used_for_build(self):
+        """
+        Delete all repository sections used to build the image matching
+        configured profiles
+        """
+        used_for_build = self.get_repository_sections_used_for_build()
+        all_repos = self.get_repository_sections()
+        self.xml_data.set_repository([
+            repo for repo in all_repos if repo not in used_for_build
+        ])
+
     def translate_obs_to_ibs_repositories(self):
         """
         Change obs repotype to ibs type

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -147,6 +147,9 @@
     <repository type="rpm-md" imageinclude="true">
         <source path="obs://Devel:PubCloud:AmazonEC2/SLE_12_GA"/>
     </repository>
+    <repository type="rpm-md" imageonly="true">
+        <source path="obs://Devel:Docker:Images:SLE12SP2/SLE_12_SP2_Docker"/>
+    </repository>
     <packages type="image" patternType="plusRecommended">
         <namedCollection name="base"/>
         <product name="openSUSE"/>

--- a/test/unit/system_setup_test.py
+++ b/test/unit/system_setup_test.py
@@ -716,7 +716,7 @@ class TestSystemSetup(object):
         repo = mock.Mock()
         mock_repo.return_value = repo
         self.setup_with_real_xml.import_repositories_marked_as_imageinclude()
-        repo.add_repo.assert_called_once_with(
+        assert repo.add_repo.call_args_list[0] == call(
             '95811799a6d1889c5b2363d3886986de',
             'http://download.opensuse.org/repositories/Devel:PubCloud:AmazonEC2/SLE_12_GA',
             'rpm-md',

--- a/test/unit/tasks_image_info_test.py
+++ b/test/unit/tasks_image_info_test.py
@@ -144,7 +144,7 @@ class TestImageInfoTask(object):
         self.task.process()
         mock_state.assert_called_once_with()
 
-    @patch('kiwi.xml_state.XMLState.delete_repository_sections')
+    @patch('kiwi.xml_state.XMLState.delete_repository_sections_used_for_build')
     @patch('kiwi.tasks.image_info.DataOutput')
     def test_process_image_info_delete_repos(self, mock_out, mock_delete_repos):
         self._init_command_args()

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -228,7 +228,7 @@ class TestSystemBuildTask(object):
             'kiwi::system::build'
         )
 
-    @patch('kiwi.xml_state.XMLState.delete_repository_sections')
+    @patch('kiwi.xml_state.XMLState.delete_repository_sections_used_for_build')
     @patch('kiwi.logger.Logger.set_logfile')
     def test_process_system_prepare_ignore_repos(
         self, mock_log, mock_delete_repos

--- a/test/unit/tasks_system_prepare_test.py
+++ b/test/unit/tasks_system_prepare_test.py
@@ -202,7 +202,7 @@ class TestSystemPrepareTask(object):
             'kiwi::system::prepare'
         )
 
-    @patch('kiwi.xml_state.XMLState.delete_repository_sections')
+    @patch('kiwi.xml_state.XMLState.delete_repository_sections_used_for_build')
     def test_process_system_prepare_delete_repos(self, mock_delete_repos):
         self._init_command_args()
         self.task.command_args['--ignore-repos'] = True

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -165,11 +165,11 @@ class TestXMLState(object):
 
     def test_add_repository(self):
         self.state.add_repository('repo', 'type', 'alias', 1)
-        assert self.state.xml_data.get_repository()[2].get_source().get_path() \
+        assert self.state.xml_data.get_repository()[3].get_source().get_path() \
             == 'repo'
-        assert self.state.xml_data.get_repository()[2].get_type() == 'type'
-        assert self.state.xml_data.get_repository()[2].get_alias() == 'alias'
-        assert self.state.xml_data.get_repository()[2].get_priority() == 1
+        assert self.state.xml_data.get_repository()[3].get_type() == 'type'
+        assert self.state.xml_data.get_repository()[3].get_alias() == 'alias'
+        assert self.state.xml_data.get_repository()[3].get_priority() == 1
 
     def test_get_to_become_deleted_packages(self):
         assert self.state.get_to_become_deleted_packages() == [
@@ -502,6 +502,10 @@ class TestXMLState(object):
     def test_delete_repository_sections(self):
         self.state.delete_repository_sections()
         assert self.state.get_repository_sections() == []
+
+    def test_delete_repository_sections_used_for_build(self):
+        self.state.delete_repository_sections_used_for_build()
+        assert self.state.get_repository_sections()[0].get_imageonly()
 
     def test_get_build_type_vmconfig_entries(self):
         assert self.state.get_build_type_vmconfig_entries() == []


### PR DESCRIPTION
This commit fixes #395, with it, using --ignore-repos, does not
delete imageonly repositories from the description file. This way
imageonly is prepared to be used in the buildservice even when using
the 'obsrepositories:/' reference style.