### PR TITLE
[boot] fix double quote in grub menu which makes kernel updates for C…

### DIFF
--- a/kiwi/bootloader/template/grub2.py
+++ b/kiwi/bootloader/template/grub2.py
@@ -34,7 +34,7 @@ class BootLoaderTemplateGrub2(object):
             set timeout=${boot_timeout}
             if [ -n "$$extra_cmdline" ]; then
               submenu "Bootable snapshot $$snapshot_num" {
-                menuentry "If OK, run 'snapper rollback' and reboot." { true; }
+                menuentry "If OK, run snapper rollback and reboot." { true; }
               }
             fi
         ''').strip() + os.linesep


### PR DESCRIPTION
Fixes #496 .

Changes proposed in this pull request:
* It seems the double quote in grub.cfg from kiwi breaks on kernel update on CentOS / RHEL / Fedora
* so removed double quote, then system still boots after kernel update
