### PR TITLE
Move check_image_include_repos_http_resolvable

### DIFF
--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -138,7 +138,6 @@ class SystemBuildTask(CliTask):
         self.runtime_checker.check_boot_image_reference_correctly_setup()
         self.runtime_checker.check_docker_tool_chain_installed()
         self.runtime_checker.check_volume_setup_has_no_root_definition()
-        self.runtime_checker.check_image_include_repos_http_resolvable()
         self.runtime_checker.check_target_directory_not_in_shared_cache(
             abs_target_dir_path
         )
@@ -180,6 +179,8 @@ class SystemBuildTask(CliTask):
             # This build should use the internal SUSE buildservice
             # Be aware that the buildhost has to provide access
             self.xml_state.translate_obs_to_ibs_repositories()
+
+        self.runtime_checker.check_image_include_repos_http_resolvable()
 
         package_requests = False
         if self.command_args['--add-package']:

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -124,7 +124,6 @@ class SystemPrepareTask(CliTask):
         self.runtime_checker.check_boot_image_reference_correctly_setup()
         self.runtime_checker.check_docker_tool_chain_installed()
         self.runtime_checker.check_volume_setup_has_no_root_definition()
-        self.runtime_checker.check_image_include_repos_http_resolvable()
         self.runtime_checker.check_target_directory_not_in_shared_cache(
             abs_root_path
         )
@@ -166,6 +165,8 @@ class SystemPrepareTask(CliTask):
             # This build should use the internal SUSE buildservice
             # Be aware that the buildhost has to provide access
             self.xml_state.translate_obs_to_ibs_repositories()
+
+        self.runtime_checker.check_image_include_repos_http_resolvable()
 
         package_requests = False
         if self.command_args['--add-package']:


### PR DESCRIPTION
Call the check_image_include_repos_http_resolvable runtime check
after the check and setup for the obs runtime environment. In
case of obs uri types and a kiwi build outside of the buildservice
those source locations could be translated into a public url and
thus allow for use with the imageinclude attribute. However
building inside of the buildservice maps those to a local path
which is private to the used worked instance. In such a case
the obs uri type is translated into a suse uri type and running
the check_image_include_repos_http_resolvable after that
translation will run from the translated and thus correct
source uri information

