### PR TITLE
Add OCI reference in skopeo copy call and umoci config call

### DIFF
--- a/kiwi/archive/tar.py
+++ b/kiwi/archive/tar.py
@@ -181,7 +181,7 @@ class ArchiveTar(object):
             version_line = command.output.splitlines()[0]
             version_string = version_line.split()[-1]
             version_info = tuple(int(elt) for elt in version_string.split('.'))
-        except:
+        except Exception:
             raise KiwiArchiveTarError(
                 "Unable to parse tar version string")
         return version_info >= (1, 27)

--- a/kiwi/container/oci.py
+++ b/kiwi/container/oci.py
@@ -152,7 +152,8 @@ class ContainerImageOCI(object):
             image_tar.extract(container_dir)
             Command.run([
                 'umoci', 'config', '--image',
-                container_dir, '--tag', self.container_tag
+                '{0}:base_layer'.format(container_dir),
+                '--tag', self.container_tag
             ])
         else:
             Command.run(

--- a/kiwi/system/root_import/docker.py
+++ b/kiwi/system/root_import/docker.py
@@ -42,5 +42,6 @@ class RootImportDocker(RootImportOCI):
             skopeo_uri = self.unknown_uri
 
         Command.run([
-            'skopeo', 'copy', skopeo_uri, 'oci:{0}'.format(self.oci_layout_dir)
+            'skopeo', 'copy', skopeo_uri,
+            'oci:{0}:base_layer'.format(self.oci_layout_dir)
         ])

--- a/kiwi/system/root_import/oci.py
+++ b/kiwi/system/root_import/oci.py
@@ -52,7 +52,7 @@ class RootImportOCI(RootImportBase):
         self.extract_oci_image()
         Command.run([
             'umoci', 'unpack', '--image',
-            self.oci_layout_dir, self.oci_unpack_dir
+            '{0}:base_layer'.format(self.oci_layout_dir), self.oci_unpack_dir
         ])
 
         synchronizer = DataSync(
@@ -91,7 +91,8 @@ class RootImportOCI(RootImportBase):
             skopeo_uri = self.unknown_uri
 
         Command.run([
-            'skopeo', 'copy', skopeo_uri, 'oci:{0}'.format(self.oci_layout_dir)
+            'skopeo', 'copy', skopeo_uri,
+            'oci:{0}:base_layer'.format(self.oci_layout_dir)
         ])
 
     def __del__(self):

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1292,7 +1292,7 @@ class XMLState(object):
         """
         try:
             repo_prio = int(repo_prio)
-        except:
+        except Exception:
             repo_prio = None
         self.xml_data.add_repository(
             xml_parse.repository(

--- a/test/unit/container_image_oci_test.py
+++ b/test/unit/container_image_oci_test.py
@@ -207,7 +207,7 @@ class TestContainerImageOCI(object):
         assert mock_command.call_args_list == [
             call([
                 'umoci', 'config', '--image',
-                'kiwi_oci_dir/umoci_layout', '--tag', 'latest'
+                'kiwi_oci_dir/umoci_layout:base_layer', '--tag', 'latest'
             ]),
             call([
                 'umoci', 'unpack', '--image',

--- a/test/unit/system_root_import_docker_test.py
+++ b/test/unit/system_root_import_docker_test.py
@@ -37,7 +37,7 @@ class TestRootImportDocker(object):
         uncompress.uncompress.assert_called_once_with(True)
         mock_run.assert_called_once_with([
             'skopeo', 'copy', 'docker-archive:tmp_uncompressed',
-            'oci:kiwi_layout_dir'
+            'oci:kiwi_layout_dir:base_layer'
         ])
 
     @patch('os.path.exists')
@@ -64,6 +64,6 @@ class TestRootImportDocker(object):
         docker_import.extract_oci_image()
         mock_run.assert_called_once_with([
             'skopeo', 'copy', 'docker://opensuse',
-            'oci:kiwi_layout_dir'
+            'oci:kiwi_layout_dir:base_layer'
         ])
         assert mock_warn.called

--- a/test/unit/system_root_import_oci_test.py
+++ b/test/unit/system_root_import_oci_test.py
@@ -59,11 +59,11 @@ class TestRootImportOCI(object):
         assert mock_run.call_args_list == [
             call([
                 'skopeo', 'copy', 'oci:kiwi_uncompressed:tag',
-                'oci:kiwi_layout_dir'
+                'oci:kiwi_layout_dir:base_layer'
             ]),
             call([
                 'umoci', 'unpack', '--image',
-                'kiwi_layout_dir', 'kiwi_unpack_dir'
+                'kiwi_layout_dir:base_layer', 'kiwi_unpack_dir'
             ])
         ]
 
@@ -86,7 +86,7 @@ class TestRootImportOCI(object):
         self.oci_import.extract_oci_image()
         mock_run.assert_called_once_with([
             'skopeo', 'copy', 'oci://some_image',
-            'oci:kiwi_layout_dir'
+            'oci:kiwi_layout_dir:base_layer'
         ])
         assert mock_warn.called
 
@@ -111,7 +111,7 @@ class TestRootImportOCI(object):
         oci_import.extract_oci_image()
         mock_run.assert_called_once_with([
             'skopeo', 'copy', 'oci:kiwi_uncompressed',
-            'oci:kiwi_layout_dir'
+            'oci:kiwi_layout_dir:base_layer'
         ])
         mock_tar.assert_called_once_with('/image.tar.xz')
 

--- a/test/unit/test_helper.py
+++ b/test/unit/test_helper.py
@@ -38,7 +38,7 @@ class raises(object):
                 func(*args, **kw)
             except self.exceptions:
                 pass
-            except:
+            except Exception:
                 raise
             else:
                 message = "%s() did not raise %s" % (name, self.valid)


### PR DESCRIPTION
Skopeo, since v1.24, does no longer assume 'latest' as the default
tag/reference and requires explicit tag or reference in skopeo
call. In KIWI the default was only used to import the base rootfs,
with this commit the imported container is tagged as 'base_layer'.
The current patch works for all skopeo versions.
