### PR TITLE
Fix url validation in buildservice

### DIFF
--- a/kiwi/system/uri.py
+++ b/kiwi/system/uri.py
@@ -26,6 +26,7 @@ from kiwi.mount_manager import MountManager
 from kiwi.path import Path
 from kiwi.defaults import Defaults
 from kiwi.runtime_config import RuntimeConfig
+from kiwi.logger import log
 
 from kiwi.exceptions import (
     KiwiUriStyleUnknown,
@@ -247,12 +248,12 @@ class Uri(object):
                 request = requests.get(download_link)
                 request.raise_for_status()
                 return request.url
-            elif self.runtime_config.is_obs_public():
+            else:
+                log.warning(
+                    'Using {0} without location verification due to build '
+                    'in isolated environment'.format(download_link)
+                )
                 return download_link
-            raise KiwiUriOpenError(
-                'build service is not public, download link'
-                'cannot be verified'
-            )
         except Exception as e:
             raise KiwiUriOpenError(
                 '{0}: {1}'.format(type(e).__name__, format(e))

--- a/kiwi/system/uri.py
+++ b/kiwi/system/uri.py
@@ -243,9 +243,16 @@ class Uri(object):
                     project.replace(':', ':/'), repository
                 ]
             )
-            request = requests.get(download_link)
-            request.raise_for_status()
-            return request.url
+            if not Defaults.is_buildservice_worker():
+                request = requests.get(download_link)
+                request.raise_for_status()
+                return request.url
+            elif self.runtime_config.is_obs_public():
+                return download_link
+            raise KiwiUriOpenError(
+                'build service is not public, download link'
+                'cannot be verified'
+            )
         except Exception as e:
             raise KiwiUriOpenError(
                 '{0}: {1}'.format(type(e).__name__, format(e))

--- a/test/unit/system_uri_test.py
+++ b/test/unit/system_uri_test.py
@@ -61,6 +61,27 @@ class TestUri(object):
         uri.runtime_config = self.runtime_config
         assert uri.translate()
 
+    @raises(KiwiUriOpenError)
+    @patch('kiwi.system.uri.Defaults.is_buildservice_worker')
+    def test_translate_obs_uri_in_private_buildservice(
+            mock_buildservice, self
+    ):
+        mock_buildservice.return_value = True
+        self.runtime_config.is_obs_public = mock.Mock(
+            return_value=False
+        )
+        uri = Uri('obs://openSUSE:Leap:42.2/standard', 'rpm-md')
+        uri.runtime_config = self.runtime_config
+        uri.translate(False)
+
+    @patch('kiwi.system.uri.Defaults.is_buildservice_worker')
+    def test_translate_obs_uri_inside_buildservice(self, mock_buildservice):
+        mock_buildservice.return_value = True
+        uri = Uri('obs://openSUSE:Leap:42.2/standard', 'rpm-md')
+        uri.runtime_config = self.runtime_config
+        assert uri.translate(False) == \
+            'obs_server/openSUSE:/Leap:/42.2/standard'
+
     def test_is_remote(self):
         uri = Uri('https://example.com', 'rpm-md')
         assert uri.is_remote() is True

--- a/test/unit/system_uri_test.py
+++ b/test/unit/system_uri_test.py
@@ -70,6 +70,9 @@ class TestUri(object):
         self.runtime_config.is_obs_public = mock.Mock(
             return_value=False
         )
+        self.runtime_config.get_obs_download_server_url = mock.Mock(
+            return_value='obs_server'
+        )
         uri = Uri('obs://openSUSE:Leap:42.2/standard', 'rpm-md')
         uri.runtime_config = self.runtime_config
         uri.translate(False)

--- a/test/unit/system_uri_test.py
+++ b/test/unit/system_uri_test.py
@@ -61,29 +61,17 @@ class TestUri(object):
         uri.runtime_config = self.runtime_config
         assert uri.translate()
 
-    @raises(KiwiUriOpenError)
+    @patch('kiwi.logger.log.warning')
     @patch('kiwi.system.uri.Defaults.is_buildservice_worker')
-    def test_translate_obs_uri_in_private_buildservice(
-            mock_buildservice, self
+    def test_translate_obs_uri_inside_buildservice(
+            self, mock_buildservice, mock_warn
     ):
-        mock_buildservice.return_value = True
-        self.runtime_config.is_obs_public = mock.Mock(
-            return_value=False
-        )
-        self.runtime_config.get_obs_download_server_url = mock.Mock(
-            return_value='obs_server'
-        )
-        uri = Uri('obs://openSUSE:Leap:42.2/standard', 'rpm-md')
-        uri.runtime_config = self.runtime_config
-        uri.translate(False)
-
-    @patch('kiwi.system.uri.Defaults.is_buildservice_worker')
-    def test_translate_obs_uri_inside_buildservice(self, mock_buildservice):
         mock_buildservice.return_value = True
         uri = Uri('obs://openSUSE:Leap:42.2/standard', 'rpm-md')
         uri.runtime_config = self.runtime_config
         assert uri.translate(False) == \
             'obs_server/openSUSE:/Leap:/42.2/standard'
+        assert mock_warn.called
 
     def test_is_remote(self):
         uri = Uri('https://example.com', 'rpm-md')


### PR DESCRIPTION
This patch changes the remote URL validation strategy when running
inside the build service. By design, inside the build service build
environment connections to the outside world are not allowed, thus
any validation attempting to do that will fail. With this patch, when
running inside the build service, KIWI will not try to test if any
download URL is reachable.

Fixes #418
