### PR TITLE
Fixed validation of isohybrid warnings

### DIFF
--- a/kiwi/iso.py
+++ b/kiwi/iso.py
@@ -130,7 +130,7 @@ class Iso(object):
                     if ignore_error in error:
                         ignore = True
                         break
-                if not ignore:
+                if not ignore and error:
                     error_fatal_list.append(error)
             if error_fatal_list:
                 raise KiwiCommandError(

--- a/test/unit/iso_test.py
+++ b/test/unit/iso_test.py
@@ -288,7 +288,7 @@ class TestIso(object):
         command = mock.Mock()
         command.error = \
             'isohybrid: Warning: more than 1024 cylinders: 1817\n' + \
-            'isohybrid: Not all BIOSes will be able to boot this device'
+            'isohybrid: Not all BIOSes will be able to boot this device\n'
         mock_command.return_value = command
         Iso.create_hybrid(42, mbrid, 'some-iso', 'efi')
         mock_command.assert_called_once_with(


### PR DESCRIPTION
The list of warning messages is evaluated line by line
and those not matching the ignore warnings list are treated
as errors. However if an empty line exists it did not match
the ignore warnings list but is also not an error. This
patch makes sure only non empty warning information has
an effect

