### PR TITLE
Rename source label

### DIFF
--- a/kiwi/container/oci.py
+++ b/kiwi/container/oci.py
@@ -108,10 +108,10 @@ class ContainerImageOCI(object):
                 self.xz_options = custom_args['xz_options']
 
         # for builds inside the buildservice we include a reference to the
-        # specific build. Thus source label only exists inside the
+        # specific build. Thus disturl label only exists inside the
         # buildservice.
         if Defaults.is_buildservice_worker():
-            self._append_buildservice_source_label()
+            self._append_buildservice_disturl_label()
 
         if not custom_args or 'container_name' not in custom_args:
             log.info(
@@ -213,20 +213,20 @@ class ContainerImageOCI(object):
             image_dir, xz_options=self.xz_options
         )
 
-    def _append_buildservice_source_label(self):
+    def _append_buildservice_disturl_label(self):
         with open(os.sep + Defaults.get_buildservice_env_name()) as env:
             for line in env:
                 if line.startswith('BUILD_DISTURL') and '=' in line:
-                    source = line.split('=')[1].strip()
-                    if source:
+                    disturl = line.split('=')[1].strip()
+                    if disturl:
                         self.labels.append(
                             ''.join([
                                 '--config.label='
-                                'org.opencontainers.image.source=',
+                                'org.openbuildservice.disturl=',
                                 line.split('=')[1].strip()
                             ])
                         )
-            log.warning('Could not find DISTURL inside .buildenv')
+            log.warning('Could not find BUILD_DISTURL inside .buildenv')
 
     def __del__(self):
         if self.oci_dir:

--- a/test/unit/container_image_oci_test.py
+++ b/test/unit/container_image_oci_test.py
@@ -80,14 +80,14 @@ class TestContainerImageOCI(object):
         container = ContainerImageOCI('root_dir')
         mock_open.assert_called_once_with('/.buildenv')
         assert container.labels == [
-            '--config.label=org.opencontainers.image.source='
+            '--config.label=org.openbuildservice.disturl='
             'obs://build.opensuse.org/some:project'
         ]
 
     @patch('kiwi.defaults.Defaults.is_buildservice_worker')
     @patch_open
     @patch('kiwi.logger.log.warning')
-    def test_init_in_buildservice_without_source(
+    def test_init_in_buildservice_without_disturl(
         self, mock_warn, mock_open, mock_buildservice
     ):
         mock_buildservice.return_value = True


### PR DESCRIPTION
This commit renames the source label to a more explicit name. This
commit also relates to bsc#1055542 and fixes #473
