### PR TITLE
Include default container name

### DIFF
--- a/kiwi/container/oci.py
+++ b/kiwi/container/oci.py
@@ -25,6 +25,7 @@ from kiwi.path import Path
 from kiwi.command import Command
 from kiwi.utils.sync import DataSync
 from kiwi.archive.tar import ArchiveTar
+from kiwi.logger import log
 
 
 class ContainerImageOCI(object):
@@ -57,7 +58,7 @@ class ContainerImageOCI(object):
         self.oci_root_dir = None
 
         self.xz_options = None
-        self.container_name = ''
+        self.container_name = 'kiwi-container'
         self.container_tag = 'latest'
         self.entry_command = []
         self.entry_subcommand = []
@@ -105,6 +106,12 @@ class ContainerImageOCI(object):
 
             if 'xz_options' in custom_args:
                 self.xz_options = custom_args['xz_options']
+
+        if not custom_args or 'container_name' not in custom_args:
+            log.info(
+                'No container configuration provided, '
+                'using default container name "kiwi-container:latest"'
+            )
 
         if not self.entry_command and not self.entry_subcommand:
             self.entry_subcommand = ['--config.cmd=/bin/bash']

--- a/test/unit/container_image_oci_test.py
+++ b/test/unit/container_image_oci_test.py
@@ -63,6 +63,11 @@ class TestContainerImageOCI(object):
         assert container.labels == custom_args['labels']
         assert container.xz_options == custom_args['xz_options']
 
+    def test_init_without_custom_args(self):
+        container = ContainerImageOCI('root_dir')
+        assert container.container_name == 'kiwi-container'
+        assert container.container_tag == 'latest'
+
     @patch('kiwi.container.oci.Path.wipe')
     def test_del(self, mock_wipe):
         self.oci.oci_dir = 'dir_a'


### PR DESCRIPTION
This commit includes a default container name for KIWI container
images. This makes possible to create OCI and Docker containers
without forcing the user to include a `<contaierconfig>` section in
the description file.