### PR TITLE
Allow to choose dracut live module

### DIFF
--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -297,8 +297,14 @@ class LiveImageBuilder(object):
 
     def _create_dracut_live_iso_config(self):
         live_config_file = self.root_dir + '/etc/dracut.conf.d/02-livecd.conf'
+        omit_modules = [
+            'kiwi-dump', 'kiwi-overlay', 'kiwi-repart', 'kiwi-lib'
+        ]
         live_config = [
-            'add_dracutmodules+=" kiwi-live pollcdrom "',
+            'add_dracutmodules+=" {0} pollcdrom "'.format(
+                Defaults.get_live_dracut_module_from_flag(self.live_type)
+            ),
+            'omit_dracutmodules+=" {0} "'.format(' '.join(omit_modules)),
             'hostonly="no"',
             'dracut_rescue_image="no"'
         ]

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -706,6 +706,20 @@ class Defaults(object):
         return 'overlay'
 
     @classmethod
+    def get_live_dracut_module_from_flag(self, flag_name):
+        """
+        Implements flag_name to dracut module name map
+        """
+        live_modules = {
+            'overlay': 'kiwi-live',
+            'dmsquash': 'dmsquash-live'
+        }
+        if flag_name in live_modules:
+            return live_modules[flag_name]
+        else:
+            return 'kiwi-live'
+
+    @classmethod
     def get_default_live_iso_root_filesystem(self):
         """
         Implements default live iso root filesystem type

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1413,11 +1413,15 @@ div {
             sch:param [ name = "types" value = "vmx oem" ]
         ]
     k.type.flags.attribute =
-        ## Specifies overlay filesystem flags for the iso image type
-        ## as they are supported by the kiwi-live dracut module.
-        ## `overlay` uses squashfs and the kernel overlayfs filesystem
+        ## Specifies live iso technology and dracut module to use.
+        ## If set to overlay the kiwi-live dracut module will be
+        ## used to support a live iso system based on squashfs+overlayfs.
+        ## If set to dmsquash the dracut standard dmsquash-live module
+        ## will be used to support a live iso system based on squashfs
+        ## and the device mapper. Please note both modules supports
+        ## a different set of live features.
         attribute flags {
-            "overlay"
+            "overlay" | "dmsquash"
         }
         >> sch:pattern [ id = "flags" is-a = "image_type"
             sch:param [ name = "attr" value = "flags" ]

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2109,10 +2109,17 @@ e.g for the syslinux loader fat is required</a:documentation>
     </define>
     <define name="k.type.flags.attribute">
       <attribute name="flags">
-        <a:documentation>Specifies overlay filesystem flags for the iso image type
-as they are supported by the kiwi-live dracut module.
-`overlay` uses squashfs and the kernel overlayfs filesystem</a:documentation>
-        <value>overlay</value>
+        <a:documentation>Specifies live iso technology and dracut module to use.
+If set to overlay the kiwi-live dracut module will be
+used to support a live iso system based on squashfs+overlayfs.
+If set to dmsquash the dracut standard dmsquash-live module
+will be used to support a live iso system based on squashfs
+and the device mapper. Please note both modules supports
+a different set of live features.</a:documentation>
+        <choice>
+          <value>overlay</value>
+          <value>dmsquash</value>
+        </choice>
       </attribute>
       <sch:pattern id="flags" is-a="image_type">
         <sch:param name="attr" value="flags"/>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2,7 +2,8 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated  by generateDS.py version 2.28a.
+# Generated  by generateDS.py version 2.28.2.
+# Python 3.4.6 (default, Mar 22 2017, 12:26:13) [GCC]
 #
 # Command line options:
 #   ('-f', '')
@@ -15,7 +16,7 @@
 #   kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Command line:
-#   /home/david/workspaces/kiwi/.env3/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
+#   /home/ms/Project/kiwi/.env3/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -2424,7 +2425,7 @@ class size(GeneratedsSuper):
     def set_valueOf_(self, valueOf_): self.valueOf_ = valueOf_
     def hasContent_(self):
         if (
-            1 if type(self.valueOf_) in [int,float] else self.valueOf_
+            (1 if type(self.valueOf_) in [int,float] else self.valueOf_)
         ):
             return True
         else:

--- a/test/unit/builder_live_test.py
+++ b/test/unit/builder_live_test.py
@@ -158,7 +158,7 @@ class TestLiveImageBuilder(object):
 
         mock_open.return_value = self.context_manager_mock
 
-        self.live_image.live_type = 'dmsquash'
+        self.live_image.live_type = 'overlay'
 
         iso_image = mock.Mock()
         iso_image.create_on_file.return_value = 'offset'
@@ -209,6 +209,10 @@ class TestLiveImageBuilder(object):
 
         assert self.file_mock.write.call_args_list == [
             call('add_dracutmodules+=" kiwi-live pollcdrom "\n'),
+            call(
+                'omit_dracutmodules+=" '
+                'kiwi-dump kiwi-overlay kiwi-repart kiwi-lib "\n'
+            ),
             call('hostonly="no"\n'),
             call('dracut_rescue_image="no"\n')
         ]

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -71,3 +71,11 @@ class TestDefaults(object):
         Defaults.set_python_default_encoding_to_utf8()
         mock_reload.assert_called_once_with(mock_sys)
         mock_sys.setdefaultencoding.assert_called_once_with('utf-8')
+
+    def test_get_live_dracut_module_from_flag(self):
+        assert Defaults.get_live_dracut_module_from_flag('foo') == \
+            'kiwi-live'
+        assert Defaults.get_live_dracut_module_from_flag('overlay') == \
+            'kiwi-live'
+        assert Defaults.get_live_dracut_module_from_flag('dmsquash') == \
+            'dmsquash-live'


### PR DESCRIPTION
There is the standard dracut dmsquash-live module based on
the device mapper technology and the kiwi-live module based
on the overlayfs technology. The setup of the live iso structure
in kiwi is compatible to both modules. Thus it makes sense
to allow to choose the technology via the flags attribute

    <type image="iso" ... flags="overlay|dmsquash"/>

Please note both modules supports a different set of live
features. This Fixes #568

