### PR TITLE
Allow to ignore certain isohybrid warnings

### DIFF
--- a/kiwi/iso.py
+++ b/kiwi/iso.py
@@ -121,12 +121,15 @@ class Iso(object):
         # appears if isohybrid can't find an efi loader. Thus we
         # are more strict and fail
         if isohybrid_call.error:
-            for ignore_error in ignore_errors:
-                if ignore_error in isohybrid_call.error:
-                    return
-            raise KiwiCommandError(
-                'isohybrid: {0}'.format(isohybrid_call.error)
-            )
+            error_list = isohybrid_call.error.split(os.linesep)
+            for error in error_list:
+                for ignore_error in ignore_errors:
+                    if ignore_error in error:
+                        error_list.remove(error)
+            if error_list:
+                raise KiwiCommandError(
+                    'isohybrid: {0}'.format(isohybrid_call.error)
+                )
 
     @classmethod
     def set_media_tag(self, isofile):

--- a/test/unit/iso_test.py
+++ b/test/unit/iso_test.py
@@ -265,6 +265,24 @@ class TestIso(object):
         Iso.create_hybrid(42, mbrid, 'some-iso', 'efi')
 
     @patch('kiwi.iso.Command.run')
+    def test_create_hybrid_with_cylinders_warning(self, mock_command):
+        mbrid = mock.Mock()
+        mbrid.get_id = mock.Mock(
+            return_value='0x0815'
+        )
+        command = mock.Mock()
+        command.error = 'isohybrid: Warning: more than 1024 cylinders: 1817'
+        mock_command.return_value = command
+        Iso.create_hybrid(42, mbrid, 'some-iso', 'efi')
+        mock_command.assert_called_once_with(
+            [
+                'isohybrid', '--offset', '42',
+                '--id', '0x0815', '--type', '0x83',
+                '--uefi', 'some-iso'
+            ]
+        )
+
+    @patch('kiwi.iso.Command.run')
     def test_set_media_tag(self, mock_command):
         Iso.set_media_tag('foo')
         mock_command.assert_called_once_with(

--- a/test/unit/iso_test.py
+++ b/test/unit/iso_test.py
@@ -264,6 +264,20 @@ class TestIso(object):
         mock_command.return_value = command
         Iso.create_hybrid(42, mbrid, 'some-iso', 'efi')
 
+    @raises(KiwiCommandError)
+    @patch('kiwi.iso.Command.run')
+    def test_create_hybrid_with_multiple_errors(self, mock_command):
+        mbrid = mock.Mock()
+        mbrid.get_id = mock.Mock(
+            return_value='0x0815'
+        )
+        command = mock.Mock()
+        command.error = \
+            'isohybrid: Warning: more than 1024 cylinders: 1817\n' + \
+            'isohybrid: Not all BIOSes will be able to boot this device\n'
+        mock_command.return_value = command
+        Iso.create_hybrid(42, mbrid, 'some-iso', 'efi')
+
     @patch('kiwi.iso.Command.run')
     def test_create_hybrid_with_cylinders_warning(self, mock_command):
         mbrid = mock.Mock()


### PR DESCRIPTION
kiwi treates warning from isohybrid as fatal errors becuase in
most cases they are fatal. However some of them are kind of
historical and should be ignored like the one described here:

* http://www.syslinux.org/archives/2015-March/023306.html

