### PR TITLE
Fixed blocksize setup in losetup

### DIFF
--- a/kiwi/boot/functions.sh
+++ b/kiwi/boot/functions.sh
@@ -9616,11 +9616,11 @@ function backupGPT {
 function loop_setup {
     local IFS=$IFS_ORIG
     local target="$@"
-    local logical_sector_size
+    local logical_block_size
     if [ ! -z "$kiwi_target_blocksize" ];then
-        logical_sector_size="-L $kiwi_target_blocksize"
+        logical_block_size="--logical-blocksize $kiwi_target_blocksize"
     fi
-    local loop=$(losetup $logical_sector_size -f --show "$target")
+    local loop=$(losetup $logical_block_size -f --show "$target")
     if [ ! -e "$loop" ];then
         return 1
     fi

--- a/kiwi/storage/loop_device.py
+++ b/kiwi/storage/loop_device.py
@@ -82,7 +82,7 @@ class LoopDevice(DeviceProvider):
         )
         loop_options = []
         if self.blocksize_bytes and self.blocksize_bytes != 512:
-            loop_options.append('-L')
+            loop_options.append('--logical-blocksize')
             loop_options.append(format(self.blocksize_bytes))
         loop_call = Command.run(
             ['losetup'] + loop_options + ['-f', '--show', self.filename]

--- a/test/unit/storage_loop_device_test.py
+++ b/test/unit/storage_loop_device_test.py
@@ -36,7 +36,8 @@ class TestLoopDevice(object):
         call = mock_command.call_args_list[1]
         assert mock_command.call_args_list[1] == \
             call([
-                'losetup', '-L', '4096', '-f', '--show', 'loop-file'
+                'losetup', '--logical-blocksize', '4096',
+                '-f', '--show', 'loop-file'
             ])
         self.loop.node_name = None
 


### PR DESCRIPTION
The -L option was used to set the blocksize value for losetup
However there is an option name clash between suse util-linux
and upstream which now leads to the problem that option -L
has changed its meaning and actually means --nooverlap which
completely breaks the call in kiwi. This patch changes the
call to use the long form --logical-blocksize

