### PR TITLE
Move man pages to correct section

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,12 +27,12 @@ install:
 	# see setup.py for details when this target is called
 	${MAKE} -C tools buildroot=${buildroot} install
 	# manual pages
-	install -d -m 755 ${buildroot}usr/share/man/man2
-	for man in doc/build/man/*.2; do \
+	install -d -m 755 ${buildroot}usr/share/man/man8
+	for man in doc/build/man/*.8; do \
 		test -e $$man && gzip -f $$man || true ;\
 	done
-	for man in doc/build/man/*.2.gz; do \
-		install -m 644 $$man ${buildroot}usr/share/man/man2 ;\
+	for man in doc/build/man/*.8.gz; do \
+		install -m 644 $$man ${buildroot}usr/share/man/man8 ;\
 	done
 	# completion
 	install -d -m 755 ${buildroot}etc/bash_completion.d

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -185,63 +185,63 @@ man_pages = [
         kiwi_doc,
         'kiwi', u'Creating Operating System Images',
         [author],
-        2
+        8
     ),
     (
         result_list_doc,
         'kiwi::result::list',
         u'List build results',
         [author],
-        2
+        8
     ),
     (
         result_bundle_doc,
         'kiwi::result::bundle',
         u'Bundle build results',
         [author],
-        2
+        8
     ),
     (
         system_prepare_doc,
         'kiwi::system::prepare',
         u'Prepare image root system',
         [author],
-        2
+        8
     ),
     (
         system_create_doc,
         'kiwi::system::create',
         u'Create image from prepared root system',
         [author],
-        2
+        8
     ),
     (
         system_update_doc,
         'kiwi::system::update',
         u'Update/Upgrade image root system',
         [author],
-        2
+        8
     ),
     (
         system_build_doc,
         'kiwi::system::build',
         u'Build image in combined prepare and create step',
         [author],
-        2
+        8
     ),
     (
         image_resize_doc,
         'kiwi::image::resize',
         u'Resize disk images to new geometry',
         [author],
-        2
+        8
     ),
     (
         image_info_doc,
         'kiwi::image::info',
         u'Provide detailed information about an image description',
         [author],
-        2
+        8
     )
 ]
 

--- a/kiwi/help.py
+++ b/kiwi/help.py
@@ -33,7 +33,7 @@ class Help(object):
         """
         Call man to show the command specific manual page
 
-        All kiwi commands store their manual page in the section '2'
+        All kiwi commands store their manual page in the section '8'
         of the man system. The calling process is replaced by the
         man process
         """

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -399,7 +399,7 @@ fi
 %dir %{_defaultdocdir}/python-kiwi
 %{_defaultdocdir}/python-kiwi/LICENSE
 %{_defaultdocdir}/python-kiwi/README
-%doc %{_mandir}/man2/*
+%doc %{_mandir}/man8/*
 
 %files -n kiwi-tools
 %defattr(-, root, root)


### PR DESCRIPTION
The man pages were incorrectly written to section 2, which is for syscalls. Since KIWI is an administrator's tool, it has been moved to section 8.

Changes proposed in this pull request:
* Move man pages from section 2 to section 8
