### PR TITLE
Accept an empty string as a repo priority

### DIFF
--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1277,6 +1277,10 @@ class XMLState(object):
         :param string repo_prio: priority number, package manager specific
         :param boolean imageinclude: setup repository inside of the image
         """
+        try:
+            repo_prio = int(repo_prio)
+        except:
+            repo_prio = None
         self.xml_data.add_repository(
             xml_parse.repository(
                 type_=repo_type,

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -181,6 +181,15 @@ class TestXMLState(object):
         assert self.state.xml_data.get_repository()[3].get_priority() == 1
         assert self.state.xml_data.get_repository()[3].get_imageinclude() is True
 
+    def test_add_repository_with_empty_values(self):
+        self.state.add_repository('repo', 'type', '', '', True)
+        assert self.state.xml_data.get_repository()[3].get_source().get_path() \
+            == 'repo'
+        assert self.state.xml_data.get_repository()[3].get_type() == 'type'
+        assert self.state.xml_data.get_repository()[3].get_alias() == ''
+        assert self.state.xml_data.get_repository()[3].get_priority() == None 
+        assert self.state.xml_data.get_repository()[3].get_imageinclude() is True
+
     def test_get_to_become_deleted_packages(self):
         assert self.state.get_to_become_deleted_packages() == [
             'kernel-debug'

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -187,7 +187,7 @@ class TestXMLState(object):
             == 'repo'
         assert self.state.xml_data.get_repository()[3].get_type() == 'type'
         assert self.state.xml_data.get_repository()[3].get_alias() == ''
-        assert self.state.xml_data.get_repository()[3].get_priority() == None 
+        assert self.state.xml_data.get_repository()[3].get_priority() is None
         assert self.state.xml_data.get_repository()[3].get_imageinclude() is True
 
     def test_get_to_become_deleted_packages(self):


### PR DESCRIPTION
xml_parse code is autogenerated, thus no changes there should be
considered. When adding a repository from the command line it
can happen that the repository priority is mapped to an empty instead
to a None valuei, when the priority is not specifically set. xml_parse
will only support a parseable string to int or a None value as the
default option, so, if an empty string is used, it throws an
exception. With the current patch anything that cannot be casted
to an int, will be considered as None.

Fixes #408
