### PR TITLE
Do not use fillup-templates/group.aaa_base

### DIFF
--- a/kiwi/system/root_init.py
+++ b/kiwi/system/root_init.py
@@ -98,11 +98,8 @@ class RootInit(object):
             rmtree(root, ignore_errors=True)
 
     def _setup_config_templates(self, root):
-        group_template = '/var/adm/fillup-templates/group.aaa_base'
         passwd_template = '/var/adm/fillup-templates/passwd.aaa_base'
         proxy_template = '/var/adm/fillup-templates/sysconfig.proxy'
-        if os.path.exists(group_template):
-            Command.run(['cp', group_template, root + '/etc/group'])
         if os.path.exists(passwd_template):
             Command.run(['cp', passwd_template, root + '/etc/passwd'])
         if os.path.exists(proxy_template):

--- a/test/unit/system_root_init_test.py
+++ b/test/unit/system_root_init_test.py
@@ -114,11 +114,6 @@ class TestRootInit(object):
             call(['mkdir', '-p', 'root_dir']),
             call([
                 'cp',
-                '/var/adm/fillup-templates/group.aaa_base',
-                'tmpdir/etc/group'
-            ]),
-            call([
-                'cp',
                 '/var/adm/fillup-templates/passwd.aaa_base',
                 'tmpdir/etc/passwd'
             ]),


### PR DESCRIPTION
When kiwi initializes a new root system it copies an existing
group template file as a start. However it has turned out if
that group template is not compatible with the target image
it might lead to a broken etc/group file in the target image
This Fixes bsc#1056668


