### PR TITLE
Remove hardcoded any /var/lib/rpm path

### DIFF
--- a/kiwi/boot/arch/arm/oemboot/linuxrc
+++ b/kiwi/boot/arch/arm/oemboot/linuxrc
@@ -418,8 +418,10 @@ if [ ! -z "$KIWI_RECOVERY" ];then
                 Echo "Failed to backup zypp database"
                 exit 1
             fi
-            rpmdb=$(rpm -E %_dbpath)
-            rpmdb=${rpmdb##\/}
+            rpmdb=usr/lib/rpm
+            if [ ! -d "$rpm" ]; then
+                rpmdb=var/lib/rpm
+            fi
             if ! cp -a $rpmdb ${rpmdb}.backup;then
                 rm -rf ${rpmdb}.backup; cd / ; umountSystem
                 Echo "Failed to backup RPM database"

--- a/kiwi/boot/arch/arm/oemboot/linuxrc
+++ b/kiwi/boot/arch/arm/oemboot/linuxrc
@@ -418,8 +418,10 @@ if [ ! -z "$KIWI_RECOVERY" ];then
                 Echo "Failed to backup zypp database"
                 exit 1
             fi
-            if ! cp -a var/lib/rpm var/lib/rpm.backup;then
-                rm -rf var/lib/rpm.backup; cd / ; umountSystem
+            rpmdb=$(rpm -E %_dbpath)
+            rpmdb=${rpmdb##\/}
+            if ! cp -a $rpmdb ${rpmdb}.backup;then
+                rm -rf ${rpmdb}.backup; cd / ; umountSystem
                 Echo "Failed to backup RPM database"
                 exit 1
             fi

--- a/kiwi/boot/arch/ppc/oemboot/linuxrc
+++ b/kiwi/boot/arch/ppc/oemboot/linuxrc
@@ -417,8 +417,10 @@ if [ ! -z "$KIWI_RECOVERY" ];then
                 Echo "Failed to backup zypp database"
                 exit 1
             fi
-            if ! cp -a var/lib/rpm var/lib/rpm.backup;then
-                rm -rf var/lib/rpm.backup; cd / ; umountSystem
+            rpmdb=$(rpm -E %_dbpath)
+            rpmdb=${rpmdb##\/}
+            if ! cp -a $rpmdb ${rpmdb}.backup;then
+                rm -rf ${rpmdb}.backup; cd / ; umountSystem
                 Echo "Failed to backup RPM database"
                 exit 1
             fi

--- a/kiwi/boot/arch/ppc/oemboot/linuxrc
+++ b/kiwi/boot/arch/ppc/oemboot/linuxrc
@@ -417,8 +417,10 @@ if [ ! -z "$KIWI_RECOVERY" ];then
                 Echo "Failed to backup zypp database"
                 exit 1
             fi
-            rpmdb=$(rpm -E %_dbpath)
-            rpmdb=${rpmdb##\/}
+            rpmdb=usr/lib/rpm
+            if [ ! -d "$rpm" ]; then
+                rpmdb=var/lib/rpm
+            fi
             if ! cp -a $rpmdb ${rpmdb}.backup;then
                 rm -rf ${rpmdb}.backup; cd / ; umountSystem
                 Echo "Failed to backup RPM database"

--- a/kiwi/boot/arch/s390/oemboot/linuxrc
+++ b/kiwi/boot/arch/s390/oemboot/linuxrc
@@ -422,8 +422,10 @@ if [ ! -z "$KIWI_RECOVERY" ];then
                 Echo "Failed to backup zypp database"
                 exit 1
             fi
-            rpmdb=$(rpm -E %_dbpath)
-            rpmdb=${rpmdb##\/}
+            rpmdb=usr/lib/rpm
+            if [ ! -d "$rpm" ]; then
+                rpmdb=var/lib/rpm
+            fi
             if ! cp -a $rpmdb ${rpmdb}.backup;then
                 rm -rf ${rpmdb}.backup; cd / ; umountSystem
                 Echo "Failed to backup RPM database"

--- a/kiwi/boot/arch/s390/oemboot/linuxrc
+++ b/kiwi/boot/arch/s390/oemboot/linuxrc
@@ -422,8 +422,10 @@ if [ ! -z "$KIWI_RECOVERY" ];then
                 Echo "Failed to backup zypp database"
                 exit 1
             fi
-            if ! cp -a var/lib/rpm var/lib/rpm.backup;then
-                rm -rf var/lib/rpm.backup; cd / ; umountSystem
+            rpmdb=$(rpm -E %_dbpath)
+            rpmdb=${rpmdb##\/}
+            if ! cp -a $rpmdb ${rpmdb}.backup;then
+                rm -rf ${rpmdb}.backup; cd / ; umountSystem
                 Echo "Failed to backup RPM database"
                 exit 1
             fi

--- a/kiwi/boot/arch/x86_64/oemboot/linuxrc
+++ b/kiwi/boot/arch/x86_64/oemboot/linuxrc
@@ -418,8 +418,10 @@ if [ ! -z "$KIWI_RECOVERY" ];then
                 Echo "Failed to backup zypp database"
                 exit 1
             fi
-            rpmdb=$(rpm -E %_dbpath)
-            rpmdb=${rpmdb##\/}
+            rpmdb=usr/lib/rpm
+            if [ ! -d "$rpm" ]; then
+                rpmdb=var/lib/rpm
+            fi
             if ! cp -a $rpmdb ${rpmdb}.backup;then
                 rm -rf ${rpmdb}.backup; cd / ; umountSystem
                 Echo "Failed to backup RPM database"

--- a/kiwi/boot/arch/x86_64/oemboot/linuxrc
+++ b/kiwi/boot/arch/x86_64/oemboot/linuxrc
@@ -418,8 +418,10 @@ if [ ! -z "$KIWI_RECOVERY" ];then
                 Echo "Failed to backup zypp database"
                 exit 1
             fi
-            if ! cp -a var/lib/rpm var/lib/rpm.backup;then
-                rm -rf var/lib/rpm.backup; cd / ; umountSystem
+            rpmdb=$(rpm -E %_dbpath)
+            rpmdb=${rpmdb##\/}
+            if ! cp -a $rpmdb ${rpmdb}.backup;then
+                rm -rf ${rpmdb}.backup; cd / ; umountSystem
                 Echo "Failed to backup RPM database"
                 exit 1
             fi

--- a/kiwi/package_manager/zypper.py
+++ b/kiwi/package_manager/zypper.py
@@ -252,11 +252,15 @@ class PackageManagerZypper(PackageManagerBase):
             48: 'db48_load'
         }
 
-        cmd = Command.run(['chroot', self.root_dir, 'rpm', '-E', '%_dbpath'])
-        rpmdb = os.sep.join([self.root_dir, cmd.output.strip()])
-        if not os.path.exists(rpmdb):
+        rpmdb_path_request = Command.run(
+            ['chroot', self.root_dir, 'rpm', '-E', '%_dbpath']
+        )
+        rpmdb_path = os.path.normpath(os.sep.join(
+            [self.root_dir, rpmdb_path_request.output.strip()]
+        ))
+        if not os.path.exists(rpmdb_path):
             raise KiwiRpmDatabaseReloadError(
-                'Unable to get the rpmdb location {0}'.format(rpmdb)
+                'Unable to get the rpmdb location {0}'.format(rpmdb_path)
             )
 
         if version not in db_load_for_version:
@@ -265,21 +269,20 @@ class PackageManagerZypper(PackageManagerBase):
             )
         if not self.database_consistent():
             reload_db_files = [
-                os.path.normpath(os.sep.join([cmd.output, 'Name'])),
-                os.path.normpath(os.sep.join([cmd.output, 'Packages']))
+                os.sep.join([rpmdb_path, 'Name']),
+                os.sep.join([rpmdb_path, 'Packages'])
             ]
             for db_file in reload_db_files:
-                root_db_file = os.sep.join([self.root_dir, db_file])
-                root_db_file_backup = '{0}.bak'.format(root_db_file)
+                db_file_backup = '{0}.bak'.format(db_file)
                 Command.run([
-                    'db_dump', '-f', root_db_file_backup, root_db_file
+                    'db_dump', '-f', db_file_backup, db_file
                 ])
-                Command.run(['rm', '-f', root_db_file])
+                Command.run(['rm', '-f', db_file])
                 Command.run([
                     db_load_for_version[version],
-                    '-f', root_db_file_backup, root_db_file
+                    '-f', db_file_backup, db_file
                 ])
-                Command.run(['rm', '-f', root_db_file_backup])
+                Command.run(['rm', '-f', db_file_backup])
             Command.run([
                 'chroot', self.root_dir, 'rpm', '--rebuilddb'
             ])


### PR DESCRIPTION
This commit changes any /var/lib/rpm reference to the call
'rpm -E %_dbpath' which returns the path of the rpmdb which
has been recently updated to a different location in recent rpm
versions. Now the rpmdb path is determined dynamically.

Fixes #537
