### PR TITLE
Added handling of formatoptions attribute

### DIFF
--- a/kiwi/storage/subformat/__init__.py
+++ b/kiwi/storage/subformat/__init__.py
@@ -49,62 +49,65 @@ class DiskFormat(object):
         target directory path name
     """
     def __new__(self, name, xml_state, root_dir, target_dir):
+        custom_args = xml_state.get_build_type_format_options()
         if name == 'qcow2':
             return DiskFormatQcow2(
-                xml_state, root_dir, target_dir
+                xml_state, root_dir, target_dir, custom_args
             )
         elif name == 'vdi':
             return DiskFormatVdi(
-                xml_state, root_dir, target_dir
+                xml_state, root_dir, target_dir, custom_args
             )
         elif name == 'vhd':
             return DiskFormatVhd(
-                xml_state, root_dir, target_dir
+                xml_state, root_dir, target_dir, custom_args
             )
         elif name == 'vhd-fixed':
-            custom_args = None
             disk_tag = xml_state.build_type.get_vhdfixedtag()
             if disk_tag:
-                custom_args = {
-                    '--tag': disk_tag
-                }
+                custom_args.update(
+                    {'--tag': disk_tag}
+                )
             return DiskFormatVhdFixed(
                 xml_state, root_dir, target_dir, custom_args
             )
         elif name == 'gce':
-            custom_args = None
             gce_license_tag = xml_state.build_type.get_gcelicense()
             if gce_license_tag:
-                custom_args = {
-                    '--tag': gce_license_tag
-                }
+                custom_args.update(
+                    {'--tag': gce_license_tag}
+                )
             return DiskFormatGce(
                 xml_state, root_dir, target_dir, custom_args
             )
         elif name == 'vmdk':
-            custom_args = None
             vmdisk_section = xml_state.get_build_type_vmdisk_section()
             if vmdisk_section:
-                custom_args = {}
                 disk_mode = vmdisk_section.get_diskmode()
                 disk_controller = vmdisk_section.get_controller()
                 if disk_mode:
-                    custom_args['subformat=%s' % disk_mode] = None
+                    custom_args.update(
+                        {'subformat={0}'.format(disk_mode): None}
+                    )
                 if disk_controller:
-                    custom_args['adapter_type=%s' % disk_controller] = None
+                    custom_args.update(
+                        {'adapter_type={0}'.format(disk_controller): None}
+                    )
             return DiskFormatVmdk(
                 xml_state, root_dir, target_dir, custom_args
             )
         elif name == 'vagrant':
             vagrant_config = xml_state.get_build_type_vagrant_config_section()
             if vagrant_config:
+                custom_args.update(
+                    {'vagrantconfig': vagrant_config}
+                )
                 provider = vagrant_config.get_provider()
             else:
                 provider = 'undefined'
             if provider == 'libvirt':
                 return DiskFormatVagrantLibVirt(
-                    xml_state, root_dir, target_dir,
-                    {'vagrantconfig': vagrant_config}
+                    xml_state, root_dir, target_dir, custom_args
                 )
             else:
                 raise KiwiDiskFormatSetupError(
@@ -114,7 +117,7 @@ class DiskFormat(object):
                 )
         elif name == 'raw':
             return DiskFormatBase(
-                xml_state, root_dir, target_dir
+                xml_state, root_dir, target_dir, custom_args
             )
         else:
             raise KiwiDiskFormatSetupError(

--- a/kiwi/storage/subformat/base.py
+++ b/kiwi/storage/subformat/base.py
@@ -139,9 +139,10 @@ class DiskFormatBase(object):
             ordered_args = OrderedDict(sorted(custom_args.items()))
             for key, value in list(ordered_args.items()):
                 options.append('-o')
-                options.append(key)
                 if value:
-                    options.append(value)
+                    options.append('{0}={1}'.format(key, value))
+                else:
+                    options.append(key)
         return options
 
     def get_target_name_for_format(self, format_name):

--- a/kiwi/storage/subformat/vhdfixed.py
+++ b/kiwi/storage/subformat/vhdfixed.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
-from collections import OrderedDict
 import struct
 from binascii import unhexlify
 import re
@@ -52,19 +51,14 @@ class DiskFormatVhdFixed(DiskFormatBase):
             disk format name: vhdfixed
         """
         self.image_format = 'vhdfixed'
-        self.options = [
-            '-o', 'subformat=fixed'
-        ]
         self.tag = None
-        if custom_args:
-            ordered_args = OrderedDict(list(custom_args.items()))
-            for key, value in list(ordered_args.items()):
-                if key == '--tag':
-                    self.tag = value
-                else:
-                    self.options.append(key)
-                    if value:
-                        self.options.append(value)
+        if '--tag' in custom_args:
+            self.tag = custom_args['--tag']
+            del custom_args['--tag']
+
+        self.options = self.get_qemu_option_list(custom_args)
+        self.options.append('-o')
+        self.options.append('subformat=fixed')
 
     def create_image_format(self):
         """

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -623,6 +623,24 @@ class XMLState(object):
         if spare_part_size:
             return self._to_mega_byte(spare_part_size)
 
+    def get_build_type_format_options(self):
+        """
+        Disk format options returned as a dictionary
+
+        :return: format options
+        :rtype: dict
+        """
+        result = {}
+        format_options = self.build_type.get_formatoptions()
+        if format_options:
+            for option in format_options.split(','):
+                key_value_list = option.split('=')
+                if len(key_value_list) == 2:
+                    result[key_value_list[0]] = key_value_list[1]
+                else:
+                    result[key_value_list[0]] = None
+        return result
+
     def get_volume_group_name(self):
         """
         Volume group name from systemdisk section

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -35,7 +35,7 @@
         <locale>de_DE</locale>
     </preferences>
     <preferences>
-        <type bootloader="grub2" image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async" btrfs_root_is_snapshot="true" spare_part="200M" xen_server="true">
+        <type bootloader="grub2" image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async" btrfs_root_is_snapshot="true" spare_part="200M" xen_server="true" formatoptions="force_size,super=man">
             <size unit="G" additive="true">1</size>
             <systemdisk name="mydisk"/>
             <machine memory="512" xen_loader="hvmloader">

--- a/test/unit/storage_subformat_qcow2_test.py
+++ b/test/unit/storage_subformat_qcow2_test.py
@@ -24,7 +24,7 @@ class TestDiskFormatQcow2(object):
 
     def test_post_init(self):
         self.disk_format.post_init({'option': 'value'})
-        assert self.disk_format.options == ['-o', 'option', 'value']
+        assert self.disk_format.options == ['-o', 'option=value']
 
     @patch('kiwi.storage.subformat.qcow2.Command.run')
     def test_create_image_format(self, mock_command):

--- a/test/unit/storage_subformat_test.py
+++ b/test/unit/storage_subformat_test.py
@@ -10,69 +10,67 @@ from kiwi.storage.subformat import DiskFormat
 
 
 class TestDiskFormat(object):
+    def setup(self):
+        self.xml_state = mock.Mock()
+        self.xml_state.get_build_type_format_options.return_value = {}
+
     @raises(KiwiDiskFormatSetupError)
     def test_format_not_implemented(self):
-        DiskFormat('foo', mock.Mock(), 'root_dir', 'target_dir')
+        DiskFormat('foo', self.xml_state, 'root_dir', 'target_dir')
 
     @raises(KiwiDiskFormatSetupError)
     def test_disk_format_vagrant_not_implemented(self):
-        xml_state = mock.Mock()
-        xml_state.get_build_type_vagrant_config_section = mock.Mock(
+        self.xml_state.get_build_type_vagrant_config_section = mock.Mock(
             return_value=None
         )
         DiskFormat(
-            'vagrant', xml_state, 'root_dir', 'target_dir'
+            'vagrant', self.xml_state, 'root_dir', 'target_dir'
         )
 
     @patch('kiwi.storage.subformat.DiskFormatQcow2')
     def test_disk_format_qcow2(self, mock_qcow2):
-        xml_state = mock.Mock()
-        DiskFormat('qcow2', xml_state, 'root_dir', 'target_dir')
+        DiskFormat('qcow2', self.xml_state, 'root_dir', 'target_dir')
         mock_qcow2.assert_called_once_with(
-            xml_state, 'root_dir', 'target_dir'
+            self.xml_state, 'root_dir', 'target_dir', {}
         )
 
     @patch('kiwi.storage.subformat.DiskFormatVdi')
     def test_disk_format_vdi(self, mock_vdi):
-        xml_state = mock.Mock()
-        DiskFormat('vdi', xml_state, 'root_dir', 'target_dir')
+        DiskFormat('vdi', self.xml_state, 'root_dir', 'target_dir')
         mock_vdi.assert_called_once_with(
-            xml_state, 'root_dir', 'target_dir'
+            self.xml_state, 'root_dir', 'target_dir', {}
         )
 
     @patch('kiwi.storage.subformat.DiskFormatVhd')
     def test_disk_format_vhd(self, mock_vhd):
-        xml_state = mock.Mock()
-        DiskFormat('vhd', xml_state, 'root_dir', 'target_dir')
+        DiskFormat('vhd', self.xml_state, 'root_dir', 'target_dir')
         mock_vhd.assert_called_once_with(
-            xml_state, 'root_dir', 'target_dir'
+            self.xml_state, 'root_dir', 'target_dir', {}
         )
 
     @patch('kiwi.storage.subformat.DiskFormatVhdFixed')
     def test_disk_format_vhdfixed(self, mock_vhdfixed):
-        xml_state = mock.Mock()
-        xml_state.build_type.get_vhdfixedtag = mock.Mock(
+        self.xml_state.build_type.get_vhdfixedtag = mock.Mock(
             return_value='disk-tag'
         )
-        DiskFormat('vhd-fixed', xml_state, 'root_dir', 'target_dir')
+        DiskFormat('vhd-fixed', self.xml_state, 'root_dir', 'target_dir')
         mock_vhdfixed.assert_called_once_with(
-            xml_state, 'root_dir', 'target_dir', {'--tag': 'disk-tag'}
+            self.xml_state, 'root_dir', 'target_dir', {'--tag': 'disk-tag'}
         )
 
     @patch('kiwi.storage.subformat.DiskFormatGce')
     def test_disk_format_gce(self, mock_gce):
-        xml_state = mock.Mock()
-        xml_state.build_type.get_gcelicense = mock.Mock(
+        self.xml_state.build_type.get_gcelicense = mock.Mock(
             return_value='gce_license_tag'
         )
-        DiskFormat('gce', xml_state, 'root_dir', 'target_dir')
+        DiskFormat('gce', self.xml_state, 'root_dir', 'target_dir')
         mock_gce.assert_called_once_with(
-            xml_state, 'root_dir', 'target_dir', {'--tag': 'gce_license_tag'}
+            self.xml_state, 'root_dir', 'target_dir',
+            {'--tag': 'gce_license_tag'}
         )
 
     @patch('kiwi.storage.subformat.DiskFormatVmdk')
     def test_disk_format_vmdk(self, mock_vmdk):
-        xml_state = mock.Mock()
         vmdisk = mock.Mock()
         vmdisk.get_controller = mock.Mock(
             return_value='controller'
@@ -80,37 +78,35 @@ class TestDiskFormat(object):
         vmdisk.get_diskmode = mock.Mock(
             return_value='disk-mode'
         )
-        xml_state.get_build_type_vmdisk_section = mock.Mock(
+        self.xml_state.get_build_type_vmdisk_section = mock.Mock(
             return_value=vmdisk
         )
-        DiskFormat('vmdk', xml_state, 'root_dir', 'target_dir')
+        DiskFormat('vmdk', self.xml_state, 'root_dir', 'target_dir')
         mock_vmdk.assert_called_once_with(
-            xml_state, 'root_dir', 'target_dir',
+            self.xml_state, 'root_dir', 'target_dir',
             {'adapter_type=controller': None, 'subformat=disk-mode': None}
         )
 
     @patch('kiwi.storage.subformat.DiskFormatVagrantLibVirt')
     def test_disk_format_vagrant_libvirt(self, mock_vagrant):
-        xml_state = mock.Mock()
         vagrant_config = mock.Mock()
         vagrant_config.get_provider = mock.Mock(
             return_value='libvirt'
         )
-        xml_state.get_build_type_vagrant_config_section = mock.Mock(
+        self.xml_state.get_build_type_vagrant_config_section = mock.Mock(
             return_value=vagrant_config
         )
         DiskFormat(
-            'vagrant', xml_state, 'root_dir', 'target_dir'
+            'vagrant', self.xml_state, 'root_dir', 'target_dir'
         )
         mock_vagrant.assert_called_once_with(
-            xml_state, 'root_dir', 'target_dir',
+            self.xml_state, 'root_dir', 'target_dir',
             {'vagrantconfig': vagrant_config}
         )
 
     @patch('kiwi.storage.subformat.DiskFormatBase')
     def test_disk_format_base(self, mock_base):
-        xml_state = mock.Mock()
-        DiskFormat('raw', xml_state, 'root_dir', 'target_dir')
+        DiskFormat('raw', self.xml_state, 'root_dir', 'target_dir')
         mock_base.assert_called_once_with(
-            xml_state, 'root_dir', 'target_dir',
+            self.xml_state, 'root_dir', 'target_dir', {}
         )

--- a/test/unit/storage_subformat_vdi_test.py
+++ b/test/unit/storage_subformat_vdi_test.py
@@ -24,7 +24,7 @@ class TestDiskFormatVdi(object):
 
     def test_post_init(self):
         self.disk_format.post_init({'option': 'value'})
-        assert self.disk_format.options == ['-o', 'option', 'value']
+        assert self.disk_format.options == ['-o', 'option=value']
 
     @patch('kiwi.storage.subformat.vdi.Command.run')
     def test_create_image_format(self, mock_command):

--- a/test/unit/storage_subformat_vhd_test.py
+++ b/test/unit/storage_subformat_vhd_test.py
@@ -24,7 +24,7 @@ class TestDiskFormatVhd(object):
 
     def test_post_init(self):
         self.disk_format.post_init({'option': 'value'})
-        assert self.disk_format.options == ['-o', 'option', 'value']
+        assert self.disk_format.options == ['-o', 'option=value']
 
     @patch('kiwi.storage.subformat.vhd.Command.run')
     def test_create_image_format(self, mock_command):

--- a/test/unit/storage_subformat_vhdfixed_test.py
+++ b/test/unit/storage_subformat_vhdfixed_test.py
@@ -28,13 +28,13 @@ class TestDiskFormatVhdFixed(object):
             return_value='1.2.3'
         )
         self.disk_format = DiskFormatVhdFixed(
-            self.xml_state, 'root_dir', 'target_dir'
+            self.xml_state, 'root_dir', 'target_dir', {'force_size': None}
         )
 
     def test_post_init(self):
         self.disk_format.post_init({'option': 'value', '--tag': 'tag'})
         assert self.disk_format.options == [
-            '-o', 'subformat=fixed', 'option', 'value'
+            '-o', 'option=value', '-o', 'subformat=fixed'
         ]
         assert self.disk_format.tag == 'tag'
 
@@ -64,7 +64,7 @@ class TestDiskFormatVhdFixed(object):
             [
                 'qemu-img', 'convert', '-f', 'raw',
                 'target_dir/some-disk-image.x86_64-1.2.3.raw', '-O', 'vpc',
-                '-o', 'subformat=fixed',
+                '-o', 'force_size', '-o', 'subformat=fixed',
                 'target_dir/some-disk-image.x86_64-1.2.3.vhdfixed'
             ]
         )

--- a/test/unit/storage_subformat_vmdk_test.py
+++ b/test/unit/storage_subformat_vmdk_test.py
@@ -155,7 +155,7 @@ class TestDiskFormatVmdk(object):
 
     def test_post_init(self):
         self.disk_format.post_init({'option': 'value'})
-        assert self.disk_format.options == ['-o', 'option', 'value']
+        assert self.disk_format.options == ['-o', 'option=value']
 
     def test_store_to_result(self):
         result = mock.Mock()

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -607,6 +607,12 @@ class TestXMLState(object):
     def test_get_spare_part(self):
         assert self.state.get_build_type_spare_part_size() == 200
 
+    def test_get_build_type_format_options(self):
+        assert self.state.get_build_type_format_options() == {
+            'super': 'man',
+            'force_size': None
+        }
+
     def test_get_derived_from_image_uri(self):
         description = XMLDescription('../data/example_config.xml')
         xml_data = description.load()


### PR DESCRIPTION
Custom disk format options passed in the formatoptions
attribute were not handled. In addition options with a
value passed to qemu were handled in the wrong way.
This commit addresses both problems and Fixes #463



