### PR TITLE
KIWI - Specfile Template - support for Fedora > 25 and CentOS / RHEL 7

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -87,11 +87,11 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 %if 0%{?fedora} || 0%{?suse_version}
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
+BuildRequires:  fdupes
 %endif
 BuildRequires:  python-devel
 BuildRequires:  python-setuptools
 %if 0%{?suse_version}
-BuildRequires:  fdupes
 BuildRequires:  shadow
 BuildRequires:  update-alternatives
 %endif
@@ -383,7 +383,7 @@ mv %{buildroot}/%{_defaultdocdir}/packages/python-kiwi/* %{buildroot}/%{_default
 rm -rf %{buildroot}/%{_defaultdocdir}/packages
 %endif
 
-%if 0%{?suse_version}
+%if 0%{?fedora} || 0%{?suse_version}
 %fdupes %{buildroot}/srv/tftpboot
 %fdupes %{buildroot}/%{python3_sitelib}/kiwi/boot
 %fdupes %{buildroot}/%{python2_sitelib}/kiwi/boot

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -62,10 +62,15 @@
 
 # RHEL // CentOS
 # use the rhel templates for CentOS, too
-%if 0%{?rhel_version} == 700 || 0%{?centos_version} == 700
+%if 0%{?rhel} == 7
 %define distro rhel-07.0
 %endif
 
+# Fedora
+# use the rhel templates for CentOS, too
+%if 0%{?fedora} >= 25
+%define distro fedora-25.0
+%endif
 
 Name:           python-kiwi
 Version:        %%VERSION
@@ -79,13 +84,20 @@ Source:         %{name}.tar.gz
 Source1:        %{name}-boot-packages
 Source2:        %{name}-rpmlintrc
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+%if 0%{?fedora} || 0%{?suse_version}
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
+%endif
 BuildRequires:  python-devel
 BuildRequires:  python-setuptools
+%if 0%{?suse_version}
 BuildRequires:  fdupes
-BuildRequires:  update-alternatives
 BuildRequires:  shadow
+BuildRequires:  update-alternatives
+%endif
+%if 0%{?fedora} || 0%{?rhel}
+BuildRequires:  chkconfig
+%endif
 
 %description
 The KIWI Image System provides an operating system image builder
@@ -103,48 +115,62 @@ Provides:       kiwi-image:iso
 Provides:       kiwi-image:vmx
 Provides:       kiwi-image:pxe
 Provides:       kiwi-image:oem
+%if 0%{?fedora} || 0%{?suse_version}
 Recommends:     jing
-Requires:       update-alternatives
-Requires:       python-docopt
-Requires:       python-setuptools
-Requires:       python-lxml
-Requires:       python-xattr
-Requires:       python-six
-Requires:       python-future
+%endif
 Requires:       python-PyYAML
+Requires:       python-docopt
+Requires:       python-future
+Requires:       python-lxml
 Requires:       python-requests
-Requires(post): update-alternatives
-Requires(postun): update-alternatives
+Requires:       python-setuptools
+Requires:       python-six
+Requires:       python-xattr
 # tools used by kiwi
 %if 0%{?suse_version}
-Requires:       zypper
-Requires:       squashfs
-Provides:       kiwi-packagemanager:zypper
-%endif
-%if 0%{?rhel_version} || 0%{?centos_version}
-Requires:       yum
-Requires:       squashfs-tools
-Provides:       kiwi-packagemanager:yum
-%endif
-Requires:       genisoimage
-Requires:       kiwi-tools
-Requires:       kiwi-man-pages
-Requires:       rsync
-Requires:       tar >= 1.2.7
-Requires:       gptfdisk
-Requires:       qemu-tools
-Requires:       dosfstools
-Requires:       e2fsprogs
-Requires:       lvm2
-Requires:       parted
-Requires:       multipath-tools
-Requires:       grub2
-Requires:       mtools
-%ifarch %arm aarch64
-Requires:       u-boot-tools
-%endif
+Requires:       update-alternatives
+Requires(post): update-alternatives
+Requires(postun): update-alternatives
 %ifarch x86_64
 Requires:       grub2-x86_64-efi
+%endif
+Requires:       qemu-tools
+Requires:       multipath-tools
+Requires:       squashfs
+Requires:       gptfdisk
+%endif
+%if 0%{?fedora} || 0%{?rhel}
+Requires:         chkconfig
+Requires(post):   chkconfig
+Requires(postun): chkconfig
+Requires:       qemu-img
+Requires:       squashfs-tools
+Requires:       device-mapper-multipath
+Requires:       gdisk
+Requires:       yum
+Provides:       kiwi-packagemanager:yum
+%if 0%{?fedora} || 0%{?rhel} >= 8
+Requires:       dnf
+Provides:       kiwi-packagemanager:dnf
+%endif
+%endif
+%if 0%{?fedora} >= 26 || 0%{?suse_version}
+Requires:       zypper
+Provides:       kiwi-packagemanager:zypper
+%endif
+Requires:       dosfstools
+Requires:       e2fsprogs
+Requires:       genisoimage
+Requires:       grub2
+Requires:       kiwi-man-pages
+Requires:       kiwi-tools
+Requires:       lvm2
+Requires:       mtools
+Requires:       parted
+Requires:       rsync
+Requires:       tar >= 1.2.7
+%ifarch %arm aarch64
+Requires:       u-boot-tools
 %endif
 %ifarch s390 s390x
 Requires:       s390-tools
@@ -155,6 +181,7 @@ Python 2 library of the KIWI Image System. Provides an operating system
 image builder for Linux supported hardware platforms as well as for
 virtualization and cloud systems like Xen, KVM, VMware, EC2 and more.
 
+%if 0%{?fedora} || 0%{?suse_version}
 # python3-kiwi
 %package -n python3-kiwi
 Summary:        KIWI - Appliance Builder Next Generation
@@ -166,47 +193,61 @@ Provides:       kiwi-image:vmx
 Provides:       kiwi-image:pxe
 Provides:       kiwi-image:oem
 Recommends:     jing
-Requires:       update-alternatives
-Requires:       python3-docopt
-Requires:       python3-setuptools
-Requires:       python3-lxml
-Requires:       python3-xattr
-Requires:       python3-six
-Requires:       python3-future
 Requires:       python3-PyYAML
+Requires:       python3-docopt
+Requires:       python3-future
+Requires:       python3-lxml
 Requires:       python3-requests
-Requires(post): update-alternatives
-Requires(postun): update-alternatives
+Requires:       python3-setuptools
+Requires:       python3-six
+Requires:       python3-xattr
 # tools used by kiwi
 %if 0%{?suse_version}
-Requires:       zypper
-Requires:       squashfs
-Provides:       kiwi-packagemanager:zypper
-%endif
-%if 0%{?rhel_version} || 0%{?centos_version}
-Requires:       yum
-Requires:       squashfs-tools
-Provides:       kiwi-packagemanager:yum
-%endif
-Requires:       genisoimage
-Requires:       kiwi-tools
-Requires:       kiwi-man-pages
-Requires:       rsync
-Requires:       tar >= 1.2.7
-Requires:       gptfdisk
-Requires:       qemu-tools
-Requires:       dosfstools
-Requires:       e2fsprogs
-Requires:       lvm2
-Requires:       parted
-Requires:       multipath-tools
-Requires:       grub2
-Requires:       mtools
-%ifarch %arm aarch64
-Requires:       u-boot-tools
-%endif
+Requires:       update-alternatives
+Requires(post): update-alternatives
+Requires(postun): update-alternatives
 %ifarch x86_64
 Requires:       grub2-x86_64-efi
+%endif
+Requires:       qemu-tools
+Requires:       multipath-tools
+Requires:       squashfs
+Requires:       gptfdisk
+%endif
+%if 0%{?fedora} || 0%{?rhel}
+Requires:         chkconfig
+Requires(post):   chkconfig
+Requires(postun): chkconfig
+Requires:       qemu-img
+Requires:       squashfs-tools
+Requires:       device-mapper-multipath
+Requires:       gdisk
+%endif
+%if 0%{?rhel} < 8
+Requires:       yum
+Provides:       kiwi-packagemanager:yum
+%endif
+%if 0%{?fedora} || 0%{?rhel} >= 8
+Requires:       dnf
+Provides:       kiwi-packagemanager:dnf
+%endif
+%if 0%{?fedora} >= 26 || 0%{?suse_version}
+Requires:       zypper
+Provides:       kiwi-packagemanager:zypper
+%endif
+Requires:       dosfstools
+Requires:       e2fsprogs
+Requires:       genisoimage
+Requires:       grub2
+Requires:       kiwi-man-pages
+Requires:       kiwi-tools
+Requires:       lvm2
+Requires:       mtools
+Requires:       parted
+Requires:       rsync
+Requires:       tar >= 1.2.7
+%ifarch %arm aarch64
+Requires:       u-boot-tools
 %endif
 %ifarch s390 s390x
 Requires:       s390-tools
@@ -216,6 +257,8 @@ Requires:       s390-tools
 Python 3 library of the KIWI Image System. Provides an operating system
 image builder for Linux supported hardware platforms as well as for
 virtualization and cloud systems like Xen, KVM, VMware, EC2 and more.
+
+%endif
 
 %package -n kiwi-tools
 Summary:        KIWI - Collection of Boot Helper Tools
@@ -248,21 +291,30 @@ needed to serve kiwi built images via PXE.
 %package -n kiwi-boot-requires
 Summary:        KIWI - buildservice package requirements for boot images
 Provides:       kiwi-boot:isoboot
-Provides:       kiwi-boot:vmxboot
 Provides:       kiwi-boot:netboot
 Provides:       kiwi-boot:oemboot
+Provides:       kiwi-boot:vmxboot
 Provides:       kiwi-filesystem:btrfs
-Provides:       kiwi-filesystem:xfs
 Provides:       kiwi-filesystem:ext3
 Provides:       kiwi-filesystem:ext4
 Provides:       kiwi-filesystem:squashfs
-Requires:       btrfsprogs
+Provides:       kiwi-filesystem:xfs
 Requires:       e2fsprogs
-Requires:       xfsprogs
+%if 0%{?fedora} || 0%{?rhel}
+Requires:       btrfs-progs
+%else
+Requires:       btrfsprogs
+%endif
+%if 0%{?fedora} || 0%{?suse_version}
 Requires:       python3-kiwi = %{version}
+%else
+Requires:       python2-kiwi = %{version}
+%endif
+Requires:       xfsprogs
 Requires:       %(echo `cat %{S:1}|grep %{_target_cpu}:%{distro}:|cut -f3- -d:`)
 License:        GPL-3.0+
 Group:          System/Management
+
 
 %description -n kiwi-boot-requires
 Meta package for the buildservice to pull in all required packages in
@@ -286,15 +338,19 @@ Provides manual pages to describe the kiwi commands
 # Build Python 2 version
 python2 setup.py build --cflags="${RPM_OPT_FLAGS}"
 
+%if 0%{?fedora} || 0%{?suse_version}
 # Build Python 3 version
 python3 setup.py build --cflags="${RPM_OPT_FLAGS}"
+%endif
 
 %install
 # Install Python 2 version
 python2 setup.py install --prefix=%{_prefix} --root=%{buildroot}
 
+%if 0%{?fedora} || 0%{?suse_version}
 # Install Python 3 version
 python3 setup.py install --prefix=%{_prefix} --root=%{buildroot}
+%endif
 
 # init alternatives setup
 mkdir -p %{buildroot}%{_sysconfdir}/alternatives
@@ -321,9 +377,17 @@ for i in KIWI pxelinux.cfg image upload boot; do \
 done
 %endif
 
+%if  0%{?fedora} || 0%{?rhel}
+install -m 755 -d %{buildroot}/%{_defaultdocdir}/python-kiwi
+mv %{buildroot}/%{_defaultdocdir}/packages/python-kiwi/* %{buildroot}/%{_defaultdocdir}/python-kiwi
+rm -rf %{buildroot}/%{_defaultdocdir}/packages
+%endif
+
+%if 0%{?suse_version}
 %fdupes %{buildroot}/srv/tftpboot
 %fdupes %{buildroot}/%{python3_sitelib}/kiwi/boot
 %fdupes %{buildroot}/%{python2_sitelib}/kiwi/boot
+%endif
 
 %post -n python2-kiwi
 %{_sbindir}/update-alternatives \
@@ -333,6 +397,7 @@ done
 %{_sbindir}/update-alternatives \
     --install %_bindir/kiwicompat kiwicompat %_bindir/kiwicompat-2 10
 
+%if 0%{?fedora} || 0%{?suse_version}
 %post -n python3-kiwi
 %{_sbindir}/update-alternatives \
     --install %_bindir/kiwi kiwi %_bindir/kiwi-ng-3 10
@@ -340,6 +405,7 @@ done
     --install %_bindir/kiwi-ng kiwi-ng %_bindir/kiwi-ng-3 10
 %{_sbindir}/update-alternatives \
     --install %_bindir/kiwicompat kiwicompat %_bindir/kiwicompat-3 10
+%endif
 
 %preun -n python2-kiwi
 %{_sbindir}/update-alternatives \
@@ -349,6 +415,7 @@ done
 %{_sbindir}/update-alternatives \
     --remove kiwicompat %_bindir/kiwicompat
 
+%if 0%{?fedora} || 0%{?suse_version}
 %preun -n python3-kiwi
 %{_sbindir}/update-alternatives \
     --remove kiwi %_bindir/kiwi
@@ -356,6 +423,7 @@ done
     --remove kiwi %_bindir/kiwi-ng
 %{_sbindir}/update-alternatives \
     --remove kiwicompat %_bindir/kiwicompat
+%endif
 
 %ifarch %ix86 x86_64
 %pre -n kiwi-pxeboot
@@ -383,6 +451,7 @@ fi
 %{python2_sitelib}/*
 %config %_sysconfdir/bash_completion.d/kiwi-ng-2*.sh
 
+%if 0%{?fedora} || 0%{?suse_version}
 %files -n python3-kiwi
 %defattr(-,root,root,-)
 %{_bindir}/kiwi-ng-3*
@@ -395,6 +464,7 @@ fi
 %ghost %_sysconfdir/alternatives/kiwicompat
 %{python3_sitelib}/*
 %config %_sysconfdir/bash_completion.d/kiwi-ng-3*.sh
+%endif
 
 %files -n kiwi-man-pages
 %defattr(-, root, root)

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -291,15 +291,16 @@ needed to serve kiwi built images via PXE.
 %package -n kiwi-boot-requires
 Summary:        KIWI - buildservice package requirements for boot images
 Provides:       kiwi-boot:isoboot
+Provides:       kiwi-boot:vmxboot
 Provides:       kiwi-boot:netboot
 Provides:       kiwi-boot:oemboot
-Provides:       kiwi-boot:vmxboot
 Provides:       kiwi-filesystem:btrfs
+Provides:       kiwi-filesystem:xfs
 Provides:       kiwi-filesystem:ext3
 Provides:       kiwi-filesystem:ext4
 Provides:       kiwi-filesystem:squashfs
-Provides:       kiwi-filesystem:xfs
 Requires:       e2fsprogs
+Requires:       xfsprogs
 %if 0%{?fedora} || 0%{?rhel}
 Requires:       btrfs-progs
 %else
@@ -310,7 +311,6 @@ Requires:       python3-kiwi = %{version}
 %else
 Requires:       python2-kiwi = %{version}
 %endif
-Requires:       xfsprogs
 Requires:       %(echo `cat %{S:1}|grep %{_target_cpu}:%{distro}:|cut -f3- -d:`)
 License:        GPL-3.0+
 Group:          System/Management


### PR DESCRIPTION
Added a working build target for Fedora > 25 and fixed CentOS / RHEL >= 7 package builds.

On CentOS, some additional python2 packages are needed. Due to missing python3 on CentOS / RHEL 7, for this target only the python2-kiwi version is build.