### PR TITLE
Make sure system image strip sections are applied in boot image

### DIFF
--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -211,6 +211,9 @@ class BootImageBase(object):
         strip_xml_state.copy_strip_sections(
             self.boot_xml_state
         )
+        self.xml_state.copy_strip_sections(
+            self.boot_xml_state
+        )
         preferences_subsection_names = [
             'bootloader_theme',
             'bootsplash_theme',

--- a/test/unit/boot_image_base_test.py
+++ b/test/unit/boot_image_base_test.py
@@ -93,6 +93,7 @@ class TestBootImageBase(object):
         assert self.xml_state.copy_repository_sections.called
         assert self.xml_state.copy_drivers_sections.called
         assert mock_strip.called
+        assert self.xml_state.copy_strip_sections.called
         assert self.xml_state.copy_preferences_subsections.called
         assert self.xml_state.copy_bootincluded_packages.called
         assert self.xml_state.copy_bootincluded_archives.called


### PR DESCRIPTION
This commit calls copy_strip_sections from the system image xml to the
boot image xml. This is needed to make sure strip sections are
applied into the boot image.

Fixes #414
