### PR TITLE
Delete atftp from boot descriptions

### DIFF
--- a/kiwi/boot/arch/arm/oemboot/suse-SLES15/config.xml
+++ b/kiwi/boot/arch/arm/oemboot/suse-SLES15/config.xml
@@ -85,7 +85,6 @@
     <packages type="bootstrap">
         <package name="kbd"/>
         <package name="gptfdisk"/>
-        <package name="atftp"/>
         <package name="bc"/>
         <package name="bind-libs"/>
         <package name="bind-utils"/>

--- a/kiwi/boot/arch/arm/oemboot/suse-leap15.0/config.xml
+++ b/kiwi/boot/arch/arm/oemboot/suse-leap15.0/config.xml
@@ -85,7 +85,6 @@
     <packages type="bootstrap">
         <package name="kbd"/>
         <package name="gptfdisk"/>
-        <package name="atftp"/>
         <package name="bc"/>
         <package name="bind-libs"/>
         <package name="bind-utils"/>

--- a/kiwi/boot/arch/ppc/netboot/suse-SLES15/config.xml
+++ b/kiwi/boot/arch/ppc/netboot/suse-SLES15/config.xml
@@ -78,7 +78,6 @@
         <package name="kernel-default"/>
     </packages>
     <packages type="image" profiles="default">
-        <package name="atftp"/>
         <package name="bc"/>
         <package name="bind-libs"/>
         <package name="bind-utils"/>
@@ -106,7 +105,6 @@
     <packages type="image" profiles="custom"><!-- empty custom section to allow bootincluding custom kernel --></packages>
     <packages type="bootstrap">
         <package name="kbd"/>
-        <package name="atftp"/>
         <package name="bc"/>
         <package name="busybox"/>
         <package name="hwinfo"/>

--- a/kiwi/boot/arch/ppc/oemboot/suse-SLES15/config.xml
+++ b/kiwi/boot/arch/ppc/oemboot/suse-SLES15/config.xml
@@ -85,7 +85,6 @@
     <packages type="bootstrap">
         <package name="kbd"/>
         <package name="gptfdisk"/>
-        <package name="atftp"/>
         <package name="bc"/>
         <package name="bind-libs"/>
         <package name="bind-utils"/>

--- a/kiwi/boot/arch/s390/netboot/suse-SLES15/config.xml
+++ b/kiwi/boot/arch/s390/netboot/suse-SLES15/config.xml
@@ -81,7 +81,6 @@
         <package name="kernel-default"/>
     </packages>
     <packages type="image" profiles="default">
-        <package name="atftp"/>
         <package name="bc"/>
         <package name="bind-libs"/>
         <package name="bind-utils"/>
@@ -106,7 +105,6 @@
     <packages type="image" profiles="custom"><!-- empty custom section to allow bootincluding custom kernel --></packages>
     <packages type="bootstrap">
         <package name="kbd"/>
-        <package name="atftp"/>
         <package name="bc"/>
         <package name="busybox"/>
         <package name="hwinfo"/>

--- a/kiwi/boot/arch/s390/oemboot/suse-SLES15/config.xml
+++ b/kiwi/boot/arch/s390/oemboot/suse-SLES15/config.xml
@@ -87,7 +87,6 @@
     <packages type="image" profiles="custom"><!-- empty custom section to allow bootincluding custom kernel --></packages>
     <packages type="bootstrap">
         <package name="kbd"/>
-        <package name="atftp"/>
         <package name="bc"/>
         <package name="bind-libs"/>
         <package name="bind-utils"/>

--- a/kiwi/boot/arch/x86_64/netboot/suse-SLES15/config.xml
+++ b/kiwi/boot/arch/x86_64/netboot/suse-SLES15/config.xml
@@ -118,7 +118,6 @@
     </packages>
     <packages type="image" profiles="default">
         <package name="adaptec-firmware"/>
-        <package name="atftp"/>
         <package name="bc"/>
         <package name="bind-libs"/>
         <package name="bind-utils"/>
@@ -146,7 +145,6 @@
     <packages type="image" profiles="custom"><!-- empty custom section to allow bootincluding custom kernel --></packages>
     <packages type="bootstrap">
         <package name="kbd"/>
-        <package name="atftp"/>
         <package name="bc"/>
         <package name="busybox"/>
         <package name="hwinfo"/>

--- a/kiwi/boot/arch/x86_64/netboot/suse-leap15.0/config.xml
+++ b/kiwi/boot/arch/x86_64/netboot/suse-leap15.0/config.xml
@@ -118,7 +118,6 @@
     </packages>
     <packages type="image" profiles="default">
         <package name="adaptec-firmware"/>
-        <package name="atftp"/>
         <package name="bc"/>
         <package name="bind-libs"/>
         <package name="bind-utils"/>
@@ -146,7 +145,6 @@
     <packages type="image" profiles="custom"><!-- empty custom section to allow bootincluding custom kernel --></packages>
     <packages type="bootstrap">
         <package name="kbd"/>
-        <package name="atftp"/>
         <package name="bc"/>
         <package name="busybox"/>
         <package name="hwinfo"/>

--- a/kiwi/boot/arch/x86_64/oemboot/suse-SLES15/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-SLES15/config.xml
@@ -96,7 +96,6 @@
         <package name="kbd"/>
         <package name="gptfdisk"/>
         <package name="adaptec-firmware"/>
-        <package name="atftp"/>
         <package name="bc"/>
         <package name="bind-libs"/>
         <package name="bind-utils"/>

--- a/kiwi/boot/arch/x86_64/oemboot/suse-leap15.0/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-leap15.0/config.xml
@@ -96,7 +96,6 @@
         <package name="kbd"/>
         <package name="gptfdisk"/>
         <package name="adaptec-firmware"/>
-        <package name="atftp"/>
         <package name="bc"/>
         <package name="bind-libs"/>
         <package name="bind-utils"/>


### PR DESCRIPTION
In SLE15 / Leap15 atftp has been dropped. This Fixes bsc#1056951

