### PR TITLE
Do not match comments and PIs in XSLT templates

### DIFF
--- a/kiwi/xsl/convert14to20.xsl
+++ b/kiwi/xsl/convert14to20.xsl
@@ -6,7 +6,7 @@
 <xsl:strip-space elements="type"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv14to20">
+<xsl:template match="*" mode="conv14to20">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv14to20"/>

--- a/kiwi/xsl/convert20to24.xsl
+++ b/kiwi/xsl/convert20to24.xsl
@@ -6,7 +6,7 @@
 <xsl:strip-space elements="type"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv20to24">
+<xsl:template match="*" mode="conv20to24">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv20to24"/>

--- a/kiwi/xsl/convert24to35.xsl
+++ b/kiwi/xsl/convert24to35.xsl
@@ -6,7 +6,7 @@
 <xsl:strip-space elements="type"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv24to35">
+<xsl:template match="*" mode="conv24to35">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv24to35"/>

--- a/kiwi/xsl/convert35to37.xsl
+++ b/kiwi/xsl/convert35to37.xsl
@@ -10,7 +10,7 @@
 <xsl:strip-space elements="type"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv35to37">
+<xsl:template match="*" mode="conv35to37">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv35to37"/>

--- a/kiwi/xsl/convert37to38.xsl
+++ b/kiwi/xsl/convert37to38.xsl
@@ -6,7 +6,7 @@
 <xsl:strip-space elements="type"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv37to38">
+<xsl:template match="*" mode="conv37to38">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv37to38"/>

--- a/kiwi/xsl/convert38to39.xsl
+++ b/kiwi/xsl/convert38to39.xsl
@@ -6,7 +6,7 @@
 <xsl:strip-space elements="preferences"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv38to39">
+<xsl:template match="*" mode="conv38to39">
         <xsl:copy>
                 <xsl:copy-of select="@*"/>
                      <xsl:apply-templates mode="conv38to39"/>

--- a/kiwi/xsl/convert39to41.xsl
+++ b/kiwi/xsl/convert39to41.xsl
@@ -4,7 +4,7 @@
         indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv39to41">
+<xsl:template match="*" mode="conv39to41">
         <xsl:copy>
                 <xsl:copy-of select="@*"/>
                      <xsl:apply-templates mode="conv39to41"/>

--- a/kiwi/xsl/convert41to42.xsl
+++ b/kiwi/xsl/convert41to42.xsl
@@ -5,7 +5,7 @@
 
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv41to42">
+<xsl:template match="*" mode="conv41to42">
         <xsl:copy>
                 <xsl:copy-of select="@*"/>
                      <xsl:apply-templates mode="conv41to42"/>

--- a/kiwi/xsl/convert42to43.xsl
+++ b/kiwi/xsl/convert42to43.xsl
@@ -5,7 +5,7 @@
 
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv42to43">
+<xsl:template match="*" mode="conv42to43">
         <xsl:copy>
                 <xsl:copy-of select="@*"/>
                      <xsl:apply-templates mode="conv42to43"/>

--- a/kiwi/xsl/convert43to44.xsl
+++ b/kiwi/xsl/convert43to44.xsl
@@ -6,7 +6,7 @@
 <xsl:strip-space elements="type"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv43to44">
+<xsl:template match="*" mode="conv43to44">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv43to44"/>

--- a/kiwi/xsl/convert44to45.xsl
+++ b/kiwi/xsl/convert44to45.xsl
@@ -6,7 +6,7 @@
 <xsl:strip-space elements="type"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv44to45">
+<xsl:template match="*" mode="conv44to45">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv44to45"/>

--- a/kiwi/xsl/convert45to46.xsl
+++ b/kiwi/xsl/convert45to46.xsl
@@ -6,7 +6,7 @@
 <xsl:strip-space elements="type"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv45to46">
+<xsl:template match="*" mode="conv45to46">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv45to46"/>

--- a/kiwi/xsl/convert46to47.xsl
+++ b/kiwi/xsl/convert46to47.xsl
@@ -6,7 +6,7 @@
 <xsl:strip-space elements="type"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv46to47">
+<xsl:template match="*" mode="conv46to47">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv46to47"/>

--- a/kiwi/xsl/convert47to48.xsl
+++ b/kiwi/xsl/convert47to48.xsl
@@ -30,7 +30,7 @@
 </xsl:template>
 
 <!-- default rule conv47to48 -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv47to48">
+<xsl:template match="*" mode="conv47to48">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv47to48"/>

--- a/kiwi/xsl/convert48to49.xsl
+++ b/kiwi/xsl/convert48to49.xsl
@@ -10,7 +10,7 @@
 <xsl:strip-space elements="type"/>
 
 <!-- default rule conv48to49 -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv48to49">
+<xsl:template match="*" mode="conv48to49">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv48to49"/>

--- a/kiwi/xsl/convert49to50.xsl
+++ b/kiwi/xsl/convert49to50.xsl
@@ -4,7 +4,7 @@
         indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv49to50">
+<xsl:template match="*" mode="conv49to50">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv49to50"/>

--- a/kiwi/xsl/convert50to51.xsl
+++ b/kiwi/xsl/convert50to51.xsl
@@ -4,7 +4,7 @@
         indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv50to51">
+<xsl:template match="*" mode="conv50to51">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv50to51"/>

--- a/kiwi/xsl/convert51to52.xsl
+++ b/kiwi/xsl/convert51to52.xsl
@@ -4,7 +4,7 @@
         indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv51to52">
+<xsl:template match="*" mode="conv51to52">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv51to52"/>

--- a/kiwi/xsl/convert52to53.xsl
+++ b/kiwi/xsl/convert52to53.xsl
@@ -4,7 +4,7 @@
         indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv52to53">
+<xsl:template match="*" mode="conv52to53">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv52to53"/>

--- a/kiwi/xsl/convert53to54.xsl
+++ b/kiwi/xsl/convert53to54.xsl
@@ -4,7 +4,7 @@
         indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv53to54">
+<xsl:template match="*" mode="conv53to54">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv53to54"/>

--- a/kiwi/xsl/convert54to55.xsl
+++ b/kiwi/xsl/convert54to55.xsl
@@ -4,7 +4,7 @@
         indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv54to55">
+<xsl:template match="*" mode="conv54to55">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv54to55"/>

--- a/kiwi/xsl/convert55to56.xsl
+++ b/kiwi/xsl/convert55to56.xsl
@@ -4,7 +4,7 @@
     indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv55to56">
+<xsl:template match="*" mode="conv55to56">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv55to56"/>

--- a/kiwi/xsl/convert56to57.xsl
+++ b/kiwi/xsl/convert56to57.xsl
@@ -4,7 +4,7 @@
     indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv56to57">
+<xsl:template match="*" mode="conv56to57">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv56to57"/>

--- a/kiwi/xsl/convert57to58.xsl
+++ b/kiwi/xsl/convert57to58.xsl
@@ -4,7 +4,7 @@
         indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv57to58">
+<xsl:template match="*" mode="conv57to58">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv57to58"/>

--- a/kiwi/xsl/convert58to59.xsl
+++ b/kiwi/xsl/convert58to59.xsl
@@ -4,7 +4,7 @@
         indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv58to59">
+<xsl:template match="*" mode="conv58to59">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv58to59"/>

--- a/kiwi/xsl/convert59to60.xsl
+++ b/kiwi/xsl/convert59to60.xsl
@@ -5,7 +5,7 @@
     indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv59to60">
+<xsl:template match="*" mode="conv59to60">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv59to60"/>

--- a/kiwi/xsl/convert60to61.xsl
+++ b/kiwi/xsl/convert60to61.xsl
@@ -5,7 +5,7 @@
     indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv60to61">
+<xsl:template match="*" mode="conv60to61">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv60to61"/>

--- a/kiwi/xsl/convert61to62.xsl
+++ b/kiwi/xsl/convert61to62.xsl
@@ -5,7 +5,7 @@
     indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv61to62">
+<xsl:template match="*" mode="conv61to62">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv61to62"/>

--- a/kiwi/xsl/convert62to63.xsl
+++ b/kiwi/xsl/convert62to63.xsl
@@ -4,7 +4,7 @@
         indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv62to63">
+<xsl:template match="*" mode="conv62to63">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv62to63"/>

--- a/kiwi/xsl/convert63to64.xsl
+++ b/kiwi/xsl/convert63to64.xsl
@@ -4,7 +4,7 @@
         indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv63to64">
+<xsl:template match="*" mode="conv63to64">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv63to64"/>

--- a/kiwi/xsl/convert64to65.xsl
+++ b/kiwi/xsl/convert64to65.xsl
@@ -4,7 +4,7 @@
         indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv64to65">
+<xsl:template match="*" mode="conv64to65">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv64to65"/>

--- a/kiwi/xsl/convert65to66.xsl
+++ b/kiwi/xsl/convert65to66.xsl
@@ -4,7 +4,7 @@
         indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv65to66">
+<xsl:template match="*" mode="conv65to66">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv65to66"/>

--- a/kiwi/xsl/convert66to67.xsl
+++ b/kiwi/xsl/convert66to67.xsl
@@ -4,7 +4,7 @@
         indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
 
 <!-- default rule -->
-<xsl:template match="*|processing-instruction()|comment()" mode="conv66to67">
+<xsl:template match="*" mode="conv66to67">
     <xsl:copy>
         <xsl:copy-of select="@*"/>
         <xsl:apply-templates mode="conv66to67"/>
@@ -72,7 +72,7 @@
     Delete defaultprebuilt section
 </para>
 <xsl:template match="defaultprebuilt" mode="conv66to67">
-    <xsl:apply-templates select="*|processing-instruction()" mode="conv66to67"/>
+    <xsl:apply-templates select="*" mode="conv66to67"/>
 </xsl:template>
 
 <!-- Delete defaultdestination section -->
@@ -80,7 +80,7 @@
     Delete defaultdestination section
 </para>
 <xsl:template match="defaultdestination" mode="conv66to67">
-    <xsl:apply-templates select="*|processing-instruction()" mode="conv66to67"/>
+    <xsl:apply-templates select="*" mode="conv66to67"/>
 </xsl:template>
 
 <!-- Delete defaultroot section -->
@@ -88,7 +88,7 @@
     Delete defaultroot section
 </para>
 <xsl:template match="defaultroot" mode="conv66to67">
-    <xsl:apply-templates select="*|processing-instruction()" mode="conv66to67"/>
+    <xsl:apply-templates select="*" mode="conv66to67"/>
 </xsl:template>
 
 <!-- Delete partitioner section -->
@@ -96,7 +96,7 @@
     Delete partitioner section
 </para>
 <xsl:template match="partitioner" mode="conv66to67">
-    <xsl:apply-templates select="*|processing-instruction()" mode="conv66to67"/>
+    <xsl:apply-templates select="*" mode="conv66to67"/>
 </xsl:template>
 
 <!-- Delete rpm-force section -->
@@ -104,7 +104,7 @@
     Delete rpm-force section
 </para>
 <xsl:template match="rpm-force" mode="conv66to67">
-    <xsl:apply-templates select="*|processing-instruction()" mode="conv66to67"/>
+    <xsl:apply-templates select="*" mode="conv66to67"/>
 </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
I wanted to add a simple vim modeline to my XML description:

<!--
vim: et:sts=2:sw=2
-->

This made kiwi consume insane amounts of memory during the XSLT
transform step. While this may be a bug in my version of lxml, we do not
transform comments on processing instructions in the conversion
templates, so the easiest solution is not to match them.

Signed-off-by: Michal Marek <MichalMarek1@eaton.com>

