### PR TITLE
Update device node names for devmapper nodes

### DIFF
--- a/kiwi/boot/functions.sh
+++ b/kiwi/boot/functions.sh
@@ -7232,6 +7232,8 @@ function ddn {
             echo $1"_part"$2
             return
         fi
+        echo $1"-part"$2
+        return
     elif echo $1 | grep -q "^\/dev\/ram";then
         name=$(echo $1 | tr -d /dev)
         echo /dev/mapper/${name}p$2


### PR DESCRIPTION
Partition devices created by the device mapper could
use the _part or the -part naming schema. This patch
allows for both variants and Fixes #480


