### PR TITLE
Added e2fsprogs to s390/netboot

### DIFF
--- a/kiwi/boot/arch/s390/netboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/s390/netboot/suse-SLES12/config.xml
@@ -102,6 +102,7 @@
         <package name="tar"/>
         <package name="xfsprogs"/>
         <package name="s390-tools"/>
+        <package name="e2fsprogs"/>
     </packages>
     <packages type="image" profiles="custom"><!-- empty custom section to allow bootincluding custom kernel --></packages>
     <packages type="bootstrap">

--- a/kiwi/boot/arch/s390/netboot/suse-SLES15/config.xml
+++ b/kiwi/boot/arch/s390/netboot/suse-SLES15/config.xml
@@ -101,6 +101,7 @@
         <package name="tar"/>
         <package name="xfsprogs"/>
         <package name="s390-tools"/>
+        <package name="e2fsprogs"/>
     </packages>
     <packages type="image" profiles="custom"><!-- empty custom section to allow bootincluding custom kernel --></packages>
     <packages type="bootstrap">

--- a/kiwi/boot/arch/s390/netboot/suse-tumbleweed/config.xml
+++ b/kiwi/boot/arch/s390/netboot/suse-tumbleweed/config.xml
@@ -102,6 +102,7 @@
         <package name="tar"/>
         <package name="xfsprogs"/>
         <package name="s390-tools"/>
+        <package name="e2fsprogs"/>
     </packages>
     <packages type="image" profiles="custom"><!-- empty custom section to allow bootincluding custom kernel --></packages>
     <packages type="bootstrap">


### PR DESCRIPTION
During bootup of a diskful netclient when it comes to e2
filesystem operations the tools were missing. Fixes #479


