### PR TITLE
Refactor xen build

### DIFF
--- a/kiwi/boot/arch/arm/oemboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/arm/oemboot/suse-SLES12/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-oemboot-suse-SLES12">
+<image schemaversion="6.6" name="initrd-oemboot-suse-SLES12">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/arm/oemboot/suse-SLES15/config.xml
+++ b/kiwi/boot/arch/arm/oemboot/suse-SLES15/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-oemboot-suse-SLE15">
+<image schemaversion="6.6" name="initrd-oemboot-suse-SLE15">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/arm/oemboot/suse-leap42.1/config.xml
+++ b/kiwi/boot/arch/arm/oemboot/suse-leap42.1/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-oemboot-suse-leap-42.1">
+<image schemaversion="6.6" name="initrd-oemboot-suse-leap-42.1">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/arm/oemboot/suse-leap42.2/config.xml
+++ b/kiwi/boot/arch/arm/oemboot/suse-leap42.2/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-oemboot-suse-leap-42.2">
+<image schemaversion="6.6" name="initrd-oemboot-suse-leap-42.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/arm/oemboot/suse-leap42.3/config.xml
+++ b/kiwi/boot/arch/arm/oemboot/suse-leap42.3/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-oemboot-suse-leap-42.3">
+<image schemaversion="6.6" name="initrd-oemboot-suse-leap-42.3">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/arm/oemboot/suse-tumbleweed/config.xml
+++ b/kiwi/boot/arch/arm/oemboot/suse-tumbleweed/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-oemboot-suse-tumbleweed">
+<image schemaversion="6.6" name="initrd-oemboot-suse-tumbleweed">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/arm/vmxboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/arm/vmxboot/suse-SLES12/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-vmxboot-suse-SLES12">
+<image schemaversion="6.6" name="initrd-vmxboot-suse-SLES12">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/arm/vmxboot/suse-SLES15/config.xml
+++ b/kiwi/boot/arch/arm/vmxboot/suse-SLES15/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-vmxboot-suse-SLE15">
+<image schemaversion="6.6" name="initrd-vmxboot-suse-SLE15">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/arm/vmxboot/suse-leap42.1/config.xml
+++ b/kiwi/boot/arch/arm/vmxboot/suse-leap42.1/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-vmxboot-suse-leap-42.1">
+<image schemaversion="6.6" name="initrd-vmxboot-suse-leap-42.1">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/arm/vmxboot/suse-leap42.2/config.xml
+++ b/kiwi/boot/arch/arm/vmxboot/suse-leap42.2/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-vmxboot-suse-leap-42.2">
+<image schemaversion="6.6" name="initrd-vmxboot-suse-leap-42.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/arm/vmxboot/suse-leap42.3/config.xml
+++ b/kiwi/boot/arch/arm/vmxboot/suse-leap42.3/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-vmxboot-suse-leap-42.3">
+<image schemaversion="6.6" name="initrd-vmxboot-suse-leap-42.3">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/arm/vmxboot/suse-tumbleweed/config.xml
+++ b/kiwi/boot/arch/arm/vmxboot/suse-tumbleweed/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-vmxboot-suse-tumbleweed">
+<image schemaversion="6.6" name="initrd-vmxboot-suse-tumbleweed">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/ppc/netboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/ppc/netboot/suse-SLES12/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-netboot-suse-SLES12">
+<image schemaversion="6.6" name="initrd-netboot-suse-SLES12">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/ppc/oemboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/ppc/oemboot/suse-SLES12/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-oemboot-suse-SLES12">
+<image schemaversion="6.6" name="initrd-oemboot-suse-SLES12">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/ppc/vmxboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/ppc/vmxboot/suse-SLES12/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-vmxboot-suse-SLES12">
+<image schemaversion="6.6" name="initrd-vmxboot-suse-SLES12">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/s390/netboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/s390/netboot/suse-SLES12/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-netboot-suse-SLES12">
+<image schemaversion="6.6" name="initrd-netboot-suse-SLES12">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/s390/netboot/suse-tumbleweed/config.xml
+++ b/kiwi/boot/arch/s390/netboot/suse-tumbleweed/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-netboot-suse-tumbleweed">
+<image schemaversion="6.6" name="initrd-netboot-suse-tumbleweed">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/s390/oemboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/s390/oemboot/suse-SLES12/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-oemboot-suse-SLES12">
+<image schemaversion="6.6" name="initrd-oemboot-suse-SLES12">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/s390/oemboot/suse-tumbleweed/config.xml
+++ b/kiwi/boot/arch/s390/oemboot/suse-tumbleweed/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-oemboot-suse-tumbleweed">
+<image schemaversion="6.6" name="initrd-oemboot-suse-tumbleweed">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/s390/vmxboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/s390/vmxboot/suse-SLES12/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-vmxboot-suse-SLES12">
+<image schemaversion="6.6" name="initrd-vmxboot-suse-SLES12">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/s390/vmxboot/suse-tumbleweed/config.xml
+++ b/kiwi/boot/arch/s390/vmxboot/suse-tumbleweed/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-vmxboot-suse-tumbleweed">
+<image schemaversion="6.6" name="initrd-vmxboot-suse-tumbleweed">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/isoboot/fedora-25.0/config.xml
+++ b/kiwi/boot/arch/x86_64/isoboot/fedora-25.0/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-isoboot-fedora-25.0">
+<image schemaversion="6.6" name="initrd-isoboot-fedora-25.0">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/x86_64/isoboot/rhel-07.0/config.xml
+++ b/kiwi/boot/arch/x86_64/isoboot/rhel-07.0/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-isoboot-rhel-07.0">
+<image schemaversion="6.6" name="initrd-isoboot-rhel-07.0">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/x86_64/isoboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/x86_64/isoboot/suse-SLES12/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-isoboot-suse-SLES12">
+<image schemaversion="6.6" name="initrd-isoboot-suse-SLES12">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/x86_64/isoboot/suse-SLES15/config.xml
+++ b/kiwi/boot/arch/x86_64/isoboot/suse-SLES15/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-isoboot-suse-SLES15">
+<image schemaversion="6.6" name="initrd-isoboot-suse-SLES15">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/isoboot/suse-leap42.1/config.xml
+++ b/kiwi/boot/arch/x86_64/isoboot/suse-leap42.1/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-isoboot-suse-leap-42.1">
+<image schemaversion="6.6" name="initrd-isoboot-suse-leap-42.1">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/isoboot/suse-leap42.2/config.xml
+++ b/kiwi/boot/arch/x86_64/isoboot/suse-leap42.2/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-isoboot-suse-leap-42.2">
+<image schemaversion="6.6" name="initrd-isoboot-suse-leap-42.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/isoboot/suse-leap42.3/config.xml
+++ b/kiwi/boot/arch/x86_64/isoboot/suse-leap42.3/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-isoboot-suse-leap-42.3">
+<image schemaversion="6.6" name="initrd-isoboot-suse-leap-42.3">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/isoboot/suse-tumbleweed/config.xml
+++ b/kiwi/boot/arch/x86_64/isoboot/suse-tumbleweed/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-isoboot-suse-tumbleweed">
+<image schemaversion="6.6" name="initrd-isoboot-suse-tumbleweed">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/x86_64/isoboot/ubuntu-xenial/config.xml
+++ b/kiwi/boot/arch/x86_64/isoboot/ubuntu-xenial/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-isoboot-ubuntu-xenial">
+<image schemaversion="6.6" name="initrd-isoboot-ubuntu-xenial">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/netboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/x86_64/netboot/suse-SLES12/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-netboot-suse-SLES12">
+<image schemaversion="6.6" name="initrd-netboot-suse-SLES12">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/x86_64/netboot/suse-SLES15/config.xml
+++ b/kiwi/boot/arch/x86_64/netboot/suse-SLES15/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-netboot-suse-SLES15">
+<image schemaversion="6.6" name="initrd-netboot-suse-SLES15">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/netboot/suse-leap42.1/config.xml
+++ b/kiwi/boot/arch/x86_64/netboot/suse-leap42.1/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-netboot-suse-leap-42.1">
+<image schemaversion="6.6" name="initrd-netboot-suse-leap-42.1">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/netboot/suse-leap42.2/config.xml
+++ b/kiwi/boot/arch/x86_64/netboot/suse-leap42.2/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-netboot-suse-leap-42.2">
+<image schemaversion="6.6" name="initrd-netboot-suse-leap-42.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/netboot/suse-leap42.3/config.xml
+++ b/kiwi/boot/arch/x86_64/netboot/suse-leap42.3/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-netboot-suse-leap-42.3">
+<image schemaversion="6.6" name="initrd-netboot-suse-leap-42.3">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/netboot/suse-tumbleweed/config.xml
+++ b/kiwi/boot/arch/x86_64/netboot/suse-tumbleweed/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-netboot-suse-tumbleweed">
+<image schemaversion="6.6" name="initrd-netboot-suse-tumbleweed">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/x86_64/oemboot/rhel-07.0/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/rhel-07.0/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-oemboot-rhel-07.0">
+<image schemaversion="6.6" name="initrd-oemboot-rhel-07.0">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/oemboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-SLES12/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-oemboot-suse-SLES12">
+<image schemaversion="6.6" name="initrd-oemboot-suse-SLES12">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/x86_64/oemboot/suse-SLES15/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-SLES15/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-oemboot-suse-SLE15">
+<image schemaversion="6.6" name="initrd-oemboot-suse-SLE15">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/oemboot/suse-leap42.1/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-leap42.1/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-oemboot-suse-leap-42.1">
+<image schemaversion="6.6" name="initrd-oemboot-suse-leap-42.1">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/oemboot/suse-leap42.2/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-leap42.2/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-oemboot-suse-leap-42.2">
+<image schemaversion="6.6" name="initrd-oemboot-suse-leap-42.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/oemboot/suse-leap42.3/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-leap42.3/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-oemboot-suse-leap-42.3">
+<image schemaversion="6.6" name="initrd-oemboot-suse-leap-42.3">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/oemboot/suse-tumbleweed/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-tumbleweed/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-oemboot-suse-tumbleweed">
+<image schemaversion="6.6" name="initrd-oemboot-suse-tumbleweed">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/x86_64/oemboot/ubuntu-xenial/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/ubuntu-xenial/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-oemboot-ubuntu-xenial">
+<image schemaversion="6.6" name="initrd-oemboot-ubuntu-xenial">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/vmxboot/rhel-07.0/config.xml
+++ b/kiwi/boot/arch/x86_64/vmxboot/rhel-07.0/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-vmxboot-rhel-07.0">
+<image schemaversion="6.6" name="initrd-vmxboot-rhel-07.0">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/x86_64/vmxboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/x86_64/vmxboot/suse-SLES12/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-vmxboot-suse-SLES12">
+<image schemaversion="6.6" name="initrd-vmxboot-suse-SLES12">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/x86_64/vmxboot/suse-SLES15/config.xml
+++ b/kiwi/boot/arch/x86_64/vmxboot/suse-SLES15/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-vmxboot-suse-SLE15">
+<image schemaversion="6.6" name="initrd-vmxboot-suse-SLE15">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/vmxboot/suse-leap42.1/config.xml
+++ b/kiwi/boot/arch/x86_64/vmxboot/suse-leap42.1/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-vmxboot-suse-leap-42.1">
+<image schemaversion="6.6" name="initrd-vmxboot-suse-leap-42.1">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/vmxboot/suse-leap42.2/config.xml
+++ b/kiwi/boot/arch/x86_64/vmxboot/suse-leap42.2/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-vmxboot-suse-leap-42.2">
+<image schemaversion="6.6" name="initrd-vmxboot-suse-leap-42.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/vmxboot/suse-leap42.3/config.xml
+++ b/kiwi/boot/arch/x86_64/vmxboot/suse-leap42.3/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-vmxboot-suse-leap-42.3">
+<image schemaversion="6.6" name="initrd-vmxboot-suse-leap-42.3">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/arch/x86_64/vmxboot/suse-tumbleweed/config.xml
+++ b/kiwi/boot/arch/x86_64/vmxboot/suse-tumbleweed/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-vmxboot-suse-tumbleweed">
+<image schemaversion="6.6" name="initrd-vmxboot-suse-tumbleweed">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/kiwi/boot/arch/x86_64/vmxboot/ubuntu-xenial/config.xml
+++ b/kiwi/boot/arch/x86_64/vmxboot/ubuntu-xenial/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-vmxboot-ubuntu-xenial">
+<image schemaversion="6.6" name="initrd-vmxboot-ubuntu-xenial">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/functions.sh
+++ b/kiwi/boot/functions.sh
@@ -6796,7 +6796,7 @@ function xenServer {
         # no xen domain set, assume domU
         return 1
     fi
-    if [ $kiwi_xendomain = "dom0" ];then
+    if [ "$kiwi_xendomain" = "dom0" ];then
         # xen dom0 requested
         return 0
     fi

--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -185,17 +185,6 @@ class BootLoaderConfigBase(object):
             return False
         return True
 
-    def get_hypervisor_domain(self):
-        """
-        Hypervisor domain name
-
-        :return: domain name
-        :rtype: string
-        """
-        machine = self.xml_state.get_build_type_machine_section()
-        if machine:
-            return machine.get_domain()
-
     def get_boot_cmdline(self, uuid=None):
         """
         Boot commandline arguments passed to the kernel

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -129,23 +129,20 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         self.theme = self.get_boot_theme()
         self.timeout = self.get_boot_timeout_seconds()
         self.failsafe_boot = self.failsafe_boot_entry_requested()
-        self.hypervisor_domain = self.get_hypervisor_domain()
+        self.xen_guest = self.xml_state.is_xen_guest()
         self.firmware = FirmWare(
             self.xml_state
         )
-        self.hybrid_boot = True
-        self.multiboot = False
-        if self.hypervisor_domain:
-            if self.hypervisor_domain == 'dom0':
-                self.hybrid_boot = False
-                self.multiboot = True
-            elif self.hypervisor_domain == 'domU':
-                self.hybrid_boot = False
-                self.multiboot = False
 
-        self.xen_guest = False
-        if self.hypervisor_domain == 'domU' or self.firmware.ec2_mode():
-            self.xen_guest = True
+        if self.xml_state.is_xen_server():
+            self.hybrid_boot = False
+            self.multiboot = True
+        elif self.xen_guest:
+            self.hybrid_boot = False
+            self.multiboot = False
+        else:
+            self.hybrid_boot = True
+            self.multiboot = False
 
         self.grub2 = BootLoaderTemplateGrub2()
         self.config = None

--- a/kiwi/bootloader/config/isolinux.py
+++ b/kiwi/bootloader/config/isolinux.py
@@ -94,14 +94,10 @@ class BootLoaderConfigIsoLinux(BootLoaderConfigBase):
             [self.cmdline, Defaults.get_failsafe_kernel_options()]
         )
         self.failsafe_boot = self.failsafe_boot_entry_requested()
-        self.hypervisor_domain = self.get_hypervisor_domain()
 
         self.multiboot = False
-        if self.hypervisor_domain:
-            if self.hypervisor_domain == 'dom0':
-                self.multiboot = True
-            elif self.hypervisor_domain == 'domU':
-                self.multiboot = False
+        if self.xml_state.is_xen_server():
+            self.multiboot = True
 
         self.isolinux = BootLoaderTemplateIsoLinux()
         self.config = None

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -100,7 +100,7 @@ class DiskBuilder(object):
         self.force_mbr = xml_state.build_type.get_force_mbr()
         self.luks = xml_state.build_type.get_luks()
         self.luks_os = xml_state.build_type.get_luksOS()
-        self.machine = xml_state.get_build_type_machine_section()
+        self.xen_server = xml_state.is_xen_server()
         self.requested_filesystem = xml_state.build_type.get_filesystem()
         self.requested_boot_filesystem = \
             xml_state.build_type.get_bootfilesystem()
@@ -866,7 +866,7 @@ class DiskBuilder(object):
                 self.root_dir, ''.join(['/boot/', boot_names.kernel_name])
             )
 
-            if self.machine and self.machine.get_domain() == 'dom0':
+            if self.xen_server:
                 if kernel.get_xen_hypervisor():
                     log.info('--> boot image Xen hypervisor as xen.gz')
                     kernel.copy_xen_hypervisor(

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -69,7 +69,6 @@ class InstallImageBuilder(object):
             self.arch = 'ix86'
         self.root_dir = root_dir
         self.target_dir = target_dir
-        self.machine = xml_state.get_build_type_machine_section()
         self.boot_image_task = boot_image_task
         self.xml_state = xml_state
         self.diskname = ''.join(
@@ -301,7 +300,7 @@ class InstallImageBuilder(object):
                 'No kernel in boot image tree %s found' %
                 self.boot_image_task.boot_root_directory
             )
-        if self.machine and self.machine.get_domain() == 'dom0':
+        if self.xml_state.is_xen_server():
             if kernel.get_xen_hypervisor():
                 kernel.copy_xen_hypervisor(self.pxe_dir, '/pxeboot.xen.gz')
             else:
@@ -328,7 +327,7 @@ class InstallImageBuilder(object):
                 'No kernel in boot image tree %s found' %
                 self.boot_image_task.boot_root_directory
             )
-        if self.machine and self.machine.get_domain() == 'dom0':
+        if self.xml_state.is_xen_server():
             if kernel.get_xen_hypervisor():
                 kernel.copy_xen_hypervisor(boot_path, '/xen.gz')
             else:

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -72,7 +72,6 @@ class LiveImageBuilder(object):
         self.types = Defaults.get_live_iso_types()
         self.hybrid = xml_state.build_type.get_hybrid()
         self.volume_id = xml_state.build_type.get_volid()
-        self.machine = xml_state.get_build_type_machine_section()
         self.mbrid = SystemIdentifier()
         self.mbrid.calculate_id()
         self.filesystem_custom_parameters = {
@@ -275,7 +274,7 @@ class LiveImageBuilder(object):
                 'No kernel in boot image tree %s found' %
                 self.boot_image_task.boot_root_directory
             )
-        if self.machine and self.machine.get_domain() == 'dom0':
+        if self.xml_state.is_xen_server():
             if kernel.get_xen_hypervisor():
                 kernel.copy_xen_hypervisor(boot_path, '/xen.gz')
             else:

--- a/kiwi/builder/pxe.py
+++ b/kiwi/builder/pxe.py
@@ -57,7 +57,7 @@ class PxeBuilder(object):
     def __init__(self, xml_state, target_dir, root_dir, custom_args=None):
         self.target_dir = target_dir
         self.compressed = xml_state.build_type.get_compressed()
-        self.machine = xml_state.get_build_type_machine_section()
+        self.xen_server = xml_state.is_xen_server()
         self.pxedeploy = xml_state.get_build_type_pxedeploy_section()
         self.filesystem = FileSystemBuilder(
             xml_state, target_dir, root_dir + '/'
@@ -146,7 +146,7 @@ class PxeBuilder(object):
             )
 
         # extract hypervisor from boot(initrd) root system
-        if self.machine and self.machine.get_domain() == 'dom0':
+        if self.xen_server:
             kernel_data = kernel.get_xen_hypervisor()
             if kernel_data:
                 self.hypervisor_filename = ''.join(

--- a/kiwi/config/strip.xml
+++ b/kiwi/config/strip.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-strip-metadata">
+<image schemaversion="6.6" name="initrd-strip-metadata">
     <description type="boot">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -574,7 +574,7 @@ class Defaults(object):
         :return: firmware names
         :rtype: list
         """
-        return ['ec2', 'ec2hvm']
+        return ['ec2']
 
     @classmethod
     def get_efi_module_directory_name(self, arch):

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -57,7 +57,7 @@ div {
         attribute xsi:schemaLocation { xsd:anyURI }
     k.image.schemaversion.attribute =
         ## The allowed Schema version (fixed value)
-        attribute schemaversion { "6.5" }
+        attribute schemaversion { "6.6" }
     k.image.kiwirevision.attribute =
         ## A kiwi git revision number which is known to build
         ## a working image from this description. If the kiwi git
@@ -1284,7 +1284,17 @@ div {
             sch:param [ name = "attr" value = "bootloader_console" ]
             sch:param [ name = "types" value = "oem vmx iso" ]
         ]
-    k.type.btrfs_root_is_snapshot =
+    k.type.xen_server.attribute =
+        ## Specify the image is a Xen dom0 (Xen Server) image
+        ## The information is used to create a correct bootloader
+        ## configuration with regards to the required loading of
+        ## the Xen Hypervisor
+        attribute xen_server { xsd:boolean }
+        >> sch:pattern [ id = "xen_server" is-a = "image_type"
+            sch:param [ name = "attr" value = "xen_server" ]
+            sch:param [ name = "types" value = "oem vmx" ]
+        ]
+    k.type.btrfs_root_is_snapshot.attribute =
         ## Tell kiwi to install the system into a btrfs snapshot
         ## The snapshot layout is compatible with the snapper management
         ## toolkit. By default no snapshots are used
@@ -1293,7 +1303,7 @@ div {
             sch:param [ name = "attr" value = "btrfs_root_is_snapshot" ]
             sch:param [ name = "types" value = "oem vmx docker" ]
         ]
-    k.type.btrfs_root_is_readonly_snapshot =
+    k.type.btrfs_root_is_readonly_snapshot.attribute =
         ## Tell kiwi to set the btrfs root filesystem snapshot read-only
         ## Once all data has been placed to the root filesystem snapshot
         ## it will be turned into read-only mode if this option is set to
@@ -1305,7 +1315,7 @@ div {
             sch:param [ name = "attr" value = "btrfs_root_is_readonly_snapshot" ]
             sch:param [ name = "types" value = "oem vmx docker" ]
         ]
-    k.type.target_blocksize =
+    k.type.target_blocksize.attribute =
         ## Specifies the image blocksize in bytes which has to match
         ## the logical (SSZ) blocksize of the target storage device.
         ## By default 512 byte is used which works on many disks
@@ -1316,7 +1326,7 @@ div {
             sch:param [ name = "attr" value = "target_blocksize" ]
             sch:param [ name = "types" value = "oem vmx" ]
         ]
-    k.type.target_removable =
+    k.type.target_removable.attribute =
         ## Indicate if the target disk for oem images is deployed
         ## to a removable device e.g a USB stick or not. This only
         ## affects the EFI setup if requested and in the end avoids
@@ -1328,7 +1338,7 @@ div {
             sch:param [ name = "attr" value = "target_removable" ]
             sch:param [ name = "types" value = "oem vmx" ]
         ]
-    k.type.spare_part =
+    k.type.spare_part.attribute =
         ## Request a spare partition right before the root partition
         ## of the requested size. The attribute takes a size value
         ## and allows a unit in MB or GB, e.g 200M. If no unit is given
@@ -1756,8 +1766,8 @@ div {
         k.type.efipartsize.attribute? &
         k.type.bootprofile.attribute? &
         k.type.boottimeout.attribute? &
-        k.type.btrfs_root_is_snapshot? &
-        k.type.btrfs_root_is_readonly_snapshot? &
+        k.type.btrfs_root_is_snapshot.attribute? &
+        k.type.btrfs_root_is_readonly_snapshot.attribute? &
         k.type.checkprebuilt.attribute? &
         k.type.compressed.attribute? &
         k.type.devicepersistency.attribute? &
@@ -1790,14 +1800,15 @@ div {
         k.type.primary.attribute? &
         k.type.ramonly.attribute? &
         k.type.rootfs_label.attribute? &
-        k.type.spare_part? &
-        k.type.target_blocksize? &
-        k.type.target_removable? &
+        k.type.spare_part.attribute? &
+        k.type.target_blocksize.attribute? &
+        k.type.target_removable.attribute? &
         k.type.vga.attribute? &
         k.type.vhdfixedtag.attribute? &
         k.type.volid.attribute? &
         k.type.wwid_wait_timeout.attribute? &
-        k.type.derived_from.attribute?
+        k.type.derived_from.attribute? &
+        k.type.xen_server.attribute?
     k.type =
         ## The Image Type of the Logical Extend
         element type { 
@@ -2491,9 +2502,9 @@ div {
     k.machine.arch.attribute =
         ## the VM architecture type (vmdk only)
         attribute arch { "ix86" | "x86_64" }
-    k.machine.domain.attribute =
-        ## The domain setup for the VM (xen only)
-        attribute domain { "dom0" | "domU" }
+    k.machine.xen_loader.attribute =
+        ## the Xen target loader which is expected to load this guest
+        attribute xen_loader { "hvmloader" | "pygrub" | "pvgrub" }
     k.machine.guestOS.attribute =
         ## The virtual guestOS identification string for the VM
         ## (vmdk and ovf, note the name designation is different for the two
@@ -2525,7 +2536,7 @@ div {
         k.machine.ovftype.attribute? &
         k.machine.HWversion.attribute? &
         k.machine.arch.attribute? &
-        k.machine.domain.attribute? &
+        k.machine.xen_loader.attribute? &
         k.machine.guestOS.attribute? &
         k.machine.memory.attribute? &
         k.machine.ncpus.attribute?

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -105,7 +105,7 @@ second the location of the XSD Schema
     <define name="k.image.schemaversion.attribute">
       <attribute name="schemaversion">
         <a:documentation>The allowed Schema version (fixed value)</a:documentation>
-        <value>6.5</value>
+        <value>6.6</value>
       </attribute>
     </define>
     <define name="k.image.kiwirevision.attribute">
@@ -1959,7 +1959,20 @@ By default a graphics console setup is used</a:documentation>
         <sch:param name="types" value="oem vmx iso"/>
       </sch:pattern>
     </define>
-    <define name="k.type.btrfs_root_is_snapshot">
+    <define name="k.type.xen_server.attribute">
+      <attribute name="xen_server">
+        <a:documentation>Specify the image is a Xen dom0 (Xen Server) image
+The information is used to create a correct bootloader
+configuration with regards to the required loading of
+the Xen Hypervisor</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+      <sch:pattern id="xen_server" is-a="image_type">
+        <sch:param name="attr" value="xen_server"/>
+        <sch:param name="types" value="oem vmx"/>
+      </sch:pattern>
+    </define>
+    <define name="k.type.btrfs_root_is_snapshot.attribute">
       <attribute name="btrfs_root_is_snapshot">
         <a:documentation>Tell kiwi to install the system into a btrfs snapshot
 The snapshot layout is compatible with the snapper management
@@ -1971,7 +1984,7 @@ toolkit. By default no snapshots are used</a:documentation>
         <sch:param name="types" value="oem vmx docker"/>
       </sch:pattern>
     </define>
-    <define name="k.type.btrfs_root_is_readonly_snapshot">
+    <define name="k.type.btrfs_root_is_readonly_snapshot.attribute">
       <attribute name="btrfs_root_is_readonly_snapshot">
         <a:documentation>Tell kiwi to set the btrfs root filesystem snapshot read-only
 Once all data has been placed to the root filesystem snapshot
@@ -1986,7 +1999,7 @@ is writable</a:documentation>
         <sch:param name="types" value="oem vmx docker"/>
       </sch:pattern>
     </define>
-    <define name="k.type.target_blocksize">
+    <define name="k.type.target_blocksize.attribute">
       <attribute name="target_blocksize">
         <a:documentation>Specifies the image blocksize in bytes which has to match
 the logical (SSZ) blocksize of the target storage device.
@@ -2000,7 +2013,7 @@ desired target by calling: blockdev --report device</a:documentation>
         <sch:param name="types" value="oem vmx"/>
       </sch:pattern>
     </define>
-    <define name="k.type.target_removable">
+    <define name="k.type.target_removable.attribute">
       <attribute name="target_removable">
         <a:documentation>Indicate if the target disk for oem images is deployed
 to a removable device e.g a USB stick or not. This only
@@ -2015,7 +2028,7 @@ expected to be non-removable</a:documentation>
         <sch:param name="types" value="oem vmx"/>
       </sch:pattern>
     </define>
-    <define name="k.type.spare_part">
+    <define name="k.type.spare_part.attribute">
       <attribute name="spare_part">
         <a:documentation>Request a spare partition right before the root partition
 of the requested size. The attribute takes a size value
@@ -2644,10 +2657,10 @@ to work on.</a:documentation>
           <ref name="k.type.boottimeout.attribute"/>
         </optional>
         <optional>
-          <ref name="k.type.btrfs_root_is_snapshot"/>
+          <ref name="k.type.btrfs_root_is_snapshot.attribute"/>
         </optional>
         <optional>
-          <ref name="k.type.btrfs_root_is_readonly_snapshot"/>
+          <ref name="k.type.btrfs_root_is_readonly_snapshot.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.checkprebuilt.attribute"/>
@@ -2744,13 +2757,13 @@ to work on.</a:documentation>
           <ref name="k.type.rootfs_label.attribute"/>
         </optional>
         <optional>
-          <ref name="k.type.spare_part"/>
+          <ref name="k.type.spare_part.attribute"/>
         </optional>
         <optional>
-          <ref name="k.type.target_blocksize"/>
+          <ref name="k.type.target_blocksize.attribute"/>
         </optional>
         <optional>
-          <ref name="k.type.target_removable"/>
+          <ref name="k.type.target_removable.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.vga.attribute"/>
@@ -2766,6 +2779,9 @@ to work on.</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.derived_from.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.xen_server.attribute"/>
         </optional>
       </interleave>
     </define>
@@ -3908,12 +3924,13 @@ configuration options which are used inside a vagrant box</a:documentation>
         </choice>
       </attribute>
     </define>
-    <define name="k.machine.domain.attribute">
-      <attribute name="domain">
-        <a:documentation>The domain setup for the VM (xen only)</a:documentation>
+    <define name="k.machine.xen_loader.attribute">
+      <attribute name="xen_loader">
+        <a:documentation>the Xen target loader which is expected to load this guest</a:documentation>
         <choice>
-          <value>dom0</value>
-          <value>domU</value>
+          <value>hvmloader</value>
+          <value>pygrub</value>
+          <value>pvgrub</value>
         </choice>
       </attribute>
     </define>
@@ -3984,7 +4001,7 @@ formats)</a:documentation>
           <ref name="k.machine.arch.attribute"/>
         </optional>
         <optional>
-          <ref name="k.machine.domain.attribute"/>
+          <ref name="k.machine.xen_loader.attribute"/>
         </optional>
         <optional>
           <ref name="k.machine.guestOS.attribute"/>

--- a/kiwi/system/profile.py
+++ b/kiwi/system/profile.py
@@ -45,10 +45,10 @@ class Profile(object):
         self._profile_names_to_profile()
         self._packages_marked_for_deletion_to_profile()
         self._type_to_profile()
+        self._type_complex_to_profile()
         self._preferences_to_profile()
         self._systemdisk_to_profile()
         self._strip_to_profile()
-        self._machine_to_profile()
         self._oemconfig_to_profile()
         self._drivers_to_profile()
 
@@ -172,11 +172,10 @@ class Profile(object):
             self.xml_state.get_drivers_list()
         )
 
-    def _machine_to_profile(self):
+    def _type_complex_to_profile(self):
         # kiwi_xendomain
-        machine = self.xml_state.get_build_type_machine_section()
-        if machine:
-            self.dot_profile['kiwi_xendomain'] = machine.get_domain()
+        if self.xml_state.is_xen_server():
+            self.dot_profile['kiwi_xendomain'] = 'dom0'
 
     def _strip_to_profile(self):
         # kiwi_strip_delete
@@ -207,7 +206,8 @@ class Profile(object):
 
             volume_count = 1
             for volume in self.xml_state.get_volumes():
-                self.dot_profile['kiwi_Volume_' + format(volume_count)] = '|'.join(
+                volume_id_name = 'kiwi_Volume_{id}'.format(id=volume_count)
+                self.dot_profile[volume_id_name] = '|'.join(
                     [
                         volume.name,
                         'size:all' if volume.fullsize else volume.size,

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated  by generateDS.py version 2.27a.
+# Generated  by generateDS.py version 2.28a.
 #
 # Command line options:
 #   ('-f', '')
@@ -15,7 +15,7 @@
 #   kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Command line:
-#   /home/ms/Project/kiwi/.tox/2.7/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
+#   /home/ms/Project/kiwi/.env3/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -87,7 +87,7 @@ except ImportError:
 try:
     from generatedssuper import GeneratedsSuper
 except ImportError as exp:
-
+    
     class GeneratedsSuper(object):
         tzoff_pattern = re_.compile(r'(\+|-)((0\d|1[0-3]):[0-5]\d|14:00)$')
         class _FixedOffsetTZ(datetime_.tzinfo):
@@ -401,7 +401,13 @@ except ImportError as exp:
             else:
                 result = GeneratedsSuper.gds_encode(str(instring))
             return result
-
+        def __eq__(self, other):
+            if type(self) != type(other):
+                return False
+            return self.__dict__ == other.__dict__
+        def __ne__(self, other):
+            return not self.__eq__(other)
+    
     def getSubclassFromModule_(module, class_):
         '''Get the subclass of a class from a specific module.'''
         name = class_.__name__ + 'Sub'
@@ -570,7 +576,8 @@ class MixedContainer:
         return self.value
     def getName(self):
         return self.name
-    def export(self, outfile, level, name, namespace, pretty_print=True):
+    def export(self, outfile, level, name, namespace,
+               pretty_print=True):
         if self.category == MixedContainer.CategoryText:
             # Prevent exporting empty content as empty lines.
             if self.value.strip():
@@ -579,7 +586,8 @@ class MixedContainer:
             self.exportSimple(outfile, level, name)
         else:    # category == MixedContainer.CategoryComplex
             self.value.export(
-                outfile, level, namespace, name, pretty_print=pretty_print)
+                outfile, level, namespace, name,
+                pretty_print=pretty_print)
     def exportSimple(self, outfile, level, name):
         if self.content_type == MixedContainer.TypeString:
             outfile.write('<%s>%s</%s>' % (
@@ -597,7 +605,9 @@ class MixedContainer:
                 self.name, self.value, self.name))
         elif self.content_type == MixedContainer.TypeBase64:
             outfile.write('<%s>%s</%s>' % (
-                self.name, base64.b64encode(self.value), self.name))
+                self.name,
+                base64.b64encode(self.value),
+                self.name))
     def to_etree(self, element):
         if self.category == MixedContainer.CategoryText:
             # Prevent exporting empty content as empty lines.
@@ -613,7 +623,8 @@ class MixedContainer:
                     else:
                         element.text += self.value
         elif self.category == MixedContainer.CategorySimple:
-            subelement = etree_.SubElement(element, '%s' % self.name)
+            subelement = etree_.SubElement(
+                element, '%s' % self.name)
             subelement.text = self.to_etree_simple()
         else:    # category == MixedContainer.CategoryComplex
             self.value.to_etree(element)
@@ -636,12 +647,14 @@ class MixedContainer:
             showIndent(outfile, level)
             outfile.write(
                 'model_.MixedContainer(%d, %d, "%s", "%s"),\n' % (
-                    self.category, self.content_type, self.name, self.value))
+                    self.category, self.content_type,
+                    self.name, self.value))
         elif self.category == MixedContainer.CategorySimple:
             showIndent(outfile, level)
             outfile.write(
                 'model_.MixedContainer(%d, %d, "%s", "%s"),\n' % (
-                    self.category, self.content_type, self.name, self.value))
+                    self.category, self.content_type,
+                    self.name, self.value))
         else:    # category == MixedContainer.CategoryComplex
             showIndent(outfile, level)
             outfile.write(
@@ -653,10 +666,13 @@ class MixedContainer:
 
 
 class MemberSpec_(object):
-    def __init__(self, name='', data_type='', container=0, optional=0):
+    def __init__(self, name='', data_type='', container=0,
+            optional=0, child_attrs=None, choice=None):
         self.name = name
         self.data_type = data_type
         self.container = container
+        self.child_attrs = child_attrs
+        self.choice = choice
         self.optional = optional
     def set_name(self, name): self.name = name
     def get_name(self): return self.name
@@ -672,6 +688,10 @@ class MemberSpec_(object):
             return self.data_type
     def set_container(self, container): self.container = container
     def get_container(self): return self.container
+    def set_child_attrs(self, child_attrs): self.child_attrs = child_attrs
+    def get_child_attrs(self): return self.child_attrs
+    def set_choice(self, choice): self.choice = choice
+    def get_choice(self): return self.choice
     def set_optional(self, optional): self.optional = optional
     def get_optional(self): return self.optional
 
@@ -2621,7 +2641,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, efipartsize=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, checkprebuilt=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsnocheck=None, fsmountoptions=None, gcelicense=None, hybrid=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, containerconfig=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, efipartsize=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, checkprebuilt=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsnocheck=None, fsmountoptions=None, gcelicense=None, hybrid=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, containerconfig=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2677,6 +2697,7 @@ class type_(GeneratedsSuper):
         self.volid = _cast(None, volid)
         self.wwid_wait_timeout = _cast(int, wwid_wait_timeout)
         self.derived_from = _cast(None, derived_from)
+        self.xen_server = _cast(bool, xen_server)
         if containerconfig is None:
             self.containerconfig = []
         else:
@@ -2859,6 +2880,8 @@ class type_(GeneratedsSuper):
     def set_wwid_wait_timeout(self, wwid_wait_timeout): self.wwid_wait_timeout = wwid_wait_timeout
     def get_derived_from(self): return self.derived_from
     def set_derived_from(self, derived_from): self.derived_from = derived_from
+    def get_xen_server(self): return self.xen_server
+    def set_xen_server(self, xen_server): self.xen_server = xen_server
     def validate_partition_size_type(self, value):
         # Validate type partition-size-type, a restriction on xs:token.
         if value is not None and Validate_simpletypes_:
@@ -3070,6 +3093,9 @@ class type_(GeneratedsSuper):
         if self.derived_from is not None and 'derived_from' not in already_processed:
             already_processed.add('derived_from')
             outfile.write(' derived_from=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.derived_from), input_name='derived_from')), ))
+        if self.xen_server is not None and 'xen_server' not in already_processed:
+            already_processed.add('xen_server')
+            outfile.write(' xen_server="%s"' % self.gds_format_boolean(self.xen_server, input_name='xen_server'))
     def exportChildren(self, outfile, level, namespace_='', name_='type', fromsubclass_=False, pretty_print=True):
         if pretty_print:
             eol_ = '\n'
@@ -3447,6 +3473,15 @@ class type_(GeneratedsSuper):
         if value is not None and 'derived_from' not in already_processed:
             already_processed.add('derived_from')
             self.derived_from = value
+        value = find_attr_value_('xen_server', node)
+        if value is not None and 'xen_server' not in already_processed:
+            already_processed.add('xen_server')
+            if value in ('true', '1'):
+                self.xen_server = True
+            elif value in ('false', '0'):
+                self.xen_server = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         if nodeName_ == 'containerconfig':
             obj_ = containerconfig.factory()
@@ -6477,7 +6512,7 @@ class machine(GeneratedsSuper):
     which are used by the virtual machine when running the image."""
     subclass = None
     superclass = None
-    def __init__(self, min_memory=None, max_memory=None, min_cpu=None, max_cpu=None, ovftype=None, HWversion=None, arch=None, domain=None, guestOS=None, memory=None, ncpus=None, vmconfig_entry=None, vmdisk=None, vmdvd=None, vmnic=None):
+    def __init__(self, min_memory=None, max_memory=None, min_cpu=None, max_cpu=None, ovftype=None, HWversion=None, arch=None, xen_loader=None, guestOS=None, memory=None, ncpus=None, vmconfig_entry=None, vmdisk=None, vmdvd=None, vmnic=None):
         self.original_tagname_ = None
         self.min_memory = _cast(int, min_memory)
         self.max_memory = _cast(int, max_memory)
@@ -6486,7 +6521,7 @@ class machine(GeneratedsSuper):
         self.ovftype = _cast(None, ovftype)
         self.HWversion = _cast(int, HWversion)
         self.arch = _cast(None, arch)
-        self.domain = _cast(None, domain)
+        self.xen_loader = _cast(None, xen_loader)
         self.guestOS = _cast(None, guestOS)
         self.memory = _cast(int, memory)
         self.ncpus = _cast(int, ncpus)
@@ -6551,8 +6586,8 @@ class machine(GeneratedsSuper):
     def set_HWversion(self, HWversion): self.HWversion = HWversion
     def get_arch(self): return self.arch
     def set_arch(self, arch): self.arch = arch
-    def get_domain(self): return self.domain
-    def set_domain(self, domain): self.domain = domain
+    def get_xen_loader(self): return self.xen_loader
+    def set_xen_loader(self, xen_loader): self.xen_loader = xen_loader
     def get_guestOS(self): return self.guestOS
     def set_guestOS(self, guestOS): self.guestOS = guestOS
     def get_memory(self): return self.memory
@@ -6612,9 +6647,9 @@ class machine(GeneratedsSuper):
         if self.arch is not None and 'arch' not in already_processed:
             already_processed.add('arch')
             outfile.write(' arch=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.arch), input_name='arch')), ))
-        if self.domain is not None and 'domain' not in already_processed:
-            already_processed.add('domain')
-            outfile.write(' domain=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.domain), input_name='domain')), ))
+        if self.xen_loader is not None and 'xen_loader' not in already_processed:
+            already_processed.add('xen_loader')
+            outfile.write(' xen_loader=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.xen_loader), input_name='xen_loader')), ))
         if self.guestOS is not None and 'guestOS' not in already_processed:
             already_processed.add('guestOS')
             outfile.write(' guestOS=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.guestOS), input_name='guestOS')), ))
@@ -6699,11 +6734,11 @@ class machine(GeneratedsSuper):
             already_processed.add('arch')
             self.arch = value
             self.arch = ' '.join(self.arch.split())
-        value = find_attr_value_('domain', node)
-        if value is not None and 'domain' not in already_processed:
-            already_processed.add('domain')
-            self.domain = value
-            self.domain = ' '.join(self.domain.split())
+        value = find_attr_value_('xen_loader', node)
+        if value is not None and 'xen_loader' not in already_processed:
+            already_processed.add('xen_loader')
+            self.xen_loader = value
+            self.xen_loader = ' '.join(self.xen_loader.split())
         value = find_attr_value_('guestOS', node)
         if value is not None and 'guestOS' not in already_processed:
             already_processed.add('guestOS')

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -452,6 +452,19 @@ class XMLState(object):
         """
         return self.get_products('image')
 
+    def is_xen_server(self):
+        return self.build_type.get_xen_server()
+
+    def is_xen_guest(self):
+        firmware = self.build_type.get_firmware()
+        machine_section = self.get_build_type_machine_section()
+        if firmware and firmware in Defaults.get_ec2_capable_firmware_names():
+            # the image is targeted to run in Amazon EC2 which is a Xen system
+            return True
+        elif machine_section and machine_section.get_xen_loader():
+            # the image provides a machine section with a guest loader setup
+            return True
+
     def get_build_type_system_disk_section(self):
         """
         First system disk section from the build type section

--- a/kiwi/xsl/convert65to66.xsl
+++ b/kiwi/xsl/convert65to66.xsl
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*|processing-instruction()|comment()" mode="conv65to66">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv65to66"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<!-- remove inherit attribute from image -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>6.4</literal> to <literal>6.5</literal>.
+</para>
+<xsl:template match="image" mode="conv65to66">
+    <xsl:choose>
+        <!-- nothing to do if already at 6.6 -->
+        <xsl:when test="@schemaversion > 6.5">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="6.6">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion' and local-name() != 'inherit']"/>
+                <xsl:apply-templates  mode="conv65to66"/>  
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<para xmlns="http://docbook.org/ns/docbook">
+    Add xen_server attribute to type for dom0 configurations
+</para>
+<xsl:template match="type[machine[@domain='dom0']]" mode="conv65to66">
+     <type>
+         <xsl:copy-of select="@*"/>
+         <xsl:attribute name="xen_server">
+             <xsl:value-of select="'true'"/>
+         </xsl:attribute>
+         <xsl:apply-templates  mode="conv65to66"/>
+     </type>
+</xsl:template>
+
+<para xmlns="http://docbook.org/ns/docbook">
+    Delete domain attribute from machine sections
+</para>
+<xsl:template match="machine" mode="conv65to66">
+    <machine>
+        <xsl:copy-of select="@*[not(local-name(.) = 'domain')]"/>
+        <xsl:variable name="domain_name" select="@domain"/>
+        <xsl:apply-templates mode="conv65to66"/>
+    </machine>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/kiwi/xsl/master.xsl
+++ b/kiwi/xsl/master.xsl
@@ -36,6 +36,7 @@
 <xsl:import href="convert62to63.xsl"/>
 <xsl:import href="convert63to64.xsl"/>
 <xsl:import href="convert64to65.xsl"/>
+<xsl:import href="convert65to66.xsl"/>
 <xsl:import href="pretty.xsl"/>
 
 
@@ -166,8 +167,12 @@
         <xsl:apply-templates select="exslt:node-set($v64)" mode="conv64to65"/>
     </xsl:variable>
 
+    <xsl:variable name="v66">
+        <xsl:apply-templates select="exslt:node-set($v65)" mode="conv65to66"/>
+    </xsl:variable>
+
     <xsl:apply-templates
-        select="exslt:node-set($v65)" mode="pretty"
+        select="exslt:node-set($v66)" mode="pretty"
     />
 </xsl:template>
 

--- a/test/data/example_arm_disk_size_config.xml
+++ b/test/data/example_arm_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_btrfs_config.xml
+++ b/test/data/example_btrfs_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="6.6" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
     <drivers>
         <file name="crypto/*"/>
         <file name="drivers/acpi/*"/>
@@ -35,10 +35,10 @@
         <locale>de_DE</locale>
     </preferences>
     <preferences>
-        <type bootloader="grub2" image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async" btrfs_root_is_snapshot="true" spare_part="200M">
+        <type bootloader="grub2" image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async" btrfs_root_is_snapshot="true" spare_part="200M" xen_server="true">
             <size unit="G" additive="true">1</size>
             <systemdisk name="mydisk"/>
-            <machine memory="512" domain="domU">
+            <machine memory="512" xen_loader="hvmloader">
                 <vmdisk id="0" device="/dev/xvda" controller="ide"/>
                 <vmnic interface=""/>
                 <vmdvd id="0" controller="scsi"/>
@@ -66,7 +66,7 @@
     </preferences>
     <preferences profiles="xenFlavour">
         <type image="vmx" filesystem="ext3" boot="vmxboot/example-distribution" bootprofile="xen" bootkernel="xenk" bootloader="grub2" kernelcmdline="splash">
-            <machine memory="512" domain="domU">
+            <machine memory="512" xen_loader="hvmloader">
                 <vmdisk id="0" device="/dev/xvda" controller="ide"/>
                 <vmnic interface=""/>
             </machine>
@@ -76,9 +76,6 @@
                 <oem-systemsize>2048</oem-systemsize>
                 <oem-swap>true</oem-swap>
             </oemconfig>
-            <machine domain="dom0">
-                <vmdisk id="0" controller="ide"/>
-            </machine>
         </type>
     </preferences>
     <preferences profiles="vmxFlavour">
@@ -113,15 +110,15 @@
                     <port number="80"/>
                     <port number="8080"/>
                 </expose>
-                <volumes> 
+                <volumes>
                     <volume name="/tmp"/>
                     <volume name="/var/log"/>
                 </volumes>
-                <environment> 
+                <environment>
                     <env name="PATH" value="/bin:/usr/bin:/home/user/bin"/>
                     <env name="SOMEVAR" value="somevalue"/>
                 </environment>
-                <labels> 
+                <labels>
                     <label name="somelabel" value="labelvalue"/>
                     <label name="someotherlabel" value="anotherlabelvalue"/>
                 </labels>

--- a/test/data/example_disk_config.xml
+++ b/test/data/example_disk_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_config.xml
+++ b/test/data/example_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_empty_vol_config.xml
+++ b/test/data/example_disk_size_empty_vol_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_vol_root_config.xml
+++ b/test/data/example_disk_size_vol_root_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_volume_config.xml
+++ b/test/data/example_disk_size_volume_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_dot_profile_config.xml
+++ b/test/data/example_dot_profile_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -20,7 +20,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" primary="true" filesystem="ext3" boot="oemboot/suse-13.2" installiso="true" bootloader="grub2" kernelcmdline="splash" firmware="efi" ramonly="true">
+        <type image="oem" primary="true" filesystem="ext3" boot="oemboot/suse-13.2" installiso="true" bootloader="grub2" kernelcmdline="splash" firmware="efi" ramonly="true" xen_server="true">
             <systemdisk>
                 <volume name="usr/lib" size="1G"/>
                 <volume name="@root" freespace="500M"/>

--- a/test/data/example_lvm_default_config.xml
+++ b/test/data/example_lvm_default_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_no_root_config.xml
+++ b/test/data/example_lvm_no_root_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_no_root_full_usr_config.xml
+++ b/test/data/example_lvm_no_root_full_usr_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_preferred_config.xml
+++ b/test/data/example_lvm_preferred_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_multiple_users_config.xml
+++ b/test/data/example_multiple_users_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_no_imageinclude_config.xml
+++ b/test/data/example_no_imageinclude_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="6.6" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -15,7 +15,7 @@
         <type bootloader="grub2" image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async">
             <size unit="G" additive="true">1</size>
             <systemdisk name="mydisk"/>
-            <machine memory="512" domain="domU">
+            <machine memory="512" xen_loader="pvgrub">
                 <vmdisk id="0" device="/dev/xvda" controller="ide"/>
                 <vmnic interface=""/>
                 <vmdvd id="0" controller="scsi"/>

--- a/test/data/example_ppc_disk_size_config.xml
+++ b/test/data/example_ppc_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_pxe_config.xml
+++ b/test/data/example_pxe_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.6" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_runtime_checker_config.xml
+++ b/test/data/example_runtime_checker_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="6.6" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
     <drivers>
         <file name="crypto/*"/>
         <file name="drivers/acpi/*"/>
@@ -40,7 +40,7 @@
             <systemdisk name="mydisk">
                 <volume name="root" size="6G" mountpoint="/"/>
             </systemdisk>
-            <machine memory="512" domain="domU">
+            <machine memory="512" xen_loader="pvgrub">
                 <vmdisk id="0" device="/dev/xvda" controller="ide"/>
                 <vmnic interface=""/>
             </machine>
@@ -68,19 +68,16 @@
     </preferences>
     <preferences profiles="xenFlavour">
         <type image="vmx" filesystem="ext3" boot="vmxboot/example-distribution" bootprofile="xen" bootkernel="xenk" bootloader="grub2" kernelcmdline="splash">
-            <machine memory="512" domain="domU">
+            <machine memory="512" xen_loader="pvgrub">
                 <vmdisk id="0" device="/dev/xvda" controller="ide"/>
                 <vmnic interface=""/>
             </machine>
         </type>
-        <type image="oem" filesystem="ext3" boot="oemboot/example-distribution" bootprofile="xen" bootkernel="xenk" installiso="true" bootloader="grub2" kernelcmdline="splash">
+        <type image="oem" filesystem="ext3" boot="oemboot/example-distribution" bootprofile="xen" bootkernel="xenk" installiso="true" bootloader="grub2" kernelcmdline="splash" xen_server="true">
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>
                 <oem-swap>true</oem-swap>
             </oemconfig>
-            <machine domain="dom0">
-                <vmdisk id="0" controller="ide"/>
-            </machine>
         </type>
     </preferences>
     <preferences profiles="vmxFlavour">

--- a/test/data/isoboot/example-distribution-no-delete-section/config.xml
+++ b/test/data/isoboot/example-distribution-no-delete-section/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-isoboot-suse-13.2">
+<image schemaversion="6.6" name="initrd-isoboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/data/isoboot/example-distribution/config.xml
+++ b/test/data/isoboot/example-distribution/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-isoboot-suse-13.2">
+<image schemaversion="6.6" name="initrd-isoboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/data/oemboot/example-distribution/config.xml
+++ b/test/data/oemboot/example-distribution/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.5" name="initrd-oemboot-suse-13.2">
+<image schemaversion="6.6" name="initrd-oemboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/unit/bootloader_config_base_test.py
+++ b/test/unit/bootloader_config_base_test.py
@@ -85,9 +85,6 @@ class TestBootLoaderConfigBase(object):
         mock_installprovidefailsafe.return_value = False
         assert self.bootloader.failsafe_boot_entry_requested() is False
 
-    def test_get_hypervisor_domain(self):
-        assert self.bootloader.get_hypervisor_domain() == 'domU'
-
     def test_get_boot_cmdline(self):
         assert self.bootloader.get_boot_cmdline() == 'splash'
 

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -26,10 +26,9 @@ from kiwi.bootloader.config.grub2 import BootLoaderConfigGrub2
 class TestBootLoaderConfigGrub2(object):
     @patch('kiwi.bootloader.config.grub2.FirmWare')
     @patch('kiwi.bootloader.config.base.BootLoaderConfigBase.get_boot_theme')
-    @patch('kiwi.bootloader.config.base.BootLoaderConfigBase.get_hypervisor_domain')
     @patch('platform.machine')
     def setup(
-        self, mock_machine, mock_domain, mock_theme, mock_firmware
+        self, mock_machine, mock_theme, mock_firmware
     ):
         self.context_manager_mock = mock.Mock()
         self.file_mock = mock.Mock()
@@ -62,7 +61,6 @@ class TestBootLoaderConfigGrub2(object):
         ]
         mock_machine.return_value = 'x86_64'
         mock_theme.return_value = None
-        mock_domain.return_value = None
         kiwi.bootloader.config.grub2.Path = mock.Mock()
         kiwi.bootloader.config.base.Path = mock.Mock()
 
@@ -87,6 +85,12 @@ class TestBootLoaderConfigGrub2(object):
 
         self.state = XMLState(
             XMLDescription('../data/example_config.xml').load()
+        )
+        self.state.is_xen_server = mock.Mock(
+            return_value=False
+        )
+        self.state.is_xen_guest = mock.Mock(
+            return_value=False
         )
         self.bootloader = BootLoaderConfigGrub2(
             self.state, 'root_dir', {'grub_directory_name': 'grub2'}
@@ -200,10 +204,14 @@ class TestBootLoaderConfigGrub2(object):
 
     @patch('os.path.exists')
     @patch('platform.machine')
-    @patch('kiwi.bootloader.config.base.BootLoaderConfigBase.get_hypervisor_domain')
-    def test_post_init_dom0(self, mock_domain, mock_machine, mock_exists):
+    def test_post_init_dom0(self, mock_machine, mock_exists):
+        self.state.is_xen_server = mock.Mock(
+            return_value=True
+        )
+        self.state.is_xen_guest = mock.Mock(
+            return_value=False
+        )
         mock_machine.return_value = 'x86_64'
-        mock_domain.return_value = 'dom0'
         mock_exists.return_value = True
         self.bootloader.post_init(None)
         assert self.bootloader.multiboot is True
@@ -212,23 +220,18 @@ class TestBootLoaderConfigGrub2(object):
 
     @patch('os.path.exists')
     @patch('platform.machine')
-    @patch('kiwi.bootloader.config.base.BootLoaderConfigBase.get_hypervisor_domain')
-    def test_post_init_domU(self, mock_domain, mock_machine, mock_exists):
+    def test_post_init_domU(self, mock_machine, mock_exists):
+        self.state.is_xen_server = mock.Mock(
+            return_value=False
+        )
+        self.state.is_xen_guest = mock.Mock(
+            return_value=True
+        )
         mock_machine.return_value = 'x86_64'
-        mock_domain.return_value = 'domU'
         mock_exists.return_value = True
         self.bootloader.post_init(None)
         assert self.bootloader.multiboot is False
         assert self.bootloader.hybrid_boot is False
-        assert self.bootloader.xen_guest is True
-
-    @patch('os.path.exists')
-    @patch('platform.machine')
-    def test_post_init_ec2(self, mock_machine, mock_exists):
-        mock_machine.return_value = 'x86_64'
-        mock_exists.return_value = True
-        self.bootloader.firmware.ec2_mode.return_value = 'ec2hvm'
-        self.bootloader.post_init(None)
         assert self.bootloader.xen_guest is True
 
     @patch_open

--- a/test/unit/bootloader_config_isolinux_test.py
+++ b/test/unit/bootloader_config_isolinux_test.py
@@ -28,6 +28,12 @@ class TestBootLoaderConfigIsoLinux(object):
         self.state = XMLState(
             description.load()
         )
+        self.state.is_xen_server = mock.Mock(
+            return_value=False
+        )
+        self.state.is_xen_guest = mock.Mock(
+            return_value=False
+        )
         kiwi.bootloader.config.isolinux.Path = mock.Mock()
         kiwi.bootloader.config.base.Path = mock.Mock()
         self.isolinux = mock.Mock()
@@ -36,9 +42,6 @@ class TestBootLoaderConfigIsoLinux(object):
         )
         self.bootloader = BootLoaderConfigIsoLinux(
             self.state, 'root_dir'
-        )
-        self.bootloader.get_hypervisor_domain = mock.Mock(
-            return_value='domU'
         )
 
     @raises(KiwiBootLoaderIsoLinuxPlatformError)
@@ -59,10 +62,11 @@ class TestBootLoaderConfigIsoLinux(object):
     @patch('os.path.exists')
     @patch('platform.machine')
     def test_post_init_dom0(self, mock_machine, mock_exists):
+        self.state.is_xen_server = mock.Mock(
+            return_value=True
+        )
         mock_machine.return_value = 'x86_64'
-        self.bootloader.get_hypervisor_domain.return_value = 'dom0'
         mock_exists.return_value = True
-
         self.bootloader.post_init(None)
         assert self.bootloader.multiboot is True
 

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -168,11 +168,6 @@ class TestDiskBuilder(object):
         )
         self.disk_builder.root_filesystem_is_overlay = False
         self.disk_builder.build_type_name = 'oem'
-        self.machine = mock.Mock()
-        self.machine.get_domain = mock.Mock(
-            return_value='dom0'
-        )
-        self.disk_builder.machine = self.machine
         self.disk_builder.image_format = None
 
     @patch('os.path.exists')
@@ -596,7 +591,26 @@ class TestDiskBuilder(object):
     ):
         self.kernel.get_xen_hypervisor.return_value = False
         self.disk_builder.volume_manager_name = None
+        self.disk_builder.xen_server = True
         self.disk_builder.create_disk()
+
+    @patch('kiwi.builder.disk.FileSystem')
+    @patch_open
+    @patch('kiwi.builder.disk.Command.run')
+    def test_create_disk_standard_root_xen_server_boot(
+        self, mock_command, mock_open, mock_fs
+    ):
+        filesystem = mock.Mock()
+        mock_fs.return_value = filesystem
+        self.disk_builder.volume_manager_name = None
+        self.disk_builder.xen_server = True
+        self.firmware.efi_mode = mock.Mock(
+            return_value=False
+        )
+        self.disk_builder.create_disk()
+        self.kernel.copy_xen_hypervisor.assert_called_once_with(
+            'root_dir', '/boot/xen.gz'
+        )
 
     @patch('kiwi.builder.disk.FileSystem')
     @patch_open

--- a/test/unit/builder_install_test.py
+++ b/test/unit/builder_install_test.py
@@ -64,10 +64,6 @@ class TestInstallImageBuilder(object):
         self.install_image = InstallImageBuilder(
             self.xml_state, 'root_dir', 'target_dir', self.boot_image_task
         )
-        self.install_image.machine = mock.Mock()
-        self.install_image.machine.get_domain = mock.Mock(
-            return_value='dom0'
-        )
 
     @patch('platform.machine')
     def test_setup_ix86(self, mock_machine):

--- a/test/unit/builder_live_test.py
+++ b/test/unit/builder_live_test.py
@@ -70,10 +70,6 @@ class TestLiveImageBuilder(object):
             self.xml_state, 'target_dir', 'root_dir',
             custom_args={'signing_keys': ['key_file_a', 'key_file_b']}
         )
-        self.live_image.machine = mock.Mock()
-        self.live_image.machine.get_domain = mock.Mock(
-            return_value='dom0'
-        )
         self.result = mock.Mock()
         self.live_image.result = self.result
         self.live_image.hybrid = True

--- a/test/unit/builder_pxe_test.py
+++ b/test/unit/builder_pxe_test.py
@@ -53,11 +53,6 @@ class TestPxeBuilder(object):
             self.xml_state, 'target_dir', 'root_dir',
             custom_args={'signing_keys': ['key_file_a', 'key_file_b']}
         )
-        self.machine = mock.Mock()
-        self.machine.get_domain = mock.Mock(
-            return_value='dom0'
-        )
-        self.pxe.machine = self.machine
         self.pxe.image_name = 'myimage'
 
     @patch('kiwi.builder.pxe.Checksum')

--- a/test/unit/system_profile_test.py
+++ b/test/unit/system_profile_test.py
@@ -97,7 +97,7 @@ class TestProfile(object):
             'kiwi_type': 'oem',
             'kiwi_vga': None,
             'kiwi_wwid_wait_timeout': None,
-            'kiwi_xendomain': None
+            'kiwi_xendomain': 'dom0'
         }
         assert result == [
             "kiwi_Volume_1='usr_lib|size:1024|usr/lib'",
@@ -122,7 +122,8 @@ class TestProfile(object):
             "kiwi_ramonly='true'",
             "kiwi_splash_theme='openSUSE'",
             "kiwi_timezone='Europe/Berlin'",
-            "kiwi_type='oem'"
+            "kiwi_type='oem'",
+            "kiwi_xendomain='dom0'"
         ]
 
     @patch('kiwi.system.profile.NamedTemporaryFile')

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -625,3 +625,15 @@ class TestXMLState(object):
     def test_set_derived_from_image_uri_not_applied(self, mock_log_warn):
         self.state.set_derived_from_image_uri('file:///new_uri')
         assert mock_log_warn.called
+
+    def test_is_xen_server(self):
+        assert self.state.is_xen_server() is True
+
+    def test_is_xen_guest_by_machine_setup(self):
+        assert self.state.is_xen_guest() is True
+
+    def test_is_xen_guest_by_firmware_setup(self):
+        description = XMLDescription('../data/example_config.xml')
+        xml_data = description.load()
+        state = XMLState(xml_data, ['ec2Flavour'], 'vmx')
+        assert state.is_xen_guest() is True


### PR DESCRIPTION
First start to refactor the way Xen images are configured in the XML description
The changes here references issue #429 

* Update to schema 6.6 with auto conversion via XSLT stylesheet
* Deleted domain attribute from machine section
* Added xen_server attribute to specify a type to be a Xen dom0
* Added xen_loader attribute in machine section to specify the target guest loader this image is expected to become loaded with. There is currently no code which produces a different bootloader setup depending on the value of xen_loader. But there is now a way for us to actually handle it when needed
* Refactor code which deals with Xen to be more clear and straight forward