### PR TITLE
Extend checkmedia runtime check

### DIFF
--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -391,12 +391,25 @@ class RuntimeChecker(object):
         Checkmedia tool and its related boot code are only available
         for x86 platforms.
         """
-        arch = platform.machine()
-        message = dedent('''\n
+        message_arch_unsupported = dedent('''\n
             The attribute 'mediacheck' is only supported for
             x86 platforms, thus it can't be set to 'true'
             for the current ({0}) architecture.
         ''')
-        if self.xml_state.build_type.get_mediacheck() is True and \
-                arch not in ['x86_64', 'i586', 'i686']:
-            raise KiwiRuntimeError(message.format(arch))
+        message_tool_not_found = dedent('''\n
+            Required tool {name} not found in caller environment
+
+            The attribute 'mediacheck' is set to 'true' which requires
+            the above tool to be installed on the build system
+        ''')
+        if self.xml_state.build_type.get_mediacheck() is True:
+            arch = platform.machine()
+            tool = 'tagmedia'
+            if arch not in ['x86_64', 'i586', 'i686']:
+                raise KiwiRuntimeError(
+                    message_arch_unsupported.format(arch)
+                )
+            elif not Path.which(filename=tool, access_mode=os.X_OK):
+                raise KiwiRuntimeError(
+                    message_tool_not_found.format(name=tool)
+                )

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -156,10 +156,24 @@ class TestRuntimeChecker(object):
 
     @raises(KiwiRuntimeError)
     @patch('platform.machine')
-    def test_check_mediacheck_only_for_x86_arch(
+    def test_check_mediacheck_only_for_x86_arch_invalid_arch(
         self, mock_machine
     ):
         mock_machine.return_value = 'aarch64'
+        xml_state = XMLState(
+            self.description.load(), ['vmxFlavour'], 'iso'
+        )
+        runtime_checker = RuntimeChecker(xml_state)
+        runtime_checker.check_mediacheck_only_for_x86_arch()
+
+    @raises(KiwiRuntimeError)
+    @patch('platform.machine')
+    @patch('kiwi.runtime_checker.Path.which')
+    def test_check_mediacheck_only_for_x86_arch_tagmedia_missing(
+        self, mock_which, mock_machine
+    ):
+        mock_machine.return_value = 'x86_64'
+        mock_which.return_value = False
         xml_state = XMLState(
             self.description.load(), ['vmxFlavour'], 'iso'
         )


### PR DESCRIPTION
In addition to the correct architecture the check also includes
the lookup of the required tagmedia tool to be present on the
building host. This Fixes #538


