### PR TITLE
Fix RHEL spec check

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -223,7 +223,7 @@ Requires:       squashfs-tools
 Requires:       device-mapper-multipath
 Requires:       gdisk
 %endif
-%if 0%{?rhel} < 8
+%if 0%{?rhel} && 0%{?rhel} < 8
 Requires:       yum
 Provides:       kiwi-packagemanager:yum
 %endif


### PR DESCRIPTION
Fixes #N/A.

Changes proposed in this pull request:
* Check if OS is RHEL before checking OS-version, else yum will become a requirement on SLES etc.

Note; I haven't checked this on any other OS than SLES12-SP2, so please do before merging...
