### PR TITLE
Update dropped feature list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ branches:
 matrix:
   include:
   - python: 3.4
-    env: TOXENV=3.4,check,doc_travis
+    env: TOXENV=unit_py3,check,doc_travis
   - python: 2.7
-    env: TOXENV=2.7,check,doc_travis
+    env: TOXENV=unit_py2,check,doc_travis
 before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -y git

--- a/.virtualenv.dev-requirements.txt
+++ b/.virtualenv.dev-requirements.txt
@@ -17,12 +17,6 @@ setuptools
 tox
 
 # python unit testing framework
-
-# py 1.5 was released but pytest-cov requires py<1.5
-# Thus we also install py in a lower version to temporarily
-# fix the version conflict
-py==1.4.34
-
 pytest
 pytest-cov
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ version := $(shell \
 
 .PHONY: test
 test:
-	tox -e 3.4
+	tox -e unit_py3
 
 flake:
 	tox -e check

--- a/doc/source/overview/legacy_kiwi.rst
+++ b/doc/source/overview/legacy_kiwi.rst
@@ -109,6 +109,17 @@ consider to use the legacy KIWI version.
    Many distributions also dropped the lxc tools from the distribution
    in favour of docker.
 
+*  OEM Recovery/Restore
+
+   Recovery/Restore in the world of images has been moved from the OS
+   layer into higher layers. For example in Cloud and Public Cloud
+   environments disk and image recovery as well as backup strategies
+   are part of cloud services. Pure OS recovery and snapshots for consumer
+   machines are developed as build in solutions of the distribution.
+   SUSE as an example provides this via ReaR (Relax-and-Recover) and
+   snapshot based filesystems (btrfs+snapper). Therefore the recovery
+   solution offered in the legacy KIWI version will not be continued.
+
 Compatibility
 -------------
 

--- a/doc/source/overview/legacy_kiwi.rst
+++ b/doc/source/overview/legacy_kiwi.rst
@@ -111,14 +111,15 @@ consider to use the legacy KIWI version.
 
 *  OEM Recovery/Restore
 
-   Recovery/Restore in the world of images has been moved from the OS
-   layer into higher layers. For example in Cloud and Public Cloud
-   environments disk and image recovery as well as backup strategies
-   are part of cloud services. Pure OS recovery and snapshots for consumer
-   machines are developed as build in solutions of the distribution.
-   SUSE as an example provides this via ReaR (Relax-and-Recover) and
-   snapshot based filesystems (btrfs+snapper). Therefore the recovery
-   solution offered in the legacy KIWI version will not be continued.
+   Recovery/Restore in the world of images has been moved from the
+   operating system layer into higher layers. For example, in private and
+   public Cloud environments disk and image recovery as well as backup
+   strategies are part of Cloud services. Pure operating system recovery
+   and snapshots for consumer machines are provided as features of the
+   distribution. SUSE as an example provides this via Rear
+   (Relax-and-Recover) and snapshot based filesystems (btrfs+snapper).
+   Therefore the recovery feature offered in the legacy KIWI version
+   will not be continued.
 
 Compatibility
 -------------

--- a/tox.ini
+++ b/tox.ini
@@ -83,7 +83,7 @@ deps =
     -r.virtualenv.dev-requirements.txt
 changedir=doc
 commands =
-    - travis-sphinx --nowarn --source ./source build
+    - travis-sphinx build --nowarn --source ./source
     - bash -c 'cp -a ./source/development/schema/images ./target/doc/build/development || true'
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,9 +15,8 @@ skip_missing_interpreters = True
 skipsdist = True
 envlist =
     check,
-    3.4,
-    3.5,
-    2.7,
+    unit_py3,
+    unit_py2,
     doc
 
 
@@ -30,124 +29,131 @@ whitelist_externals =
     /usr/bin/shellcheck
     /bin/bash
 basepython =
-    {check,doc,doc_travis,doc_travis_deploy,schema}: python3.4
-    3.4: python3.4
-    3.5: python3.5
-    2.7: python2.7
-# {toxworkdir} defaults to .tox
+    {check,doc,doc_travis,doc_travis_deploy}: python3.4
+    unit_py3: python3.4
+    unit_py2: python2.7
 envdir =
-    {3.4,check,doc,doc_travis,doc_travis_deploy,schema}: {toxworkdir}/3.4
-    3.5: {toxworkdir}/3.5
-    2.7: {toxworkdir}/2.7
+    {check,doc,doc_travis,doc_travis_deploy}: {toxworkdir}/3.4
+    unit_py3: {toxworkdir}/3.4
+    unit_py2: {toxworkdir}/2.7
+passenv =
+    *
+usedevelop = True
+deps =
+    -r.virtualenv.dev-requirements.txt
+
+
+# Unit Test run with basepython set to 2.x
+[testenv:unit_py2]
+skip_install = True
+usedevelop = True
 setenv =
     PYTHONPATH={toxinidir}/test
     PYTHONUNBUFFERED=yes
     WITH_COVERAGE=yes
 passenv =
     *
-usedevelop = True
-deps =
-    -r.virtualenv.dev-requirements.txt
+deps = {[testenv]deps}
 changedir=test/unit
 commands =
-    py.test {posargs:--no-cov-on-fail --cov=kiwi --cov-report=term-missing --cov-fail-under=100 --cov-config .coveragerc}
+    bash -c 'cd ../../ && ./setup.py develop'
+    py.test --no-cov-on-fail --cov=kiwi \
+        --cov-report=term-missing --cov-fail-under=100 --cov-config .coveragerc
 
 
+# Unit Test run with basepython set to 3.x
+[testenv:unit_py3]
+skip_install = True
+usedevelop = True
+setenv =
+    PYTHONPATH={toxinidir}/test
+    PYTHONUNBUFFERED=yes
+    WITH_COVERAGE=yes
+passenv =
+    *
+deps = {[testenv]deps}
+changedir=test/unit
+commands =
+    bash -c 'cd ../../ && ./setup.py develop'
+    py.test --no-cov-on-fail --cov=kiwi \
+        --cov-report=term-missing --cov-fail-under=100 --cov-config .coveragerc
+
+
+# Documentation build run, collection of doc.X targets
 [testenv:doc]
 skip_install = True
 usedevelop = True
-deps =
-    -r.virtualenv.dev-requirements.txt
+deps = {[testenv]deps}
 changedir=doc
 commands =
     make clean
     {[testenv:doc.linkcheck]commands}
-#    {[testenv:doc.spell]commands}
     {[testenv:doc.html]commands}
     {[testenv:doc.man]commands}
-
-
-[testenv:schema]
-skip_install = True
-usedevelop = True
-deps =
-    -r.virtualenv.dev-requirements.txt
-commands =
     {[testenv:doc.schema]commands}
 
 
+# Documentation build suitable for doc deployment in travis env
 [testenv:doc_travis]
 skip_install = True
 usedevelop = True
-deps =
-    -r.virtualenv.dev-requirements.txt
+deps = {[testenv:doc]deps}
 changedir=doc
 commands =
-    - travis-sphinx build --nowarn --source ./source
-    - bash -c 'cp -a ./source/development/schema/images ./target/doc/build/development || true'
+    travis-sphinx build --nowarn --source ./source
+    bash -c 'cp -a ./source/development/schema/images ./target/doc/build/development || true'
 
 
+# Documentation deploy from travis env
 [testenv:doc_travis_deploy]
 skip_install = True
 usedevelop = True
-deps =
-    -r.virtualenv.dev-requirements.txt
+deps = {[testenv:doc]deps}
 changedir=doc
 commands =
-    - travis-sphinx deploy
+    travis-sphinx deploy
 
 
-[testenv:doc.spell]
-setenv =
-    SPELLCHECK=1
-deps =
-    {[testenv:doc]deps}
-skip_install = True
-usedevelop = True
-changedir=doc
-commands =
-    - sphinx-build -b spelling source dist/spelling
-
-
+# Documentation build html result
 [testenv:doc.html]
 skip_install = True
-deps =
-    {[testenv:doc]deps}
+deps = {[testenv:doc]deps}
 changedir=doc
 commands =
     make html
 
 
+# Documentation build man pages
 [testenv:doc.man]
 skip_install = True
-deps =
-    {[testenv:doc]deps}
+deps = {[testenv:doc]deps}
 changedir=doc
 commands =
     make man
 
 
+# Documentation link check
 [testenv:doc.linkcheck]
 skip_install = True
-deps =
-    {[testenv:doc]deps}
+deps = {[testenv:doc]deps}
 commands =
     make linkcheck
 
 
+# Documentation build schema documentation
 [testenv:doc.schema]
 skip_install = True
-deps =
-    {[testenv:doc]deps}
+deps = {[testenv:doc]deps}
 commands =
     bash -c 'cd {toxinidir}/helper && ./schema_docs.sh'
 
+
+# Source code quality/integrity check
 [testenv:check]
-deps =
-    -r.virtualenv.dev-requirements.txt
+deps = {[testenv]deps}
 skip_install = True
-usedevelop = False
+usedevelop = True
 commands =
-    {posargs:flake8 --statistics -j auto --count {toxinidir}/kiwi}
-    {posargs:flake8 --statistics -j auto --count {toxinidir}/test/unit}
+    flake8 --statistics -j auto --count {toxinidir}/kiwi
+    flake8 --statistics -j auto --count {toxinidir}/test/unit
     bash -c 'shellcheck -e SC1091,SC1090,SC2001,SC2174 {toxinidir}/dracut/modules.d/*/*'


### PR DESCRIPTION
Legacy kiwi's oem recovery feature will not be ported
due to technologes like ReaR, snapper, btrfs and due
to the container, cloud and public cloud orientation of
OS images


