### PR TITLE
Prefer image packages section for bootincludes

### DIFF
--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -262,6 +262,15 @@ class XMLState(object):
         """
         return self.get_packages_sections(['bootstrap'])
 
+    def get_image_packages_sections(self):
+        """
+        List of packages sections matching type="image"
+
+        :return: <packages>
+        :rtype: list
+        """
+        return self.get_packages_sections(['image'])
+
     def get_bootstrap_packages(self):
         """
         List of packages from the type="bootstrap" packages section(s)
@@ -1441,18 +1450,23 @@ class XMLState(object):
 
     def copy_bootincluded_packages(self, target_state):
         """
-        Copy packages marked as bootinclude to the packages type=bootstrap
-        section in the target xml state. The package will also be removed
-        from the packages type=delete section in the target xml state
-        if present there
+        Copy packages marked as bootinclude to the packages type=image
+        (or type=bootstrap if no type=image was found) section in the
+        target xml state. The package will also be removed from the
+        packages type=delete section in the target xml state if
+        present there
 
         :param object target_state: XMLState instance
         """
-        target_bootstrap_packages_sections = \
-            target_state.get_bootstrap_packages_sections()
-        if target_bootstrap_packages_sections:
-            target_bootstrap_packages_section = \
-                target_bootstrap_packages_sections[0]
+        target_packages_sections = \
+            target_state.get_image_packages_sections()
+        if not target_packages_sections:
+            # no packages type=image section was found, add to bootstrap
+            target_packages_sections = \
+                target_state.get_bootstrap_packages_sections()
+        if target_packages_sections:
+            target_packages_section = \
+                target_packages_sections[0]
             package_names_added = []
             packages_sections = self.get_packages_sections(
                 ['image', 'bootstrap', self.get_build_type_name()]
@@ -1463,7 +1477,7 @@ class XMLState(object):
             if package_list:
                 for package in package_list:
                     if package.package_section.get_bootinclude():
-                        target_bootstrap_packages_section.add_package(
+                        target_packages_section.add_package(
                             xml_parse.package(
                                 name=package.package_section.get_name()
                             )

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -436,13 +436,26 @@ class TestXMLState(object):
         )
         assert self.boot_state.build_type.get_firmware() == 'efi'
 
-    def test_copy_bootincluded_packages(self):
+    def test_copy_bootincluded_packages_with_no_image_packages(self):
         self.state.copy_bootincluded_packages(self.boot_state)
         bootstrap_packages = self.boot_state.get_bootstrap_packages()
         assert 'plymouth-branding-openSUSE' in bootstrap_packages
         assert 'grub2-branding-openSUSE' in bootstrap_packages
         assert 'gfxboot-branding-openSUSE' in bootstrap_packages
         to_delete_packages = self.boot_state.get_to_become_deleted_packages()
+        assert 'gfxboot-branding-openSUSE' not in to_delete_packages
+
+    def test_copy_bootincluded_packages_with_image_packages(self):
+        boot_description = XMLDescription(
+            '../data/isoboot/example-distribution/config.xml'
+        )
+        boot_state = XMLState(boot_description.load(), ['std'])
+        self.state.copy_bootincluded_packages(boot_state)
+        image_packages = boot_state.get_system_packages()
+        assert 'plymouth-branding-openSUSE' in image_packages
+        assert 'grub2-branding-openSUSE' in image_packages
+        assert 'gfxboot-branding-openSUSE' in image_packages
+        to_delete_packages = boot_state.get_to_become_deleted_packages()
         assert 'gfxboot-branding-openSUSE' not in to_delete_packages
 
     def test_copy_bootincluded_archives(self):


### PR DESCRIPTION
If a package is marked bootinclude prefer <packages type="image">
section in the target XML as primary target and only if no such
section exists put the package in the <packages type="bootstrap">
section

