### PR TITLE
Fixup encoding handling for profile file

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -17,6 +17,8 @@
 #
 import os
 import glob
+import sys
+from six.moves import reload_module
 from collections import namedtuple
 import platform
 from pkg_resources import resource_filename
@@ -842,6 +844,22 @@ class Defaults(object):
         :rtype: string
         """
         return os.sep.join([root_dir, 'image', 'imported_root'])
+
+    @classmethod
+    def set_python_default_encoding_to_utf8(self):
+        """
+        Set python default encoding to utf-8 if not already done
+
+        This is not a safe operation since sys.setdefaultencoding()
+        was removed from sys on purpose when Python starts. Reenabling
+        it and changing the default encoding can break code that relies
+        on ascii being the default. Within the scope of kiwi the
+        operation is safe because all data is expected to be utf-8
+        everywhere and considered a bug if this is not the case
+        """
+        if sys.version_info.major < 3:
+            reload_module(sys)  # Reload required to get setdefaultencoding back
+            sys.setdefaultencoding('utf-8')
 
     def get(self, key):
         """

--- a/kiwi/system/profile.py
+++ b/kiwi/system/profile.py
@@ -72,6 +72,8 @@ class Profile(object):
         :return: profile dump for bash
         :rtype: string
         """
+        Defaults.set_python_default_encoding_to_utf8()
+
         sorted_profile = collections.OrderedDict(
             sorted(self.dot_profile.items())
         )

--- a/test/data/example_dot_profile_config.xml
+++ b/test/data/example_dot_profile_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.6" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.6" name="LimeJeOS-openSUSE-13.2" displayname="schäfer">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -32,6 +32,7 @@
                 <oem-systemsize>2048</oem-systemsize>
                 <oem-swap>true</oem-swap>
                 <oem-recovery>false</oem-recovery>
+                <oem-boot-title>schäfer</oem-boot-title>
             </oemconfig>
             <machine memory="512" guestOS="suse" HWversion="4">
                 <vmdisk id="0" controller="ide"/>

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -63,3 +63,11 @@ class TestDefaults(object):
         assert Defaults.get_grub_boot_directory_name(
             lookup_path='lookup_path'
         ) == 'grub'
+
+    @patch('kiwi.defaults.sys')
+    @patch('kiwi.defaults.reload_module')
+    def test_set_python_default_encoding_to_utf8(self, mock_reload, mock_sys):
+        mock_sys.version_info.major = 2
+        Defaults.set_python_default_encoding_to_utf8()
+        mock_reload.assert_called_once_with(mock_sys)
+        mock_sys.setdefaultencoding.assert_called_once_with('utf-8')

--- a/test/unit/system_profile_test.py
+++ b/test/unit/system_profile_test.py
@@ -1,3 +1,4 @@
+# vim: set fileencoding=utf-8
 from mock import patch
 
 import mock
@@ -40,7 +41,7 @@ class TestProfile(object):
             'kiwi_delete': '',
             'kiwi_devicepersistency': None,
             'kiwi_bootloader_console': None,
-            'kiwi_displayname': 'LimeJeOS-openSUSE-13.2',
+            'kiwi_displayname': 'schäfer',
             'kiwi_drivers': '',
             'kiwi_firmware': 'efi',
             'kiwi_fsmountoptions': None,
@@ -78,7 +79,7 @@ class TestProfile(object):
             'kiwi_oemskipverify': None,
             'kiwi_oemswapMB': None,
             'kiwi_oemswap': 'true',
-            'kiwi_oemtitle': None,
+            'kiwi_oemtitle': 'schäfer',
             'kiwi_oemunattended_id': None,
             'kiwi_oemunattended': None,
             'kiwi_oemvmcp_parmfile': None,
@@ -107,7 +108,7 @@ class TestProfile(object):
             "kiwi_Volume_5='usr_bin|size:all|usr/bin'",
             "kiwi_bootloader='grub2'",
             "kiwi_cmdline='splash'",
-            "kiwi_displayname='LimeJeOS-openSUSE-13.2'",
+            "kiwi_displayname='schäfer'",
             "kiwi_firmware='efi'",
             "kiwi_hwclock='utc'",
             "kiwi_iname='LimeJeOS-openSUSE-13.2'",
@@ -119,12 +120,26 @@ class TestProfile(object):
             "kiwi_lvmgroup='systemVG'",
             "kiwi_oemrootMB='2048'",
             "kiwi_oemswap='true'",
+            "kiwi_oemtitle='schäfer'",
             "kiwi_ramonly='true'",
             "kiwi_splash_theme='openSUSE'",
             "kiwi_timezone='Europe/Berlin'",
             "kiwi_type='oem'",
             "kiwi_xendomain='dom0'"
         ]
+
+    @patch('kiwi.system.profile.NamedTemporaryFile')
+    @patch('kiwi.path.Path.which')
+    def test_create_displayname_is_image_name(self, mock_which, mock_temp):
+        mock_which.return_value = 'cp'
+        mock_temp.return_value = self.tmpfile
+        description = XMLDescription('../data/example_pxe_config.xml')
+        profile = Profile(
+            XMLState(description.load())
+        )
+        profile.create()
+        os.remove(self.tmpfile.name)
+        assert profile.dot_profile['kiwi_displayname'] == 'LimeJeOS-openSUSE-13.2'
 
     @patch('kiwi.system.profile.NamedTemporaryFile')
     @patch('kiwi.path.Path.which')


### PR DESCRIPTION
If an element like displayname or oem-boot-title contains characters outside of the ascii table this causes trouble when kiwi writes out the profile file and the code is called through python2. The reason here is that the default encoding on write() (and other methods) is set to ascii in python2 and when it receives unicode characters outside of the ascii spec a UnicodeEncodeError is thrown. Now all of kiwi is using Unicode which means this does not produce a problem when calling the code through python3 because the default encoding is utf-8 there. This patch introduces a method which allows to change python's default encoding and calls it at the code point where we write the profile because we got unicode and we want to write unicode in any case. This fixes at least one situation for python2-kiwi to allow the use of non ascii characters in the XML setup. If other places will be found the same approach should allow to fix it for python2

