### PR TITLE
Fixed Uri is_remote method

### DIFF
--- a/kiwi/system/uri.py
+++ b/kiwi/system/uri.py
@@ -196,13 +196,18 @@ class Uri(object):
 
         :rtype: bool
         """
-        if self.is_remote():
-            uri = urlparse(self.uri)
-            if uri.scheme == 'obs' and not self.runtime_config.is_obs_public():
-                return False
-            else:
-                return True
+        uri = urlparse(self.uri)
+        if not uri.scheme:
+            # unknown uri schema is considered not public
+            return False
+        elif uri.scheme == 'obs':
+            # obs is public but only if the configured download_server is public
+            return self.runtime_config.is_obs_public()
+        elif uri.scheme in self.remote_uri_types:
+            # listed in remote uri types, thus public
+            return True
         else:
+            # unknown uri type considered not public
             return False
 
     def get_fragment(self):

--- a/kiwi/system/uri.py
+++ b/kiwi/system/uri.py
@@ -179,15 +179,16 @@ class Uri(object):
             raise KiwiUriStyleUnknown(
                 'URI scheme not detected %s' % self.uri
             )
-        if uri.scheme in self.remote_uri_types:
+        if uri.scheme == 'obs' and Defaults.is_buildservice_worker():
+            return False
+        elif uri.scheme in self.remote_uri_types:
             return True
+        elif uri.scheme in self.local_uri_type:
+            return False
         else:
-            if uri.scheme in self.local_uri_type:
-                return False
-            else:
-                raise KiwiUriTypeUnknown(
-                    'URI type %s unknown' % uri.scheme
-                )
+            raise KiwiUriTypeUnknown(
+                'URI type %s unknown' % uri.scheme
+            )
 
     def is_public(self):
         """

--- a/test/unit/system_root_import_base_test.py
+++ b/test/unit/system_root_import_base_test.py
@@ -9,7 +9,9 @@ from kiwi.exceptions import KiwiRootImportError
 
 class TestRootImportBase(object):
     @patch('os.path.exists')
-    def test_init(self, mock_path):
+    @patch('kiwi.system.uri.Defaults.is_buildservice_worker')
+    def test_init(self, mock_buildservice, mock_path):
+        mock_buildservice.return_value = False
         mock_path.return_value = True
         with patch.dict('os.environ', {'HOME': '../data'}):
             RootImportBase('root_dir', Uri('file:///image.tar.xz'))

--- a/test/unit/system_root_import_docker_test.py
+++ b/test/unit/system_root_import_docker_test.py
@@ -11,9 +11,12 @@ class TestRootImportDocker(object):
     @patch('kiwi.command.Command.run')
     @patch('kiwi.system.root_import.docker.Compress')
     @patch('kiwi.system.root_import.oci.mkdtemp')
+    @patch('kiwi.system.uri.Defaults.is_buildservice_worker')
     def test_extract_oci_image(
-        self, mock_mkdtemp, mock_compress, mock_run, mock_exists
+        self, mock_buildservice, mock_mkdtemp, mock_compress,
+        mock_run, mock_exists
     ):
+        mock_buildservice.return_value = False
         mock_exists.return_value = True
         uncompress = mock.Mock()
         uncompress.uncompressed_filename = 'tmp_uncompressed'
@@ -41,9 +44,11 @@ class TestRootImportDocker(object):
     @patch('kiwi.command.Command.run')
     @patch('kiwi.system.root_import.oci.mkdtemp')
     @patch('kiwi.system.root_import.base.log.warning')
+    @patch('kiwi.system.uri.Defaults.is_buildservice_worker')
     def test_extract_oci_image_unknown_uri(
-        self, mock_warn, mock_mkdtemp, mock_run, mock_exists
+        self, mock_buildservice, mock_warn, mock_mkdtemp, mock_run, mock_exists
     ):
+        mock_buildservice.return_value = False
         mock_exists.return_value = True
         tmpdirs = ['kiwi_unpack_dir', 'kiwi_layout_dir']
 

--- a/test/unit/system_uri_test.py
+++ b/test/unit/system_uri_test.py
@@ -77,6 +77,8 @@ class TestUri(object):
 
     @patch('kiwi.system.uri.requests')
     def test_is_public(self, mock_request):
+        uri = Uri('xxx', 'rpm-md')
+        assert uri.is_public() is False
         uri = Uri('https://example.com', 'rpm-md')
         assert uri.is_public() is True
         uri = Uri('obs://openSUSE:Leap:42.2/standard', 'yast2')

--- a/test/unit/system_uri_test.py
+++ b/test/unit/system_uri_test.py
@@ -67,6 +67,14 @@ class TestUri(object):
         uri = Uri('dir:///path/to/repo', 'rpm-md')
         assert uri.is_remote() is False
 
+    @patch('kiwi.system.uri.Defaults.is_buildservice_worker')
+    def test_is_remote_in_buildservice(
+        self, mock_buildservice
+    ):
+        mock_buildservice.return_value = True
+        uri = Uri('obs://openSUSE:Leap:42.2/standard', 'yast2')
+        assert uri.is_remote() is False
+
     @patch('kiwi.system.uri.requests')
     def test_is_public(self, mock_request):
         uri = Uri('https://example.com', 'rpm-md')


### PR DESCRIPTION
If called inside of the buildservice the obs uri type is not
a remote uri because the translation ends in a local path


