### PR TITLE
Refactor handling of obs repositories

### DIFF
--- a/doc/source/commands/image_info.rst
+++ b/doc/source/commands/image_info.rst
@@ -13,7 +13,6 @@ SYNOPSIS
        [--resolve-package-list]
        [--ignore-repos]
        [--add-repo=<source,type,alias,priority>...]
-       [--obs-repo-internal]
    kiwi image info help
 
 DESCRIPTION
@@ -44,12 +43,6 @@ OPTIONS
 --ignore-repos
 
   Ignore all repos from the XML configuration.
-
---obs-repo-internal
-
-  When using obs repos resolve them using the SUSE internal
-  buildservice. This only works if access to SUSE's internal
-  buildservice is granted.
 
 --resolve-package-list
 

--- a/doc/source/commands/kiwi.rst
+++ b/doc/source/commands/kiwi.rst
@@ -138,7 +138,21 @@ setup parameters:
 .. code-block:: yaml
 
    xz:
-    - options: XZ-compression-options
+     - options: -a -b -c
+
+       # Specifies XZ-compression-options
+       # For details see man xz
+
+   obs:
+     - download_url: url
+
+       # Specifies download server url of an open buildservice instance
+       # defaults to: http://download.opensuse.org
+
+     - public: true|false
+
+       # Specifies if the buildservice instance is public or private
+       # defaults to: true
 
 COMPATIBILITY
 -------------

--- a/doc/source/commands/kiwi.rst
+++ b/doc/source/commands/kiwi.rst
@@ -147,7 +147,7 @@ setup parameters:
      - download_url: url
 
        # Specifies download server url of an open buildservice instance
-       # defaults to: http://download.opensuse.org
+       # defaults to: http://download.opensuse.org/repositories
 
      - public: true|false
 

--- a/doc/source/commands/system_build.rst
+++ b/doc/source/commands/system_build.rst
@@ -15,7 +15,6 @@ SYNOPSIS
        [--ignore-repos]
        [--set-repo=<source,type,alias,priority,imageinclude>]
        [--add-repo=<source,type,alias,priority,imageinclude>...]
-       [--obs-repo-internal]
        [--add-package=<name>...]
        [--delete-package=<name>...]
        [--signing-key=<key-file>...]
@@ -81,16 +80,6 @@ OPTIONS
 
   Path to the XML description. This is a directory containing at least
   one _config.xml_ or _*.kiwi_ XML file.
-
---obs-repo-internal
-
-  The repository source type **obs://** by default points to the
-  `Open Build Service <http://download.opensuse.org>`_. With the
-  *--obs-repo-internal* option the source type is changed to the
-  **ibs://** type, pointing to the **Internal Build Service**.
-  This allows to build images with repositories pointing to the SUSE
-  internal build service. Please note this requires access permissions
-  to the SUSE internal build service on the machine building the image.
 
 --set-repo=<source,type,alias,priority,imageinclude>
 

--- a/doc/source/commands/system_prepare.rst
+++ b/doc/source/commands/system_prepare.rst
@@ -15,7 +15,6 @@ SYNOPSIS
        [--ignore-repos]
        [--set-repo=<source,type,alias,priority,imageinclude>]
        [--add-repo=<source,type,alias,priority,imageinclude>...]
-       [--obs-repo-internal]
        [--add-package=<name>...]
        [--delete-package=<name>...]
        [--signing-key=<key-file>...]
@@ -77,10 +76,6 @@ OPTIONS
 
   Path to the kiwi XML description. Inside of that directory there
   must be at least a config.xml of \*.kiwi XML description.
-
---obs-repo-internal
-
-  See the kiwi::system::build manual page for further details
 
 --root=<directory>
 

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -70,10 +70,18 @@ class Defaults(object):
         ]
 
     @classmethod
-    def is_obs_worker(self):
+    def is_buildservice_worker(self):
         # the presence of /.buildenv on the build host indicates
         # we are building inside of the open buildservice
         return os.path.exists('/.buildenv')
+
+    @classmethod
+    def get_obs_download_server_url(self):
+        """
+        The default download server url hosting the public open
+        buildservice repositories
+        """
+        return 'http://download.opensuse.org'
 
     @classmethod
     def get_s390_disk_block_size(self):

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -81,7 +81,7 @@ class Defaults(object):
         The default download server url hosting the public open
         buildservice repositories
         """
-        return 'http://download.opensuse.org'
+        return 'http://download.opensuse.org/repositories'
 
     @classmethod
     def get_s390_disk_block_size(self):

--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -53,7 +53,7 @@ class RuntimeChecker(object):
                 'No repositories configured'
             )
 
-    def check_image_include_repos_http_resolvable(self):
+    def check_image_include_repos_publicly_resolvable(self):
         """
         Verify that all repos marked with the imageinclude attribute
         can be resolved into a http based web URL
@@ -74,7 +74,7 @@ class RuntimeChecker(object):
                 repo_source = xml_repo.get_source().get_path()
                 repo_type = xml_repo.get_type()
                 uri = Uri(repo_source, repo_type)
-                if not uri.is_remote():
+                if not uri.is_public():
                     raise KiwiRuntimeError(message % repo_source)
 
     def check_target_directory_not_in_shared_cache(self, target_dir):

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -136,7 +136,9 @@ class SystemSetup(object):
             repo_repository_gpgcheck = xml_repo.get_repository_gpgcheck()
             repo_package_gpgcheck = xml_repo.get_package_gpgcheck()
             uri = Uri(repo_source, repo_type)
-            repo_source_translated = uri.translate()
+            repo_source_translated = uri.translate(
+                check_build_environment=False
+            )
             if not repo_alias:
                 repo_alias = uri.alias()
             log.info('Setting up image repository %s', repo_source)

--- a/kiwi/system/uri.py
+++ b/kiwi/system/uri.py
@@ -88,6 +88,15 @@ class Uri(object):
         be adapted e.g loop mounted in case of an ISO or updated
         by the service URL in case of an open buildservice project
         name
+
+        :param bool check_build_environment:
+
+            specify if the uri translation should depend on the
+            environment the build is called in. As of today this only
+            effects the translation result if the image build happens
+            inside of the Open Build Service
+
+        :rtype: string
         """
         uri = urlparse(self.uri)
         if not uri.scheme:

--- a/kiwi/tasks/image_info.py
+++ b/kiwi/tasks/image_info.py
@@ -21,7 +21,6 @@ usage: kiwi image info -h | --help
            [--resolve-package-list]
            [--ignore-repos]
            [--add-repo=<source,type,alias,priority>...]
-           [--obs-repo-internal]
        kiwi image info help
 
 commands:
@@ -36,11 +35,6 @@ options:
         description and optional metadata files
     --ignore-repos
         ignore all repos from the XML configuration
-    --obs-repo-internal
-        Obsolete and kept for compatibility only:
-        For changing to another/private buildservice instance please
-        configure access and privacy information in the kiwi config
-        file
     --resolve-package-list
         solve package dependencies and return a list of all
         packages including their attributes e.g size,

--- a/kiwi/tasks/image_info.py
+++ b/kiwi/tasks/image_info.py
@@ -37,9 +37,10 @@ options:
     --ignore-repos
         ignore all repos from the XML configuration
     --obs-repo-internal
-        when using obs:// repos resolve them using the SUSE internal
-        buildservice. This only works if access to SUSE's internal
-        buildservice is granted
+        Obsolete and kept for compatibility only:
+        For changing to another/private buildservice instance please
+        configure access and privacy information in the kiwi config
+        file
     --resolve-package-list
         solve package dependencies and return a list of all
         packages including their attributes e.g size,
@@ -87,11 +88,6 @@ class ImageInfoTask(CliTask):
                 )
 
         self.runtime_checker.check_repositories_configured()
-
-        if self.command_args['--obs-repo-internal']:
-            # This build should use the internal SUSE buildservice
-            # Be aware that the buildhost has to provide access
-            self.xml_state.translate_obs_to_ibs_repositories()
 
         result = {
             'image': self.xml_state.xml_data.get_name()

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -62,9 +62,10 @@ options:
     --ignore-repos
         ignore all repos from the XML configuration
     --obs-repo-internal
-        when using obs:// repos resolve them using the SUSE internal
-        buildservice. This only works if access to SUSE's internal
-        buildservice is granted
+        Obsolete and kept for compatibility only:
+        For changing to another/private buildservice instance please
+        configure access and privacy information in the kiwi config
+        file
     --set-container-derived-from=<uri>
         overwrite the source location of the base container
         for the selected image type. The setting is only effective
@@ -167,20 +168,7 @@ class SystemBuildTask(CliTask):
             )
 
         self.runtime_checker.check_repositories_configured()
-
-        if Defaults.is_obs_worker():
-            # This build runs inside of a buildservice worker. Therefore
-            # the repo defintions and the base image uri are adapted
-            # accordingly
-            self.xml_state.translate_obs_to_suse_repositories()
-            self.xml_state.translate_obs_to_suse_derived_from_image_uri()
-
-        elif self.command_args['--obs-repo-internal']:
-            # This build should use the internal SUSE buildservice
-            # Be aware that the buildhost has to provide access
-            self.xml_state.translate_obs_to_ibs_repositories()
-
-        self.runtime_checker.check_image_include_repos_http_resolvable()
+        self.runtime_checker.check_image_include_repos_publicly_resolvable()
 
         package_requests = False
         if self.command_args['--add-package']:

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -23,7 +23,6 @@ usage: kiwi system build -h | --help
            [--ignore-repos]
            [--set-repo=<source,type,alias,priority,imageinclude>]
            [--add-repo=<source,type,alias,priority,imageinclude>...]
-           [--obs-repo-internal]
            [--add-package=<name>...]
            [--delete-package=<name>...]
            [--set-container-derived-from=<uri>]
@@ -61,11 +60,6 @@ options:
         description and optional metadata files
     --ignore-repos
         ignore all repos from the XML configuration
-    --obs-repo-internal
-        Obsolete and kept for compatibility only:
-        For changing to another/private buildservice instance please
-        configure access and privacy information in the kiwi config
-        file
     --set-container-derived-from=<uri>
         overwrite the source location of the base container
         for the selected image type. The setting is only effective

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -23,7 +23,6 @@ usage: kiwi system prepare -h | --help
            [--ignore-repos]
            [--set-repo=<source,type,alias,priority,imageinclude>]
            [--add-repo=<source,type,alias,priority,imageinclude>...]
-           [--obs-repo-internal]
            [--add-package=<name>...]
            [--delete-package=<name>...]
            [--set-container-derived-from=<uri>]
@@ -59,11 +58,6 @@ options:
         description and optional metadata files
     --ignore-repos
         ignore all repos from the XML configuration
-    --obs-repo-internal
-        Obsolete and kept for compatibility only:
-        For changing to another/private buildservice instance please
-        configure access and privacy information in the kiwi config
-        file
     --root=<directory>
         the path to the new root directory of the system
     --set-container-derived-from=<uri>

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -60,9 +60,10 @@ options:
     --ignore-repos
         ignore all repos from the XML configuration
     --obs-repo-internal
-        when using obs:// repos resolve them using the SUSE internal
-        buildservice. This only works if access to SUSE's internal
-        buildservice is granted
+        Obsolete and kept for compatibility only:
+        For changing to another/private buildservice instance please
+        configure access and privacy information in the kiwi config
+        file
     --root=<directory>
         the path to the new root directory of the system
     --set-container-derived-from=<uri>
@@ -153,20 +154,7 @@ class SystemPrepareTask(CliTask):
             )
 
         self.runtime_checker.check_repositories_configured()
-
-        if Defaults.is_obs_worker():
-            # This build runs inside of a buildservice worker. Therefore
-            # the repo defintions and the base image uri are adapted
-            # accordingly
-            self.xml_state.translate_obs_to_suse_repositories()
-            self.xml_state.translate_obs_to_suse_derived_from_image_uri()
-
-        elif self.command_args['--obs-repo-internal']:
-            # This build should use the internal SUSE buildservice
-            # Be aware that the buildhost has to provide access
-            self.xml_state.translate_obs_to_ibs_repositories()
-
-        self.runtime_checker.check_image_include_repos_http_resolvable()
+        self.runtime_checker.check_image_include_repos_publicly_resolvable()
 
         package_requests = False
         if self.command_args['--add-package']:

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -19,7 +19,6 @@ import re
 import copy
 import platform
 from collections import namedtuple
-from six.moves.urllib.parse import urlparse
 from textwrap import dedent
 
 # project
@@ -1193,49 +1192,6 @@ class XMLState(object):
         self.xml_data.set_repository([
             repo for repo in all_repos if repo not in used_for_build
         ])
-
-    def translate_obs_to_ibs_repositories(self):
-        """
-        Change obs repotype to ibs type
-
-        This will result in pointing to build.suse.de instead of
-        build.opensuse.org
-        """
-        for repository in self.get_repository_sections():
-            source_path = repository.get_source()
-            source_uri = urlparse(source_path.get_path())
-            if source_uri.scheme == 'obs':
-                source_path.set_path(
-                    source_path.get_path().replace('obs:', 'ibs:')
-                )
-
-    def translate_obs_to_suse_repositories(self):
-        """
-        Change obs: repotype to suse: type
-
-        This will result in a local repo path suitable for a
-        buildservice worker instance
-        """
-        for repository in self.get_repository_sections_used_for_build():
-            source_path = repository.get_source()
-            source_uri = urlparse(source_path.get_path())
-            if source_uri.scheme == 'obs':
-                source_path.set_path(
-                    source_path.get_path().replace('obs:', 'suse:')
-                )
-
-    def translate_obs_to_suse_derived_from_image_uri(self):
-        """
-        Change obs: repotype to suse: type
-
-        This will result in a local base image path, which is needed
-        by RootImport.
-        """
-        uri_obj = self.get_derived_from_image_uri()
-        if uri_obj:
-            uri = uri_obj.uri
-            if urlparse(uri).scheme == 'obs':
-                self.set_derived_from_image_uri(uri.replace('obs:', 'suse:'))
 
     def set_repository(
         self, repo_source, repo_type, repo_alias, repo_prio,

--- a/test/data/.config/kiwi/config.yml
+++ b/test/data/.config/kiwi/config.yml
@@ -1,2 +1,6 @@
 xz:
   - options: -a -b xxx
+
+obs:
+  - download_url: http://example.com
+  - public: true

--- a/test/unit/builder_container_test.py
+++ b/test/unit/builder_container_test.py
@@ -16,7 +16,8 @@ class TestContainerBuilder(object):
     def setup(self, mock_exists, mock_machine):
         mock_exists.return_value = True
         mock_machine.return_value = 'x86_64'
-        self.uri = Uri('file:///image_file.tar.xz')
+        with patch.dict('os.environ', {'HOME': '../data'}):
+            self.uri = Uri('file:///image_file.tar.xz')
         self.xml_state = mock.Mock()
         self.xml_state.get_derived_from_image_uri.return_value = self.uri
         self.container_config = {

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -39,7 +39,6 @@ class TestCli(object):
             '--help': False,
             '--ignore-repos': False,
             '--clear-cache': False,
-            '--obs-repo-internal': False,
             '--root': 'directory',
             '--set-repo': None,
             '--add-package': [],

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -19,8 +19,8 @@ class TestRuntimeChecker(object):
         self.runtime_checker = RuntimeChecker(self.xml_state)
 
     @raises(KiwiRuntimeError)
-    def test_check_image_include_repos_http_resolvable(self):
-        self.runtime_checker.check_image_include_repos_http_resolvable()
+    def test_check_image_include_repos_publicly_resolvable(self):
+        self.runtime_checker.check_image_include_repos_publicly_resolvable()
 
     @raises(KiwiRuntimeError)
     def test_invalid_target_dir_pointing_to_shared_cache_1(self):

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -4,6 +4,7 @@ from .test_helper import raises
 
 from kiwi.runtime_config import RuntimeConfig
 from kiwi.exceptions import KiwiRuntimeConfigFormatError
+from kiwi.defaults import Defaults
 
 
 class TestRuntimeConfig(object):
@@ -12,9 +13,27 @@ class TestRuntimeConfig(object):
             self.runtime_config = RuntimeConfig()
 
     @raises(KiwiRuntimeConfigFormatError)
-    def test_get_xz_options_invalid_yaml_format(self):
-        self.runtime_config.config_data = {'xz': 'invalid'}
+    def test_invalid_yaml_format(self):
+        self.runtime_config.config_data = {'xz': None}
         self.runtime_config.get_xz_options()
 
     def test_get_xz_options(self):
         assert self.runtime_config.get_xz_options() == ['-a', '-b', 'xxx']
+
+    def test_is_obs_public(self):
+        assert self.runtime_config.is_obs_public() is True
+
+    def test_is_obs_public_default(self):
+        with patch.dict('os.environ', {'HOME': './'}):
+            runtime_config = RuntimeConfig()
+            assert runtime_config.is_obs_public() is True
+
+    def test_get_obs_download_server_url(self):
+        assert self.runtime_config.get_obs_download_server_url() == \
+            'http://example.com'
+
+    def test_get_obs_download_server_url_default(self):
+        with patch.dict('os.environ', {'HOME': './'}):
+            runtime_config = RuntimeConfig()
+            assert runtime_config.get_obs_download_server_url() == \
+                Defaults.get_obs_download_server_url()

--- a/test/unit/system_root_import_base_test.py
+++ b/test/unit/system_root_import_base_test.py
@@ -1,4 +1,4 @@
-from mock import patch
+from mock import patch, call
 
 from .test_helper import raises
 
@@ -11,8 +11,12 @@ class TestRootImportBase(object):
     @patch('os.path.exists')
     def test_init(self, mock_path):
         mock_path.return_value = True
-        RootImportBase('root_dir', Uri('file:///image.tar.xz'))
-        mock_path.assert_called_once_with('/image.tar.xz')
+        with patch.dict('os.environ', {'HOME': '../data'}):
+            RootImportBase('root_dir', Uri('file:///image.tar.xz'))
+        assert mock_path.call_args_list == [
+            call('../data/.config/kiwi/config.yml'),
+            call('/image.tar.xz')
+        ]
 
     @raises(KiwiRootImportError)
     def test_init_remote_uri(self):
@@ -28,12 +32,16 @@ class TestRootImportBase(object):
     @raises(KiwiRootImportError)
     def test_init_non_existing(self, mock_path):
         mock_path.return_value = False
-        RootImportBase('root_dir', Uri('file:///image.tar.xz'))
+        with patch.dict('os.environ', {'HOME': '../data'}):
+            RootImportBase('root_dir', Uri('file:///image.tar.xz'))
         mock_path.assert_called_once_with('/image.tar.xz')
 
     @raises(NotImplementedError)
     @patch('os.path.exists')
     def test_data_sync(self, mock_path):
         mock_path.return_value = True
-        root_import = RootImportBase('root_dir', Uri('file:///image.tar.xz'))
+        with patch.dict('os.environ', {'HOME': '../data'}):
+            root_import = RootImportBase(
+                'root_dir', Uri('file:///image.tar.xz')
+            )
         root_import.sync_data()

--- a/test/unit/system_root_import_docker_test.py
+++ b/test/unit/system_root_import_docker_test.py
@@ -25,9 +25,10 @@ class TestRootImportDocker(object):
 
         mock_mkdtemp.side_effect = call_mkdtemp
 
-        docker_import = RootImportDocker(
-            'root_dir', Uri('file:///image.tar.xz')
-        )
+        with patch.dict('os.environ', {'HOME': '../data'}):
+            docker_import = RootImportDocker(
+                'root_dir', Uri('file:///image.tar.xz')
+            )
         docker_import.extract_oci_image()
         mock_compress.assert_called_once_with('/image.tar.xz')
         uncompress.uncompress.assert_called_once_with(True)
@@ -51,9 +52,10 @@ class TestRootImportDocker(object):
 
         mock_mkdtemp.side_effect = call_mkdtemp
 
-        docker_import = RootImportDocker(
-            'root_dir', Uri('docker://opensuse')
-        )
+        with patch.dict('os.environ', {'HOME': '../data'}):
+            docker_import = RootImportDocker(
+                'root_dir', Uri('docker://opensuse')
+            )
         docker_import.extract_oci_image()
         mock_run.assert_called_once_with([
             'skopeo', 'copy', 'docker://opensuse',

--- a/test/unit/system_root_import_oci_test.py
+++ b/test/unit/system_root_import_oci_test.py
@@ -20,9 +20,10 @@ class TestRootImportOCI(object):
             return tmpdirs.pop()
 
         mock_mkdtemp.side_effect = call_mkdtemp
-        self.oci_import = RootImportOCI(
-            'root_dir', Uri('file:///image.tar.xz#tag')
-        )
+        with patch.dict('os.environ', {'HOME': '../data'}):
+            self.oci_import = RootImportOCI(
+                'root_dir', Uri('file:///image.tar.xz#tag')
+            )
         assert self.oci_import.image_file == '/image.tar.xz'
 
     @patch('os.path.exists')
@@ -103,9 +104,10 @@ class TestRootImportOCI(object):
             return tmpdirs.pop()
 
         mock_mkdtemp.side_effect = call_mkdtemp
-        oci_import = RootImportOCI(
-            'root_dir', Uri('file:///image.tar.xz')
-        )
+        with patch.dict('os.environ', {'HOME': '../data'}):
+            oci_import = RootImportOCI(
+                'root_dir', Uri('file:///image.tar.xz')
+            )
         oci_import.extract_oci_image()
         mock_run.assert_called_once_with([
             'skopeo', 'copy', 'oci:kiwi_uncompressed',

--- a/test/unit/system_setup_test.py
+++ b/test/unit/system_setup_test.py
@@ -712,20 +712,26 @@ class TestSystemSetup(object):
         )
 
     @patch('kiwi.system.setup.Repository')
-    def test_import_repositories_marked_as_imageinclude(self, mock_repo):
+    @patch('kiwi.system.setup.Uri')
+    def test_import_repositories_marked_as_imageinclude(
+        self, mock_uri, mock_repo
+    ):
+        uri = mock.Mock()
+        mock_uri.return_value = uri
+        uri.translate = mock.Mock(
+            return_value="uri"
+        )
+        uri.alias = mock.Mock(
+            return_value="uri-alias"
+        )
+        uri.credentials_file_name = mock.Mock(
+            return_value='kiwiRepoCredentials'
+        )
+        mock_uri.return_value = uri
         repo = mock.Mock()
         mock_repo.return_value = repo
         self.setup_with_real_xml.import_repositories_marked_as_imageinclude()
         assert repo.add_repo.call_args_list[0] == call(
-            '95811799a6d1889c5b2363d3886986de',
-            'http://download.opensuse.org/repositories/Devel:PubCloud:AmazonEC2/SLE_12_GA',
-            'rpm-md',
-            None,
-            None,
-            None,
-            None,
-            None,
-            'kiwiRepoCredentials',
-            None,
-            None
+            'uri-alias', 'uri', 'rpm-md', None, None, None, None, None,
+            'kiwiRepoCredentials', None, None
         )

--- a/test/unit/system_uri_test.py
+++ b/test/unit/system_uri_test.py
@@ -19,35 +19,67 @@ class TestUri(object):
     def setup_class(self):
         self.mock_mkdtemp = mock.Mock()
         self.mock_manager = mock.Mock()
+        self.runtime_config = mock.Mock()
+        self.runtime_config.get_obs_download_server_url = mock.Mock(
+            return_value='http://download.opensuse.org'
+        )
 
     @raises(KiwiUriStyleUnknown)
     def test_is_remote_raises_style_error(self):
         uri = Uri('xxx', 'rpm-md')
+        uri.runtime_config = self.runtime_config
         uri.is_remote()
 
     @raises(KiwiUriTypeUnknown)
     def test_is_remote_raises_type_error(self):
         uri = Uri('xtp://download.example.com', 'rpm-md')
+        uri.runtime_config = self.runtime_config
         uri.is_remote()
 
     @raises(KiwiUriStyleUnknown)
     def test_translate_unknown_style(self):
         uri = Uri('xxx', 'rpm-md')
+        uri.runtime_config = self.runtime_config
         uri.translate()
 
     @raises(KiwiUriStyleUnknown)
     def test_translate_unsupported_style(self):
         uri = Uri('ms://foo', 'rpm-md')
+        uri.runtime_config = self.runtime_config
+        uri.translate()
+
+    @raises(KiwiUriStyleUnknown)
+    @patch('kiwi.system.uri.Defaults.is_buildservice_worker')
+    def test_translate_obsrepositories_outside_buildservice(
+        self, mock_buildservice
+    ):
+        mock_buildservice.return_value = False
+        uri = Uri('obsrepositories:/')
+        uri.runtime_config = self.runtime_config
         uri.translate()
 
     def test_is_remote(self):
         uri = Uri('https://example.com', 'rpm-md')
+        uri.runtime_config = self.runtime_config
         assert uri.is_remote() is True
         uri = Uri('dir:///path/to/repo', 'rpm-md')
+        uri.runtime_config = self.runtime_config
         assert uri.is_remote() is False
+
+    def test_is_public(self):
+        uri = Uri('https://example.com', 'rpm-md')
+        uri.runtime_config = self.runtime_config
+        assert uri.is_public() is True
+        uri = Uri('obs://13.2/repo/oss', 'yast2')
+        self.runtime_config.is_obs_public = mock.Mock(
+            return_value=False
+        )
+        uri.runtime_config = self.runtime_config
+        assert uri.is_public() is False
 
     def test_alias(self):
         uri = Uri('https://example.com', 'rpm-md')
+        uri.runtime_config = self.runtime_config
         assert uri.alias() == hashlib.md5(
             'https://example.com'.encode()).hexdigest(
         )
@@ -57,6 +89,7 @@ class TestUri(object):
             'http://example.com/foo?credentials=my_credentials&x=2',
             'rpm-md'
         )
+        uri.runtime_config = self.runtime_config
         assert uri.credentials_file_name() == 'my_credentials'
 
     def test_credentials_default_file_name(self):
@@ -64,6 +97,7 @@ class TestUri(object):
             'http://example.com/foo',
             'rpm-md'
         )
+        uri.runtime_config = self.runtime_config
         assert uri.credentials_file_name() == 'kiwiRepoCredentials'
 
     def test_translate_http_path_with_credentials(self):
@@ -71,42 +105,45 @@ class TestUri(object):
             'http://example.com/foo?credentials=kiwiRepoCredentials',
             'rpm-md'
         )
+        uri.runtime_config = self.runtime_config
         assert uri.translate() == 'http://example.com/foo'
-
-    def test_translate_ibs_project(self):
-        uri = Uri('ibs://Devel:PubCloud/SLE_12_GA', 'rpm-md')
-        assert uri.translate() == \
-            'http://download.suse.de/ibs/Devel:/PubCloud/SLE_12_GA'
 
     def test_translate_obs_distro(self):
         uri = Uri('obs://13.2/repo/oss', 'yast2')
+        uri.runtime_config = self.runtime_config
         assert uri.translate() == \
             'http://download.opensuse.org/distribution/13.2/repo/oss'
 
     def test_translate_obs_factory_distro(self):
         uri = Uri('obs://openSUSE:Factory/standard', 'yast2')
+        uri.runtime_config = self.runtime_config
         assert uri.translate() == \
             'http://download.opensuse.org/tumbleweed/repo/oss'
 
     def test_translate_obs_project(self):
         uri = Uri('obs://Virt:Appliances/SLE_12', 'rpm-md')
+        uri.runtime_config = self.runtime_config
         assert uri.translate() == \
             'http://download.opensuse.org/repositories/Virt:Appliances/SLE_12'
 
     def test_translate_dir_path(self):
         uri = Uri('dir:///some/path', 'rpm-md')
+        uri.runtime_config = self.runtime_config
         assert uri.translate() == '/some/path'
 
     def test_translate_http_path(self):
         uri = Uri('http://example.com/foo', 'rpm-md')
+        uri.runtime_config = self.runtime_config
         assert uri.translate() == 'http://example.com/foo'
 
     def test_translate_https_path(self):
         uri = Uri('https://example.com/foo', 'rpm-md')
+        uri.runtime_config = self.runtime_config
         assert uri.translate() == 'https://example.com/foo'
 
     def test_translate_ftp_path(self):
         uri = Uri('ftp://example.com/foo', 'rpm-md')
+        uri.runtime_config = self.runtime_config
         assert uri.translate() == 'ftp://example.com/foo'
 
     @patch('kiwi.system.uri.MountManager')
@@ -117,6 +154,7 @@ class TestUri(object):
         manager.mountpoint = mock_mkdtemp.return_value
         mock_manager.return_value = manager
         uri = Uri('iso:///image/CDs/openSUSE-13.2-DVD-x86_64.iso', 'yast2')
+        uri.runtime_config = self.runtime_config
         result = uri.translate()
         mock_manager.assert_called_once_with(
             device='/image/CDs/openSUSE-13.2-DVD-x86_64.iso',
@@ -126,20 +164,46 @@ class TestUri(object):
         assert result == 'tmpdir'
         uri.mount_stack = []
 
-    def test_translate_suse_buildservice_path(self):
-        uri = Uri('suse://openSUSE:13.2/standard', 'yast2')
+    @patch('kiwi.system.uri.Defaults.is_buildservice_worker')
+    def test_translate_buildservice_path(self, mock_buildservice):
+        mock_buildservice.return_value = True
+        uri = Uri('obs://openSUSE:13.2/standard', 'yast2')
+        uri.runtime_config = self.runtime_config
         assert uri.translate() == \
             '/usr/src/packages/SOURCES/repos/openSUSE:13.2/standard'
 
-    def test_translate_suse_buildservice_container_path(self):
-        uri = Uri('suse://project/repo/container#latest', 'container')
+    @patch('kiwi.system.uri.Defaults.is_buildservice_worker')
+    def test_translate_buildservice_project(self, mock_buildservice):
+        mock_buildservice.return_value = True
+        uri = Uri('obs://Virt:Appliances/SLE_12', 'rpm-md')
+        uri.runtime_config = self.runtime_config
+        assert uri.translate() == \
+            '/usr/src/packages/SOURCES/repos/Virt:Appliances/SLE_12'
+
+    @patch('kiwi.system.uri.Defaults.is_buildservice_worker')
+    def test_translate_buildservice_container_path(self, mock_buildservice):
+        mock_buildservice.return_value = True
+        uri = Uri('obs://project/repo/container#latest', 'container')
+        uri.runtime_config = self.runtime_config
         assert uri.translate() == \
             '/usr/src/packages/SOURCES/containers/project/repo/container#latest'
 
-    def test_translate_buildservice_obsrepositories_container_path(self):
+    @patch('kiwi.system.uri.Defaults.is_buildservice_worker')
+    def test_translate_buildservice_obsrepositories_container_path(
+        self, mock_buildservice
+    ):
+        mock_buildservice.return_value = True
         uri = Uri('obsrepositories:/container#latest', 'container')
+        uri.runtime_config = self.runtime_config
         assert uri.translate() == \
             '/usr/src/packages/SOURCES/containers/_obsrepositories/container#latest'
+
+    @patch('kiwi.system.uri.Defaults.is_buildservice_worker')
+    def test_translate_buildservice_obsrepositories(self, mock_buildservice):
+        mock_buildservice.return_value = True
+        uri = Uri('obsrepositories:/')
+        uri.runtime_config = self.runtime_config
+        assert uri.translate() == '/usr/src/packages/SOURCES/repos'
 
     @patch('kiwi.system.uri.MountManager')
     @patch('kiwi.system.uri.mkdtemp')
@@ -153,6 +217,7 @@ class TestUri(object):
         )
         mock_manager.return_value = manager
         uri = Uri('iso:///image/CDs/openSUSE-13.2-DVD-x86_64.iso', 'yast2')
+        uri.runtime_config = self.runtime_config
         uri.translate()
         uri.__del__()
         manager.umount.assert_called_once_with()

--- a/test/unit/tasks_image_info_test.py
+++ b/test/unit/tasks_image_info_test.py
@@ -83,7 +83,6 @@ class TestImageInfoTask(object):
         self.task.command_args['info'] = False
         self.task.command_args['--description'] = '../data/description'
         self.task.command_args['--add-repo'] = []
-        self.task.command_args['--obs-repo-internal'] = False
         self.task.command_args['--ignore-repos'] = False
         self.task.command_args['--resolve-package-list'] = False
 
@@ -135,14 +134,6 @@ class TestImageInfoTask(object):
         mock_state.assert_called_once_with(
             'http://example.com', 'yast2', 'alias', None
         )
-
-    @patch('kiwi.xml_state.XMLState.translate_obs_to_ibs_repositories')
-    @patch('kiwi.tasks.image_info.DataOutput')
-    def test_process_image_info_use_ibs_repos(self, mock_out, mock_state):
-        self._init_command_args()
-        self.task.command_args['--obs-repo-internal'] = True
-        self.task.process()
-        mock_state.assert_called_once_with()
 
     @patch('kiwi.xml_state.XMLState.delete_repository_sections_used_for_build')
     @patch('kiwi.tasks.image_info.DataOutput')

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -78,7 +78,6 @@ class TestSystemBuildTask(object):
         self.task.command_args['--allow-existing-root'] = True
         self.task.command_args['--description'] = '../data/description'
         self.task.command_args['--target-dir'] = 'some-target'
-        self.task.command_args['--obs-repo-internal'] = None
         self.task.command_args['--set-repo'] = None
         self.task.command_args['--add-repo'] = []
         self.task.command_args['--add-package'] = []
@@ -95,7 +94,7 @@ class TestSystemBuildTask(object):
         self.task.command_args['build'] = True
         self.task.process()
         self.runtime_checker.check_docker_tool_chain_installed.assert_called_once_with()
-        self.runtime_checker.check_image_include_repos_http_resolvable.assert_called_once_with()
+        self.runtime_checker.check_image_include_repos_publicly_resolvable.assert_called_once_with()
         self.runtime_checker.check_target_directory_not_in_shared_cache.assert_called_once_with(self.abs_target_dir)
         self.runtime_checker.check_repositories_configured.assert_called_once_with()
         self.system_prepare.setup_repositories.assert_called_once_with(False, None)
@@ -197,27 +196,6 @@ class TestSystemBuildTask(object):
         mock_add_repo.assert_called_once_with(
             'http://example.com', 'yast2', 'alias', '99', False
         )
-
-    @patch('kiwi.logger.Logger.set_logfile')
-    @patch('kiwi.xml_state.XMLState.translate_obs_to_ibs_repositories')
-    def test_process_system_prepare_use_ibs_repos(
-        self, mock_ibs_repo, mock_log
-    ):
-        self._init_command_args()
-        self.task.command_args['--obs-repo-internal'] = True
-        self.task.process()
-        mock_ibs_repo.assert_called_once_with()
-
-    @patch('kiwi.logger.Logger.set_logfile')
-    @patch('kiwi.xml_state.XMLState.translate_obs_to_suse_repositories')
-    @patch('os.path.exists')
-    def test_process_system_prepare_use_suse_repos(
-        self, mock_exists, mock_suse_repos, mock_log
-    ):
-        self._init_command_args()
-        mock_exists.return_value = True
-        self.task.process()
-        mock_suse_repos.assert_called_once_with()
 
     def test_process_system_build_help(self):
         self._init_command_args()

--- a/test/unit/tasks_system_prepare_test.py
+++ b/test/unit/tasks_system_prepare_test.py
@@ -70,7 +70,6 @@ class TestSystemPrepareTask(object):
         self.task.command_args['--allow-existing-root'] = False
         self.task.command_args['--set-repo'] = None
         self.task.command_args['--add-repo'] = []
-        self.task.command_args['--obs-repo-internal'] = False
         self.task.command_args['--add-package'] = []
         self.task.command_args['--delete-package'] = []
         self.task.command_args['--ignore-repos'] = False
@@ -85,7 +84,7 @@ class TestSystemPrepareTask(object):
         self.task.command_args['--clear-cache'] = True
         self.task.process()
         self.runtime_checker.check_docker_tool_chain_installed.assert_called_once_with()
-        self.runtime_checker.check_image_include_repos_http_resolvable.assert_called_once_with()
+        self.runtime_checker.check_image_include_repos_publicly_resolvable.assert_called_once_with()
         self.runtime_checker.check_target_directory_not_in_shared_cache.assert_called_once_with(
             self.abs_root_dir
         )
@@ -175,23 +174,6 @@ class TestSystemPrepareTask(object):
         mock_state.assert_called_once_with(
             'http://example.com', 'yast2', 'alias', '99', True
         )
-
-    @patch('kiwi.xml_state.XMLState.translate_obs_to_ibs_repositories')
-    def test_process_system_prepare_use_ibs_repos(self, mock_state):
-        self._init_command_args()
-        self.task.command_args['--obs-repo-internal'] = True
-        self.task.process()
-        mock_state.assert_called_once_with()
-
-    @patch('kiwi.xml_state.XMLState.translate_obs_to_suse_repositories')
-    @patch('os.path.exists')
-    def test_process_system_prepare_use_suse_repos(
-        self, mock_exists, mock_suse_repos
-    ):
-        self._init_command_args()
-        mock_exists.return_value = True
-        self.task.process()
-        mock_suse_repos.assert_called_once_with()
 
     def test_process_system_prepare_help(self):
         self._init_command_args()

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -143,26 +143,6 @@ class TestXMLState(object):
     def test_get_bootstrap_collection_type(self):
         assert self.state.get_bootstrap_collection_type() == 'onlyRequired'
 
-    def test_translate_obs_to_ibs_repositories(self):
-        self.state.translate_obs_to_ibs_repositories()
-        source_path = self.state.xml_data.get_repository()[1].get_source()
-        assert source_path.get_path() == \
-            'ibs://Devel:PubCloud:AmazonEC2/SLE_12_GA'
-
-    def test_translate_obs_to_suse_repositories(self):
-        self.state.translate_obs_to_suse_repositories()
-        source_path = self.state.xml_data.get_repository()[1].get_source()
-        assert source_path.get_path() == \
-            'suse://Devel:PubCloud:AmazonEC2/SLE_12_GA'
-
-    def test_translate_obs_to_suse_derived_from_image_uri(self):
-        description = XMLDescription('../data/example_config.xml')
-        xml_data = description.load()
-        state = XMLState(xml_data, ['derivedContainer'], 'docker')
-        state.translate_obs_to_suse_derived_from_image_uri()
-        assert state.get_derived_from_image_uri().uri == \
-            'suse://project/repo/image#mytag'
-
     def test_set_repository(self):
         self.state.set_repository('repo', 'type', 'alias', 1, True)
         assert self.state.xml_data.get_repository()[0].get_source().get_path() \


### PR DESCRIPTION
* Delete kiwi internal ibs: and suse: types
* Delete handling for --obs-repo-internal and provide a
  compatibility message to the user
* Buildservice download server url and scope can be configured
  via ~/.config/kiwi/config.yml
* Translate obs urls to http in import_repositories_marked_as_imageinclude
* Use new Uri.is_public method in renamed runtime check
  check_image_include_repos_publicly_resolvable

