### PR TITLE
Fix content layout of zypper credentials file

### DIFF
--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -208,8 +208,12 @@ class RepositoryZypper(RepositoryBase):
             if user and secret:
                 uri = ''.join([uri, '?credentials=', credentials_file])
                 with open(repo_secret, 'w') as credentials:
-                    credentials.write('username={0}'.format(user))
-                    credentials.write('password={0}'.format(secret))
+                    credentials.write('username={0}{1}'.format(
+                        user, os.linesep)
+                    )
+                    credentials.write('password={0}{1}'.format(
+                        secret, os.linesep)
+                    )
 
         repo_file = ''.join(
             [self.shared_zypper_dir['reposd-dir'], '/', name, '.repo']

--- a/test/unit/repository_zypper_test.py
+++ b/test/unit/repository_zypper_test.py
@@ -219,7 +219,8 @@ class TestRepositoryZypper(object):
             '../data/shared-dir/zypper/credentials/credentials_file', 'w'
         )
         assert self.file_mock.write.call_args_list == [
-            call('username=user'), call('password=secret')
+            call('username=user\n'),
+            call('password=secret\n')
         ]
         mock_command.assert_called_once_with(
             ['zypper'] + self.repo.zypper_args + [


### PR DESCRIPTION
Missing line break for entries in zypper credentials file


