### PR TITLE
Exclude kiwi files from images

### DIFF
--- a/kiwi/builder/archive.py
+++ b/kiwi/builder/archive.py
@@ -85,7 +85,8 @@ class ArchiveBuilder(object):
                 self._target_file_for('tar')
             )
             archive.create_xz_compressed(
-                self.root_dir, xz_options=self.xz_options
+                self.root_dir, xz_options=self.xz_options,
+                exclude=Defaults.get_exclude_list_for_root_data_sync()
             )
             checksum = Checksum(self.filename)
             log.info('--> Creating archive checksum')

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -526,10 +526,7 @@ class DiskBuilder(object):
             return True
 
     def _get_exclude_list_for_root_data_sync(self, device_map):
-        exclude_list = [
-            'image', '.profile', '.kconfig',
-            Defaults.get_shared_cache_location()
-        ]
+        exclude_list = Defaults.get_exclude_list_for_root_data_sync()
         if 'boot' in device_map and self.bootloader == 'grub2_s390x_emu':
             exclude_list.append('boot/zipl/*')
             exclude_list.append('boot/zipl/.*')

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -163,7 +163,10 @@ class LiveImageBuilder(object):
                 root_dir=self.root_dir,
                 custom_args=self.filesystem_custom_parameters
             )
-            live_type_image.create_on_file(self.live_image_file)
+            live_type_image.create_on_file(
+                self.live_image_file,
+                exclude=Defaults.get_exclude_list_for_root_data_sync()
+            )
             Command.run(
                 ['mv', self.live_image_file, self.media_dir]
             )

--- a/kiwi/container/oci.py
+++ b/kiwi/container/oci.py
@@ -117,10 +117,11 @@ class ContainerImageOCI(object):
 
         :param string base_image: archive used as a base image
         """
-        exclude_list = [
-            'image', '.profile', '.kconfig', 'boot', 'dev', 'sys', 'proc',
-            Defaults.get_shared_cache_location()
-        ]
+        exclude_list = Defaults.get_exclude_list_for_root_data_sync()
+        exclude_list.append('boot')
+        exclude_list.append('dev')
+        exclude_list.append('sys')
+        exclude_list.append('proc')
 
         self.oci_dir = mkdtemp(prefix='kiwi_oci_dir.')
         self.oci_root_dir = mkdtemp(prefix='kiwi_oci_root_dir.')

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -73,7 +73,9 @@ class Defaults(object):
     def is_buildservice_worker(self):
         # the presence of /.buildenv on the build host indicates
         # we are building inside of the open buildservice
-        return os.path.exists('/.buildenv')
+        return os.path.exists(
+            os.sep + Defaults.get_buildservice_env_name()
+        )
 
     @classmethod
     def get_buildservice_env_name(self):
@@ -127,6 +129,20 @@ class Defaults(object):
         return os.path.abspath(os.path.normpath(
             Cli().get_global_args().get('--shared-cache-dir')
         )).lstrip(os.sep)
+
+    @classmethod
+    def get_exclude_list_for_root_data_sync(self):
+        """
+        Returns the list of files or folders that are created
+        by KIWI for its own purposes. Those files should be not
+        be included in the resulting image.
+        """
+        exclude_list = [
+            'image', '.profile', '.kconfig',
+            Defaults.get_buildservice_env_name(),
+            Defaults.get_shared_cache_location()
+        ]
+        return exclude_list
 
     @classmethod
     def get_failsafe_kernel_options(self):

--- a/test/unit/builder_archive_test.py
+++ b/test/unit/builder_archive_test.py
@@ -62,7 +62,9 @@ class TestArchiveBuilder(object):
             'target_dir/myimage.x86_64-1.2.3.tar'
         )
         archive.create_xz_compressed.assert_called_once_with(
-            'root_dir', xz_options=None
+            'root_dir', exclude=[
+                'image', '.profile', '.kconfig', '.buildenv', 'var/cache/kiwi'
+            ], xz_options=None
         )
         mock_checksum.assert_called_once_with(
             'target_dir/myimage.x86_64-1.2.3.tar.xz'

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -329,7 +329,7 @@ class TestDiskBuilder(object):
         call = filesystem.sync_data.call_args_list[2]
         assert filesystem.sync_data.call_args_list[2] == \
             call([
-                'image', '.profile', '.kconfig', 'var/cache/kiwi',
+                'image', '.profile', '.kconfig', '.buildenv', 'var/cache/kiwi',
                 'boot/*', 'boot/.*', 'boot/efi/*', 'boot/efi/.*'
             ])
         assert mock_open.call_args_list[0:3] == [
@@ -449,7 +449,7 @@ class TestDiskBuilder(object):
         call = filesystem.sync_data.call_args_list[2]
         assert filesystem.sync_data.call_args_list[2] == \
             call([
-                'image', '.profile', '.kconfig', 'var/cache/kiwi',
+                'image', '.profile', '.kconfig', '.buildenv', 'var/cache/kiwi',
                 'boot/*', 'boot/.*', 'boot/efi/*', 'boot/efi/.*'
             ])
         assert mock_open.call_args_list == [
@@ -547,7 +547,7 @@ class TestDiskBuilder(object):
         assert squashfs.create_on_file.call_args_list == [
             call(exclude=['var/cache/kiwi'], filename='tempname'),
             call(exclude=[
-                'image', '.profile', '.kconfig', 'var/cache/kiwi',
+                'image', '.profile', '.kconfig', '.buildenv', 'var/cache/kiwi',
                 'boot/*', 'boot/.*', 'boot/efi/*', 'boot/efi/.*'
             ], filename='tempname')
         ]
@@ -708,7 +708,7 @@ class TestDiskBuilder(object):
         volume_manager.mount_volumes.call_args_list[0].assert_called_once_with()
         volume_manager.get_fstab.assert_called_once_with(None, 'btrfs')
         volume_manager.sync_data.assert_called_once_with([
-            'image', '.profile', '.kconfig', 'var/cache/kiwi',
+            'image', '.profile', '.kconfig', '.buildenv', 'var/cache/kiwi',
             'boot/*', 'boot/.*', 'boot/efi/*', 'boot/efi/.*'
         ])
         volume_manager.umount_volumes.call_args_list[0].assert_called_once_with()

--- a/test/unit/builder_live_test.py
+++ b/test/unit/builder_live_test.py
@@ -152,7 +152,10 @@ class TestLiveImageBuilder(object):
             device_provider=None, name='squashfs', root_dir='root_dir'
         )
         live_type_image.create_on_file.assert_called_once_with(
-            'target_dir/result-image-read-only.x86_64-1.2.3'
+            'target_dir/result-image-read-only.x86_64-1.2.3',
+            exclude=[
+                'image', '.profile', '.kconfig', '.buildenv', 'var/cache/kiwi'
+            ]
         )
         assert mock_command.call_args_list[0] == call(
             [
@@ -160,9 +163,9 @@ class TestLiveImageBuilder(object):
                 'temp_media_dir'
             ]
         )
-        mock_open.assert_called_once_with(
+        assert call(
             'temp_media_dir/config.isoclient', 'w'
-        )
+        ) in mock_open.call_args_list
         assert file_mock.write.call_args_list == [
             call('IMAGE="loop;result-image.x86_64;1.2.3"\n'),
             call('UNIONFS_CONFIG="tmpfs,loop,overlay"\n')

--- a/test/unit/container_image_oci_test.py
+++ b/test/unit/container_image_oci_test.py
@@ -130,8 +130,8 @@ class TestContainerImageOCI(object):
         )
         oci_root.sync_data.assert_called_once_with(
             exclude=[
-                'image', '.profile', '.kconfig', 'boot', 'dev', 'sys', 'proc',
-                'var/cache/kiwi'
+                'image', '.profile', '.kconfig', '.buildenv',
+                'var/cache/kiwi', 'boot', 'dev', 'sys', 'proc',
             ],
             options=['-a', '-H', '-X', '-A', '--delete']
         )
@@ -195,8 +195,8 @@ class TestContainerImageOCI(object):
         )
         oci_root.sync_data.assert_called_once_with(
             exclude=[
-                'image', '.profile', '.kconfig', 'boot', 'dev', 'sys', 'proc',
-                'var/cache/kiwi'
+                'image', '.profile', '.kconfig', '.buildenv',
+                'var/cache/kiwi', 'boot', 'dev', 'sys', 'proc'
             ],
             options=['-a', '-H', '-X', '-A', '--delete']
         )


### PR DESCRIPTION
This commit from one hand includes a
get_exclude_list_for_root_data_sync method in Defaults which returns
a list of the files used by KIWI that should not be part of the
resulting image. From the other hand makes use of the exclusion
default list in live, archive and container images, it fixes #423.
