### PR TITLE
Cleanup use of python interpreter invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 buildroot = /
 python_version = 3
+python_lookup_name = python
+python = $(shell which $(python_lookup_name))
 
 LC = LC_MESSAGES
 
 version := $(shell \
-    python -c 'from kiwi.version import __version__; print(__version__)'\
+    $(python) -c \
+    'from kiwi.version import __version__; print(__version__)'\
 )
 
 .PHONY: test
@@ -124,7 +127,7 @@ build: clean po tox sdist_prepare
 	# managed in the spec file
 	sed -ie "s@>=[0-9.]*'@'@g" setup.py
 	# build the sdist source tarball
-	python setup.py sdist
+	$(python) setup.py sdist
 	# cleanup sdist_prepare actions
 	rm -f boot_arch.tgz && \
 		rmdir kiwi/boot/arch && mv boot_arch kiwi/boot/arch
@@ -146,7 +149,7 @@ build: clean po tox sdist_prepare
 	helper/kiwi-boot-packages > dist/python-kiwi-boot-packages
 
 pypi: clean po tox sdist_prepare
-	python setup.py sdist upload
+	$(python) setup.py sdist upload
 	rm -f boot_arch.tgz && \
 		rmdir kiwi/boot/arch && mv boot_arch kiwi/boot/arch
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ python_version = 3
 LC = LC_MESSAGES
 
 version := $(shell \
-    python3 -c 'from kiwi.version import __version__; print(__version__)'\
+    python -c 'from kiwi.version import __version__; print(__version__)'\
 )
 
 .PHONY: test
@@ -124,7 +124,7 @@ build: clean po tox sdist_prepare
 	# managed in the spec file
 	sed -ie "s@>=[0-9.]*'@'@g" setup.py
 	# build the sdist source tarball
-	python3 setup.py sdist
+	python setup.py sdist
 	# cleanup sdist_prepare actions
 	rm -f boot_arch.tgz && \
 		rmdir kiwi/boot/arch && mv boot_arch kiwi/boot/arch
@@ -146,7 +146,7 @@ build: clean po tox sdist_prepare
 	helper/kiwi-boot-packages > dist/python-kiwi-boot-packages
 
 pypi: clean po tox sdist_prepare
-	python3 setup.py sdist upload
+	python setup.py sdist upload
 	rm -f boot_arch.tgz && \
 		rmdir kiwi/boot/arch && mv boot_arch kiwi/boot/arch
 

--- a/helper/completion_generator
+++ b/helper/completion_generator
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/python
 
 from textwrap import dedent
 

--- a/helper/kiwi-boot-packages
+++ b/helper/kiwi-boot-packages
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/python
 
 import os
 import sys

--- a/helper/kiwi-boot-packages
+++ b/helper/kiwi-boot-packages
@@ -14,9 +14,10 @@ def get_boot_description_packages_for_arch(boot_description_dir, arch):
         package_type = packages.attributes['type'].value
         if not package_type == 'delete':
             for package in packages.getElementsByTagName('package'):
-                for_arch = None
-                if 'arch' in package.attributes:
+                try:
                     for_arch = package.attributes['arch'].value
+                except KeyError:
+                    for_arch = None
                 if for_arch:
                     if for_arch == arch:
                         package_list.append(

--- a/helper/schema_parser.py
+++ b/helper/schema_parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """
 Usage: schema_parser.py SCHEMA [--output=ARG]
 


### PR DESCRIPTION
Prevent strict call of a specific version of the python
interpreter. All code has been written to work with py2
and py3 thus the venv environment setup should decide
what version a call of python is. Fixes #424

