### PR TITLE
Dracut kiwi lib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
 - sudo apt-get install -y xsltproc
 - sudo apt-get install -y genisoimage
 - sudo apt-get install -y enchant
+- sudo apt-get install -y shellcheck
 install:
 - pip install --upgrade pip
 - pip install -r .travis.requirements.txt

--- a/.virtualenv.dev-requirements.txt
+++ b/.virtualenv.dev-requirements.txt
@@ -17,6 +17,12 @@ setuptools
 tox
 
 # python unit testing framework
+
+# py 1.5 was released but pytest-cov requires py<1.5
+# Thus we also install py in a lower version to temporarily
+# fix the version conflict
+py==1.4.34
+
 pytest
 pytest-cov
 

--- a/dracut/modules.d/90kiwi-live/kiwi-generator.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-generator.sh
@@ -2,23 +2,23 @@
 
 type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 
-[ -z "$root" ] && root=$(getarg root=)
+[ -z "${root}" ] && root=$(getarg root=)
 
 if [ "${root%%:*}" = "live" ] ; then
-    liveroot=$root
+    liveroot="${root}"
 fi
 
 [ "${liveroot%%:*}" = "live" ] || exit 0
 
-case "$liveroot" in
+case "${liveroot}" in
     live:CDLABEL=*|CDLABEL=*) \
         root="${root#live:}"
-        root="$(echo $root | sed 's,/,\\x2f,g')"
+        root="$(echo "${root}" | sed 's,/,\\x2f,g')"
         root="live:/dev/disk/by-label/${root#CDLABEL=}"
         rootok=1 ;;
 esac
 
-[ "$rootok" != "1" ] && exit 0
+[ "${rootok}" != "1" ] && exit 0
 
 GENERATOR_DIR="$2"
 [ -z "$GENERATOR_DIR" ] && exit 1

--- a/dracut/modules.d/90kiwi-live/kiwi-live-checkmedia.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-live-checkmedia.sh
@@ -3,6 +3,7 @@ type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 type runMediaCheck >/dev/null 2>&1 || . /lib/kiwi-live-lib.sh
 
 if getargbool 0 mediacheck; then
-    initGlobalDevices ${root#live:}
+    declare root=${root}
+    initGlobalDevices "${root#live:}"
     runMediaCheck
 fi

--- a/dracut/modules.d/90kiwi-live/kiwi-live-genrules.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-live-genrules.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-case "$root" in
+declare root=${root}
+
+case "${root}" in
     live:/dev/*)
     {
         printf 'KERNEL=="%s", RUN+="/sbin/initqueue --settled --onetime --unique /sbin/kiwi-live-root %s"\n' \

--- a/dracut/modules.d/90kiwi-live/kiwi-live-root.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-live-root.sh
@@ -9,7 +9,7 @@ PATH=/usr/sbin:/usr/bin:/sbin:/bin
 setupDebugMode
 
 # device nodes and types
-initGlobalDevices $1
+initGlobalDevices "$1"
 
 # live options and their default values
 initGlobalOptions
@@ -22,13 +22,14 @@ iso_mount_point=$(mountIso)
 
 # mount squashfs compressed container
 container_mount_point=$(
-    mountCompressedContainerFromIso ${iso_mount_point}
+    mountCompressedContainerFromIso "${iso_mount_point}"
 )
 
 # mount readonly root filesystem from container
-mountReadOnlyRootImageFromContainer ${container_mount_point}
+mountReadOnlyRootImageFromContainer "${container_mount_point}"
 
 # prepare overlay for generated systemd LiveOS_rootfs service
+declare isodiskdev=${isodiskdev}
 if getargbool 0 rd.live.overlay.persistent && [ ! -z "${isodiskdev}" ]; then
     if ! preparePersistentOverlay; then
         warn "Failed to setup persistent write space !"

--- a/dracut/modules.d/90kiwi-live/module-setup.sh
+++ b/dracut/modules.d/90kiwi-live/module-setup.sh
@@ -3,7 +3,8 @@
 # called by dracut
 check() {
     # a live host-only image doesn't really make a lot of sense
-    [[ $hostonly ]] && return 1
+    declare hostonly=${hostonly}
+    [[ ${hostonly} ]] && return 1
     return 255
 }
 
@@ -20,17 +21,19 @@ installkernel() {
 
 # called by dracut
 install() {
+    declare moddir=${moddir}
+    declare systemdutildir=${systemdutildir}
     inst_multiple \
         umount dmsetup blockdev blkid lsblk dd losetup \
         isoinfo grep cut partprobe find wc fdisk tail mkfs.ext4 mkfs.xfs \
         checkmedia dialog
-    inst_hook cmdline 30 "$moddir/parse-kiwi-live.sh"
-    inst_hook pre-udev 30 "$moddir/kiwi-live-genrules.sh"
-    inst_hook pre-mount 30 "$moddir/kiwi-live-checkmedia.sh"
-    inst_script "$moddir/kiwi-live-root.sh" "/sbin/kiwi-live-root"
-    inst_script "$moddir/kiwi-generator.sh" \
-        $systemdutildir/system-generators/dracut-kiwi-generator
-    inst_simple "$moddir/kiwi-live-lib.sh" "/lib/kiwi-live-lib.sh"
+    inst_hook cmdline 30 "${moddir}/parse-kiwi-live.sh"
+    inst_hook pre-udev 30 "${moddir}/kiwi-live-genrules.sh"
+    inst_hook pre-mount 30 "${moddir}/kiwi-live-checkmedia.sh"
+    inst_script "${moddir}/kiwi-live-root.sh" "/sbin/kiwi-live-root"
+    inst_script "${moddir}/kiwi-generator.sh" \
+        "${systemdutildir}/system-generators/dracut-kiwi-generator"
+    inst_simple "${moddir}/kiwi-live-lib.sh" "/lib/kiwi-live-lib.sh"
     inst_rules 60-cdrom_id.rules
     dracut_need_initqueue
 }

--- a/dracut/modules.d/90kiwi-live/parse-kiwi-live.sh
+++ b/dracut/modules.d/90kiwi-live/parse-kiwi-live.sh
@@ -2,30 +2,30 @@
 # live images are specified with
 # root=live:CDLABEL=label
 
-[ -z "$root" ] && root=$(getarg root=)
+[ -z "${root}" ] && root=$(getarg root=)
 
 if [ "${root%%:*}" = "live" ] ; then
-    liveroot=$root
+    liveroot=${root}
 fi
 
 [ "${liveroot%%:*}" = "live" ] || return 1
 
 modprobe -q loop
 
-case "$liveroot" in
+case "${liveroot}" in
     live:CDLABEL=*|CDLABEL=*) \
         root="${root#live:}"
-        root="$(echo $root | sed 's,/,\\x2f,g')"
+        root="$(echo "${root}" | sed 's,/,\\x2f,g')"
         root="live:/dev/disk/by-label/${root#CDLABEL=}"
         rootok=1 ;;
 esac
 
 [ "$rootok" = "1" ] || return 1
 
-info "root was $liveroot, is now $root"
+info "root was ${liveroot}, is now ${root}"
 
 # make sure that init doesn't complain
-[ -z "$root" ] && root="live"
+[ -z "${root}" ] && root="live"
 
 wait_for_dev -n /run/rootfsbase
 

--- a/dracut/modules.d/90kiwi-overlay/kiwi-generator.sh
+++ b/dracut/modules.d/90kiwi-overlay/kiwi-generator.sh
@@ -2,23 +2,23 @@
 
 type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 
-[ -z "$root" ] && root=$(getarg root=)
+[ -z "${root}" ] && root=$(getarg root=)
 
 if [ "${root%%:*}" = "overlay" ] ; then
-    overlayroot=$root
+    overlayroot=${root}
 fi
 
 [ "${overlayroot%%:*}" = "overlay" ] || exit 0
 
-case "$overlayroot" in
+case "${overlayroot}" in
     overlay:UUID=*|UUID=*) \
         root="${root#overlay:}"
-        root="$(echo $root | sed 's,/,\\x2f,g')"
+        root="$(echo "${root}" | sed 's,/,\\x2f,g')"
         root="overlay:/dev/disk/by-uuid/${root#UUID=}"
         rootok=1 ;;
 esac
 
-[ "$rootok" != "1" ] && exit 0
+[ "${rootok}" != "1" ] && exit 0
 
 GENERATOR_DIR="$2"
 [ -z "$GENERATOR_DIR" ] && exit 1

--- a/dracut/modules.d/90kiwi-overlay/kiwi-overlay-genrules.sh
+++ b/dracut/modules.d/90kiwi-overlay/kiwi-overlay-genrules.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-case "$root" in
+declare root=${root}
+
+case "${root}" in
     overlay:/dev/*)
     {
         printf 'KERNEL=="%s", RUN+="/sbin/initqueue --settled --onetime --unique /sbin/kiwi-overlay-root %s"\n' \

--- a/dracut/modules.d/90kiwi-overlay/kiwi-overlay-root.sh
+++ b/dracut/modules.d/90kiwi-overlay/kiwi-overlay-root.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 
 #======================================
@@ -24,11 +24,11 @@ function initGlobalDevices {
     fi
     write_partition="$1"
     root_disk=/dev/$(
-        lsblk -n -r -s -o NAME,TYPE ${write_partition} |\
+        lsblk -n -r -s -o NAME,TYPE "${write_partition}" |\
         grep disk | cut -f1 -d ' '
     )
     read_only_partition=/dev/$(
-        lsblk -r --fs -o NAME,FSTYPE ${root_disk} |\
+        lsblk -r --fs -o NAME,FSTYPE "${root_disk}" |\
         grep squashfs | cut -f1 -d ' '
     )
 }
@@ -36,16 +36,16 @@ function initGlobalDevices {
 function mountReadOnlyRootImage {
     local root_mount_point=/run/rootfsbase
     mkdir -m 0755 -p ${root_mount_point}
-    if ! mount -n ${read_only_partition} ${root_mount_point}; then
+    if ! mount -n "${read_only_partition}" "${root_mount_point}"; then
         die "Failed to mount overlay(ro) root filesystem"
     fi
-    echo ${root_mount_point}
+    echo "${root_mount_point}"
 }
 
 function preparePersistentOverlay {
     local overlay_mount_point=/run/overlayfs
     mkdir -m 0755 -p ${overlay_mount_point}
-    if ! mount ${write_partition}  ${overlay_mount_point}; then
+    if ! mount "${write_partition}" "${overlay_mount_point}"; then
         die "Failed to mount overlay(rw) filesystem"
     fi
     mkdir -m 0755 -p ${overlay_mount_point}/rw
@@ -61,7 +61,7 @@ PATH=/usr/sbin:/usr/bin:/sbin:/bin
 setupDebugMode
 
 # device nodes and types
-initGlobalDevices $1
+initGlobalDevices "$1"
 
 # load required kernel modules
 loadKernelModules

--- a/dracut/modules.d/90kiwi-overlay/module-setup.sh
+++ b/dracut/modules.d/90kiwi-overlay/module-setup.sh
@@ -13,12 +13,14 @@ installkernel() {
 
 # called by dracut
 install() {
+    declare moddir=${moddir}
+    declare systemdutildir=${systemdutildir}
     inst_multiple \
         lsblk losetup grep cut mount
-    inst_hook cmdline 30 "$moddir/parse-kiwi-overlay.sh"
-    inst_hook pre-udev 30 "$moddir/kiwi-overlay-genrules.sh"
-    inst_script "$moddir/kiwi-overlay-root.sh" "/sbin/kiwi-overlay-root"
-    inst_script "$moddir/kiwi-generator.sh" \
-        $systemdutildir/system-generators/dracut-kiwi-generator
+    inst_hook cmdline 30 "${moddir}/parse-kiwi-overlay.sh"
+    inst_hook pre-udev 30 "${moddir}/kiwi-overlay-genrules.sh"
+    inst_script "${moddir}/kiwi-overlay-root.sh" "/sbin/kiwi-overlay-root"
+    inst_script "${moddir}/kiwi-generator.sh" \
+        "${systemdutildir}/system-generators/dracut-kiwi-generator"
     dracut_need_initqueue
 }

--- a/dracut/modules.d/90kiwi-overlay/parse-kiwi-overlay.sh
+++ b/dracut/modules.d/90kiwi-overlay/parse-kiwi-overlay.sh
@@ -2,7 +2,7 @@
 # overlay images are specified with
 # root=overlay:UUID=uuid
 
-[ -z "$root" ] && root=$(getarg root=)
+[ -z "${root}" ] && root=$(getarg root=)
 
 if [ "${root%%:*}" = "overlay" ] ; then
     overlayroot=$root
@@ -12,20 +12,20 @@ fi
 
 modprobe -q loop
 
-case "$overlayroot" in
+case "${overlayroot}" in
     overlay:UUID=*|UUID=*) \
         root="${root#overlay:}"
-        root="$(echo $root | sed 's,/,\\x2f,g')"
+        root="$(echo "${root}" | sed 's,/,\\x2f,g')"
         root="overlay:/dev/disk/by-uuid/${root#UUID=}"
         rootok=1 ;;
 esac
 
-[ "$rootok" = "1" ] || return 1
+[ "${rootok}" = "1" ] || return 1
 
-info "root was $overlayroot, is now $root"
+info "root was ${overlayroot}, is now ${root}"
 
 # make sure that init doesn't complain
-[ -z "$root" ] && root="overlay"
+[ -z "${root}" ] && root="overlay"
 
 wait_for_dev -n /run/rootfsbase
 

--- a/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
+++ b/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
@@ -1,0 +1,311 @@
+#!/bin/bash
+type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
+type lookup_disk_device_from_root >/dev/null 2>&1 || . /lib/kiwi-lib.sh
+type create_parted_partitions >/dev/null 2>&1 || . /lib/kiwi-partitions-lib.sh
+type resize_filesystem >/dev/null 2>&1 || . /lib/kiwi-filesystem-lib.sh
+type activate_volume_group >/dev/null 2>&1 || . /lib/kiwi-lvm-lib.sh
+type activate_mdraid >/dev/null 2>&1 || . /lib/kiwi-mdraid-lib.sh
+type luks_system >/dev/null 2>&1 || . /lib/kiwi-luks-lib.sh
+
+#======================================
+# Functions
+#--------------------------------------
+function initialize {
+    declare root=${root}
+    local profile=/.profile
+    local partition_ids=/config.partids
+
+    test -f ${profile} || \
+        die "No profile setup found"
+    test -f ${partition_ids} || \
+        die "No partition id setup found"
+
+    import_file ${profile}
+    import_file ${partition_ids}
+
+    disk=$(lookup_disk_device_from_root)
+    export disk
+
+    root_device=${root#block:}
+    export root_device
+
+    swapsize=$(get_requested_swap_size)
+    export swapsize
+
+    disk_free_mbytes=$((
+        $(get_free_disk_bytes "${disk}") / 1048576
+    ))
+    export disk_free_mbytes
+
+    disk_root_mbytes=$((
+        $(get_block_device_kbsize "${root_device}") / 1024
+    ))
+    export disk_root_mbytes
+}
+
+function get_requested_swap_size {
+    declare kiwi_oemswapMB=${kiwi_oemswapMB}
+    declare kiwi_oemswap=${kiwi_oemswap}
+    local swapsize
+    if [ ! -z "${kiwi_oemswapMB}" ];then
+        # swap size configured by kiwi description
+        swapsize=${kiwi_oemswapMB}
+    else
+        # default swap size is twice times ramsize
+        swapsize=$((
+            $(grep MemTotal: /proc/meminfo | tr -dc '0-9') * 2 / 1024
+        ))
+    fi
+    if [ ! "${kiwi_oemswap}" = "true" ];then
+        # no swap wanted by kiwi description
+        swapsize=0
+    fi
+    echo ${swapsize}
+}
+
+function deactivate_device_mappings {
+    if lvm_system;then
+        deactivate_volume_group
+    fi
+    if mdraid_system;then
+        deactivate_mdraid
+    fi
+    if luks_system "${disk}";then
+        deactivate_luks
+    fi
+}
+
+function finalize_disk_repart {
+    declare kiwi_RootPart=${kiwi_RootPart}
+    finalize_partition_table "${disk}"
+    set_root_map \
+        "$(get_partition_node_name "${disk}" "${kiwi_RootPart}")"
+}
+
+function repart_standard_disk {
+    # """
+    # repartition disk with read/write root filesystem
+    # Image partition table layout is:
+    # =====================================
+    # pX:   [ boot ]
+    # pX+1: ( root )  [+luks +raid]
+    # -------------------------------------
+    # """
+    declare kiwi_oemrootMB=${kiwi_oemrootMB}
+    declare kiwi_RootPart=${kiwi_RootPart}
+    if [ -z "${kiwi_oemrootMB}" ];then
+        local disk_have_root_system_mbytes=$((
+            disk_root_mbytes + disk_free_mbytes - swapsize
+        ))
+        local min_additional_mbytes=${swapsize}
+    else
+        local disk_have_root_system_mbytes=${kiwi_oemrootMB}
+        local min_additional_mbytes=$((
+            swapsize + kiwi_oemrootMB - disk_root_mbytes
+        ))
+    fi
+    if [ "${min_additional_mbytes}" -lt 5 ];then
+        min_additional_mbytes=5
+    fi
+    local new_parts=0
+    if [ "${kiwi_oemswap}" = "true" ];then
+        new_parts=$((new_parts + 1))
+    fi
+    # check if we can repart this disk
+    if ! check_repart_possible \
+        ${disk_root_mbytes} ${disk_free_mbytes} ${min_additional_mbytes}
+    then
+        return 1
+    fi
+    # deactivate all active device mappings
+    deactivate_device_mappings
+    # repart root partition
+    local command_query
+    local root_part_size=+${disk_have_root_system_mbytes}M
+    if [ -z "${kiwi_oemrootMB}" ] && [ ${new_parts} -eq 0 ];then
+        # no new parts and no rootsize limit, use rest disk space
+        root_part_size=.
+    fi
+    command_query="
+        d ${kiwi_RootPart}
+        n p:lxroot ${kiwi_RootPart} . ${root_part_size}
+    "
+    create_parted_partitions \
+        "${disk}" "${command_query}"
+    # add swap partition
+    create_swap_partition "$new_parts"
+    # finalize table changes
+    finalize_disk_repart
+}
+
+function repart_lvm_disk {
+    # """
+    # repartition disk if LVM partition plus boot partition
+    # is used. Initial partition table layout is:
+    # =====================================
+    # pX:   ( boot )
+    # pX+1: ( LVM  )  [+luks +raid]
+    # -------------------------------------
+    # """
+    declare kiwi_oemrootMB=${kiwi_oemrootMB}
+    declare kiwi_RootPart=${kiwi_RootPart}
+    if [ -z "${kiwi_oemrootMB}" ];then
+        local disk_have_root_system_mbytes=$((
+            disk_root_mbytes + disk_free_mbytes
+        ))
+        local min_additional_mbytes=${swapsize}
+    else
+        local disk_have_root_system_mbytes=$((
+            kiwi_oemrootMB + swapsize
+        ))
+        local min_additional_mbytes=$((
+            swapsize + kiwi_oemrootMB - disk_root_mbytes
+        ))
+    fi
+    if [ "${min_additional_mbytes}" -lt 5 ];then
+        min_additional_mbytes=5
+    fi
+    # check if we can repart this disk
+    if ! check_repart_possible \
+        ${disk_root_mbytes} ${disk_free_mbytes} ${min_additional_mbytes}
+    then
+        return 1
+    fi
+    # deactivate all active device mappings
+    deactivate_device_mappings
+    # create lvm.conf appropriate for resize
+    setup_lvm_config
+    # repart lvm partition
+    local command_query
+    local lvm_part_size=+${disk_have_root_system_mbytes}M
+    if [ -z "${kiwi_oemrootMB}" ];then
+        # no rootsize limit, use rest disk space
+        lvm_part_size=.
+    fi
+    command_query="
+        d ${kiwi_RootPart}
+        n p:lxlvm ${kiwi_RootPart} . ${lvm_part_size}
+        t ${kiwi_RootPart} 8e
+    "
+    create_parted_partitions \
+        "${disk}" "${command_query}"
+    # finalize table changes
+    finalize_disk_repart
+}
+
+function create_swap_volume {
+    if [ "${swapsize}" -gt "0" ];then
+        if create_volume "LVSwap" "${swapsize}";then
+            set_swap_map "$(get_volume_path_for_volume "LVSwap")"
+        fi
+    fi
+}
+
+function create_swap_partition {
+    declare kiwi_oemrootMB=${kiwi_oemrootMB}
+    declare kiwi_RootPart=${kiwi_RootPart}
+    local new_parts=$1
+    if [ "${swapsize}" -gt "0" ];then
+        local swap_part=$((kiwi_RootPart + 1))
+        local swap_part_size=+${swapsize}M
+        if [ -z "${kiwi_oemrootMB}" ] && [ "${new_parts}" -eq "1" ];then
+            # exactly one new part and no rootsize limit, use rest disk space
+            swap_part_size=.
+        fi
+        command_query="
+            n p:lxswap ${swap_part} . ${swap_part_size}
+            t ${swap_part} 82
+        "
+        create_parted_partitions \
+            "${disk}" "${command_query}"
+        set_swap_map \
+            "$(get_persistent_device_from_unix_node \
+                "$(get_partition_node_name "${disk}" "${swap_part}")" "by-id"
+            )"
+    fi
+}
+
+function check_repart_possible {
+    declare kiwi_oemrootMB=${kiwi_oemrootMB}
+    local disk_root_mbytes=$1
+    local disk_free_mbytes=$2
+    local min_additional_mbytes=$3
+    if [ ! -z "${kiwi_oemrootMB}" ];then
+        if [ "${kiwi_oemrootMB}" -lt "${disk_root_mbytes}" ];then
+            # specified oem-systemsize is smaller than root partition
+            warn "Requested OEM systemsize is smaller than root partition"
+            warn "Disk won't be re-partitioned !"
+            echo
+            warn "Current Root partition: ${disk_root_mbytes} MB"
+            warn "==> Requested size: ${kiwi_oemrootMB} MB"
+            return 1
+        fi
+    fi
+    if [ "${min_additional_mbytes}" -gt "${disk_free_mbytes}" ];then
+        # Requested sizes for root and swap exceeds free space on disk
+        warn "Requested sizes exceeds free space on the disk:"
+        warn "Disk won't be re-partitioned !"
+        echo
+        warn "Minimum required additional size: ${min_additional_mbytes} MB:"
+        if [ ! -z "${kiwi_oemrootMB}" ];then
+            local share=$((kiwi_oemrootMB - disk_root_mbytes))
+            warn "==> Root's share is: ${share} MB"
+        fi
+        if [ ${swapsize} -gt 0 ];then
+            warn "==> Swap's share is: ${swapsize} MB"
+        fi
+        warn "Free Space on disk: ${disk_free_mbytes} MB"
+        return 1
+    fi
+    return 0
+}
+
+#======================================
+# Perform repart/resize operations
+#--------------------------------------
+PATH=/usr/sbin:/usr/bin:/sbin:/bin
+
+setup_debug
+
+# initialize for disk repartition
+initialize
+
+# prepare disk for repartition
+if [ "$(get_partition_table_type "${disk}")" = 'gpt' ];then
+    relocate_gpt_at_end_of_disk "${disk}"
+fi
+
+# wait for the root device to appear
+wait_for_storage_device "${root_device}"
+
+# resize disk partition table
+if lvm_system;then
+    repart_lvm_disk || return
+else
+    repart_standard_disk || return
+fi
+
+# resize luks if present
+if luks_system "${disk}";then
+    activate_luks "$(get_root_map)"
+    resize_luks
+fi
+
+# resize raid if present
+if mdraid_system;then
+    activate_mdraid
+    resize_mdraid
+fi
+
+# resize volumes and filesystems
+if lvm_system; then
+    resize_pyhiscal_volumes
+    activate_volume_group
+    create_swap_volume
+    resize_lvm_volumes_and_filesystems
+else
+    resize_filesystem "$(get_root_map)"
+fi
+
+# create swap space
+create_swap "$(get_swap_map)"

--- a/dracut/modules.d/90kiwi-repart/kiwi-update-fstab.sh
+++ b/dracut/modules.d/90kiwi-repart/kiwi-update-fstab.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
+type merge_swap_to_fstab >/dev/null 2>&1 || . /lib/kiwi-filesystem-lib.sh
+
+merge_swap_to_fstab

--- a/dracut/modules.d/90kiwi-repart/module-setup.sh
+++ b/dracut/modules.d/90kiwi-repart/module-setup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# called by dracut
+depends() {
+    echo rootfs-block dm kiwi-lib
+    return 0
+}
+
+# called by dracut
+installkernel() {
+    instmods squashfs loop
+}
+
+# called by dracut
+install() {
+    declare moddir=${moddir}
+    inst_hook pre-mount 20 "${moddir}/kiwi-repart-disk.sh"
+    inst_hook pre-pivot 20 "${moddir}/kiwi-update-fstab.sh"
+    dracut_need_initqueue
+}

--- a/dracut/modules.d/99kiwi-lib/kiwi-dialog-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-dialog-lib.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
+
+function run_dialog {
+    # """
+    # Run the dialog program via the systemd service either in a
+    # framebuffer terminal or on the console. The return code of
+    # the function is the return code of the dialog call. The
+    # output of the dialog call is stored in a file and can be
+    # one time read via the get_dialog_result function
+    # """
+    local dialog_result=/tmp/dialog_result
+    local dialog_exit_code=/tmp/dialog_code
+    {
+        echo "dialog $* 2>$dialog_result"
+        echo -n \$? >$dialog_exit_code
+    } >/bin/dracut-interactive
+    _run_interactive
+    return "$(cat $dialog_exit_code)"
+}
+
+function get_dialog_result {
+    local dialog_result=/tmp/dialog_result
+    [ -e "${dialog_result}" ] && cat ${dialog_result}; rm -f ${dialog_result}
+}
+
+#=========================================
+# Methods considered private
+#-----------------------------------------
+function _setup_interactive_service {
+    local service=/usr/lib/systemd/system/dracut-run-interactive.service
+    local script=/bin/dracut-interactive
+    local unicode_font=/lib/b16.pcf.gz
+    [ -e ${service} ] && return
+    {
+        echo "[Unit]"
+        echo "Description=Dracut Run Interactive"
+        echo "DefaultDependencies=no"
+        echo "After=systemd-vconsole-setup.service"
+        echo "Wants=systemd-vconsole-setup.service"
+        echo "Conflicts=emergency.service emergency.target"
+        echo "[Service]"
+        echo "Environment=HOME=/"
+        echo "Environment=DRACUT_SYSTEMD=1"
+        echo "Environment=NEWROOT=/sysroot"
+        echo "WorkingDirectory=/"
+        if _fbiterm_ok; then
+            echo "ExecStart=fbiterm -m ${unicode_font} -- /bin/bash ${script}"
+        else
+            echo "ExecStart=/bin/bash ${script}"
+        fi
+        echo "Type=oneshot"
+        echo "StandardInput=tty-force"
+        echo "StandardOutput=inherit"
+        echo "StandardError=inherit"
+        echo "KillMode=process"
+        echo "IgnoreSIGPIPE=no"
+        echo "TaskMax=infinity"
+        echo "KillSignal=SIGHUP"
+    } > ${service}
+}
+
+function _run_interactive {
+    _setup_interactive_service
+    systemctl start dracut-run-interactive.service
+}
+
+function _fbiterm_ok {
+    if [ ! -e /dev/fb0 ];then
+        # no framebuffer device found
+        return 1
+    fi
+    if ! command -v fbiterm &>/dev/null;then
+        # no framebuffer terminal program found
+        return 1
+    fi
+    if command -v isconsole &>/dev/null;then
+        if ! isconsole;then
+            # inappropriate ioctl (not a linux console)
+            return 1
+        fi
+    elif ! fbiterm echo &>/dev/null;then
+        # fbiterm can't be called with echo test cmd
+        return 1
+    fi
+    return 0
+}

--- a/dracut/modules.d/99kiwi-lib/kiwi-filesystem-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-filesystem-lib.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
+
+function resize_filesystem {
+    local device=$1
+    test -n "${device}" || return
+    local resize_fs
+    local mpoint=/fs-resize
+    local fstype
+    fstype=$(probe_filesystem "${device}")
+    case ${fstype} in
+    ext2|ext3|ext4)
+        resize_fs="resize2fs -f -p ${device}"
+    ;;
+    btrfs)
+        resize_fs="mkdir -p ${mpoint} && mount ${device} ${mpoint} &&"
+        resize_fs="${resize_fs} btrfs filesystem resize max ${mpoint}"
+        resize_fs="${resize_fs};umount ${mpoint} && rmdir ${mpoint}"
+    ;;
+    xfs)
+        resize_fs="mkdir -p ${mpoint} && mount ${device} ${mpoint} &&"
+        resize_fs="${resize_fs} xfs_growfs ${mpoint}"
+        resize_fs="${resize_fs};umount ${mpoint} && rmdir ${mpoint}"
+    ;;
+    *)
+        # don't know how to resize this filesystem
+        warn "Don't know how to resize ${fstype}... skipped"
+        return
+    ;;
+    esac
+    if _is_ramdisk_device "${device}"; then
+        check_filesystem "${device}"
+    fi
+    info "Resizing ${fstype} filesystem on ${device}..."
+    if ! eval "${resize_fs}"; then
+        die "Failed to resize filesystem"
+    fi
+}
+
+function check_filesystem {
+    local device=$1
+    test -n "${device}" || return
+    local check_fs
+    local fstype
+    fstype=$(probe_filesystem "${device}")
+    case ${fstype} in
+    ext2|ext3|ext4)
+        check_fs="e2fsck -p -f ${device}"
+    ;;
+    btrfs)
+        check_fs="btrfsck ${device}"
+    ;;
+    xfs)
+        check_fs="xfs_repair -n ${device}"
+    ;;
+    *)
+        # don't know how to check this filesystem
+        warn "Don't know how to check ${fstype}... skipped"
+        return
+    ;;
+    esac
+    info "Checking ${fstype} filesystem on ${device}..."
+    if ! eval "${check_fs}"; then
+        die "Failed to check filesystem"
+    fi
+}
+
+function probe_filesystem {
+    local device=$1
+    test -n "${device}" || return
+    local fstype
+    fstype=$(blkid "${device}" -s TYPE -o value)
+    if [ -z "${fstype}" ];then
+        fstype=unknown
+    fi
+    if [ "${fstype}" = "crypto_LUKS" ];then
+        fstype=luks
+    fi
+    echo ${fstype}
+}
+
+function create_swap {
+    # """
+    # create swap signature on device and create a
+    # fstab reference file which is used by a pre-pivot
+    # hook to update the system fstab
+    # """
+    local device=$1
+    test -n "${device}" || return
+    if ! mkswap "${device}" 1>&2;then
+        die "Failed to create swap signature"
+    fi
+    echo "${device} swap swap defaults 0 0" > /fstab.swap
+}
+
+function merge_swap_to_fstab {
+    if [ -f /sysroot/etc/fstab ];then
+        test -f /fstab.swap && cat /fstab.swap >> /sysroot/etc/fstab
+    fi
+}
+
+#======================================
+# Methods considered private
+#--------------------------------------
+function _is_ramdisk_device {
+    local device=$1
+    if echo "${device}" | grep -qi "/dev/ram";then
+        return 1
+    fi
+    return 0
+}

--- a/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
+
+function setup_debug {
+    if getargbool 0 rd.kiwi.debug; then
+        local log=/run/initramfs/log
+        mkdir -p ${log}
+        exec >> ${log}/boot.kiwi
+        exec 2>> ${log}/boot.kiwi
+        set -x
+    fi
+}
+
+function set_root_map {
+    root_map=$1
+    export root_map
+}
+
+function set_swap_map {
+    swap_map=$1
+    export swap_map
+}
+
+function get_root_map {
+    echo "${root_map}"
+}
+
+function get_swap_map {
+    echo "${swap_map}"
+}
+
+function lookup_disk_device_from_root {
+    declare root=${root}
+    local root_device=${root#block:}
+    if [ -z "${root_device}" ];then
+        die "No root device found"
+    fi
+    if [ -L "${root_device}" ];then
+        root_device=/dev/$(basename "$(readlink "${root_device}")")
+    fi
+    echo /dev/"$(
+        lsblk -n -r -s -o NAME,TYPE "${root_device}" |\
+        grep disk | cut -f1 -d ' '
+    )"
+}
+
+function udev_pending {
+    declare DEVICE_TIMEOUT=${DEVICE_TIMEOUT}
+    local limit=30
+    if [[ "${DEVICE_TIMEOUT}" =~ ^[0-9]+$ ]]; then
+        limit=$(((DEVICE_TIMEOUT + 1)/ 2))
+    fi
+    udevadm settle --timeout=${limit}
+}
+
+function get_persistent_device_from_unix_node {
+    local unix_device=$1
+    local schema=$2
+    local node
+    local persistent_name
+    node=$(basename "${unix_device}")
+    udev_pending
+    for persistent_name in /dev/disk/${schema}/*; do
+        if [ "$(basename "$(readlink "${persistent_name}")")" = "${node}" ];then
+            echo "${persistent_name}"
+            return
+        fi
+    done
+}
+
+function import_file {
+    # """
+    # import file with key=value format. the function
+    # will export each entry of the file as variable into
+    # the current shell environment
+    # """
+    local source_format=/tmp/source_file_formatted
+    # create clean input, no empty lines and comments
+    grep -v '^$' "$1" | grep -v '^[ \t]*#' > ${source_format}
+    # remove start/stop quoting from values
+    sed -i -e s"#\(^[a-zA-Z0-9_]\+\)=[\"']\(.*\)[\"']#\1=\2#" ${source_format}
+    # remove backslash quotes if any
+    sed -i -e s"#\\\\\(.\)#\1#g" ${source_format}
+    # quote simple quotation marks
+    sed -i -e s"#'\+#'\\\\''#g" ${source_format}
+    # add '...' quoting to values
+    sed -i -e s"#\(^[a-zA-Z0-9_]\+\)=\(.*\)#\1='\2'#" ${source_format}
+    source ${source_format} &>/dev/null
+    while read -r line;do
+        local key
+        key=$(echo "${line}" | cut -d '=' -f1)
+        eval "export ${key}" &>/dev/null
+    done < ${source_format}
+}

--- a/dracut/modules.d/99kiwi-lib/kiwi-luks-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-luks-lib.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
+type set_root_map >/dev/null 2>&1 || . /lib/kiwi-lib.sh
+type wait_for_storage_device >/dev/null 2>&1 || . /lib/kiwi-partitions-lib.sh
+type ask_for_password >/dev/null 2>&1 || . /lib/dracut-crypt-lib.sh
+
+function luks_system {
+    declare kiwi_RootPart=${kiwi_RootPart}
+    local disk=$1
+    local device
+    device=$(get_partition_node_name "${disk}" "${kiwi_RootPart}")
+    if cryptsetup isLuks "${device}" &>/dev/null;then
+        return 0
+    fi
+    return 1
+}
+
+function deactivate_luks {
+    /usr/lib/systemd/systemd-cryptsetup detach luks
+}
+
+function resize_luks {
+    cryptsetup resize luks
+}
+
+function activate_luks {
+    local device=$1
+    /usr/lib/systemd/systemd-cryptsetup attach luks "${device}"
+    wait_for_storage_device "/dev/mapper/luks"
+    set_root_map "/dev/mapper/luks"
+}

--- a/dracut/modules.d/99kiwi-lib/kiwi-lvm-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-lvm-lib.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
+type udev_pending >/dev/null 2>&1 || . /lib/kiwi-lib.sh
+
+function lvm_system {
+    declare kiwi_lvm=${kiwi_lvm}
+    if [ "${kiwi_lvm}" = "true" ];then
+        return 0
+    fi
+    return 1
+}
+
+function setup_lvm_config {
+    mkdir -p /etc/lvm
+    cat > /etc/lvm/lvm.conf <<- EOF
+		global {
+		    locking_type = 0
+		    use_lvmetad = 0
+		}
+	EOF
+}
+
+function activate_volume_group {
+    declare kiwi_lvmgroup=${kiwi_lvmgroup}
+    local vg_count=0
+    local vg_name
+    if lvm_system;then
+        for vg_name in $(vgs --noheadings -o vg_name 2>/dev/null);do
+            if [ "${vg_name}" = "${kiwi_lvmgroup}" ];then
+                vg_count=$((vg_count + 1))
+            fi
+        done
+        if [ ${vg_count} -gt 1 ];then
+            die "Duplicate VolumeGroup name ${kiwi_lvmgroup} found !"
+        fi
+        vgchange -a y "${kiwi_lvmgroup}"
+        udev_pending
+    fi
+}
+
+function deactivate_volume_group {
+    declare kiwi_lvmgroup=${kiwi_lvmgroup}
+    vgchange -a n "${kiwi_lvmgroup}"
+    udev_pending
+}
+
+function create_volume {
+    declare kiwi_lvmgroup=${kiwi_lvmgroup}
+    local volume_name=$1
+    local volume_mb_size=$2
+    if [ ! -f "$(get_volume_path_for_volume "${volume_name}")" ];then
+        lvcreate --yes --wipesignatures y \
+            --size "${volume_mb_size}M" -n "${volume_name}" "${kiwi_lvmgroup}"
+    fi
+}
+
+function get_volume_path_for_volume {
+    declare kiwi_lvmgroup=${kiwi_lvmgroup}
+    echo "/dev/${kiwi_lvmgroup}/$1"
+}
+
+function resize_pyhiscal_volumes {
+    pvresize "$(get_root_map)"
+}
+
+function resize_lvm_volumes_and_filesystems {
+    declare kiwi_lvmgroup=${kiwi_lvmgroup}
+    local volume_name
+    local resize_mode
+    local resize_prefix
+    local volume_size
+    local volspec
+    local all_free_volume
+    for volspec in $(read_volume_setup "/.profile" "skip_all_free_volume");do
+        volume_name=$(get_volume_name "${volspec}")
+        resize_mode=$(get_volume_size_mode "${volspec}")
+        volume_size=$(get_volume_size "${volspec}")
+        info "Resizing volume ${volume_name}..."
+        if [ ! "${resize_mode}" = "size" ];then
+            resize_prefix=+
+        fi
+        if lvextend -L "${resize_prefix}${volume_size}M" \
+            "/dev/${kiwi_lvmgroup}/${volume_name}"
+        then
+            resize_filesystem "/dev/${kiwi_lvmgroup}/${volume_name}"
+        else
+            warn "Warning: requested size cannot be reached !"
+        fi
+    done
+    all_free_volume=$(get_all_free_volume)
+    if [ ! -z "${all_free_volume}" ];then
+        if lvextend -l +100%FREE "/dev/${kiwi_lvmgroup}/${all_free_volume}";then
+            resize_filesystem "/dev/${kiwi_lvmgroup}/${all_free_volume}"
+        fi
+    fi
+}
+
+function read_volume_setup {
+    # """
+    # read the volume setup from the profile file and return
+    # a list with the following values:
+    #
+    # volume_name,resize_mode,requested_size,mount_point ...
+    # """
+    local profile=$1
+    local skip_all_free_volume=$2
+    local volume
+    local name
+    local mode
+    local size
+    local mpoint
+    local result
+    local volspec
+    result=$(
+        while read -r volspec;do
+            if ! [[ "${volspec}" =~ "kiwi_Volume_" ]];then
+                continue
+            fi
+            volume=$(echo "${volspec}" | cut -f2 -d= | tr -d \' | tr -d \")
+            size=$(echo "${volume}" | cut -f2 -d\| | cut -f2 -d:)
+            if [ "${size}" = "all" ] && [ ! -z "${skip_all_free_volume}" ];then
+                continue
+            fi
+            mode=$(echo "${volume}" | cut -f2 -d\| | cut -f1 -d:)
+            name=$(echo "${volume}" | cut -f1 -d\|)
+            mpoint=$(echo "${volume}" | cut -f3 -d\|)
+            if [ -z "${mpoint}" ];then
+                mpoint=noop
+            fi
+            echo "${name},${mode},${size},${mpoint}"
+        done < "${profile}"
+    )
+    echo "${result}"
+}
+
+function read_volume_setup_all_free {
+    # """
+    # read the volume setup for kiwi_allFreeVolume from the profile
+    # file and return a list with the following values:
+    #
+    # volume_name,mount_point
+    #
+    # If no kiwi_allFreeVolume was configured only the default
+    # volume_name which takes the rest space is returned
+    # """
+    local profile=$1
+    local size
+    local volume
+    local name
+    local mpoint
+    while read -r volspec;do
+        if ! [[ "${volspec}" =~ "kiwi_Volume_" ]];then
+            continue
+        fi
+        volume=$(echo "${volspec}" | cut -f2 -d= | tr -d \' | tr -d \")
+        size=$(echo "${volume}" | cut -f2 -d\| | cut -f2 -d:)
+        if [ "${size}" = "all" ];then
+            name=$(echo "${volume}" | cut -f1 -d\|)
+            mpoint=$(echo "${volume}" | cut -f3 -d\|)
+            echo "${name},${mpoint}"
+            return
+        fi
+    done < "${profile}"
+    echo LVRoot,
+}
+
+function get_all_free_volume {
+    read_volume_setup_all_free "/.profile" | cut -f1 -d,
+}
+
+function get_volume_name {
+    echo "$1" | cut -f1 -d,
+}
+
+function get_volume_mount_point {
+    echo "$1" | cut -f4 -d,
+}
+
+function get_volume_size_mode {
+    echo "$1" | cut -f2 -d,
+}
+
+function get_volume_size {
+    echo "$1" | cut -f3 -d,
+}

--- a/dracut/modules.d/99kiwi-lib/kiwi-mdraid-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-mdraid-lib.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
+type set_root_map >/dev/null 2>&1 || . /lib/kiwi-lib.sh
+type wait_for_storage_device >/dev/null 2>&1 || . /lib/kiwi-partitions-lib.sh
+
+function mdraid_system {
+    declare kiwi_RaidDev=${kiwi_RaidDev}
+    if [ ! -z "${kiwi_RaidDev}" ];then
+        return 0
+    fi
+    return 1
+}
+
+function deactivate_mdraid {
+    declare kiwi_RaidDev=${kiwi_RaidDev}
+    mdadm --stop "${kiwi_RaidDev}"
+}
+
+function activate_mdraid {
+    declare kiwi_RaidDev=${kiwi_RaidDev}
+    mdadm --assemble --scan "${kiwi_RaidDev}"
+    wait_for_storage_device "${kiwi_RaidDev}"
+    set_root_map "${kiwi_RaidDev}"
+}
+
+function resize_mdraid {
+    declare kiwi_RaidDev=${kiwi_RaidDev}
+    mdadm --grow --size=max "${kiwi_RaidDev}"
+}

--- a/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
@@ -1,0 +1,463 @@
+#!/bin/bash
+type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
+type udev_pending >/dev/null 2>&1 || . /lib/kiwi-lib.sh
+
+#======================================
+# Global exports
+#--------------------------------------
+export partedTableType
+export partedOutput
+export partedCylCount
+export partedCylKSize
+export partedStartSectors
+export partedEndSectors
+
+#======================================
+# Library Methods
+#--------------------------------------
+function create_parted_partitions {
+    # """
+    # create partitions using parted
+    # """
+    local disk_device=$1
+    local partition_setup=$2
+    local index=0
+    local commands
+    local partid
+    local part_name
+    local part_start_cyl
+    local part_stop_cyl
+    local part_type
+    local cmd_list
+    local cmd
+
+    _parted_init "${disk_device}"
+    _parted_sector_init "${disk_device}"
+
+    # put partition setup in a command list(cmd_list)
+    for cmd in ${partition_setup};do
+        cmd_list[$index]=${cmd}
+        index=$((index + 1))
+    done
+
+    # operate on index based cmd_list
+    index=0
+    for cmd in ${cmd_list[*]};do
+        case ${cmd} in
+        "d")
+            # delete a partition...
+            partid=${cmd_list[$index + 1]}
+            partid=$((partid / 1))
+            commands="${commands} rm $partid"
+            _parted_write "${disk_device}" "${commands}"
+            unset commands
+        ;;
+        "n")
+            # create a partition...
+            part_name=${cmd_list[$index + 1]}
+            partid=${cmd_list[$index + 2]}
+            partid=$((partid / 1))
+            part_start_cyl=${cmd_list[$index + 3]}
+            if [ ! "${partedTableType}" = "gpt" ];then
+                part_name=primary
+            else
+                part_name=$(echo ${part_name} | cut -f2 -d:)
+            fi
+            if [ "${part_start_cyl}" = "1" ];then
+                part_start_cyl=$(echo "${partedStartSectors}" |\
+                    cut -f ${partid} -d:
+                )
+            fi
+            if [ "${part_start_cyl}" = "." ];then
+                # start is next cylinder according to previous partition
+                part_start_cyl=$((partid - 1))
+                if [ ${part_start_cyl} -gt 0 ];then
+                    part_start_cyl=$(echo "${partedEndSectors}" |\
+                        cut -f ${part_start_cyl} -d:
+                    )
+                else
+                    part_start_cyl=$(echo "${partedStartSectors}" |\
+                        cut -f ${partid} -d:
+                    )
+                fi
+            fi
+            part_stop_cyl=${cmd_list[$index + 4]}
+            if [ "${part_stop_cyl}" = "." ];then
+                # use rest of the disk for partition end
+                part_stop_cyl=${partedCylCount}
+            elif echo "${part_stop_cyl}" | grep -qi M;then
+                # calculate stopp cylinder from size
+                part_stop_cyl=$((partid - 1))
+                if [ ${part_stop_cyl} -gt 0 ];then
+                    part_stop_cyl=$(_parted_end_cylinder ${part_stop_cyl})
+                fi
+                local part_size_mbytes
+                part_size_mbytes=$(
+                    echo "${cmd_list[$index + 4]}" | cut -f1 -dM | tr -d +
+                )
+                local part_size_cyl
+                part_size_cyl=$(
+                    _parted_mb_to_cylinder "${part_size_mbytes}"
+                )
+                part_stop_cyl=$((1 + part_stop_cyl + part_size_cyl))
+                if [ "${part_stop_cyl}" -gt "${partedCylCount}" ];then
+                    # given size is out of bounds, reduce to end of disk
+                    part_stop_cyl=${partedCylCount}
+                fi
+            fi
+            commands="${commands} mkpart ${part_name}"
+            commands="${commands} ${part_start_cyl} ${part_stop_cyl}"
+            _parted_write "${disk_device}" "${commands}"
+            _parted_sector_init "${disk_device}"
+            unset commands
+        ;;
+        "t")
+            # change a partition type...
+            part_type=${cmd_list[$index + 2]}
+            partid=${cmd_list[$index + 1]}
+            local flagok=1
+            if [ "${part_type}" = "82" ];then
+                # parted can not consistently set swap flag.
+                # There is no general solution to this issue.
+                # Thus swap flag setup is skipped
+                flagok=0
+            elif [ "${part_type}" = "fd" ];then
+                commands="${commands} set ${partid} raid on"
+            elif [ "${part_type}" = "8e" ];then
+                commands="${commands} set ${partid} lvm on"
+            elif [ "${part_type}" = "83" ];then
+                # default partition type set by parted is linux(83)
+                flagok=0
+            fi
+            if [ ! "${partedTableType}" = "gpt" ] && [ ${flagok} = 1 ];then
+                _parted_write "${disk_device}" "${commands}"
+            fi
+            unset commands
+        ;;
+        esac
+        index=$((index + 1))
+    done
+    partprobe "${disk_device}"
+}
+
+function create_fdasd_partitions {
+    # """
+    # create partitions using fdasd (s390)
+    # """
+    local disk_device=$1
+    local partition_setup=$2
+    local partition_setup_file=/run/fdasd.cmds
+    local ignore_cmd=0
+    local ignore_cmd_once=0
+    local cmd
+    for cmd in ${partition_setup};do
+        if [ "${ignore_cmd}" = 1 ] && echo "${cmd}" | grep -qE '[dntwq]';then
+            ignore_cmd=0
+        elif [ "${ignore_cmd}" = 1 ];then
+            continue
+        fi
+        if [ "${ignore_cmd_once}" = "1" ];then
+            ignore_cmd_once=0
+            continue
+        fi
+        if [ "${cmd}" = "a" ];then
+            ignore_cmd=1
+            continue
+        fi
+        if [[ "${cmd}" =~ ^p: ]];then
+            ignore_cmd_once=1
+            continue
+        fi
+        if [ "${cmd}" = "83" ] || [ "${cmd}" = "8e" ];then
+            cmd=1
+        fi
+        if [ "${cmd}" = "82" ];then
+            cmd=2
+        fi
+        if [ "${cmd}" = "." ];then
+            echo >> ${partition_setup_file}
+            continue
+        fi
+        echo $cmd >> ${partition_setup_file}
+    done
+    echo "w" >> ${partition_setup_file}
+    echo "q" >> ${partition_setup_file}
+    if ! fdasd "${disk_device}" < ${partition_setup_file} 1>&2;then
+        die "Failed to create partition table"
+    fi
+    partprobe "${disk_device}"
+}
+
+function get_partition_node_name {
+    local disk=$1
+    local partid=$2
+    local index=1
+    local part
+    for partnode in $(
+        lsblk -r -o NAME,TYPE "${disk}" | grep part | cut -f1 -d ' '
+    );do
+        if [ "${index}" = "${partid}" ];then
+            echo "/dev/${partnode}"
+            return 0
+        fi
+        index=$((index + 1))
+    done
+    return 1
+}
+
+function wait_for_storage_device {
+    # """
+    # function to check access on a storage device which could be
+    # a whole disk or a partition. The function will wait until
+    # the size of the storage device could be obtained and is
+    # greater than zero or the timeout is reached. Default timeout
+    # is set to 60 seconds, however it can be set to different
+    # value by setting the DEVICE_TIMEOUT variable on the kernel
+    # command line.
+    # """
+    declare DEVICE_TIMEOUT=${DEVICE_TIMEOUT}
+    local device=$1
+    local check=0
+    local limit=30
+    local storage_size=0
+    if [[ "${DEVICE_TIMEOUT}" =~ ^[0-9]+$ ]]; then
+        limit=$(((DEVICE_TIMEOUT + 1)/ 2))
+    fi
+    udev_pending
+    while true;do
+        storage_size=$(get_block_device_kbsize "${device}")
+        if [ "${storage_size}" -gt 0 ]; then
+            sleep 1; return 0
+        fi
+        if [ "${check}" -eq "${limit}" ]; then
+            die "Storage device ${device} did not appear"
+        fi
+        info "Waiting for storage device ${device} to settle..."
+        check=$((check + 1))
+        sleep 2
+    done
+}
+
+function get_block_device_kbsize {
+    local device=$1
+    if [ ! -e "${device}" ];then
+        echo 0; return 1
+    fi
+    echo $(($(blockdev --getsize64 "${device}") / 1024))
+}
+
+function get_free_disk_bytes {
+    local disk=$1
+    local pt_table_type
+    local disk_bytes
+    local max_dos_disk
+    pt_table_type=$(get_partition_table_type "${disk}")
+    disk_bytes=$(blockdev --getsize64 "${disk}")
+    # max msdos table geometry is at 2TB - 512
+    # max sector count taken from parted
+    max_dos_disk=$((4294967295 * 512))
+    if \
+        [ "${pt_table_type}" = "dos" ] && \
+        [ "${disk_bytes}" -gt "${max_dos_disk}" ]
+    then
+        warn "msdos table allows a max disk size of 2TB"
+        warn "disk expansion will be truncated to 2TB"
+        disk_bytes=${max_dos_disk}
+    fi
+    local rest_bytes
+    rest_bytes=${disk_bytes}
+    local part_bytes=0
+    for part in $(
+        lsblk -r -o NAME,TYPE "${disk}" | grep part | cut -f1 -d ' '
+    );do
+        part_bytes=$((part_bytes + $(blockdev --getsize64 /dev/"${part}")))
+    done
+    rest_bytes=$((rest_bytes - part_bytes))
+    echo ${rest_bytes}
+}
+
+function get_partition_table_type {
+    blkid -s PTTYPE -o value "$1"
+}
+
+function relocate_gpt_at_end_of_disk {
+    local cmd
+    local cmd_file=/part.input
+    rm -f ${cmd_file} && for cmd in x e w y; do
+        echo $cmd >> ${cmd_file}
+    done
+    if ! gdisk "$1" < ${cmd_file} &>/dev/null; then
+        die "Failed to write backup GPT at end of disk"
+    fi
+}
+
+function activate_boot_partition {
+    local disk_device=$1
+    local boot_partition_id=$2
+    if [[ "$(uname -m)" =~ i.86|x86_64 ]];then
+        if [ "$(get_partition_table_type)" = "msdos" ];then
+            parted "${disk_device}" set "${boot_partition_id}" boot on
+        fi
+    fi
+}
+
+function create_hybrid_gpt {
+    local disk_device=$1
+    local partition_count
+    partition_count=$(lsblk -r -o NAME,TYPE "${disk_device}" | grep -c part)
+    if [ "${partition_count}" -gt 3 ]; then
+        # The max number of partitions to embed is 3
+        # see man sgdisk for details
+        partition_count=3
+    fi
+    if ! sgdisk -h $(seq -s : 1 "${partition_count}") "${disk_device}";then
+        die "Failed to create hybrid GPT/MBR !"
+    fi
+}
+
+function finalize_partition_table {
+    # """
+    # finalize partition table with flags which
+    # could have got lost during repartition
+    # """
+    declare kiwi_BootPart=${kiwi_BootPart}
+    declare kiwi_gpt_hybrid_mbr=${kiwi_gpt_hybrid_mbr}
+    local disk_device=$1
+    if [ ! -z "${kiwi_BootPart}" ];then
+        activate_boot_partition "${disk_device}" "${kiwi_BootPart}"
+    fi
+    if [ "${kiwi_gpt_hybrid_mbr}" = "true" ];then
+        create_hybrid_gpt "${disk_device}"
+    fi
+}
+
+#======================================
+# Methods considered private
+#--------------------------------------
+function _parted_init {
+    # """
+    # initialize current partition table output
+    # as well as the number of cylinders and the
+    # cyliner size in kB for this disk
+    # """
+    local disk_device=$1
+    local IFS=""
+    local parted
+    local header
+    local ccount
+    local cksize
+    local diskhd
+    local plabel
+    parted=$(
+        parted -m -s "${disk_device}" unit cyl print | grep -v Warning:
+    )
+    header=$(echo "${parted}" | head -n 3 | tail -n 1)
+    ccount=$(
+        echo "${parted}" | grep ^"${disk_device}" | cut -f 2 -d: | tr -d cyl
+    )
+    cksize=$(echo "${header}" | cut -f4 -d: | cut -f1 -dk)
+    diskhd=$(echo "${parted}" | head -n 3 | tail -n 2 | head -n 1)
+    plabel=$(echo "${diskhd}" | cut -f6 -d:)
+    if [[ "${plabel}" =~ gpt ]];then
+        plabel=gpt
+    fi
+    export partedTableType=${plabel}
+    export partedOutput=${parted}
+    export partedCylCount=${ccount}
+    export partedCylKSize=${cksize}
+}
+
+function _parted_sector_init {
+    # """
+    # calculate aligned start/end sectors of
+    # the current table.
+    #
+    # Uses following kiwi profile values if present:
+    #
+    # kiwi_align
+    # kiwi_sectorsize
+    # kiwi_startsector
+    #
+    # """
+    declare kiwi_align=${kiwi_align}
+    declare kiwi_sectorsize=${kiwi_sectorsize}
+    declare kiwi_startsector=${kiwi_startsector}
+    local disk_device=$1
+    local s_start
+    local s_stopp
+    local align=1048576
+    local sector_size=512
+    local sector_start=2048
+    local part
+    [ ! -z "${kiwi_align}" ] && align=${kiwi_align}
+    [ ! -z "${kiwi_sectorsize}" ] && sector_size=${kiwi_sectorsize}
+    [ ! -z "${kiwi_startsector}" ] && sector_start=${kiwi_startsector}
+    local align=$((align / sector_size))
+
+    unset partedStartSectors
+    unset partedEndSectors
+
+    for part in $(
+        parted -m -s "${disk_device}" unit s print |\
+        grep -E "^[1-9]+:" | cut -f2-3 -d: | tr -d s
+    );do
+        s_start=$(echo "${part}" | cut -f1 -d:)
+        s_stopp=$(echo "${part}" | cut -f2 -d:)
+        if [ -z "${partedStartSectors}" ];then
+            partedStartSectors=${s_start}s
+        else
+            partedStartSectors=${partedStartSectors}:${s_start}s
+        fi
+        if [ -z "${partedEndSectors}" ];then
+            partedEndSectors=$((s_stopp/align*align+align))s
+        else
+            partedEndSectors=${partedEndSectors}:$((s_stopp/align*align+align))s
+        fi
+    done
+    # The default start sector applies for an empty disk
+    if [ -z "${partedStartSectors}" ];then
+        partedStartSectors=${sector_start}s
+    fi
+}
+
+function _parted_end_cylinder {
+    # """
+    # return end cylinder of given partition, next
+    # partition must start at return value plus 1
+    # """
+    local partition_id=$(($1 + 3))
+    local IFS=""
+    local header
+    local ccount
+    header=$(echo "${partedOutput}" | head -n "${partition_id}" | tail -n 1)
+    ccount=$(echo "${header}" | cut -f3 -d: | tr -d cyl)
+    echo "${ccount}"
+}
+
+function _parted_mb_to_cylinder {
+    # """
+    # convert partition size in MB to cylinder count
+    # """
+    local sizeBytes=$(($1 * 1048576))
+    # bc truncates to zero decimal places, which results in
+    # a partition that is slightly smaller than the requested
+    # size. Add one cylinder to compensate.
+    local required_cylinders
+    required_cylinders=$(
+        echo "scale=0; ${sizeBytes} / (${partedCylKSize} * 1000) + 1" | bc
+    )
+    echo "${required_cylinders}"
+}
+
+function _parted_write {
+    # """
+    # call parted with current command queue.
+    # and reinitialize the new table data
+    # """
+    local disk_device=$1
+    local commands=$2
+    if ! parted -a cyl -m -s "${disk_device}" unit cyl "${commands}";then
+        die "Failed to create partition table"
+    fi
+    _parted_init "${disk_device}"
+}

--- a/dracut/modules.d/99kiwi-lib/module-setup.sh
+++ b/dracut/modules.d/99kiwi-lib/module-setup.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# called by dracut
+check() {
+    return 0
+}
+
+# called by dracut
+depends() {
+    echo udev-rules
+    return 0
+}
+
+# called by dracut
+install() {
+    declare moddir=${moddir}
+    inst_multiple \
+        blkid blockdev parted dd mkdir grep fdasd cut tail head tr bc \
+        basename partprobe gdisk sgdisk mkswap readlink \
+        btrfs xfs_growfs resize2fs \
+        e2fsck btrfsck xfs_repair \
+        vgs vgchange lvextend lvcreate lvresize pvresize \
+        fbiterm mdadm cryptsetup
+    inst_simple \
+        "${moddir}/kiwi-lib.sh" "/lib/kiwi-lib.sh"
+    inst_simple \
+        "${moddir}/kiwi-partitions-lib.sh" "/lib/kiwi-partitions-lib.sh"
+    inst_simple \
+        "${moddir}/kiwi-filesystem-lib.sh" "/lib/kiwi-filesystem-lib.sh"
+    inst_simple \
+        "${moddir}/kiwi-dialog-lib.sh" "/lib/kiwi-dialog-lib.sh"
+    inst_simple \
+        "${moddir}/kiwi-mdraid-lib.sh" "/lib/kiwi-mdraid-lib.sh"
+    inst_simple \
+        "${moddir}/kiwi-lvm-lib.sh" "/lib/kiwi-lvm-lib.sh"
+    inst_simple \
+        "${moddir}/kiwi-luks-lib.sh" "/lib/kiwi-luks-lib.sh"
+    inst_simple \
+        "/usr/share/fbiterm/fonts/b16.pcf.gz" "/lib/b16.pcf.gz"
+}

--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -91,6 +91,14 @@ class BootImageBase(object):
         """
         pass
 
+    def include_file(self, filename):
+        """
+        Include file to boot image
+
+        Implementation in specialized boot image class
+        """
+        pass
+
     def dump(self, filename):
         """
         Pickle dump this instance to a file. If the object dump

--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -68,7 +68,7 @@ class BootLoaderConfigBase(object):
         raise NotImplementedError
 
     def setup_disk_image_config(
-        self, boot_uuid, root_uuid, hypervisor, kernel, initrd
+        self, boot_uuid, root_uuid, hypervisor, kernel, initrd, boot_options
     ):
         """
         Create boot config file to boot from disk.

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -253,7 +253,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
 
     def setup_disk_image_config(
         self, boot_uuid, root_uuid, hypervisor='xen.gz', kernel='linux.vmx',
-        initrd='initrd.vmx'
+        initrd='initrd.vmx', boot_options=''
     ):
         """
         Create the grub.cfg in memory from a template suitable to boot
@@ -266,9 +266,11 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         :param string initrd: initrd name
         """
         log.info('Creating grub2 config file from template')
-        self.cmdline = self.get_boot_cmdline(root_uuid)
+        self.cmdline = ' '.join(
+            [self.get_boot_cmdline(root_uuid), boot_options]
+        )
         self.cmdline_failsafe = ' '.join(
-            [self.cmdline, Defaults.get_failsafe_kernel_options()]
+            [self.cmdline, Defaults.get_failsafe_kernel_options(), boot_options]
         )
         parameters = {
             'search_params': ' '.join(['--fs-uuid', '--set=root', boot_uuid]),

--- a/kiwi/bootloader/config/zipl.py
+++ b/kiwi/bootloader/config/zipl.py
@@ -147,7 +147,7 @@ class BootLoaderConfigZipl(BootLoaderConfigBase):
 
     def setup_disk_image_config(
         self, boot_uuid=None, root_uuid=None, hypervisor=None,
-        kernel='linux.vmx', initrd='initrd.vmx'
+        kernel='linux.vmx', initrd='initrd.vmx', boot_options=''
     ):
         """
         Create the zipl config in memory from a template suitable to
@@ -172,8 +172,10 @@ class BootLoaderConfigZipl(BootLoaderConfigBase):
             'title': self.quote_title(self.get_menu_entry_title()),
             'kernel_file': kernel,
             'initrd_file': initrd,
-            'boot_options': self.cmdline,
-            'failsafe_boot_options': self.cmdline_failsafe
+            'boot_options': ' '.join([self.cmdline, boot_options]),
+            'failsafe_boot_options': ' '.join(
+                [self.cmdline_failsafe, boot_options]
+            )
         }
         log.info('--> Using standard disk boot template')
         template = self.zipl.get_template(self.failsafe_boot)

--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -261,6 +261,36 @@ class RuntimeChecker(object):
                     )
                 )
 
+    def check_dracut_module_for_disk_oem_in_package_list(self):
+        """
+        OEM images if configured to use dracut as initrd system
+        requires the KIWI provided dracut-kiwi-oem-repart module
+        to be installed at the time dracut is called. Thus this
+        runtime check examines if the required package is part of
+        the package list in the image description.
+        """
+        message = dedent('''\n
+            Required dracut module package missing in package list
+
+            The package '{0}' is required for the selected
+            oem image type. Please add the following in your
+            <packages type="image"> section to your system XML
+            description:
+
+            <package name="{0}"/>
+        ''')
+        required_dracut_package = 'dracut-kiwi-oem-repart'
+        initrd_system = self.xml_state.get_initrd_system()
+        build_type = self.xml_state.get_build_type_name()
+        if build_type == 'oem' and initrd_system == 'dracut':
+            package_names = \
+                self.xml_state.get_bootstrap_packages() + \
+                self.xml_state.get_system_packages()
+            if required_dracut_package not in package_names:
+                raise KiwiRuntimeError(
+                    message.format(required_dracut_package)
+                )
+
     def check_dracut_module_for_live_iso_in_package_list(self):
         """
         Live ISO images uses a dracut initrd to boot and requires

--- a/kiwi/storage/disk.py
+++ b/kiwi/storage/disk.py
@@ -132,7 +132,7 @@ class Disk(DeviceProvider):
 
         Populates kiwi_RootPart(id) and kiwi_RaidPart(id) as well
         as the default raid device node at boot time which is
-        configured to be kiwi_RaidDev(/dev/md0)
+        configured to be kiwi_RaidDev(/dev/mdX)
 
         :param int mbsize: partition size
         """
@@ -140,7 +140,6 @@ class Disk(DeviceProvider):
         self._add_to_map('root')
         self._add_to_public_id_map('kiwi_RootPart')
         self._add_to_public_id_map('kiwi_RaidPart')
-        self._add_to_public_id_map('kiwi_RaidDev', '/dev/md0')
 
     def create_root_readonly_partition(self, mbsize):
         """

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -144,6 +144,7 @@ class SystemBuildTask(CliTask):
         self.runtime_checker.check_mediacheck_only_for_x86_arch()
         self.runtime_checker.check_dracut_module_for_live_iso_in_package_list()
         self.runtime_checker.check_dracut_module_for_disk_overlay_in_package_list()
+        self.runtime_checker.check_dracut_module_for_disk_oem_in_package_list()
 
         if self.command_args['--ignore-repos']:
             self.xml_state.delete_repository_sections()

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -130,6 +130,7 @@ class SystemPrepareTask(CliTask):
         self.runtime_checker.check_mediacheck_only_for_x86_arch()
         self.runtime_checker.check_dracut_module_for_live_iso_in_package_list()
         self.runtime_checker.check_dracut_module_for_disk_overlay_in_package_list()
+        self.runtime_checker.check_dracut_module_for_disk_oem_in_package_list()
 
         if self.command_args['--ignore-repos']:
             self.xml_state.delete_repository_sections()

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -308,6 +308,42 @@ This package contains the basic PXE directory structure which is
 needed to serve kiwi built images via PXE.
 %endif
 
+%package -n dracut-kiwi-lib
+Summary:        KIWI - Dracut kiwi Library
+BuildRequires:  dracut
+Requires:       bc
+Requires:       cryptsetup
+Requires:       btrfsprogs
+Requires:       coreutils
+Requires:       e2fsprogs
+Requires:       fbiterm
+Requires:       gptfdisk
+Requires:       grep
+Requires:       lvm2
+Requires:       mdadm
+Requires:       parted
+Requires:       util-linux
+Requires:       xfsprogs
+Requires:       dialog
+License:        GPL-3.0+
+Group:          System/Management
+
+%description -n dracut-kiwi-lib
+This package contains a collection of methods to provide a library
+for tasks done in other kiwi dracut modules
+
+%package -n dracut-kiwi-oem-repart
+Summary:        KIWI - Dracut module for oem(repart) image type
+BuildRequires:  dracut
+Requires:       dracut-kiwi-lib
+License:        GPL-3.0+
+Group:          System/Management
+
+%description -n dracut-kiwi-oem-repart
+This package contains the kiwi-repart dracut module which is
+used to repartition the oem disk image to the current disk
+geometry according to the setup in the kiwi image configuration
+
 %package -n dracut-kiwi-live
 Summary:        KIWI - Dracut module for iso(live) image type
 BuildRequires:  dracut
@@ -532,6 +568,14 @@ fi
 %exclude %{_bindir}/kiwi-ng*
 %exclude %{_bindir}/kiwicompat-*
 %{_bindir}/*
+
+%files -n dracut-kiwi-lib
+%defattr(-, root, root)
+%{_usr}/lib/dracut/modules.d/99kiwi-lib
+
+%files -n dracut-kiwi-oem-repart
+%defattr(-, root, root)
+%{_usr}/lib/dracut/modules.d/90kiwi-repart
 
 %files -n dracut-kiwi-live
 %defattr(-, root, root)

--- a/test/data/example_runtime_checker_config.xml
+++ b/test/data/example_runtime_checker_config.xml
@@ -35,21 +35,6 @@
         <locale>de_DE</locale>
     </preferences>
     <preferences>
-        <type bootloader="grub2" image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="my_edit_boot_install" filesystem="ext4">
-            <size unit="G" additive="true">1</size>
-            <systemdisk name="mydisk">
-                <volume name="root" size="6G" mountpoint="/"/>
-            </systemdisk>
-            <machine memory="512" xen_loader="pvgrub">
-                <vmdisk id="0" device="/dev/xvda" controller="ide"/>
-                <vmnic interface=""/>
-            </machine>
-            <oemconfig>
-                <oem-systemsize>2048</oem-systemsize>
-                <oem-swap>true</oem-swap>
-                <oem-recovery>false</oem-recovery>
-            </oemconfig>
-        </type>
         <version>1.13.2</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_US</locale>
@@ -88,15 +73,20 @@
                 <vmnic driver="e1000" interface="0" mode="bridged"/>
             </machine>
         </type>
-        <type image="oem" filesystem="ext3" boot="oemboot/example-distribution" installiso="true" bootloader="grub2" kernelcmdline="splash">
+        <type bootloader="grub2" image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="my_edit_boot_install" filesystem="ext4" initrd_system="dracut">
+            <size unit="G" additive="true">1</size>
+            <systemdisk name="mydisk">
+                <volume name="root" size="6G" mountpoint="/"/>
+            </systemdisk>
+            <machine memory="512" xen_loader="pvgrub">
+                <vmdisk id="0" device="/dev/xvda" controller="ide"/>
+                <vmnic interface=""/>
+            </machine>
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>
                 <oem-swap>true</oem-swap>
+                <oem-recovery>false</oem-recovery>
             </oemconfig>
-            <machine memory="512" guestOS="suse" HWversion="4">
-                <vmdisk id="0" controller="ide"/>
-                <vmnic driver="e1000" interface="0" mode="bridged"/>
-            </machine>
         </type>
         <type image="iso" mediacheck="true"/>
     </preferences>

--- a/test/unit/boot_image_builtin_kiwi_test.py
+++ b/test/unit/boot_image_builtin_kiwi_test.py
@@ -46,6 +46,10 @@ class TestBootImageKiwi(object):
             self.xml_state, 'some-target-dir'
         )
 
+    def test_include_file(self):
+        # is a nop for builtin kiwi initrd and does nothing
+        self.boot_image.include_file('/root/a')
+
     @patch('kiwi.defaults.Defaults.get_boot_image_description_path')
     def test_prepare(self, mock_boot_path):
         mock_boot_path.return_value = '../data'

--- a/test/unit/bootloader_config_base_test.py
+++ b/test/unit/bootloader_config_base_test.py
@@ -29,7 +29,8 @@ class TestBootLoaderConfigBase(object):
     @raises(NotImplementedError)
     def test_setup_disk_image_config(self):
         self.bootloader.setup_disk_image_config(
-            'boot_uuid', 'root_uuid', 'hypervisor', 'kernel', 'initrd'
+            'boot_uuid', 'root_uuid', 'hypervisor',
+            'kernel', 'initrd', 'options'
         )
 
     @raises(NotImplementedError)

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -382,6 +382,35 @@ class TestBootLoaderConfigGrub2(object):
             True, True, 'gfxterm'
         )
 
+    def test_setup_disk_image_config_custom_boot_options(self):
+        self.bootloader.multiboot = False
+        template = mock.Mock()
+        template.substitute = mock.Mock()
+        self.grub2.get_disk_template = mock.Mock(
+            return_value=template
+        )
+        self.bootloader.setup_disk_image_config(
+            boot_uuid='boot_uuid', root_uuid='root_uuid', boot_options='foo'
+        )
+        template.substitute.assert_called_once_with(
+            {
+                'title': 'Bob',
+                'boot_directory_name': 'grub2',
+                'kernel_file': 'linux.vmx',
+                'failsafe_boot_options': 'splash foo ide=nodma apm=off '
+                'noresume edd=off powersaved=off nohz=off highres=off '
+                'processor.max+cstate=1 nomodeset x11failsafe foo',
+                'default_boot': '0',
+                'boot_options': 'splash foo',
+                'boot_timeout': 10,
+                'gfxmode': '800x600',
+                'bootpath': '/',
+                'search_params': '--fs-uuid --set=root boot_uuid',
+                'initrd_file': 'initrd.vmx',
+                'theme': None
+            }
+        )
+
     def test_setup_install_image_config_standard(self):
         self.bootloader.multiboot = False
         self.bootloader.setup_install_image_config(self.mbrid)

--- a/test/unit/bootloader_config_zipl_test.py
+++ b/test/unit/bootloader_config_zipl_test.py
@@ -151,7 +151,10 @@ class TestBootLoaderConfigZipl(object):
         self.bootloader.target_table_type = 'msdos'
         command_results = [
             self.command_type(output='bogus data\n'),
-            self.command_type(output='/dev/sda: 242251 cylinders, 256 heads, 63 sectors/track\n')
+            self.command_type(
+                output='/dev/sda: 242251 cylinders, 256 heads, '
+                '63 sectors/track\n'
+            )
         ]
 
         def side_effect(arg):
@@ -202,7 +205,7 @@ class TestBootLoaderConfigZipl(object):
 
         mock_command.side_effect = side_effect
 
-        self.bootloader.setup_disk_image_config()
+        self.bootloader.setup_disk_image_config(boot_options='foo')
 
         self.zipl.get_template.assert_called_once_with(True)
         self.template.substitute.assert_called_once_with(
@@ -214,10 +217,12 @@ class TestBootLoaderConfigZipl(object):
                 'kernel_file': 'linux.vmx',
                 'title': 'image-name_(_OEM_)',
                 'geometry': '10017,15,12',
-                'boot_options': 'cmdline',
+                'boot_options': 'cmdline foo',
                 'target_type': 'CDL',
                 'boot_timeout': '200',
-                'failsafe_boot_options': 'cmdline ide=nodma apm=off noresume edd=off powersaved=off nohz=off highres=off processor.max+cstate=1 nomodeset x11failsafe',
+                'failsafe_boot_options': 'cmdline ide=nodma apm=off '
+                'noresume edd=off powersaved=off nohz=off highres=off '
+                'processor.max+cstate=1 nomodeset x11failsafe foo',
                 'default_boot': '1',
                 'bootpath': '.'
             }
@@ -227,14 +232,27 @@ class TestBootLoaderConfigZipl(object):
     def test_setup_disk_image_config_fcp(self, mock_command):
         self.bootloader.target_table_type = 'msdos'
         command_results = [
-            self.command_type(output='/dev/sda: 242251 cylinders, 256 heads, 63 sectors/track\n'),
-            self.command_type(output='/dev/sda: 242251 cylinders, 256 heads, 63 sectors/track\n'),
-            self.command_type(output='/dev/sda: 242251 cylinders, 256 heads, 63 sectors/track\n'),
-            self.command_type(output='''BYT;
-/dev/sda:312500000s:scsi:512:512:msdos:ATA WDC WD1600HLFS-7;
-1:2048s:251660287s:251658240s:ext4::type=83;
-2:251660288s:312499999s:60839712s:linux-swap(v1)::type=82;'''),
-            self.command_type(output='/dev/sda: 242251 cylinders, 256 heads, 63 sectors/track\n')
+            self.command_type(
+                output='/dev/sda: 242251 cylinders, 256 heads, '
+                '63 sectors/track\n'
+            ),
+            self.command_type(
+                output='/dev/sda: 242251 cylinders, 256 heads, '
+                '63 sectors/track\n'
+            ),
+            self.command_type(
+                output='/dev/sda: 242251 cylinders, 256 heads, '
+                '63 sectors/track\n'
+            ),
+            self.command_type(
+                output='BYT; /dev/sda:312500000s:scsi:512:512:msdos:ATA '
+                'WDC WD1600HLFS-7; 1:2048s:251660287s:251658240s:ext4::type=83;'
+                ' 2:251660288s:312499999s:60839712s:linux-swap(v1)::type=82;'
+            ),
+            self.command_type(
+                output='/dev/sda: 242251 cylinders, 256 heads, '
+                '63 sectors/track\n'
+            )
         ]
 
         def side_effect(arg):
@@ -254,10 +272,12 @@ class TestBootLoaderConfigZipl(object):
                 'kernel_file': 'linux.vmx',
                 'title': 'image-name_(_OEM_)',
                 'geometry': '242251,256,63',
-                'boot_options': 'cmdline',
+                'boot_options': 'cmdline ',
                 'target_type': 'CDL',
                 'boot_timeout': '200',
-                'failsafe_boot_options': 'cmdline ide=nodma apm=off noresume edd=off powersaved=off nohz=off highres=off processor.max+cstate=1 nomodeset x11failsafe',
+                'failsafe_boot_options': 'cmdline ide=nodma apm=off noresume '
+                'edd=off powersaved=off nohz=off highres=off '
+                'processor.max+cstate=1 nomodeset x11failsafe ',
                 'default_boot': '1',
                 'bootpath': '.'
             }

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -187,3 +187,11 @@ class TestRuntimeChecker(object):
         )
         runtime_checker = RuntimeChecker(xml_state)
         runtime_checker.check_dracut_module_for_live_iso_in_package_list()
+
+    @raises(KiwiRuntimeError)
+    def test_check_dracut_module_for_disk_oem_in_package_list(self):
+        xml_state = XMLState(
+            self.description.load(), ['vmxFlavour'], 'oem'
+        )
+        runtime_checker = RuntimeChecker(xml_state)
+        runtime_checker.check_dracut_module_for_disk_oem_in_package_list()

--- a/test/unit/storage_disk_test.py
+++ b/test/unit/storage_disk_test.py
@@ -84,7 +84,6 @@ class TestDisk(object):
         )
         assert self.disk.public_partition_id_map['kiwi_RootPart'] == 1
         assert self.disk.public_partition_id_map['kiwi_RaidPart'] == 1
-        assert self.disk.public_partition_id_map['kiwi_RaidDev'] == '/dev/md0'
 
     def test_create_root_readonly_partition(self):
         self.disk.create_root_readonly_partition(100)

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -103,6 +103,7 @@ class TestSystemBuildTask(object):
         self.runtime_checker.check_dracut_module_for_live_iso_in_package_list.assert_called_once_with()
         self.runtime_checker.check_repositories_configured.assert_called_once_with()
         self.runtime_checker.check_dracut_module_for_disk_overlay_in_package_list.assert_called_once_with()
+        self.runtime_checker.check_dracut_module_for_disk_oem_in_package_list.assert_called_once_with()
         self.runtime_checker.check_efi_mode_for_disk_overlay_correctly_setup.assert_called_once_with()
         self.system_prepare.setup_repositories.assert_called_once_with(False, None)
         self.system_prepare.install_bootstrap.assert_called_once_with(

--- a/test/unit/tasks_system_prepare_test.py
+++ b/test/unit/tasks_system_prepare_test.py
@@ -95,6 +95,7 @@ class TestSystemPrepareTask(object):
         self.runtime_checker.check_dracut_module_for_live_iso_in_package_list.assert_called_once_with()
         self.runtime_checker.check_repositories_configured.assert_called_once_with()
         self.runtime_checker.check_dracut_module_for_disk_overlay_in_package_list.assert_called_once_with()
+        self.runtime_checker.check_dracut_module_for_disk_oem_in_package_list.assert_called_once_with()
         self.runtime_checker.check_efi_mode_for_disk_overlay_correctly_setup.assert_called_once_with()
         self.system_prepare.setup_repositories.assert_called_once_with(True, None)
         self.system_prepare.install_bootstrap.assert_called_once_with(

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ whitelist_externals =
     /usr/bin/cp
     /usr/bin/true
     /usr/bin/test
+    /usr/bin/shellcheck
     /bin/bash
 basepython =
     {check,doc,doc_travis,doc_travis_deploy,schema}: python3.4
@@ -149,3 +150,4 @@ usedevelop = False
 commands =
     {posargs:flake8 --statistics -j auto --count {toxinidir}/kiwi}
     {posargs:flake8 --statistics -j auto --count {toxinidir}/test/unit}
+    bash -c 'shellcheck -e SC1091,SC1090,SC2001,SC2174 {toxinidir}/dracut/modules.d/*/*'


### PR DESCRIPTION
Added dracut kiwi oem module and library
    
A new dracut module kiwi-repart used to be the successor of
the custom kiwi oemboot code to repartition the disk has
been added. Along with the module a dracut library kiwi-lib
will also be delivered.


