### PR TITLE
Allow imageinclude repositories inside the build service

### DIFF
--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -74,7 +74,7 @@ class RuntimeChecker(object):
                 repo_source = xml_repo.get_source().get_path()
                 repo_type = xml_repo.get_type()
                 uri = Uri(repo_source, repo_type)
-                if not uri.is_remote() or Defaults.is_obs_worker():
+                if not uri.is_remote():
                     raise KiwiRuntimeError(message % repo_source)
 
     def check_target_directory_not_in_shared_cache(self, target_dir):


### PR DESCRIPTION
With this PR `imageinclude` attribute can be used in buildservice projects. It is a reponsability of the buildservice to translate those repositories to a correct URL using the `--ignore-repos` and `--add-repo` flags at runtime.

Fixes #397