### PR TITLE
Make sure toplevel target dir keeps permissions

### DIFF
--- a/kiwi/utils/sync.py
+++ b/kiwi/utils/sync.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+import os
+from stat import ST_MODE
 import xattr
 
 # project
@@ -69,11 +71,21 @@ class DataSync(object):
                 exclude_options.append(
                     '/' + item
                 )
+        target_entry_permissions = oct(os.stat(self.target_dir)[ST_MODE])
         Command.run(
             ['rsync'] + rsync_options + exclude_options + [
                 self.source_dir, self.target_dir
             ]
         )
+        # rsync applies the permissions of the source directory
+        # also to the target directory which is unwanted because
+        # only permissions of the files and directories from the
+        # source directory and its contents should be transfered
+        # but not from the source directory itself. Therefore
+        # the permission bits of the target directory before the
+        # sync are applied back after sync to ensure they have
+        # not changed
+        os.chmod(self.target_dir, target_entry_permissions)
 
     def target_supports_extended_attributes(self):
         """

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -674,8 +674,11 @@ class TestBootLoaderConfigGrub2(object):
     @patch('os.path.exists')
     @patch('platform.machine')
     @patch('kiwi.logger.log.info')
+    @patch('os.chmod')
+    @patch('os.stat')
     def test_setup_disk_boot_images_bios_plus_efi_secure_boot(
-        self, mock_log, mock_machine, mock_exists, mock_command
+        self, mock_stat, mock_chmod, mock_log, mock_machine,
+        mock_exists, mock_command
     ):
         mock_machine.return_value = 'x86_64'
         self.firmware.efi_mode = mock.Mock(
@@ -706,9 +709,11 @@ class TestBootLoaderConfigGrub2(object):
     @patch('platform.machine')
     @patch('kiwi.logger.log.info')
     @patch('glob.iglob')
+    @patch('os.chmod')
+    @patch('os.stat')
     def test_setup_disk_boot_images_bios_plus_efi_secure_boot_no_shim_install(
-        self, mock_glob, mock_log, mock_machine, mock_exists,
-        mock_command, mock_which
+        self, mock_stat, mock_chmod, mock_glob, mock_log, mock_machine,
+        mock_exists, mock_command, mock_which
     ):
         # we expect the copy of shim.efi and grub.efi from the fallback
         # code if no shim_install was found for building the disk image
@@ -826,8 +831,11 @@ class TestBootLoaderConfigGrub2(object):
     @patch('platform.machine')
     @patch('kiwi.logger.log.info')
     @patch('glob.iglob')
+    @patch('os.chmod')
+    @patch('os.stat')
     def test_setup_install_boot_images_efi_secure_boot(
-        self, mock_glob, mock_log, mock_machine, mock_exists, mock_command
+        self, mock_stat, mock_chmod, mock_glob, mock_log,
+        mock_machine, mock_exists, mock_command
     ):
         mock_machine.return_value = 'x86_64'
         self.firmware.efi_mode = mock.Mock(

--- a/test/unit/container_setup_base_test.py
+++ b/test/unit/container_setup_base_test.py
@@ -112,13 +112,16 @@ class TestContainerSetupBase(object):
         ]
 
     @patch('kiwi.container.setup.base.Command.run')
-    def test_setup_static_device_nodes(self, mock_command):
+    @patch('kiwi.container.setup.base.DataSync')
+    def test_setup_static_device_nodes(self, mock_DataSync, mock_command):
+        data = mock.Mock()
+        mock_DataSync.return_value = data
         self.container.setup_static_device_nodes()
-        mock_command.assert_called_once_with(
-            [
-                'rsync', '-z', '-a', '-x', '--devices', '--specials',
-                '/dev/', 'root_dir/dev/'
-            ]
+        mock_DataSync.assert_called_once_with(
+            '/dev/', 'root_dir/dev/'
+        )
+        data.sync_data.assert_called_once_with(
+            options=['-z', '-a', '-x', '--devices', '--specials']
         )
 
     @patch('kiwi.container.setup.base.Command.run')

--- a/test/unit/system_setup_test.py
+++ b/test/unit/system_setup_test.py
@@ -183,32 +183,46 @@ class TestSystemSetup(object):
         self.file_mock.write.assert_called_once_with('a\n')
 
     @patch('kiwi.command.Command.run')
+    @patch('kiwi.system.setup.DataSync')
     @patch('os.path.exists')
-    def test_import_overlay_files_copy_links(self, mock_os_path, mock_command):
+    def test_import_overlay_files_copy_links(
+        self, mock_os_path, mock_DataSync, mock_command
+    ):
+        data = mock.Mock()
+        mock_DataSync.return_value = data
         mock_os_path.return_value = True
         self.setup.import_overlay_files(
             follow_links=True, preserve_owner_group=True
         )
-        mock_command.assert_called_once_with(
-            [
-                'rsync', '-r', '-p', '-t', '-D', '-H', '-X', '-A',
-                '--one-file-system', '--copy-links', '-o', '-g',
-                'description_dir/root/', 'root_dir'
+        mock_DataSync.assert_called_once_with(
+            'description_dir/root/', 'root_dir'
+        )
+        data.sync_data.assert_called_once_with(
+            options=[
+                '-r', '-p', '-t', '-D', '-H', '-X', '-A',
+                '--one-file-system', '--copy-links', '-o', '-g'
             ]
         )
 
     @patch('kiwi.command.Command.run')
+    @patch('kiwi.system.setup.DataSync')
     @patch('os.path.exists')
-    def test_import_overlay_files_links(self, mock_os_path, mock_command):
+    def test_import_overlay_files_links(
+        self, mock_os_path, mock_DataSync, mock_command
+    ):
+        data = mock.Mock()
+        mock_DataSync.return_value = data
         mock_os_path.return_value = True
         self.setup.import_overlay_files(
             follow_links=False, preserve_owner_group=True
         )
-        mock_command.assert_called_once_with(
-            [
-                'rsync', '-r', '-p', '-t', '-D', '-H', '-X', '-A',
-                '--one-file-system', '--links', '-o', '-g',
-                'description_dir/root/', 'root_dir'
+        mock_DataSync.assert_called_once_with(
+            'description_dir/root/', 'root_dir'
+        )
+        data.sync_data.assert_called_once_with(
+            options=[
+                '-r', '-p', '-t', '-D', '-H', '-X', '-A',
+                '--one-file-system', '--links', '-o', '-g'
             ]
         )
 
@@ -652,16 +666,21 @@ class TestSystemSetup(object):
 
     @patch('kiwi.system.setup.Command.run')
     @patch('kiwi.system.setup.Path.create')
+    @patch('kiwi.system.setup.DataSync')
     @patch('os.path.exists')
-    def test_export_modprobe_setup(self, mock_exists, mock_path, mock_command):
+    def test_export_modprobe_setup(
+        self, mock_exists, mock_DataSync, mock_path, mock_command
+    ):
+        data = mock.Mock()
+        mock_DataSync.return_value = data
         mock_exists.return_value = True
         self.setup.export_modprobe_setup('target_root_dir')
         mock_path.assert_called_once_with('target_root_dir/etc')
-        mock_command.assert_called_once_with(
-            [
-                'rsync', '-z', '-a',
-                'root_dir/etc/modprobe.d', 'target_root_dir/etc/'
-            ]
+        mock_DataSync.assert_called_once_with(
+            'root_dir/etc/modprobe.d', 'target_root_dir/etc/'
+        )
+        data.sync_data.assert_called_once_with(
+            options=['-z', '-a']
         )
 
     @patch('kiwi.system.setup.Command.run')


### PR DESCRIPTION
When syncing data via rsync we make sure the toplevel target
directory the data gets synced to does not change it's origin
permissions. This Fixes #557

