### PR TITLE
Fix isohybrid call

### DIFF
--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -23,6 +23,7 @@ from kiwi.command import Command
 from kiwi.bootloader.config import BootLoaderConfig
 from kiwi.filesystem.squashfs import FileSystemSquashFs
 from kiwi.filesystem.isofs import FileSystemIsoFs
+from kiwi.firmware import FirmWare
 from kiwi.system.identifier import SystemIdentifier
 from kiwi.path import Path
 from kiwi.defaults import Defaults
@@ -71,6 +72,7 @@ class InstallImageBuilder(object):
         self.target_dir = target_dir
         self.boot_image_task = boot_image_task
         self.xml_state = xml_state
+        self.firmware = FirmWare(xml_state)
         self.diskname = ''.join(
             [
                 target_dir, '/',
@@ -212,7 +214,8 @@ class InstallImageBuilder(object):
 
         # make it hybrid
         Iso.create_hybrid(
-            iso_header_offset, self.mbrid, self.isoname
+            iso_header_offset, self.mbrid, self.isoname,
+            self.firmware.efi_mode()
         )
 
     def create_install_pxe_archive(self):

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -233,7 +233,8 @@ class LiveImageBuilder(object):
         # make it hybrid
         if self.hybrid:
             Iso.create_hybrid(
-                iso_header_offset, self.mbrid, self.isoname
+                iso_header_offset, self.mbrid, self.isoname,
+                self.firmware.efi_mode()
             )
 
         # include metadata for checkmedia tool

--- a/test/unit/builder_install_test.py
+++ b/test/unit/builder_install_test.py
@@ -15,6 +15,13 @@ class TestInstallImageBuilder(object):
     @patch('platform.machine')
     def setup(self, mock_machine):
         mock_machine.return_value = 'x86_64'
+        self.firmware = mock.Mock()
+        self.firmware.efi_mode = mock.Mock(
+            return_value='uefi'
+        )
+        kiwi.builder.install.FirmWare = mock.Mock(
+            return_value=self.firmware
+        )
         self.bootloader = mock.Mock()
         kiwi.builder.install.BootLoaderConfig = mock.Mock(
             return_value=self.bootloader
@@ -159,7 +166,8 @@ class TestInstallImageBuilder(object):
             'target_dir/result-image.x86_64-1.2.3.install.iso'
         )
         mock_hybrid.assert_called_once_with(
-            42, self.mbrid, 'target_dir/result-image.x86_64-1.2.3.install.iso'
+            42, self.mbrid, 'target_dir/result-image.x86_64-1.2.3.install.iso',
+            'uefi'
         )
 
     @patch('kiwi.builder.install.mkdtemp')

--- a/test/unit/builder_live_test.py
+++ b/test/unit/builder_live_test.py
@@ -225,7 +225,8 @@ class TestLiveImageBuilder(object):
             'target_dir/result-image.x86_64-1.2.3.iso'
         )
         mock_hybrid.assert_called_once_with(
-            'offset', self.mbrid, 'target_dir/result-image.x86_64-1.2.3.iso'
+            'offset', self.mbrid, 'target_dir/result-image.x86_64-1.2.3.iso',
+            'uefi'
         )
         assert self.result.add.call_args_list == [
             call(

--- a/test/unit/iso_test.py
+++ b/test/unit/iso_test.py
@@ -8,7 +8,8 @@ from builtins import bytes
 from kiwi.exceptions import (
     KiwiIsoLoaderError,
     KiwiIsoToolError,
-    KiwiIsoMetaDataError
+    KiwiIsoMetaDataError,
+    KiwiCommandError
 )
 
 from kiwi.iso import Iso
@@ -239,7 +240,10 @@ class TestIso(object):
         mbrid.get_id = mock.Mock(
             return_value='0x0815'
         )
-        Iso.create_hybrid(42, mbrid, 'some-iso')
+        command = mock.Mock()
+        command.error = None
+        mock_command.return_value = command
+        Iso.create_hybrid(42, mbrid, 'some-iso', 'efi')
         mock_command.assert_called_once_with(
             [
                 'isohybrid', '--offset', '42',
@@ -247,6 +251,18 @@ class TestIso(object):
                 '--uefi', 'some-iso'
             ]
         )
+
+    @raises(KiwiCommandError)
+    @patch('kiwi.iso.Command.run')
+    def test_create_hybrid_with_error(self, mock_command):
+        mbrid = mock.Mock()
+        mbrid.get_id = mock.Mock(
+            return_value='0x0815'
+        )
+        command = mock.Mock()
+        command.error = 'some error message'
+        mock_command.return_value = command
+        Iso.create_hybrid(42, mbrid, 'some-iso', 'efi')
 
     @patch_open
     @raises(KiwiIsoMetaDataError)


### PR DESCRIPTION
isohybrid errors printed on stderr were not treated as fatal
but should be treated as such. In addition isohybrid should
distinguish for efi setup according to the efi setup of the
image itself

