### PR TITLE
Delete atftp from SLE15 boot descriptions

### DIFF
--- a/kiwi/boot/arch/x86_64/netboot/suse-SLES15/config.xml
+++ b/kiwi/boot/arch/x86_64/netboot/suse-SLES15/config.xml
@@ -121,7 +121,6 @@
         <package name="xfsprogs"/>
     </packages>
     <packages type="image">
-        <package name="atftp"/>
         <package name="bc"/>
         <package name="bind-libs"/>
         <package name="bind-utils"/>

--- a/kiwi/boot/arch/x86_64/oemboot/suse-SLES15/config.xml
+++ b/kiwi/boot/arch/x86_64/oemboot/suse-SLES15/config.xml
@@ -107,7 +107,6 @@
         <package name="kbd"/>
         <package name="gptfdisk"/>
         <package name="adaptec-firmware"/>
-        <package name="atftp"/>
         <package name="bc"/>
         <package name="bind-libs"/>
         <package name="bind-utils"/>


### PR DESCRIPTION
atftp will not be part of SLE15 per fate#323633.
This Fixes #543

