### PR TITLE
Removes the hardcoded path of the rpm database

### DIFF
--- a/kiwi/boot/arch/arm/oemboot/linuxrc
+++ b/kiwi/boot/arch/arm/oemboot/linuxrc
@@ -418,7 +418,7 @@ if [ ! -z "$KIWI_RECOVERY" ];then
                 Echo "Failed to backup zypp database"
                 exit 1
             fi
-            rpmdb=$(chroot /mnt rpm -E %_dbpath)
+            rpmdb=$(chroot /mnt rpm -E '%_dbpath')
             if [ ! $? = 0 ] || [ -z "$rpmdb" ]; then
                 Echo "Failed to backup RPM database"
                 exit 1

--- a/kiwi/boot/arch/arm/oemboot/linuxrc
+++ b/kiwi/boot/arch/arm/oemboot/linuxrc
@@ -418,10 +418,12 @@ if [ ! -z "$KIWI_RECOVERY" ];then
                 Echo "Failed to backup zypp database"
                 exit 1
             fi
-            rpmdb=usr/lib/rpm
-            if [ ! -d "$rpm" ]; then
-                rpmdb=var/lib/rpm
+            rpmdb=$(chroot /mnt rpm -E %_dbpath)
+            if [ ! $? = 0 ] || [ -z "$rpmdb" ]; then
+                Echo "Failed to backup RPM database"
+                exit 1
             fi
+            rpmdb=${rpmdb##\/}
             if ! cp -a $rpmdb ${rpmdb}.backup;then
                 rm -rf ${rpmdb}.backup; cd / ; umountSystem
                 Echo "Failed to backup RPM database"

--- a/kiwi/boot/arch/ppc/oemboot/linuxrc
+++ b/kiwi/boot/arch/ppc/oemboot/linuxrc
@@ -417,10 +417,12 @@ if [ ! -z "$KIWI_RECOVERY" ];then
                 Echo "Failed to backup zypp database"
                 exit 1
             fi
-            rpmdb=usr/lib/rpm
-            if [ ! -d "$rpm" ]; then
-                rpmdb=var/lib/rpm
+            rpmdb=$(chroot /mnt rpm -E %_dbpath)
+            if [ ! $? = 0 ] || [ -z "$rpmdb" ]; then
+                Echo "Failed to backup RPM database"
+                exit 1
             fi
+            rpmdb=${rpmdb##\/}
             if ! cp -a $rpmdb ${rpmdb}.backup;then
                 rm -rf ${rpmdb}.backup; cd / ; umountSystem
                 Echo "Failed to backup RPM database"

--- a/kiwi/boot/arch/ppc/oemboot/linuxrc
+++ b/kiwi/boot/arch/ppc/oemboot/linuxrc
@@ -417,7 +417,7 @@ if [ ! -z "$KIWI_RECOVERY" ];then
                 Echo "Failed to backup zypp database"
                 exit 1
             fi
-            rpmdb=$(chroot /mnt rpm -E %_dbpath)
+            rpmdb=$(chroot /mnt rpm -E '%_dbpath')
             if [ ! $? = 0 ] || [ -z "$rpmdb" ]; then
                 Echo "Failed to backup RPM database"
                 exit 1

--- a/kiwi/boot/arch/s390/oemboot/linuxrc
+++ b/kiwi/boot/arch/s390/oemboot/linuxrc
@@ -422,10 +422,12 @@ if [ ! -z "$KIWI_RECOVERY" ];then
                 Echo "Failed to backup zypp database"
                 exit 1
             fi
-            rpmdb=usr/lib/rpm
-            if [ ! -d "$rpm" ]; then
-                rpmdb=var/lib/rpm
+            rpmdb=$(chroot /mnt rpm -E %_dbpath)
+            if [ ! $? = 0 ] || [ -z "$rpmdb" ]; then
+                Echo "Failed to backup RPM database"
+                exit 1
             fi
+            rpmdb=${rpmdb##\/}
             if ! cp -a $rpmdb ${rpmdb}.backup;then
                 rm -rf ${rpmdb}.backup; cd / ; umountSystem
                 Echo "Failed to backup RPM database"

--- a/kiwi/boot/arch/s390/oemboot/linuxrc
+++ b/kiwi/boot/arch/s390/oemboot/linuxrc
@@ -422,7 +422,7 @@ if [ ! -z "$KIWI_RECOVERY" ];then
                 Echo "Failed to backup zypp database"
                 exit 1
             fi
-            rpmdb=$(chroot /mnt rpm -E %_dbpath)
+            rpmdb=$(chroot /mnt rpm -E '%_dbpath')
             if [ ! $? = 0 ] || [ -z "$rpmdb" ]; then
                 Echo "Failed to backup RPM database"
                 exit 1

--- a/kiwi/boot/arch/x86_64/oemboot/linuxrc
+++ b/kiwi/boot/arch/x86_64/oemboot/linuxrc
@@ -418,7 +418,7 @@ if [ ! -z "$KIWI_RECOVERY" ];then
                 Echo "Failed to backup zypp database"
                 exit 1
             fi
-            rpmdb=$(chroot /mnt rpm -E %_dbpath)
+            rpmdb=$(chroot /mnt rpm -E '%_dbpath')
             if [ ! $? = 0 ] || [ -z "$rpmdb" ]; then
                 Echo "Failed to backup RPM database"
                 exit 1

--- a/kiwi/boot/arch/x86_64/oemboot/linuxrc
+++ b/kiwi/boot/arch/x86_64/oemboot/linuxrc
@@ -418,10 +418,12 @@ if [ ! -z "$KIWI_RECOVERY" ];then
                 Echo "Failed to backup zypp database"
                 exit 1
             fi
-            rpmdb=usr/lib/rpm
-            if [ ! -d "$rpm" ]; then
-                rpmdb=var/lib/rpm
+            rpmdb=$(chroot /mnt rpm -E %_dbpath)
+            if [ ! $? = 0 ] || [ -z "$rpmdb" ]; then
+                Echo "Failed to backup RPM database"
+                exit 1
             fi
+            rpmdb=${rpmdb##\/}
             if ! cp -a $rpmdb ${rpmdb}.backup;then
                 rm -rf ${rpmdb}.backup; cd / ; umountSystem
                 Echo "Failed to backup RPM database"


### PR DESCRIPTION
With this commit the rpmdb path is evaluated from the %_dbpath
macro instead of being hardcoded.

Fixes #537
