### PR TITLE
Allow imageinclude in add|set-repo commandline

### DIFF
--- a/doc/source/commands/system_build.rst
+++ b/doc/source/commands/system_build.rst
@@ -13,8 +13,8 @@ SYNOPSIS
        [--allow-existing-root]
        [--clear-cache]
        [--ignore-repos]
-       [--set-repo=<source,type,alias,priority>]
-       [--add-repo=<source,type,alias,priority>...]
+       [--set-repo=<source,type,alias,priority,imageinclude>]
+       [--add-repo=<source,type,alias,priority,imageinclude>...]
        [--obs-repo-internal]
        [--add-package=<name>...]
        [--delete-package=<name>...]
@@ -39,10 +39,12 @@ OPTIONS
   specify package to add(install). The option can be specified
   multiple times
 
---add-repo=<source,type,alias,priority>
+--add-repo=<source,type,alias,priority,imageinclude>
 
   Add a new repository to the existing repository setup in the XML
-  description. This option can be specified multiple times
+  description. This option can be specified multiple times.
+  For details about the provided option values see the **--set-repo**
+  information below
 
 --allow-existing-root
 
@@ -90,7 +92,7 @@ OPTIONS
   internal build service. Please note this requires access permissions
   to the SUSE internal build service on the machine building the image.
 
---set-repo=<source,type,alias,priority>
+--set-repo=<source,type,alias,priority,imageinclude>
 
   Overwrite the first repository entry in the XML description with the
   provided information:
@@ -118,6 +120,11 @@ OPTIONS
     depends on the selected package manager. Please refer to the package
     manager documentation for details about the supported priority ranges
     and their meaning.
+
+  - **imageinclude**
+
+    Set to either **true** or **false** to specify if this repository
+    should be part of the system image repository setup or not
 
 --target-dir=<directory>
 

--- a/doc/source/commands/system_prepare.rst
+++ b/doc/source/commands/system_prepare.rst
@@ -13,8 +13,8 @@ SYNOPSIS
        [--allow-existing-root]
        [--clear-cache]
        [--ignore-repos]
-       [--set-repo=<source,type,alias,priority>]
-       [--add-repo=<source,type,alias,priority>...]
+       [--set-repo=<source,type,alias,priority,imageinclude>]
+       [--add-repo=<source,type,alias,priority,imageinclude>...]
        [--obs-repo-internal]
        [--add-package=<name>...]
        [--delete-package=<name>...]
@@ -41,7 +41,7 @@ OPTIONS
   specify package to add(install). The option can be specified
   multiple times
 
---add-repo=<source,type,alias,priority>
+--add-repo=<source,type,alias,priority,imageinclude>
 
   See the kiwi::system::build manual page for further details
 
@@ -86,6 +86,6 @@ OPTIONS
 
   Path to create the new root system.
 
---set-repo=<source,type,alias,priority>
+--set-repo=<source,type,alias,priority,imageinclude>
 
   See the kiwi::system::build manual page for further details

--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -160,6 +160,28 @@ class CliTask(object):
             )
         ]
 
+    def quintuple_token(self, option):
+        """
+        Helper method for commandline options of the form --option a,b,c,d,e
+
+        Make sure to provide a common result for option values which
+        separates the information in a comma separated list of values
+
+        :return: common option value representation
+        :rtype: string
+        """
+        tokens = option.split(',', 4)
+        return [
+            self._pop_token(tokens) if len(tokens) else None for _ in range(
+                0, 5
+            )
+        ]
+
     def _pop_token(self, tokens):
         token = tokens.pop(0)
-        return token if len(token) > 0 else None
+        if len(token) > 0 and token == 'true':
+            return True
+        elif len(token) > 0 and token == 'false':
+            return False
+        else:
+            return token

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -21,8 +21,8 @@ usage: kiwi system build -h | --help
            [--allow-existing-root]
            [--clear-cache]
            [--ignore-repos]
-           [--set-repo=<source,type,alias,priority>]
-           [--add-repo=<source,type,alias,priority>...]
+           [--set-repo=<source,type,alias,priority,imageinclude>]
+           [--add-repo=<source,type,alias,priority,imageinclude>...]
            [--obs-repo-internal]
            [--add-package=<name>...]
            [--delete-package=<name>...]
@@ -41,8 +41,11 @@ commands:
 options:
     --add-package=<name>
         install the given package name
-    --add-repo=<source,type,alias,priority>
-        add repository with given source, type, alias and priority
+    --add-repo=<source,type,alias,priority,imageinclude>
+        add repository with given source, type, alias, priority
+        and the imageinclude flag set to true|false which indicates
+        if this repository should be part of the system image
+        repository setup or not
     --allow-existing-root
         allow to use an existing root directory from an earlier
         build attempt. Use with caution this could cause an inconsistent
@@ -71,9 +74,11 @@ options:
         overwrite the container tag in the container configuration.
         The setting is only effective if the container configuraiton
         provides an initial tag value
-    --set-repo=<source,type,alias,priority>
-        overwrite the repo source, type, alias or priority for the first
-        repository in the XML description
+    --set-repo=<source,type,alias,priority,imageinclude>
+        overwrite the first XML listed repository source, type, alias,
+        priority and the imageinclude flag set to true|false which
+        indicates if this repository should be part of the system
+        image repository setup or not
     --signing-key=<key-file>
         includes the key-file as a trusted key for package manager validations
     --target-dir=<directory>
@@ -142,21 +147,15 @@ class SystemBuildTask(CliTask):
             self.xml_state.delete_repository_sections_used_for_build()
 
         if self.command_args['--set-repo']:
-            (repo_source, repo_type, repo_alias, repo_prio) = \
-                self.quadruple_token(self.command_args['--set-repo'])
             self.xml_state.set_repository(
-                repo_source, repo_type, repo_alias, repo_prio
+                *self.quintuple_token(self.command_args['--set-repo'])
             )
 
         if self.command_args['--add-repo']:
             for add_repo in self.command_args['--add-repo']:
-                (repo_source, repo_type, repo_alias, repo_prio) = \
-                    self.quadruple_token(add_repo)
                 self.xml_state.add_repository(
-                    repo_source, repo_type, repo_alias, repo_prio
+                    *self.quintuple_token(add_repo)
                 )
-
-                Path.create(abs_target_dir_path)
 
         if self.command_args['--set-container-tag']:
             self.xml_state.set_container_config_tag(

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -21,8 +21,8 @@ usage: kiwi system prepare -h | --help
            [--allow-existing-root]
            [--clear-cache]
            [--ignore-repos]
-           [--set-repo=<source,type,alias,priority>]
-           [--add-repo=<source,type,alias,priority>...]
+           [--set-repo=<source,type,alias,priority,imageinclude>]
+           [--add-repo=<source,type,alias,priority,imageinclude>...]
            [--obs-repo-internal]
            [--add-package=<name>...]
            [--delete-package=<name>...]
@@ -40,8 +40,11 @@ commands:
 options:
     --add-package=<name>
         install the given package name
-    --add-repo=<source,type,alias,priority>
-        add repository with given source, type, alias and priority.
+    --add-repo=<source,type,alias,priority,imageinclude>
+        add repository with given source, type, alias, priority
+        and the imageinclude flag set to true|false which indicates
+        if this repository should be part of the system image
+        repository setup or not
     --allow-existing-root
         allow to use an existing root directory. Use with caution
         this could cause an inconsistent root tree if the existing
@@ -71,9 +74,11 @@ options:
         overwrite the container tag in the container configuration.
         The setting is only effective if the container configuraiton
         provides an initial tag value
-    --set-repo=<source,type,alias,priority>
-        overwrite the repo source, type, alias or priority for the first
-        repository in the XML description
+    --set-repo=<source,type,alias,priority,imageinclude>
+        overwrite the first XML listed repository source, type, alias,
+        priority and the imageinclude flag set to true|false which
+        indicates if this repository should be part of the system
+        image repository setup or not
      --signing-key=<key-file>
         includes the key-file as a trusted key for package manager validations
 """
@@ -128,18 +133,14 @@ class SystemPrepareTask(CliTask):
             self.xml_state.delete_repository_sections_used_for_build()
 
         if self.command_args['--set-repo']:
-            (repo_source, repo_type, repo_alias, repo_prio) = \
-                self.quadruple_token(self.command_args['--set-repo'])
             self.xml_state.set_repository(
-                repo_source, repo_type, repo_alias, repo_prio
+                *self.quintuple_token(self.command_args['--set-repo'])
             )
 
         if self.command_args['--add-repo']:
             for add_repo in self.command_args['--add-repo']:
-                (repo_source, repo_type, repo_alias, repo_prio) = \
-                    self.quadruple_token(add_repo)
                 self.xml_state.add_repository(
-                    repo_source, repo_type, repo_alias, repo_prio
+                    *self.quintuple_token(add_repo)
                 )
 
         if self.command_args['--set-container-tag']:

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1224,7 +1224,10 @@ class XMLState(object):
                     source_path.get_path().replace('obs:', 'suse:')
                 )
 
-    def set_repository(self, repo_source, repo_type, repo_alias, repo_prio):
+    def set_repository(
+        self, repo_source, repo_type, repo_alias, repo_prio,
+        repo_imageinclude=False
+    ):
         """
         Overwrite repository data of the first repository
 
@@ -1232,6 +1235,7 @@ class XMLState(object):
         :param string repo_type: type name defined by schema
         :param string repo_alias: alias name
         :param string repo_prio: priority number, package manager specific
+        :param boolean imageinclude: setup repository inside of the image
         """
         repository_sections = self.get_repository_sections()
         if repository_sections:
@@ -1244,8 +1248,13 @@ class XMLState(object):
                 repository.get_source().set_path(repo_source)
             if repo_prio:
                 repository.set_priority(int(repo_prio))
+            if repo_imageinclude:
+                repository.set_imageinclude(repo_imageinclude)
 
-    def add_repository(self, repo_source, repo_type, repo_alias, repo_prio):
+    def add_repository(
+        self, repo_source, repo_type, repo_alias, repo_prio,
+        repo_imageinclude=False
+    ):
         """
         Add a new repository section at the end of the list
 
@@ -1253,13 +1262,15 @@ class XMLState(object):
         :param string repo_type: type name defined by schema
         :param string repo_alias: alias name
         :param string repo_prio: priority number, package manager specific
+        :param boolean imageinclude: setup repository inside of the image
         """
         self.xml_data.add_repository(
             xml_parse.repository(
                 type_=repo_type,
                 alias=repo_alias,
                 priority=repo_prio,
-                source=xml_parse.source(path=repo_source)
+                source=xml_parse.source(path=repo_source),
+                imageinclude=repo_imageinclude
             )
         )
 

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -181,7 +181,7 @@ class TestSystemBuildTask(object):
         self.task.command_args['--set-repo'] = 'http://example.com,yast2,alias'
         self.task.process()
         mock_set_repo.assert_called_once_with(
-            'http://example.com', 'yast2', 'alias', None
+            'http://example.com', 'yast2', 'alias', None, None
         )
 
     @patch('kiwi.xml_state.XMLState.add_repository')
@@ -191,11 +191,11 @@ class TestSystemBuildTask(object):
     ):
         self._init_command_args()
         self.task.command_args['--add-repo'] = [
-            'http://example.com,yast2,alias'
+            'http://example.com,yast2,alias,99,false'
         ]
         self.task.process()
         mock_add_repo.assert_called_once_with(
-            'http://example.com', 'yast2', 'alias', None
+            'http://example.com', 'yast2', 'alias', '99', False
         )
 
     @patch('kiwi.logger.Logger.set_logfile')

--- a/test/unit/tasks_system_prepare_test.py
+++ b/test/unit/tasks_system_prepare_test.py
@@ -162,18 +162,18 @@ class TestSystemPrepareTask(object):
         self.task.command_args['--set-repo'] = 'http://example.com,yast2,alias'
         self.task.process()
         mock_state.assert_called_once_with(
-            'http://example.com', 'yast2', 'alias', None
+            'http://example.com', 'yast2', 'alias', None, None
         )
 
     @patch('kiwi.xml_state.XMLState.add_repository')
     def test_process_system_prepare_add_repo(self, mock_state):
         self._init_command_args()
         self.task.command_args['--add-repo'] = [
-            'http://example.com,yast2,alias'
+            'http://example.com,yast2,alias,99,true'
         ]
         self.task.process()
         mock_state.assert_called_once_with(
-            'http://example.com', 'yast2', 'alias', None
+            'http://example.com', 'yast2', 'alias', '99', True
         )
 
     @patch('kiwi.xml_state.XMLState.translate_obs_to_ibs_repositories')

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -156,20 +156,22 @@ class TestXMLState(object):
             'suse://Devel:PubCloud:AmazonEC2/SLE_12_GA'
 
     def test_set_repository(self):
-        self.state.set_repository('repo', 'type', 'alias', 1)
+        self.state.set_repository('repo', 'type', 'alias', 1, True)
         assert self.state.xml_data.get_repository()[0].get_source().get_path() \
             == 'repo'
         assert self.state.xml_data.get_repository()[0].get_type() == 'type'
         assert self.state.xml_data.get_repository()[0].get_alias() == 'alias'
         assert self.state.xml_data.get_repository()[0].get_priority() == 1
+        assert self.state.xml_data.get_repository()[0].get_imageinclude() is True
 
     def test_add_repository(self):
-        self.state.add_repository('repo', 'type', 'alias', 1)
+        self.state.add_repository('repo', 'type', 'alias', 1, True)
         assert self.state.xml_data.get_repository()[3].get_source().get_path() \
             == 'repo'
         assert self.state.xml_data.get_repository()[3].get_type() == 'type'
         assert self.state.xml_data.get_repository()[3].get_alias() == 'alias'
         assert self.state.xml_data.get_repository()[3].get_priority() == 1
+        assert self.state.xml_data.get_repository()[3].get_imageinclude() is True
 
     def test_get_to_become_deleted_packages(self):
         assert self.state.get_to_become_deleted_packages() == [


### PR DESCRIPTION
The --set-repo and --add-repo commandline options now allows
additionally to specify a true|false value to indicate if the
repository should be part of the system image repository
setup or not. This Fixes #398

