### PR TITLE
package: Prepare for Tumbleweed moving to suse_version 1550

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -71,7 +71,7 @@
 
 # Tumbleweed:
 # Current Tumbleweed version, moving target
-%if 0%{?suse_version} == 1330
+%if 0%{?suse_version} >= 1330 && !0{?sle_version}
 %define distro suse-tumbleweed
 %endif
 


### PR DESCRIPTION
if suse_version is >= 1330, it can be either TW, Leap15 or SLE15 (and future products)

but both, Leap and SLE have the variable sle_version defined which does not exist in TW (TW is not based on SLE) - thus, suse_version >= 1330 and no sle_version implies TW