### PR TITLE
Only add package manager on image package requests

### DIFF
--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -172,9 +172,6 @@ class SystemPrepare(object):
 
         log.info('Installing bootstrap packages')
         bootstrap_packages = self.xml_state.get_bootstrap_packages()
-        bootstrap_packages.append(
-            self.xml_state.get_package_manager()
-        )
         collection_type = self.xml_state.get_bootstrap_collection_type()
         log.info('--> collection type: %s', collection_type)
         bootstrap_collections = self.xml_state.get_bootstrap_collections()

--- a/kiwi/tasks/image_info.py
+++ b/kiwi/tasks/image_info.py
@@ -89,8 +89,7 @@ class ImageInfoTask(CliTask):
 
         if self.command_args['--resolve-package-list']:
             solver = self._setup_solver()
-            boostrap_package_list = self.xml_state.get_bootstrap_packages() + \
-                [self.xml_state.get_package_manager()]
+            boostrap_package_list = self.xml_state.get_bootstrap_packages()
             package_list = boostrap_package_list + \
                 self.xml_state.get_system_packages()
             bootstrap_packages = solver.solve(

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -275,6 +275,10 @@ class XMLState(object):
         """
         List of packages from the type="bootstrap" packages section(s)
 
+        The list gets the selected package manager appended
+        if there is a request to install packages inside of
+        the image via a chroot operation
+
         :return: package names
         :rtype: list
         """
@@ -286,6 +290,8 @@ class XMLState(object):
         if package_list:
             for package in package_list:
                 result.append(package.package_section.get_name())
+            if self.get_system_packages():
+                result.append(self.get_package_manager())
         return sorted(list(set(result)))
 
     def get_system_packages(self):

--- a/test/data/example_no_image_packages_config.xml
+++ b/test/data/example_no_image_packages_config.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="6.7" name="LimeJeOS-openSUSE-13.2">
+    <description type="system">
+        <author>Marcus Schäfer</author>
+        <contact>ms@suse.com</contact>
+        <specification>
+            openSUSE 13.2 JeOS, is a small text based image
+        </specification>
+    </description>
+    <preferences>
+        <version>1.13.2</version>
+        <packagemanager>zypper</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us.map.gz</keytable>
+        <timezone>Europe/Berlin</timezone>
+        <hwclock>utc</hwclock>
+        <rpm-excludedocs>true</rpm-excludedocs>
+        <rpm-check-signatures>false</rpm-check-signatures>
+        <bootsplash-theme>openSUSE</bootsplash-theme>
+        <bootloader-theme>openSUSE</bootloader-theme>
+        <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" installiso="true" bootloader="grub2" kernelcmdline="splash" firmware="efi" btrfs_root_is_snapshot="true" btrfs_root_is_readonly_snapshot="true"/>
+    </preferences>
+    <repository type="yast2">
+        <source path="obs://13.2/repo/oss"/>
+    </repository>
+    <packages type="bootstrap">
+        <package name="patterns-openSUSE-base"/>
+    </packages>
+</image>

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -28,6 +28,12 @@ class TestXMLState(object):
         self.boot_state = XMLState(
             boot_description.load()
         )
+        no_image_packages_description = XMLDescription(
+            '../data/example_no_image_packages_config.xml'
+        )
+        self.no_image_packages_boot_state = XMLState(
+            no_image_packages_description.load()
+        )
 
     def test_build_type_primary_selected(self):
         assert self.state.get_build_type_name() == 'oem'
@@ -62,7 +68,10 @@ class TestXMLState(object):
 
     def test_get_bootstrap_packages(self):
         assert self.state.get_bootstrap_packages() == [
-            'filesystem'
+            'filesystem', 'zypper'
+        ]
+        assert self.no_image_packages_boot_state.get_bootstrap_packages() == [
+            'patterns-openSUSE-base'
         ]
 
     def test_get_system_packages(self):


### PR DESCRIPTION
If an image description only contains package requests
from a bootstrap section but no image packages, it's not
required to install a package manager package into the
system

