### PR TITLE
Fixed package requires for dracut-kiwi-live

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -316,7 +316,7 @@ Requires:       e2fsprogs
 Requires:       util-linux
 Requires:       dracut
 %if 0%{?fedora} || 0%{?rhel}
-Requires:       cdrkit
+Requires:       genisoimage
 %else
 Requires:       cdrkit-cdrtools-compat
 %endif


### PR DESCRIPTION
On Fedora/RHEL cdrkit is only a source package building other
packages. The package dracut-kiwi-live really needs is
genisoimage

