### PR TITLE
Fix space calculation for lvm volumes

### DIFF
--- a/kiwi/boot/arch/arm/oemboot/repart
+++ b/kiwi/boot/arch/arm/oemboot/repart
@@ -528,9 +528,9 @@ function OEMRepartLVM {
         #======================================
         # Extend allFreeVolume if not done
         #--------------------------------------
-        local all_free_mpoint=$(readVolumeSetupAllFree "/.profile"|cut -f2 -d,)
-        if [ ! -z "$all_free_mpoint" ];then
-            lvextend -l +100%FREE /dev/$kiwi_lvmgroup/$all_free_mpoint
+        local allFreeVolume=$(getAllFreeVolume)
+        if [ ! -z "$allFreeVolume" ];then
+            lvextend -l +100%FREE /dev/$kiwi_lvmgroup/$allFreeVolume
         fi
         #======================================
         # setup new device names

--- a/kiwi/boot/arch/ppc/oemboot/repart
+++ b/kiwi/boot/arch/ppc/oemboot/repart
@@ -528,9 +528,9 @@ function OEMRepartLVM {
         #======================================
         # Extend allFreeVolume if not done
         #--------------------------------------
-        local all_free_mpoint=$(readVolumeSetupAllFree "/.profile"|cut -f2 -d,)
-        if [ ! -z "$all_free_mpoint" ];then
-            lvextend -l +100%FREE /dev/$kiwi_lvmgroup/$all_free_mpoint
+        local allFreeVolume=$(getAllFreeVolume)
+        if [ ! -z "$allFreeVolume" ];then
+            lvextend -l +100%FREE /dev/$kiwi_lvmgroup/$allFreeVolume
         fi
         #======================================
         # setup new device names

--- a/kiwi/boot/arch/s390/oemboot/repart
+++ b/kiwi/boot/arch/s390/oemboot/repart
@@ -529,9 +529,9 @@ function OEMRepartLVM {
         #======================================
         # Extend allFreeVolume if not done
         #--------------------------------------
-        local all_free_mpoint=$(readVolumeSetupAllFree "/.profile"|cut -f2 -d,)
-        if [ ! -z "$all_free_mpoint" ];then
-            lvextend -l +100%FREE /dev/$kiwi_lvmgroup/$all_free_mpoint
+        local allFreeVolume=$(getAllFreeVolume)
+        if [ ! -z "$allFreeVolume" ];then
+            lvextend -l +100%FREE /dev/$kiwi_lvmgroup/$allFreeVolume
         fi
         #======================================
         # setup new device names

--- a/kiwi/boot/arch/x86_64/oemboot/repart
+++ b/kiwi/boot/arch/x86_64/oemboot/repart
@@ -528,9 +528,9 @@ function OEMRepartLVM {
         #======================================
         # Extend allFreeVolume if not done
         #--------------------------------------
-        local all_free_mpoint=$(readVolumeSetupAllFree "/.profile"|cut -f2 -d,)
-        if [ ! -z "$all_free_mpoint" ];then
-            lvextend -l +100%FREE /dev/$kiwi_lvmgroup/$all_free_mpoint
+        local allFreeVolume=$(getAllFreeVolume)
+        if [ ! -z "$allFreeVolume" ];then
+            lvextend -l +100%FREE /dev/$kiwi_lvmgroup/$allFreeVolume
         fi
         #======================================
         # setup new device names

--- a/kiwi/system/size.py
+++ b/kiwi/system/size.py
@@ -63,16 +63,24 @@ class SystemSize(object):
 
         return int(size)
 
-    def accumulate_mbyte_file_sizes(self):
+    def accumulate_mbyte_file_sizes(self, exclude=None):
         """
         Calculate data size of all data in the source tree
+
+        :param list exclude: list of paths to exclude
 
         :return: mbytes
         :rtype: int
         """
+        exclude_options = []
+        if exclude:
+            for item in exclude:
+                exclude_options.append('--exclude')
+                exclude_options.append(item)
         du_call = Command.run(
             [
-                'du', '-s', '--apparent-size', '--block-size', '1',
+                'du', '-s', '--apparent-size', '--block-size', '1'
+            ] + exclude_options + [
                 self.source_dir
             ]
         )

--- a/kiwi/volume_manager/lvm.py
+++ b/kiwi/volume_manager/lvm.py
@@ -118,12 +118,8 @@ class VolumeManagerLVM(VolumeManagerBase):
 
         canonical_volume_list = self.get_canonical_volume_list()
         for volume in canonical_volume_list.volumes:
-            [size_type, volume_mbsize] = volume.size.split(':')
             volume_mbsize = self.get_volume_mbsize(
-                volume_mbsize,
-                size_type,
-                volume.realpath,
-                filesystem_name,
+                volume, self.volumes, filesystem_name,
                 self.custom_args['image_type']
             )
             log.info(

--- a/test/unit/system_size_test.py
+++ b/test/unit/system_size_test.py
@@ -23,9 +23,12 @@ class TestSystemSize(object):
 
     @patch('kiwi.system.size.Command.run')
     def test_accumulate_mbyte_file_sizes(self, mock_command):
-        self.size.accumulate_mbyte_file_sizes()
+        self.size.accumulate_mbyte_file_sizes(['/foo'])
         mock_command.assert_called_once_with(
-            ['du', '-s', '--apparent-size', '--block-size', '1', 'directory']
+            [
+                'du', '-s', '--apparent-size', '--block-size', '1',
+                '--exclude', '/foo', 'directory'
+            ]
         )
 
     @patch('kiwi.system.size.Command.run')


### PR DESCRIPTION
It is required to take the other configured volumes into
account in order to solve the problem of nested volumes.
The size of e.g the root volume must be reduced by the size
other volumes inside of the root volume needs. This is
especially required if the root volume is not the fullsize
volume


