### PR TITLE
Allow use of more fine grain ignore repos options

### DIFF
--- a/doc/source/commands/image_info.rst
+++ b/doc/source/commands/image_info.rst
@@ -42,7 +42,11 @@ OPTIONS
 
 --ignore-repos
 
-  Ignore all repos from the XML configuration.
+  Ignore all repository configurations from the XML description.
+  Using that option is usally done with a sequence of --add-repo
+  options otherwise there are no repositories available for the
+  processing the requested image information which could lead
+  to an error.
 
 --resolve-package-list
 

--- a/doc/source/commands/system_build.rst
+++ b/doc/source/commands/system_build.rst
@@ -13,6 +13,7 @@ SYNOPSIS
        [--allow-existing-root]
        [--clear-cache]
        [--ignore-repos]
+       [--ignore-repos-used-for-build]
        [--set-repo=<source,type,alias,priority,imageinclude>]
        [--add-repo=<source,type,alias,priority,imageinclude>...]
        [--add-package=<name>...]
@@ -63,14 +64,6 @@ OPTIONS
   is shared between multiple image builds on that host for performance
   reasons.
 
---signing-key=<key-file>
-
-  set the key file to be trusted and imported into the package
-  manager database before performing any opertaion. This is useful
-  if an image build should take and validate repository and package
-  signatures during build time. This option can be specified multiple
-  times
-
 --delete-package=<name>
 
   specify package to delete. The option can be specified
@@ -80,6 +73,19 @@ OPTIONS
 
   Path to the XML description. This is a directory containing at least
   one _config.xml_ or _*.kiwi_ XML file.
+
+--ignore-repos
+
+  Ignore all repository configurations from the XML description.
+  Using that option is usally done with a sequence of --add-repo
+  options otherwise there are no repositories available for the
+  image build which would lead to an error.
+
+--ignore-repos-used-for-build
+
+  Works the same way as --ignore-repos except that repository
+  configurations which has the imageonly attribute set to true
+  will not be ignored.
 
 --set-repo=<source,type,alias,priority,imageinclude>
 
@@ -114,6 +120,14 @@ OPTIONS
 
     Set to either **true** or **false** to specify if this repository
     should be part of the system image repository setup or not
+
+--signing-key=<key-file>
+
+  set the key file to be trusted and imported into the package
+  manager database before performing any opertaion. This is useful
+  if an image build should take and validate repository and package
+  signatures during build time. This option can be specified multiple
+  times
 
 --target-dir=<directory>
 

--- a/doc/source/commands/system_prepare.rst
+++ b/doc/source/commands/system_prepare.rst
@@ -13,6 +13,7 @@ SYNOPSIS
        [--allow-existing-root]
        [--clear-cache]
        [--ignore-repos]
+       [--ignore-repos-used-for-build]
        [--set-repo=<source,type,alias,priority,imageinclude>]
        [--add-repo=<source,type,alias,priority,imageinclude>...]
        [--add-package=<name>...]
@@ -59,14 +60,6 @@ OPTIONS
   is shared between multiple image builds on that host for performance
   reasons.
 
---signing-key=<key-file>
-
-  set the key file to be trusted and imported into the package
-  manager database before performing any opertaion. This is useful
-  if an image build should take and validate repository and package
-  signatures during build time. This option can be specified multiple
-  times
-
 --delete-package=<name>
 
   specify package to delete. The option can be specified
@@ -77,6 +70,19 @@ OPTIONS
   Path to the kiwi XML description. Inside of that directory there
   must be at least a config.xml of \*.kiwi XML description.
 
+--ignore-repos
+
+  Ignore all repository configurations from the XML description.
+  Using that option is usally done with a sequence of --add-repo
+  options otherwise there are no repositories available for the
+  image build which would lead to an error.
+
+--ignore-repos-used-for-build
+
+  Works the same way as --ignore-repos except that repository
+  configurations which has the imageonly attribute set to true
+  will not be ignored.
+
 --root=<directory>
 
   Path to create the new root system.
@@ -84,3 +90,11 @@ OPTIONS
 --set-repo=<source,type,alias,priority,imageinclude>
 
   See the kiwi::system::build manual page for further details
+
+--signing-key=<key-file>
+
+  set the key file to be trusted and imported into the package
+  manager database before performing any opertaion. This is useful
+  if an image build should take and validate repository and package
+  signatures during build time. This option can be specified multiple
+  times.

--- a/kiwi/tasks/image_info.py
+++ b/kiwi/tasks/image_info.py
@@ -71,7 +71,7 @@ class ImageInfoTask(CliTask):
         )
 
         if self.command_args['--ignore-repos']:
-            self.xml_state.delete_repository_sections_used_for_build()
+            self.xml_state.delete_repository_sections()
 
         if self.command_args['--add-repo']:
             for add_repo in self.command_args['--add-repo']:

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -21,6 +21,7 @@ usage: kiwi system build -h | --help
            [--allow-existing-root]
            [--clear-cache]
            [--ignore-repos]
+           [--ignore-repos-used-for-build]
            [--set-repo=<source,type,alias,priority,imageinclude>]
            [--add-repo=<source,type,alias,priority,imageinclude>...]
            [--add-package=<name>...]
@@ -60,6 +61,9 @@ options:
         description and optional metadata files
     --ignore-repos
         ignore all repos from the XML configuration
+    --ignore-repos-used-for-build
+        ignore all repos from the XML configuration except the
+        ones marked as imageonly
     --set-container-derived-from=<uri>
         overwrite the source location of the base container
         for the selected image type. The setting is only effective
@@ -138,6 +142,8 @@ class SystemBuildTask(CliTask):
         )
 
         if self.command_args['--ignore-repos']:
+            self.xml_state.delete_repository_sections()
+        elif self.command_args['--ignore-repos-used-for-build']:
             self.xml_state.delete_repository_sections_used_for_build()
 
         if self.command_args['--set-repo']:

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -21,6 +21,7 @@ usage: kiwi system prepare -h | --help
            [--allow-existing-root]
            [--clear-cache]
            [--ignore-repos]
+           [--ignore-repos-used-for-build]
            [--set-repo=<source,type,alias,priority,imageinclude>]
            [--add-repo=<source,type,alias,priority,imageinclude>...]
            [--add-package=<name>...]
@@ -58,6 +59,9 @@ options:
         description and optional metadata files
     --ignore-repos
         ignore all repos from the XML configuration
+    --ignore-repos-used-for-build
+        ignore all repos from the XML configuration except the
+        ones marked as imageonly
     --root=<directory>
         the path to the new root directory of the system
     --set-container-derived-from=<uri>
@@ -124,6 +128,8 @@ class SystemPrepareTask(CliTask):
         )
 
         if self.command_args['--ignore-repos']:
+            self.xml_state.delete_repository_sections()
+        elif self.command_args['--ignore-repos-used-for-build']:
             self.xml_state.delete_repository_sections_used_for_build()
 
         if self.command_args['--set-repo']:

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -38,6 +38,7 @@ class TestCli(object):
             '--description': 'description',
             '--help': False,
             '--ignore-repos': False,
+            '--ignore-repos-used-for-build': False,
             '--clear-cache': False,
             '--root': 'directory',
             '--set-repo': None,

--- a/test/unit/tasks_image_info_test.py
+++ b/test/unit/tasks_image_info_test.py
@@ -135,7 +135,7 @@ class TestImageInfoTask(object):
             'http://example.com', 'yast2', 'alias', None
         )
 
-    @patch('kiwi.xml_state.XMLState.delete_repository_sections_used_for_build')
+    @patch('kiwi.xml_state.XMLState.delete_repository_sections')
     @patch('kiwi.tasks.image_info.DataOutput')
     def test_process_image_info_delete_repos(self, mock_out, mock_delete_repos):
         self._init_command_args()

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -83,6 +83,7 @@ class TestSystemBuildTask(object):
         self.task.command_args['--add-package'] = []
         self.task.command_args['--delete-package'] = []
         self.task.command_args['--ignore-repos'] = False
+        self.task.command_args['--ignore-repos-used-for-build'] = False
         self.task.command_args['--set-container-derived-from'] = None
         self.task.command_args['--set-container-tag'] = None
         self.task.command_args['--clear-cache'] = False
@@ -206,12 +207,22 @@ class TestSystemBuildTask(object):
             'kiwi::system::build'
         )
 
-    @patch('kiwi.xml_state.XMLState.delete_repository_sections_used_for_build')
+    @patch('kiwi.xml_state.XMLState.delete_repository_sections')
     @patch('kiwi.logger.Logger.set_logfile')
     def test_process_system_prepare_ignore_repos(
         self, mock_log, mock_delete_repos
     ):
         self._init_command_args()
         self.task.command_args['--ignore-repos'] = True
+        self.task.process()
+        mock_delete_repos.assert_called_once_with()
+
+    @patch('kiwi.xml_state.XMLState.delete_repository_sections_used_for_build')
+    @patch('kiwi.logger.Logger.set_logfile')
+    def test_process_system_prepare_ignore_repos_used_for_build(
+        self, mock_log, mock_delete_repos
+    ):
+        self._init_command_args()
+        self.task.command_args['--ignore-repos-used-for-build'] = True
         self.task.process()
         mock_delete_repos.assert_called_once_with()

--- a/test/unit/tasks_system_prepare_test.py
+++ b/test/unit/tasks_system_prepare_test.py
@@ -73,6 +73,7 @@ class TestSystemPrepareTask(object):
         self.task.command_args['--add-package'] = []
         self.task.command_args['--delete-package'] = []
         self.task.command_args['--ignore-repos'] = False
+        self.task.command_args['--ignore-repos-used-for-build'] = False
         self.task.command_args['--clear-cache'] = False
         self.task.command_args['--set-container-derived-from'] = None
         self.task.command_args['--set-container-tag'] = None
@@ -184,9 +185,18 @@ class TestSystemPrepareTask(object):
             'kiwi::system::prepare'
         )
 
-    @patch('kiwi.xml_state.XMLState.delete_repository_sections_used_for_build')
+    @patch('kiwi.xml_state.XMLState.delete_repository_sections')
     def test_process_system_prepare_delete_repos(self, mock_delete_repos):
         self._init_command_args()
         self.task.command_args['--ignore-repos'] = True
+        self.task.process()
+        mock_delete_repos.assert_called_once_with()
+
+    @patch('kiwi.xml_state.XMLState.delete_repository_sections_used_for_build')
+    def test_process_system_prepare_delete_repos_used_for_build(
+        self, mock_delete_repos
+    ):
+        self._init_command_args()
+        self.task.command_args['--ignore-repos-used-for-build'] = True
         self.task.process()
         mock_delete_repos.assert_called_once_with()


### PR DESCRIPTION
The meaning of the --ignore-repos option has changed back
to ignore all configured repositories. A new option
named --ignore-repos-used-for-build has been added which
allows to ignore all except imageonly repositories. The
command manual pages has been changed to document the
options. This Fixes #410

