### PR TITLE
Fixup lvm disk size setup and map cleanup

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -434,6 +434,16 @@ class Defaults(object):
         return 30
 
     @classmethod
+    def get_lvm_overhead_mbytes(self):
+        """
+        Implements empiric LVM overhead size in mbytes
+
+        :return: mbsize
+        :rtype: int
+        """
+        return 80
+
+    @classmethod
     def get_default_boot_mbytes(self):
         """
         Implements default boot partition size in mbytes

--- a/kiwi/storage/disk.py
+++ b/kiwi/storage/disk.py
@@ -341,9 +341,8 @@ class Disk(DeviceProvider):
         if self.storage_provider.is_loop() and self.is_mapped:
             log.info('Cleaning up %s instance', type(self).__name__)
             try:
-                Command.run(
-                    ['kpartx', '-s', '-d', self.storage_provider.get_device()]
-                )
+                for device_node in self.partition_map.values():
+                    Command.run(['dmsetup', 'remove', device_node])
             except Exception:
                 log.warning(
                     'cleanup of partition device maps failed, %s still busy',

--- a/kiwi/storage/setup.py
+++ b/kiwi/storage/setup.py
@@ -120,6 +120,11 @@ class DiskSetup(object):
             root_filesystem_mbytes
         )
         if self.volume_manager and self.volume_manager == 'lvm':
+            lvm_overhead_mbytes = Defaults.get_lvm_overhead_mbytes()
+            log.info(
+                '--> LVM overhead adding %s MB', lvm_overhead_mbytes
+            )
+            calculated_disk_mbytes += lvm_overhead_mbytes
             if self.build_type_name == 'vmx':
                 # only for vmx types we need to add the configured volume
                 # sizes. oem disks are self expandable and will resize to

--- a/test/unit/storage_disk_test.py
+++ b/test/unit/storage_disk_test.py
@@ -229,10 +229,11 @@ class TestDisk(object):
     @patch('kiwi.logger.log.warning')
     def test_destructor(self, mock_log_warn, mock_command):
         self.disk.is_mapped = True
+        self.disk.partition_map = {'root': '/dev/mapper/loop0p1'}
         mock_command.side_effect = Exception
         self.disk.__del__()
         mock_command.assert_called_once_with(
-            ['kpartx', '-s', '-d', '/dev/loop0']
+            ['dmsetup', 'remove', '/dev/mapper/loop0p1']
         )
         assert mock_log_warn.called
         self.disk.is_mapped = False

--- a/test/unit/storage_setup_test.py
+++ b/test/unit/storage_setup_test.py
@@ -164,6 +164,7 @@ class TestDiskSetup(object):
 
     def test_get_disksize_mbytes_empty_volumes(self):
         assert self.setup_empty_volumes.get_disksize_mbytes() == \
+            Defaults.get_lvm_overhead_mbytes() + \
             Defaults.get_default_legacy_bios_mbytes() + \
             Defaults.get_default_efi_boot_mbytes() + \
             Defaults.get_default_boot_mbytes() + \
@@ -175,6 +176,7 @@ class TestDiskSetup(object):
         mock_exists.return_value = True
         root_size = self.size.accumulate_mbyte_file_sizes.return_value
         assert self.setup_volumes.get_disksize_mbytes() == \
+            Defaults.get_lvm_overhead_mbytes() + \
             Defaults.get_default_legacy_bios_mbytes() + \
             Defaults.get_default_efi_boot_mbytes() + \
             Defaults.get_default_boot_mbytes() + \
@@ -191,6 +193,7 @@ class TestDiskSetup(object):
         mock_exists.return_value = True
         root_size = self.size.accumulate_mbyte_file_sizes.return_value
         assert self.setup_root_volume.get_disksize_mbytes() == \
+            Defaults.get_lvm_overhead_mbytes() + \
             Defaults.get_default_legacy_bios_mbytes() + \
             Defaults.get_default_efi_boot_mbytes() + \
             Defaults.get_default_boot_mbytes() + \


### PR DESCRIPTION
This change is two fold

1. Add LVM overhead for lvm based images
    
    LVM itself requires metadata stored in the metadata block
    kiwi did not take a size value for this data into account

2. Use dmsetup to cleanup device maps
    
    Instead of the broken kpartx -d we use dmsetup remove
    directly on the maps kiwi has created