### PR TITLE
Keep NVMe drivers in the initrd

### DIFF
--- a/kiwi/boot/arch/x86_64/oemboot/suse-SLES12/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-SLES12/config.xml
@@ -45,6 +45,8 @@
         <file name="drivers/md/*"/>
         <file name="drivers/message/fusion/*"/>
         <file name="drivers/net/*"/>
+        <file name="drivers/nvme/*"/>
+        <file name="drivers/nvmem/*"/>
         <file name="drivers/parport/*"/>
         <file name="drivers/scsi/*"/>
         <file name="drivers/staging/hv/*"/>

--- a/kiwi/boot/arch/x86_64/oemboot/suse-SLES15/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-SLES15/config.xml
@@ -43,6 +43,8 @@
         <file name="drivers/md/*"/>
         <file name="drivers/message/fusion/*"/>
         <file name="drivers/net/*"/>
+        <file name="drivers/nvme/*"/>
+        <file name="drivers/nvmem/*"/>
         <file name="drivers/parport/*"/>
         <file name="drivers/scsi/*"/>
         <file name="drivers/staging/hv/*"/>

--- a/kiwi/boot/arch/x86_64/oemboot/suse-leap42.2/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-leap42.2/config.xml
@@ -46,6 +46,8 @@
         <file name="drivers/md/*"/>
         <file name="drivers/message/fusion/*"/>
         <file name="drivers/net/*"/>
+        <file name="drivers/nvme/*"/>
+        <file name="drivers/nvmem/*"/>
         <file name="drivers/parport/*"/>
         <file name="drivers/scsi/*"/>
         <file name="drivers/staging/hv/*"/>

--- a/kiwi/boot/arch/x86_64/oemboot/suse-leap42.3/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-leap42.3/config.xml
@@ -43,6 +43,8 @@
         <file name="drivers/md/*"/>
         <file name="drivers/message/fusion/*"/>
         <file name="drivers/net/*"/>
+        <file name="drivers/nvme/*"/>
+        <file name="drivers/nvmem/*"/>
         <file name="drivers/parport/*"/>
         <file name="drivers/scsi/*"/>
         <file name="drivers/staging/hv/*"/>

--- a/kiwi/boot/arch/x86_64/oemboot/suse-tumbleweed/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-tumbleweed/config.xml
@@ -46,6 +46,8 @@
         <file name="drivers/md/*"/>
         <file name="drivers/message/fusion/*"/>
         <file name="drivers/net/*"/>
+        <file name="drivers/nvme/*"/>
+        <file name="drivers/nvmem/*"/>
         <file name="drivers/parport/*"/>
         <file name="drivers/scsi/*"/>
         <file name="drivers/staging/hv/*"/>


### PR DESCRIPTION
Support systems with the root filesystem on a NVMe device

