### PR TITLE
Adding --ingore-rpm-postscript-errors flag

### DIFF
--- a/kiwi/command.py
+++ b/kiwi/command.py
@@ -113,7 +113,7 @@ class Command(object):
         )
 
     @classmethod
-    def call(self, command, custom_env=None):
+    def call(self, command, custom_env=None, return_code_handler=None):
         """
         Execute a program and return an io file handle pair back.
         stdout and stderr are both on different channels. The caller
@@ -179,7 +179,7 @@ class Command(object):
             'command', [
                 'output', 'output_available',
                 'error', 'error_available',
-                'process'
+                'process', 'return_code_handler'
             ]
         )
         return command(
@@ -187,5 +187,6 @@ class Command(object):
             output_available=output_available(),
             error=process.stderr,
             error_available=error_available(),
-            process=process
+            process=process,
+            return_code_handler=return_code_handler
         )

--- a/kiwi/command_process.py
+++ b/kiwi/command_process.py
@@ -195,6 +195,10 @@ class CommandIterator(six.Iterator):
         :return: errorcode
         :rtype: int
         """
+        if self.command.return_code_handler:
+            return self.command.return_code_handler(
+                self.command.process.returncode
+            )
         return self.command.process.returncode
 
     def get_pid(self):

--- a/kiwi/package_manager/base.py
+++ b/kiwi/package_manager/base.py
@@ -203,6 +203,17 @@ class PackageManagerBase(object):
         """
         raise NotImplementedError
 
+    def ignore_postscript_errors(self):
+        """
+        Ignores the %post install script errors of rpm packages.
+
+        Implementation in specialized package manager class
+        """
+        raise NotImplementedError(
+            'Flag --ingore-rpm-postscript-error is currently only supported '
+            'for zypper package manager'
+        )
+
     def cleanup_requests(self):
         """
         Cleanup request queues

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -160,7 +160,7 @@ class SystemPrepare(object):
             repo, package_manager
         )
 
-    def install_bootstrap(self, manager):
+    def install_bootstrap(self, manager, ignore_postscript_errors=False):
         """
         Install system software using the package manager
         from the host, also known as bootstrapping
@@ -182,6 +182,8 @@ class SystemPrepare(object):
             manager.process_only_required()
         else:
             manager.process_plus_recommended()
+        if ignore_postscript_errors:
+            manager.ignore_postscript_errors()
         all_install_items = self._setup_requests(
             manager,
             bootstrap_packages,
@@ -213,7 +215,7 @@ class SystemPrepare(object):
                     'Bootstrap archive installation failed: %s' % format(e)
                 )
 
-    def install_system(self, manager):
+    def install_system(self, manager, ignore_postscript_errors=False):
         """
         Install system software using the package manager inside
         of the new root directory. This is done via a chroot operation
@@ -238,6 +240,8 @@ class SystemPrepare(object):
             manager.process_only_required()
         else:
             manager.process_plus_recommended()
+        if ignore_postscript_errors:
+            manager.ignore_postscript_errors()
         all_install_items = self._setup_requests(
             manager,
             system_packages,

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -29,6 +29,7 @@ usage: kiwi system prepare -h | --help
            [--set-container-derived-from=<uri>]
            [--set-container-tag=<name>]
            [--signing-key=<key-file>...]
+           [--ignore-rpm-postscript-errors]
        kiwi system prepare help
 
 commands:
@@ -78,8 +79,10 @@ options:
         priority and the imageinclude flag set to true|false which
         indicates if this repository should be part of the system
         image repository setup or not
-     --signing-key=<key-file>
+    --signing-key=<key-file>
         includes the key-file as a trusted key for package manager validations
+    --ignore-rpm-postscript-errors
+        ignore postscript failures of packages installed with zypper 
 """
 import os
 
@@ -177,9 +180,11 @@ class SystemPrepareTask(CliTask):
             self.command_args['--clear-cache'],
             self.command_args['--signing-key']
         )
-        system.install_bootstrap(manager)
+        system.install_bootstrap(
+            manager, self.command_args['--ignore-rpm-postscript-errors']
+        )
         system.install_system(
-            manager
+            manager, self.command_args['--ignore-rpm-postscript-errors']
         )
         if package_requests:
             if self.command_args['--add-package']:


### PR DESCRIPTION
This commit adds the --ignore-rpm-postscript-errors flag,
which enables to omit a failure when zypper returns 107 exit code.
In former zypper versions %post install script failures zypper
was not returning any error code, thus this flag allows to install
packages with flaky %post scripts as in previous zypper versions.

Fixes #539
