### PR TITLE
Checkmedia results and plymouth

### DIFF
--- a/dracut/modules.d/90kiwi-live/kiwi-live-lib.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-live-lib.sh
@@ -120,11 +120,20 @@ function runMediaCheck {
     # as part of the pre-mount hook via the dracut-pre-mount.service
     # which only shows messages on stderr to the console and we want
     # to see the check results during boot
+    type plymouth &>/dev/null && \
+        plymouth --hide-splash
     if ! command -v checkmedia &>/dev/null; then
         echo "No mediacheck program installed, mediacheck skipped" 1>&2
     elif ! checkmedia ${media_check_device} 1>&2;then
-        die "ISO check failed"
+        echo "ISO check failed" 1>&2
+        echo "Stop booting after 20sec..." 1>&2
+        sleep 20
+        die "Failed to verify system integrity"
     else
         echo "ISO check passed" 1>&2
+        echo "Continue booting after 5sec..." 1>&2
+        sleep 5
     fi
+    type plymouth &>/dev/null && \
+        plymouth --show-splash
 }

--- a/dracut/modules.d/90kiwi-live/module-setup.sh
+++ b/dracut/modules.d/90kiwi-live/module-setup.sh
@@ -23,7 +23,7 @@ install() {
     inst_multiple \
         umount dmsetup blockdev blkid lsblk dd losetup \
         isoinfo grep cut partprobe find wc fdisk tail mkfs.ext4 mkfs.xfs \
-        checkmedia
+        checkmedia dialog
     inst_hook cmdline 30 "$moddir/parse-kiwi-live.sh"
     inst_hook pre-udev 30 "$moddir/kiwi-live-genrules.sh"
     inst_hook pre-mount 30 "$moddir/kiwi-live-checkmedia.sh"

--- a/kiwi/bootloader/template/grub2.py
+++ b/kiwi/bootloader/template/grub2.py
@@ -237,7 +237,7 @@ class BootLoaderTemplateGrub2(object):
             menuentry "Mediacheck" --class os --unrestricted {
                 set gfxpayload=keep
                 echo Loading kernel...
-                $$linux ($$root)${bootpath}/${kernel_file} mediacheck=1 ${boot_options}
+                $$linux ($$root)${bootpath}/${kernel_file} mediacheck=1 plymouth.enable=0 ${boot_options}
                 echo Loading initrd...
                 $$initrd ($$root)${bootpath}/${initrd_file}
             }
@@ -249,7 +249,7 @@ class BootLoaderTemplateGrub2(object):
                 echo Loading hypervisor...
                 multiboot ${bootpath}/${hypervisor} dummy
                 echo Loading kernel...
-                module ${bootpath}/${kernel_file} dummy mediacheck=1 ${failsafe_boot_options}
+                module ${bootpath}/${kernel_file} dummy mediacheck=1 plymouth.enable=0 ${failsafe_boot_options}
                 echo Loading initrd...
                 module ${bootpath}/${initrd_file} dummy
             }
@@ -259,7 +259,7 @@ class BootLoaderTemplateGrub2(object):
             menuentry "Mediacheck" --class os --unrestricted {
                 set gfxpayload=keep
                 echo Loading kernel...
-                linux ($$root)${bootpath}/${kernel_file} mediacheck=1 ${boot_options}
+                linux ($$root)${bootpath}/${kernel_file} mediacheck=1 plymouth.enable=0 ${boot_options}
                 echo Loading initrd...
                 initrd ($$root)${bootpath}/${initrd_file}
             }

--- a/kiwi/bootloader/template/isolinux.py
+++ b/kiwi/bootloader/template/isolinux.py
@@ -77,61 +77,61 @@ class BootLoaderTemplateIsoLinux(object):
         self.menu_install_entry_multiboot = dedent('''
             label Install_${title}
                 kernel mboot.c32
-                append ${hypervisor} --- ${kernel_file} ${boot_options} cdinst=1 kiwi_hybrid=1 showopts --- ${initrd_file} showopts
+                append ${hypervisor} --- ${kernel_file} ${boot_options} cdinst=1 showopts --- ${initrd_file} showopts
         ''').strip() + self.cr
 
         self.menu_install_entry_failsafe_multiboot = dedent('''
             label Failsafe_--_Install_${title}
                 kernel mboot.c32
-                append ${hypervisor} --- ${kernel_file} ${failsafe_boot_options} cdinst=1 kiwi_hybrid=1 showopts --- ${initrd_file} showopts
+                append ${hypervisor} --- ${kernel_file} ${failsafe_boot_options} cdinst=1 showopts --- ${initrd_file} showopts
         ''').strip() + self.cr
 
         self.menu_entry_multiboot = dedent('''
             label ${title}
                 kernel mboot.c32
-                append ${hypervisor} --- ${kernel_file} ${boot_options} kiwi_hybrid=1 showopts --- ${initrd_file} showopts
+                append ${hypervisor} --- ${kernel_file} ${boot_options} showopts --- ${initrd_file} showopts
         ''').strip() + self.cr
 
         self.menu_entry_failsafe_multiboot = dedent('''
             label Failsafe_--_${title}
                 kernel mboot.c32
-                append ${hypervisor} --- ${kernel_file} ${failsafe_boot_options} kiwi_hybrid=1 showopts --- ${initrd_file} showopts
+                append ${hypervisor} --- ${kernel_file} ${failsafe_boot_options} showopts --- ${initrd_file} showopts
         ''').strip() + self.cr
 
         self.menu_mediacheck_entry_multiboot = dedent('''
             label Mediacheck
                 kernel mboot.c32
-                append ${hypervisor} --- ${kernel_file} ${boot_options} mediacheck=1 kiwi_hybrid=1 showopts --- ${initrd_file} showopts
+                append ${hypervisor} --- ${kernel_file} ${boot_options} mediacheck=1 plymouth.enable=0 showopts --- ${initrd_file} showopts
         ''').strip() + self.cr
 
         self.menu_install_entry = dedent('''
             label Install_${title}
                 kernel ${kernel_file}
-                append initrd=${initrd_file} ${boot_options} cdinst=1 kiwi_hybrid=1 showopts
+                append initrd=${initrd_file} ${boot_options} cdinst=1 showopts
         ''').strip() + self.cr
 
         self.menu_install_entry_failsafe = dedent('''
             label Failsafe_--_Install_${title}
                 kernel ${kernel_file}
-                append initrd=${initrd_file} ${failsafe_boot_options} cdinst=1 kiwi_hybrid=1 showopts
+                append initrd=${initrd_file} ${failsafe_boot_options} cdinst=1 showopts
         ''').strip() + self.cr
 
         self.menu_entry = dedent('''
             label ${title}
                 kernel ${kernel_file}
-                append initrd=${initrd_file} ${boot_options} kiwi_hybrid=1 showopts
+                append initrd=${initrd_file} ${boot_options} showopts
         ''').strip() + self.cr
 
         self.menu_entry_failsafe = dedent('''
             label Failsafe_--_${title}
                 kernel ${kernel_file}
-                append initrd=${initrd_file} ${failsafe_boot_options} kiwi_hybrid=1 showopts
+                append initrd=${initrd_file} ${failsafe_boot_options} showopts
         ''').strip() + self.cr
 
         self.menu_mediacheck_entry = dedent('''
             label Mediacheck
                 kernel ${kernel_file}
-                append initrd=${initrd_file} ${boot_options} mediacheck=1 kiwi_hybrid=1 showopts
+                append initrd=${initrd_file} ${boot_options} mediacheck=1 plymouth.enable=0 showopts
         ''').strip() + self.cr
 
     def get_install_message_template(self):

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -221,6 +221,7 @@ class SystemBuildTask(CliTask):
         setup.setup_users()
         setup.setup_keyboard_map()
         setup.setup_locale()
+        setup.setup_plymouth_splash()
         setup.setup_timezone()
 
         system.pinch_system(

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -311,6 +311,7 @@ needed to serve kiwi built images via PXE.
 %package -n dracut-kiwi-live
 Summary:        KIWI - Dracut module for iso(live) image type
 BuildRequires:  dracut
+Requires:       dialog
 Requires:       xfsprogs
 Requires:       e2fsprogs
 Requires:       util-linux

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -123,6 +123,7 @@ class TestSystemBuildTask(object):
         self.setup.setup_users.assert_called_once_with()
         self.setup.setup_keyboard_map.assert_called_once_with()
         self.setup.setup_locale.assert_called_once_with()
+        self.setup.setup_plymouth_splash.assert_called_once_with()
         self.setup.setup_timezone.assert_called_once_with()
         self.system_prepare.pinch_system.assert_called_once_with(
             manager=self.manager, force=True


### PR DESCRIPTION
Improve display of runMediaCheck results
    
The splash screen should be switched off in order to let the
user see the mediacheck results as well as a delay timeout
before the boot continues or stops is useful