### PR TITLE
Xz default options

### DIFF
--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -52,8 +52,7 @@ class BootImageBase(object):
         list of package signing keys
 
     * :attr:`custom_args`
-        Custom processing arguments defined as hash keys:
-        * xz_options: string of XZ compression parameters
+        Custom processing arguments defined as hash keys
     """
     def __init__(
         self, xml_state, target_dir, root_dir=None,
@@ -68,9 +67,6 @@ class BootImageBase(object):
         self.call_destructor = True
         self.signing_keys = signing_keys
         self.boot_root_directory = root_dir
-
-        self.xz_options = custom_args['xz_options'] if custom_args \
-            and 'xz_options' in custom_args else None
 
         if not os.path.exists(target_dir):
             raise KiwiTargetDirectoryNotFound(

--- a/kiwi/boot/image/builtin_kiwi.py
+++ b/kiwi/boot/image/builtin_kiwi.py
@@ -167,5 +167,7 @@ class BootImageKiwi(BootImageBase):
             compress = Compress(
                 os.sep.join([self.target_dir, self.initrd_base_name])
             )
-            compress.xz(self.xz_options)
+            compress.xz(
+                ['--check=crc32', '--lzma2=dict=1MiB', '-T0']
+            )
             self.initrd_filename = compress.compressed_filename

--- a/kiwi/boot/image/builtin_kiwi.py
+++ b/kiwi/boot/image/builtin_kiwi.py
@@ -168,6 +168,6 @@ class BootImageKiwi(BootImageBase):
                 os.sep.join([self.target_dir, self.initrd_base_name])
             )
             compress.xz(
-                ['--check=crc32', '--lzma2=dict=1MiB', '-T0']
+                ['--check=crc32', '--lzma2=dict=1MiB', '--threads=0']
             )
             self.initrd_filename = compress.compressed_filename

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -65,8 +65,7 @@ class Defaults(object):
     @classmethod
     def get_xz_compression_options(self):
         return [
-            '--check=crc32',
-            '--lzma2=dict=512KiB'
+            '--threads=0'
         ]
 
     @classmethod

--- a/test/unit/archive_tar_test.py
+++ b/test/unit/archive_tar_test.py
@@ -125,8 +125,8 @@ class TestArchiveTar(object):
                 ' '.join([
                     'tar', '-C', 'source-dir', '--xattrs',
                     '--xattrs-include=*', '-c', '--to-stdout',
-                    'foo', 'bar', '|', 'xz', '-f', '--check=crc32',
-                    '--lzma2=dict=512KiB', '>', 'foo.tar.xz'
+                    'foo', 'bar', '|', 'xz', '-f', '--threads=0',
+                    '>', 'foo.tar.xz'
                 ])
             ]
         )

--- a/test/unit/boot_image_builtin_kiwi_test.py
+++ b/test/unit/boot_image_builtin_kiwi_test.py
@@ -131,7 +131,9 @@ class TestBootImageKiwi(object):
                 '/usr/share/doc', '/usr/share/man', '/home', '/media', '/srv'
             ]
         )
-        compress.xz.assert_called_once_with(None)
+        compress.xz.assert_called_once_with(
+            ['--check=crc32', '--lzma2=dict=1MiB', '-T0']
+        )
 
     @patch('kiwi.boot.image.base.Path.wipe')
     @patch('os.path.exists')

--- a/test/unit/boot_image_builtin_kiwi_test.py
+++ b/test/unit/boot_image_builtin_kiwi_test.py
@@ -132,7 +132,7 @@ class TestBootImageKiwi(object):
             ]
         )
         compress.xz.assert_called_once_with(
-            ['--check=crc32', '--lzma2=dict=1MiB', '-T0']
+            ['--check=crc32', '--lzma2=dict=1MiB', '--threads=0']
         )
 
     @patch('kiwi.boot.image.base.Path.wipe')

--- a/test/unit/utils_compress_test.py
+++ b/test/unit/utils_compress_test.py
@@ -26,7 +26,7 @@ class TestCompress(object):
         self.compress.xz()
         mock_command.assert_called_once_with(
             [
-                'xz', '-f', '--check=crc32', '--lzma2=dict=512KiB', '--keep',
+                'xz', '-f', '--threads=0', '--keep',
                 'some-file'
             ]
         )


### PR DESCRIPTION
This one fixes two Issues

* Use kernel compatible XZ options for kiwi initrd
    
  The kernel requires specific XZ options for the initrd
  in order to read the compressed data. This values should
  not be configurable by the user and are set to the same
  options as used by dracut now. Fixes #435

* Change default XZ compression options
    
  Use all cpu cores by default. Fixes #433