### PR TITLE
Omit kiwi-repart dracut module in oemboot initrd

### DIFF
--- a/kiwi/boot/functions.sh
+++ b/kiwi/boot/functions.sh
@@ -1418,7 +1418,7 @@ function setupInitrd {
         # Call initrd creation tool
         #--------------------------------------
         if [ -x "$dracutExec" ]; then
-            params=" --force"
+            params=" --force -o kiwi-repart"
             Echo "Creating dracut based initrd"
             if ! $dracutExec $params;then
                 Echo "Can't create initrd with dracut"


### PR DESCRIPTION
KIWI's oemboot initrd with `initrd_system="dracut"` together with
`installiso="true"` requires to have dracut-kiwi-oem-repart package
installed in the system, thus it ends up also being included in the
recreated dracut initrd after booting the oemboot initrd from the
installation iso. This kiwi-repart module causes a boot failure in that
case since no `.profile` file is present, moreover, it has no sense to
run it at that stage, since the disk is already reparted by the
oemboot code.

This commit allows `installiso="true"` and `initrd_system="dracut"` to
play well together.
