### PR TITLE
Fix trailing pipe character in .packages file

### DIFF
--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -841,10 +841,10 @@ class SystemSetup(object):
                 'rpm', '--root', self.root_dir, '-qa', '--qf',
                 '|'.join(
                     [
-                        '%{NAME}', '%{EPOCH}', '%{VERSION}', '%{RELEASE}',
-                        '%{ARCH}', '%{DISTURL}', '\\n'
+                        '%{NAME}', '%{EPOCH}', '%{VERSION}',
+                        '%{RELEASE}', '%{ARCH}', '%{DISTURL}'
                     ]
-                )
+                ) + '\\n'
             ]
         )
         with open(filename, 'w') as packages:
@@ -856,7 +856,12 @@ class SystemSetup(object):
             [
                 'dpkg-query', '--admindir',
                 os.sep.join([self.root_dir, 'var/lib/dpkg']), '-W', '-f',
-                '${Package}|${Version}|${Architecture}\n'
+                '|'.join(
+                    [
+                        '${Package}', 'None', '${Version}',
+                        'None', '${Architecture}', 'None'
+                    ]
+                ) + '\\n'
             ]
         )
         with open(filename, 'w') as packages:

--- a/test/unit/system_setup_test.py
+++ b/test/unit/system_setup_test.py
@@ -676,7 +676,7 @@ class TestSystemSetup(object):
         assert result == 'target_dir/some-image.x86_64-1.2.3.packages'
         mock_command.assert_called_once_with([
             'rpm', '--root', 'root_dir', '-qa', '--qf',
-            '%{NAME}|%{EPOCH}|%{VERSION}|%{RELEASE}|%{ARCH}|%{DISTURL}|\\n'
+            '%{NAME}|%{EPOCH}|%{VERSION}|%{RELEASE}|%{ARCH}|%{DISTURL}\\n'
         ])
         mock_open.assert_called_once_with(
             'target_dir/some-image.x86_64-1.2.3.packages', 'w'
@@ -697,7 +697,7 @@ class TestSystemSetup(object):
         assert result == 'target_dir/some-image.x86_64-1.2.3.packages'
         mock_command.assert_called_once_with([
             'dpkg-query', '--admindir', 'root_dir/var/lib/dpkg', '-W',
-            '-f', '${Package}|${Version}|${Architecture}\n'
+            '-f', '${Package}|None|${Version}|None|${Architecture}|None\\n'
         ])
         mock_open.assert_called_once_with(
             'target_dir/some-image.x86_64-1.2.3.packages', 'w'


### PR DESCRIPTION
In addition make sure the field layout is consistent across
the .packages files no matter which package manager was used
to create the information. This Fixes #501

