### PR TITLE
Fixed dependencies for dracut-kiwi-lib

### DIFF
--- a/dracut/modules.d/99kiwi-lib/module-setup.sh
+++ b/dracut/modules.d/99kiwi-lib/module-setup.sh
@@ -15,12 +15,15 @@ depends() {
 install() {
     declare moddir=${moddir}
     inst_multiple \
-        blkid blockdev parted dd mkdir grep fdasd cut tail head tr bc \
+        blkid blockdev parted dd mkdir grep cut tail head tr bc \
         basename partprobe gdisk sgdisk mkswap readlink lsblk \
         btrfs xfs_growfs resize2fs \
         e2fsck btrfsck xfs_repair \
         vgs vgchange lvextend lvcreate lvresize pvresize \
-        fbiterm mdadm cryptsetup
+        mdadm cryptsetup
+    if [[ "$(uname -m)" =~ s390 ]];then
+        inst_multiple fdasd
+    fi
     inst_simple \
         "${moddir}/kiwi-lib.sh" "/lib/kiwi-lib.sh"
     inst_simple \
@@ -35,6 +38,4 @@ install() {
         "${moddir}/kiwi-lvm-lib.sh" "/lib/kiwi-lvm-lib.sh"
     inst_simple \
         "${moddir}/kiwi-luks-lib.sh" "/lib/kiwi-luks-lib.sh"
-    inst_simple \
-        "/usr/share/fbiterm/fonts/b16.pcf.gz" "/lib/b16.pcf.gz"
 }

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -313,11 +313,15 @@ Summary:        KIWI - Dracut kiwi Library
 BuildRequires:  dracut
 Requires:       bc
 Requires:       cryptsetup
+%if 0%{?fedora} || 0%{?rhel}
+Requires:       btrfs-progs
+Requires:       gdisk
+%else
 Requires:       btrfsprogs
+Requires:       gptfdisk
+%endif
 Requires:       coreutils
 Requires:       e2fsprogs
-Requires:       fbiterm
-Requires:       gptfdisk
 Requires:       grep
 Requires:       lvm2
 Requires:       mdadm
@@ -325,6 +329,9 @@ Requires:       parted
 Requires:       util-linux
 Requires:       xfsprogs
 Requires:       dialog
+%ifarch s390 s390x
+Requires:       s390-tools
+%endif
 License:        GPL-3.0+
 Group:          System/Management
 


### PR DESCRIPTION
Adapt package names for gdisk/gptfdisk and btrfs-progs/btrfsprogs
Install and require fdasd only on s390 architecture
Delete fbiterm requirement since the project seems unmaintained
and the use of the framebuffer terminal is an option in the code
but not mandatory. This Fixes #559

