### PR TITLE
Fix vmdk descriptor file

### DIFF
--- a/kiwi/storage/subformat/vmdk.py
+++ b/kiwi/storage/subformat/vmdk.py
@@ -238,7 +238,7 @@ class DiskFormatVmdk(DiskFormatBase):
         vmdk_descriptor_lines.append(
             'ddb.toolsVersion = "%s"' % vmdk_tools_version
         )
-        with open(vmdk_image_name, 'ab') as vmdk:
+        with open(vmdk_image_name, 'r+b') as vmdk:
             vmdk.seek(512, 0)
             vmdk.write(bytes('\n'.join(vmdk_descriptor_lines), 'utf-8'))
             vmdk.seek(0, 2)

--- a/test/unit/storage_subformat_vmdk_test.py
+++ b/test/unit/storage_subformat_vmdk_test.py
@@ -262,7 +262,7 @@ class TestDiskFormatVmdk(object):
         self.disk_format.create_image_format()
 
         assert mock_open.call_args_list == [
-            call('target_dir/some-disk-image.x86_64-1.2.3.vmdk', 'ab'),
+            call('target_dir/some-disk-image.x86_64-1.2.3.vmdk', 'r+b'),
             call('target_dir/some-disk-image.x86_64-1.2.3.vmx', 'w')
         ]
         assert self.file_mock.write.call_args_list[0] == call(
@@ -302,7 +302,7 @@ class TestDiskFormatVmdk(object):
         self.disk_format.create_image_format()
 
         assert mock_open.call_args_list == [
-            call('target_dir/some-disk-image.x86_64-1.2.3.vmdk', 'ab'),
+            call('target_dir/some-disk-image.x86_64-1.2.3.vmdk', 'r+b'),
             call('target_dir/some-disk-image.x86_64-1.2.3.vmx', 'w')
         ]
         assert self.file_mock.write.call_args_list[0] == call(


### PR DESCRIPTION
This commit fixes the descriptor file of the vmdk images. Before this
commit the descriptior file was appended at the end of the image
instead of overwritting the current one at the very beginning.

Fixes bsc#1050665