### PR TITLE
More comfort in calling with compat arguments

### DIFF
--- a/doc/source/commands/kiwi.rst
+++ b/doc/source/commands/kiwi.rst
@@ -25,7 +25,7 @@ SYNOPSIS
         [--debug]
         [--color-output]
        system <command> [<args>...]
-   kiwi --compat <legacy_args>...
+   kiwi compat <legacy_args>...
    kiwi -v | --version
    kiwi help
 
@@ -76,10 +76,6 @@ GLOBAL OPTIONS
   those escape characters. Error messages appear red, warning
   messages yellow and debugging information will be printed light
   grey.
-
---compat
-
-  Support legacy kiwi commandline, see COMPATIBILITY section for details.
 
 --debug
 
@@ -163,6 +159,6 @@ to use a legacy KIWI commandline as follows:
 
 .. code-block:: bash
 
-   $ kiwi --compat -- \
+   $ kiwi compat \
        --build kiwi-descriptions/suse/x86_64/suse-leap-42.1-JeOS \
        --type vmx -d /tmp/myimage

--- a/kiwi/kiwi_compat.py
+++ b/kiwi/kiwi_compat.py
@@ -47,6 +47,9 @@ import logging
 from docopt import docopt
 from docopt import DocoptExit
 
+# project
+from .path import Path
+
 
 class Cli(object):
     """
@@ -210,7 +213,15 @@ class Translate(object):
 class Command(object):
     @classmethod
     def execute(self, arguments):
-        os.execvp('kiwi-ng', ['kiwi'] + arguments)
+        os.execvp(Command.lookup_kiwi(), ['kiwi'] + arguments)
+
+    @classmethod
+    def lookup_kiwi(self):
+        for kiwi_name in ['kiwi-ng-3', 'kiwi-ng-2']:
+            kiwi = Path.which(kiwi_name, access_mode=os.X_OK)
+            if kiwi:
+                return kiwi
+        raise OSError('kiwi not found')
 
 
 def main():

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -7,6 +7,7 @@ from .test_helper import argv_kiwi_tests, raises
 from kiwi.cli import Cli
 from kiwi.exceptions import (
     KiwiCompatError,
+    KiwiCommandNotFound,
     KiwiLoadCommandUndefined,
     KiwiCommandNotLoaded,
     KiwiUnknownServiceName
@@ -18,6 +19,7 @@ class TestCli(object):
         self.help_global_args = {
             'help': False,
             '--compat': False,
+            'compat': False,
             '--type': None,
             'image': False,
             'system': True,
@@ -68,10 +70,21 @@ class TestCli(object):
         cli = Cli()
         assert cli.get_servicename() == 'system'
 
-    def test_get_servicename_compat(self):
+    def test_get_servicename_compat_as_option(self):
         sys.argv = [
             sys.argv[0],
             '--compat', '--',
+            '--build', 'description',
+            '--type', 'vmx',
+            '-d', 'destination'
+        ]
+        cli = Cli()
+        assert cli.get_servicename() == 'compat'
+
+    def test_get_servicename_compat_as_service(self):
+        sys.argv = [
+            sys.argv[0],
+            'compat',
             '--build', 'description',
             '--type', 'vmx',
             '-d', 'destination'
@@ -127,11 +140,17 @@ class TestCli(object):
         )
 
     @raises(KiwiCompatError)
-    @patch('os.path.exists')
+    @patch('kiwi.cli.Path.which')
     @patch('os.execvp')
-    def test_invoke_kiwicompat_exec_failed(self, mock_exec, mock_exists):
-        mock_exists.return_value = True
+    def test_invoke_kiwicompat_exec_failed(self, mock_exec, mock_which):
+        mock_which.return_value = 'kiwicompat'
         mock_exec.side_effect = Exception
+        self.cli.invoke_kiwicompat([])
+
+    @raises(KiwiCommandNotFound)
+    @patch('kiwi.cli.Path.which')
+    def test_invoke_kiwicompat_not_found(self, mock_which):
+        mock_which.return_value = None
         self.cli.invoke_kiwicompat([])
 
     @raises(SystemExit)

--- a/test/unit/kiwi_compat_test.py
+++ b/test/unit/kiwi_compat_test.py
@@ -20,20 +20,41 @@ class TestKiwiCompat(object):
         assert mock_log_error.called
 
     @patch('os.execvp')
+    @patch('kiwi.kiwi_compat.Path.which')
     @patch('logging.error')
-    def test_compat_mode_exec_failed(self, mock_log_error, mock_exec):
+    def test_compat_mode_exec_failed(self, mock_log_error, mock_which, mock_exec):
+        mock_which.return_value = 'kiwi-ng'
         sys.argv = [
             'kiwicompat',
             '--create', 'root_dir',
             '--type', 'vmx',
             '-d', 'destination'
         ]
-        mock_exec.side_effect = OSError
+        mock_exec.side_effect = OSError('exec failed')
         kiwi.kiwi_compat.main()
-        assert mock_log_error.called
+        mock_log_error.assert_called_once_with(
+            'KiwiCompatError: %s', 'exec failed'
+        )
+
+    @patch('kiwi.kiwi_compat.Path.which')
+    @patch('logging.error')
+    def test_compat_mode_kiwi_not_found(self, mock_log_error, mock_which):
+        mock_which.return_value = None
+        sys.argv = [
+            'kiwicompat',
+            '--create', 'root_dir',
+            '--type', 'vmx',
+            '-d', 'destination'
+        ]
+        kiwi.kiwi_compat.main()
+        mock_log_error.assert_called_once_with(
+            'KiwiCompatError: %s', 'kiwi not found'
+        )
 
     @patch('os.execvp')
-    def test_version_compat_mode(self, mock_exec):
+    @patch('kiwi.path.Path.which')
+    def test_version_compat_mode(self, mock_which, mock_exec):
+        mock_which.return_value = 'kiwi-ng'
         sys.argv = [
             'kiwicompat', '--version'
         ]
@@ -43,7 +64,9 @@ class TestKiwiCompat(object):
         )
 
     @patch('os.execvp')
-    def test_build_compat_mode(self, mock_exec):
+    @patch('kiwi.kiwi_compat.Path.which')
+    def test_build_compat_mode(self, mock_which, mock_exec):
+        mock_which.return_value = 'kiwi-ng'
         sys.argv = [
             'kiwicompat',
             '--build', 'description',
@@ -82,7 +105,9 @@ class TestKiwiCompat(object):
         )
 
     @patch('os.execvp')
-    def test_create_compat_mode(self, mock_exec):
+    @patch('kiwi.path.Path.which')
+    def test_create_compat_mode(self, mock_which, mock_exec):
+        mock_which.return_value = 'kiwi-ng'
         sys.argv = [
             'kiwicompat',
             '--create', 'root_dir',
@@ -101,7 +126,9 @@ class TestKiwiCompat(object):
         )
 
     @patch('os.execvp')
-    def test_prepare_compat_mode(self, mock_exec):
+    @patch('kiwi.path.Path.which')
+    def test_prepare_compat_mode(self, mock_which, mock_exec):
+        mock_which.return_value = 'kiwi-ng'
         sys.argv = [
             'kiwicompat',
             '--prepare', 'description',
@@ -134,7 +161,9 @@ class TestKiwiCompat(object):
         )
 
     @patch('os.execvp')
-    def test_upgrade_compat_mode(self, mock_exec):
+    @patch('kiwi.path.Path.which')
+    def test_upgrade_compat_mode(self, mock_which, mock_exec):
+        mock_which.return_value = 'kiwi-ng'
         sys.argv = [
             'kiwicompat',
             '--upgrade', 'root_dir',


### PR DESCRIPTION
In addition to the 'kiwi --compat -- ...' style we also support calling
the kiwi compat mode as a service via 'kiwi compat ...' The preferred
way of calling kiwi with legacy options is via the new compat service.
Thus the documentation also changed to no longer mention the --compat
option but it still exists for compatibility reasons. Fixes #407

