### PR TITLE
Export packages list file and package verification file also for dpkg

### DIFF
--- a/kiwi/builder/archive.py
+++ b/kiwi/builder/archive.py
@@ -105,7 +105,7 @@ class ArchiveBuilder(object):
             )
             self.result.add(
                 key='image_packages',
-                filename=self.system_setup.export_rpm_package_list(
+                filename=self.system_setup.export_package_list(
                     self.target_dir
                 ),
                 use_for_bundle=True,

--- a/kiwi/builder/archive.py
+++ b/kiwi/builder/archive.py
@@ -114,7 +114,7 @@ class ArchiveBuilder(object):
             )
             self.result.add(
                 key='image_verified',
-                filename=self.system_setup.export_rpm_package_verification(
+                filename=self.system_setup.export_package_verification(
                     self.target_dir
                 ),
                 use_for_bundle=True,

--- a/kiwi/builder/container.py
+++ b/kiwi/builder/container.py
@@ -140,7 +140,7 @@ class ContainerBuilder(object):
         )
         self.result.add(
             key='image_packages',
-            filename=self.system_setup.export_rpm_package_list(
+            filename=self.system_setup.export_package_list(
                 self.target_dir
             ),
             use_for_bundle=True,

--- a/kiwi/builder/container.py
+++ b/kiwi/builder/container.py
@@ -149,7 +149,7 @@ class ContainerBuilder(object):
         )
         self.result.add(
             key='image_verified',
-            filename=self.system_setup.export_rpm_package_verification(
+            filename=self.system_setup.export_package_verification(
                 self.target_dir
             ),
             use_for_bundle=True,

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -435,7 +435,7 @@ class DiskBuilder(object):
         )
         self.result.add(
             key='image_verified',
-            filename=self.system_setup.export_rpm_package_verification(
+            filename=self.system_setup.export_package_verification(
                 self.target_dir
             ),
             use_for_bundle=True,

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -426,7 +426,7 @@ class DiskBuilder(object):
         # create image root metadata
         self.result.add(
             key='image_packages',
-            filename=self.system_setup.export_rpm_package_list(
+            filename=self.system_setup.export_package_list(
                 self.target_dir
             ),
             use_for_bundle=True,

--- a/kiwi/builder/filesystem.py
+++ b/kiwi/builder/filesystem.py
@@ -144,7 +144,7 @@ class FileSystemBuilder(object):
         )
         self.result.add(
             key='image_packages',
-            filename=self.system_setup.export_rpm_package_list(
+            filename=self.system_setup.export_package_list(
                 self.target_dir
             ),
             use_for_bundle=True,

--- a/kiwi/builder/filesystem.py
+++ b/kiwi/builder/filesystem.py
@@ -153,7 +153,7 @@ class FileSystemBuilder(object):
         )
         self.result.add(
             key='image_verified',
-            filename=self.system_setup.export_rpm_package_verification(
+            filename=self.system_setup.export_package_verification(
                 self.target_dir
             ),
             use_for_bundle=True,

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -258,7 +258,7 @@ class LiveImageBuilder(object):
         )
         self.result.add(
             key='image_verified',
-            filename=self.system_setup.export_rpm_package_verification(
+            filename=self.system_setup.export_package_verification(
                 self.target_dir
             ),
             use_for_bundle=True,

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -249,7 +249,7 @@ class LiveImageBuilder(object):
         )
         self.result.add(
             key='image_packages',
-            filename=self.system_setup.export_rpm_package_list(
+            filename=self.system_setup.export_package_list(
                 self.target_dir
             ),
             use_for_bundle=True,

--- a/kiwi/builder/pxe.py
+++ b/kiwi/builder/pxe.py
@@ -203,7 +203,7 @@ class PxeBuilder(object):
         )
         self.result.add(
             key='image_verified',
-            filename=self.system_setup.export_rpm_package_verification(
+            filename=self.system_setup.export_package_verification(
                 self.target_dir
             ),
             use_for_bundle=True,

--- a/kiwi/builder/pxe.py
+++ b/kiwi/builder/pxe.py
@@ -194,7 +194,7 @@ class PxeBuilder(object):
         # create image root metadata
         self.result.add(
             key='image_packages',
-            filename=self.system_setup.export_rpm_package_list(
+            filename=self.system_setup.export_package_list(
                 self.target_dir
             ),
             use_for_bundle=True,

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -861,6 +861,23 @@ class Defaults(object):
             reload_module(sys)  # Reload required to get setdefaultencoding back
             sys.setdefaultencoding('utf-8')
 
+    @classmethod
+    def get_default_packager_tool(self, package_manager):
+        """
+        Returns the packager tool according to the package manager
+
+        :param string package_manager: is the package_manger set in XML
+
+        :return: packager tool
+        :rtype: string
+        """
+        rpm_based = ['zypper', 'yum', 'dnf']
+        deb_based = ['apt-get']
+        if package_manager in rpm_based:
+            return 'rpm'
+        elif package_manager in deb_based:
+            return 'dpkg'
+
     def get(self, key):
         """
         Implements get method for profile elements

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -420,37 +420,30 @@ class SystemSetup(object):
                 options=['-z', '-a']
             )
 
-    def export_rpm_package_list(self, target_dir):
+    def export_package_list(self, target_dir):
         """
         Export image rpm package list as metadata reference
         used by the open buildservice
 
         :param string target_dir: path name
         """
-        if os.path.exists(self.root_dir + '/var/lib/rpm/Packages'):
-            log.info('Export rpm packages metadata')
-            filename = ''.join(
-                [
-                    target_dir, '/',
-                    self.xml_state.xml_data.get_name(),
-                    '.' + self.arch,
-                    '-' + self.xml_state.get_image_version(),
-                    '.packages'
-                ]
-            )
-            query_call = Command.run(
-                [
-                    'rpm', '--root', self.root_dir, '-qa', '--qf',
-                    '|'.join(
-                        [
-                            '%{NAME}', '%{EPOCH}', '%{VERSION}', '%{RELEASE}',
-                            '%{ARCH}', '%{DISTURL}', '\\n'
-                        ]
-                    )
-                ]
-            )
-            with open(filename, 'w') as packages:
-                packages.write(query_call.output)
+        filename = ''.join(
+            [
+                target_dir, '/',
+                self.xml_state.xml_data.get_name(),
+                '.' + self.arch,
+                '-' + self.xml_state.get_image_version(),
+                '.packages'
+            ]
+        )
+        packager = Defaults.get_default_packager_tool(
+            self.xml_state.get_package_manager()
+        )
+        if packager == 'rpm':
+            self._export_rpm_package_list(filename)
+            return filename
+        elif packager == 'dpkg':
+            self._export_deb_package_list(filename)
             return filename
 
     def export_rpm_package_verification(self, target_dir):
@@ -840,3 +833,30 @@ class SystemSetup(object):
         """
         if section_content:
             return section_content[0]
+
+    def _export_rpm_package_list(self, filename):
+        log.info('Export rpm packages metadata')
+        query_call = Command.run(
+            [
+                'rpm', '--root', self.root_dir, '-qa', '--qf',
+                '|'.join(
+                    [
+                        '%{NAME}', '%{EPOCH}', '%{VERSION}', '%{RELEASE}',
+                        '%{ARCH}', '%{DISTURL}', '\\n'
+                    ]
+                )
+            ]
+        )
+        with open(filename, 'w') as packages:
+            packages.write(query_call.output)
+
+    def _export_deb_package_list(self, filename):
+        log.info('Export deb packages metadata')
+        query_call = Command.run(
+            [
+                'chroot', self.root_dir, 'dpkg-query', '-W', '-f',
+                '${Package}|${Version}|${Architecture}\n'
+            ]
+        )
+        with open(filename, 'w') as packages:
+            packages.write(query_call.output)

--- a/test/unit/builder_archive_test.py
+++ b/test/unit/builder_archive_test.py
@@ -75,6 +75,6 @@ class TestArchiveBuilder(object):
         self.setup.export_rpm_package_verification.assert_called_once_with(
             'target_dir'
         )
-        self.setup.export_rpm_package_list.assert_called_once_with(
+        self.setup.export_package_list.assert_called_once_with(
             'target_dir'
         )

--- a/test/unit/builder_archive_test.py
+++ b/test/unit/builder_archive_test.py
@@ -72,7 +72,7 @@ class TestArchiveBuilder(object):
         checksum.md5.assert_called_once_with(
             'target_dir/myimage.x86_64-1.2.3.md5'
         )
-        self.setup.export_rpm_package_verification.assert_called_once_with(
+        self.setup.export_package_verification.assert_called_once_with(
             'target_dir'
         )
         self.setup.export_package_list.assert_called_once_with(

--- a/test/unit/builder_container_test.py
+++ b/test/unit/builder_container_test.py
@@ -101,7 +101,7 @@ class TestContainerBuilder(object):
         mock_setup.return_value = container_setup
         container_image = mock.Mock()
         mock_image.return_value = container_image
-        self.setup.export_rpm_package_verification.return_value = '.verified'
+        self.setup.export_package_verification.return_value = '.verified'
         self.setup.export_package_list.return_value = '.packages'
         self.container.base_image = None
         self.container.create()
@@ -138,7 +138,7 @@ class TestContainerBuilder(object):
                 shasum=False
             )
         ]
-        self.setup.export_rpm_package_verification.assert_called_once_with(
+        self.setup.export_package_verification.assert_called_once_with(
             'target_dir'
         )
         self.setup.export_package_list.assert_called_once_with(
@@ -163,7 +163,7 @@ class TestContainerBuilder(object):
 
         container_image = mock.Mock()
         mock_image.return_value = container_image
-        self.setup.export_rpm_package_verification.return_value = '.verified'
+        self.setup.export_package_verification.return_value = '.verified'
         self.setup.export_package_list.return_value = '.packages'
 
         container.create()
@@ -203,7 +203,7 @@ class TestContainerBuilder(object):
                 shasum=False
             )
         ]
-        self.setup.export_rpm_package_verification.assert_called_once_with(
+        self.setup.export_package_verification.assert_called_once_with(
             'target_dir'
         )
         self.setup.export_package_list.assert_called_once_with(

--- a/test/unit/builder_container_test.py
+++ b/test/unit/builder_container_test.py
@@ -102,7 +102,7 @@ class TestContainerBuilder(object):
         container_image = mock.Mock()
         mock_image.return_value = container_image
         self.setup.export_rpm_package_verification.return_value = '.verified'
-        self.setup.export_rpm_package_list.return_value = '.packages'
+        self.setup.export_package_list.return_value = '.packages'
         self.container.base_image = None
         self.container.create()
         mock_setup.assert_called_once_with(
@@ -141,7 +141,7 @@ class TestContainerBuilder(object):
         self.setup.export_rpm_package_verification.assert_called_once_with(
             'target_dir'
         )
-        self.setup.export_rpm_package_list.assert_called_once_with(
+        self.setup.export_package_list.assert_called_once_with(
             'target_dir'
         )
 
@@ -164,7 +164,7 @@ class TestContainerBuilder(object):
         container_image = mock.Mock()
         mock_image.return_value = container_image
         self.setup.export_rpm_package_verification.return_value = '.verified'
-        self.setup.export_rpm_package_list.return_value = '.packages'
+        self.setup.export_package_list.return_value = '.packages'
 
         container.create()
 
@@ -206,7 +206,7 @@ class TestContainerBuilder(object):
         self.setup.export_rpm_package_verification.assert_called_once_with(
             'target_dir'
         )
-        self.setup.export_rpm_package_list.assert_called_once_with(
+        self.setup.export_package_list.assert_called_once_with(
             'target_dir'
         )
 

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -342,7 +342,7 @@ class TestDiskBuilder(object):
             call(['cp', 'root_dir/recovery.partition.size', 'boot_dir']),
             call(['mv', 'initrd', 'root_dir/boot/initrd.vmx']),
         ]
-        self.setup.export_rpm_package_list.assert_called_once_with(
+        self.setup.export_package_list.assert_called_once_with(
             'target_dir'
         )
         self.setup.export_rpm_package_verification.assert_called_once_with(
@@ -463,7 +463,7 @@ class TestDiskBuilder(object):
             call(['mv', 'initrd', 'root_dir/boot/initramfs-1.2.3.img']),
             call(['cp', 'root_dir/recovery.partition.size', 'boot_dir_kiwi'])
         ]
-        self.setup.export_rpm_package_list.assert_called_once_with(
+        self.setup.export_package_list.assert_called_once_with(
             'target_dir'
         )
         self.setup.export_rpm_package_verification.assert_called_once_with(

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -345,7 +345,7 @@ class TestDiskBuilder(object):
         self.setup.export_package_list.assert_called_once_with(
             'target_dir'
         )
-        self.setup.export_rpm_package_verification.assert_called_once_with(
+        self.setup.export_package_verification.assert_called_once_with(
             'target_dir'
         )
 
@@ -466,7 +466,7 @@ class TestDiskBuilder(object):
         self.setup.export_package_list.assert_called_once_with(
             'target_dir'
         )
-        self.setup.export_rpm_package_verification.assert_called_once_with(
+        self.setup.export_package_verification.assert_called_once_with(
             'target_dir'
         )
 

--- a/test/unit/builder_filesystem_test.py
+++ b/test/unit/builder_filesystem_test.py
@@ -100,7 +100,7 @@ class TestFileSystemBuilder(object):
         self.filesystem.sync_data.assert_called_once_with(
             ['image', '.profile', '.kconfig', 'var/cache/kiwi']
         )
-        self.setup.export_rpm_package_verification.assert_called_once_with(
+        self.setup.export_package_verification.assert_called_once_with(
             'target_dir'
         )
         self.setup.export_package_list.assert_called_once_with(
@@ -130,7 +130,7 @@ class TestFileSystemBuilder(object):
         self.filesystem.create_on_file.assert_called_once_with(
             'target_dir/myimage.x86_64-1.2.3.squashfs', None
         )
-        self.setup.export_rpm_package_verification.assert_called_once_with(
+        self.setup.export_package_verification.assert_called_once_with(
             'target_dir'
         )
         self.setup.export_package_list.assert_called_once_with(

--- a/test/unit/builder_filesystem_test.py
+++ b/test/unit/builder_filesystem_test.py
@@ -103,7 +103,7 @@ class TestFileSystemBuilder(object):
         self.setup.export_rpm_package_verification.assert_called_once_with(
             'target_dir'
         )
-        self.setup.export_rpm_package_list.assert_called_once_with(
+        self.setup.export_package_list.assert_called_once_with(
             'target_dir'
         )
 
@@ -133,6 +133,6 @@ class TestFileSystemBuilder(object):
         self.setup.export_rpm_package_verification.assert_called_once_with(
             'target_dir'
         )
-        self.setup.export_rpm_package_list.assert_called_once_with(
+        self.setup.export_package_list.assert_called_once_with(
             'target_dir'
         )

--- a/test/unit/builder_live_test.py
+++ b/test/unit/builder_live_test.py
@@ -134,7 +134,7 @@ class TestLiveImageBuilder(object):
         )
         mock_size.return_value = rootsize
         self.setup.export_rpm_package_verification.return_value = '.verified'
-        self.setup.export_rpm_package_list.return_value = '.packages'
+        self.setup.export_package_list.return_value = '.packages'
 
         self.live_image.create()
 
@@ -253,7 +253,7 @@ class TestLiveImageBuilder(object):
         self.setup.export_rpm_package_verification.assert_called_once_with(
             'target_dir'
         )
-        self.setup.export_rpm_package_list.assert_called_once_with(
+        self.setup.export_package_list.assert_called_once_with(
             'target_dir'
         )
 

--- a/test/unit/builder_live_test.py
+++ b/test/unit/builder_live_test.py
@@ -133,7 +133,7 @@ class TestLiveImageBuilder(object):
             return_value=8192
         )
         mock_size.return_value = rootsize
-        self.setup.export_rpm_package_verification.return_value = '.verified'
+        self.setup.export_package_verification.return_value = '.verified'
         self.setup.export_package_list.return_value = '.packages'
 
         self.live_image.create()
@@ -250,7 +250,7 @@ class TestLiveImageBuilder(object):
                 shasum=False
             )
         ]
-        self.setup.export_rpm_package_verification.assert_called_once_with(
+        self.setup.export_package_verification.assert_called_once_with(
             'target_dir'
         )
         self.setup.export_package_list.assert_called_once_with(

--- a/test/unit/builder_pxe_test.py
+++ b/test/unit/builder_pxe_test.py
@@ -84,7 +84,7 @@ class TestPxeBuilder(object):
             'initrd_dir'
         )
         self.boot_image_task.create_initrd.assert_called_once_with()
-        self.setup.export_rpm_package_list.assert_called_once_with(
+        self.setup.export_package_list.assert_called_once_with(
             'target_dir'
         )
         self.setup.export_rpm_package_verification.assert_called_once_with(

--- a/test/unit/builder_pxe_test.py
+++ b/test/unit/builder_pxe_test.py
@@ -87,7 +87,7 @@ class TestPxeBuilder(object):
         self.setup.export_package_list.assert_called_once_with(
             'target_dir'
         )
-        self.setup.export_rpm_package_verification.assert_called_once_with(
+        self.setup.export_package_verification.assert_called_once_with(
             'target_dir'
         )
         # warning for not implemented pxedeploy handling


### PR DESCRIPTION
With this PR the methods `export_rpm_package_list` and `export_rpm_package_verification` are renamed to `export_package_list` and `export_package_verification` respectively. Also the new renamed methods are can list and verify deb or rpm packages, depending on the selected package manager on the description file. 

Fixes #457