### PR TITLE
Follow up fix for isohybrid error handling

### DIFF
--- a/kiwi/iso.py
+++ b/kiwi/iso.py
@@ -102,7 +102,8 @@ class Iso(object):
         ignore_errors = [
             # we ignore this error message, for details see:
             # http://www.syslinux.org/archives/2015-March/023306.html
-            'Warning: more than 1024 cylinders'
+            'Warning: more than 1024 cylinders',
+            'Not all BIOSes will be able to boot this device'
         ]
         isohybrid_parameters = [
             '--offset', format(offset),
@@ -122,13 +123,20 @@ class Iso(object):
         # are more strict and fail
         if isohybrid_call.error:
             error_list = isohybrid_call.error.split(os.linesep)
+            error_fatal_list = []
             for error in error_list:
+                ignore = False
                 for ignore_error in ignore_errors:
                     if ignore_error in error:
-                        error_list.remove(error)
-            if error_list:
+                        ignore = True
+                        break
+                if not ignore:
+                    error_fatal_list.append(error)
+            if error_fatal_list:
                 raise KiwiCommandError(
-                    'isohybrid: {0}'.format(isohybrid_call.error)
+                    'isohybrid issue not ignored by kiwi: {0}'.format(
+                        error_fatal_list
+                    )
                 )
 
     @classmethod

--- a/test/unit/iso_test.py
+++ b/test/unit/iso_test.py
@@ -274,7 +274,8 @@ class TestIso(object):
         command = mock.Mock()
         command.error = \
             'isohybrid: Warning: more than 1024 cylinders: 1817\n' + \
-            'isohybrid: Not all BIOSes will be able to boot this device\n'
+            'isohybrid: Not all BIOSes will be able to boot this device\n' + \
+            'isohybrid: some other error we do not ignore'
         mock_command.return_value = command
         Iso.create_hybrid(42, mbrid, 'some-iso', 'efi')
 
@@ -285,7 +286,9 @@ class TestIso(object):
             return_value='0x0815'
         )
         command = mock.Mock()
-        command.error = 'isohybrid: Warning: more than 1024 cylinders: 1817'
+        command.error = \
+            'isohybrid: Warning: more than 1024 cylinders: 1817\n' + \
+            'isohybrid: Not all BIOSes will be able to boot this device'
         mock_command.return_value = command
         Iso.create_hybrid(42, mbrid, 'some-iso', 'efi')
         mock_command.assert_called_once_with(


### PR DESCRIPTION
Allow to handle multiple messages from isohybrid as warnings.
Only if the list of messages still contains information after all
non error conditions had been checked out, an exception is
thrown

