### PR TITLE
Extend CommandCapabilities to also check version

### DIFF
--- a/kiwi/archive/tar.py
+++ b/kiwi/archive/tar.py
@@ -19,8 +19,8 @@ import os
 
 # project
 from kiwi.command import Command
-from kiwi.exceptions import KiwiArchiveTarError
 from kiwi.defaults import Defaults
+from kiwi.utils.command_capabilities import CommandCapabilities
 
 
 class ArchiveTar(object):
@@ -49,7 +49,7 @@ class ArchiveTar(object):
         self.create_from_file_list = create_from_file_list
         self.file_list = file_list
 
-        if self._does_tar_command_support_xattrs():
+        if CommandCapabilities.check_version('tar', (1, 27)):
             self.xattrs_options = [
                 '--xattrs', '--xattrs-include=*'
             ]
@@ -173,15 +173,3 @@ class ArchiveTar(object):
             archive_items.append('--exclude')
             archive_items.append('./' + exclude)
         return archive_items
-
-    def _does_tar_command_support_xattrs(self):
-        command = Command.run(['tar', '--version'])
-
-        try:
-            version_line = command.output.splitlines()[0]
-            version_string = version_line.split()[-1]
-            version_info = tuple(int(elt) for elt in version_string.split('.'))
-        except Exception:
-            raise KiwiArchiveTarError(
-                "Unable to parse tar version string")
-        return version_info >= (1, 27)

--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -773,3 +773,10 @@ class KiwiSizeError(KiwiError):
     Exception is raised when the convertion from a given size in string
     format to a number.
     """
+
+
+class KiwiCommandCapabilitiesError(KiwiError):
+    """
+    Exception is raised when some the CommandCapabilities methods fails,
+    usually meaning there is some issue trying to parse some command output.
+    """

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -227,7 +227,8 @@ class SystemSetup(object):
                 'Setting up keytable: %s', self.preferences['keytable']
             )
             if CommandCapabilities.has_option_in_help(
-                'systemd-firstboot', '--keymap', root=self.root_dir
+                'systemd-firstboot', '--keymap',
+                root=self.root_dir, raise_on_error=False
             ):
                 Path.wipe(self.root_dir + '/etc/vconsole.conf')
                 Command.run([
@@ -260,7 +261,8 @@ class SystemSetup(object):
                 )
             log.info('Setting up locale: %s', self.preferences['locale'])
             if CommandCapabilities.has_option_in_help(
-                'systemd-firstboot', '--locale', root=self.root_dir
+                'systemd-firstboot', '--locale',
+                root=self.root_dir, raise_on_error=False
             ):
                 Path.wipe(self.root_dir + '/etc/locale.conf')
                 Command.run([
@@ -289,7 +291,8 @@ class SystemSetup(object):
                 'Setting up timezone: %s', self.preferences['timezone']
             )
             if CommandCapabilities.has_option_in_help(
-                'systemd-firstboot', '--timezone', root=self.root_dir
+                'systemd-firstboot', '--timezone',
+                root=self.root_dir, raise_on_error=False
             ):
                 Path.wipe(self.root_dir + '/etc/localtime')
                 Command.run([

--- a/kiwi/utils/command_capabilities.py
+++ b/kiwi/utils/command_capabilities.py
@@ -15,10 +15,12 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+import re
 
 # project
 from kiwi.command import Command
 from kiwi.logger import log
+from kiwi.exceptions import KiwiCommandCapabilitiesError
 
 
 class CommandCapabilities(object):
@@ -29,7 +31,8 @@ class CommandCapabilities(object):
     """
     @classmethod
     def has_option_in_help(
-        self, call, flag, help_flags=['--help'], root=None
+        self, call, flag, help_flags=['--help'],
+        root=None, raise_on_error=True
     ):
         """
         Checks if the given flag is present in the help output
@@ -53,5 +56,50 @@ class CommandCapabilities(object):
                 if flag in line:
                     return True
         except Exception:
-            log.warning('Could not parse {0} output'.format(call))
+            message = 'Could not parse {} output'.format(call)
+            if raise_on_error:
+                raise KiwiCommandCapabilitiesError(message)
+            log.warning(message)
         return False
+
+    @classmethod
+    def check_version(
+        self, call, version_waterline, version_flags=['--version'],
+        root=None, raise_on_error=True
+    ):
+        """
+        Checks if the given command version is equal or higher than
+        the given version tuple.
+
+        :param string call: the command the check
+        :param tuple version_waterline: minimum desired version of the command
+        :param list version_flags: a list with the required command arguments.
+        :param string root: root directory of the env to validate
+
+        :return: True if the current command version is equal or higher to
+        version_waterline
+        :rtype: boolean
+        """
+        if root:
+            arguments = ['chroot', root, call] + version_flags
+        else:
+            arguments = [call] + version_flags
+        version_info = None
+        try:
+            command = Command.run(arguments)
+            for line in command.output.splitlines():
+                match = re.search('[0-9]+(\.[0-9]+)*', line)
+                if match:
+                    version_info = tuple(
+                        int(elt) for elt in match.group(0).split('.')
+                    )
+                    break
+            if version_info is None:
+                raise Exception
+        except Exception:
+            message = 'Could not parse {0} version'.format(call)
+            if raise_on_error:
+                raise KiwiCommandCapabilitiesError(message)
+            log.warning(message)
+            return False
+        return version_info >= version_waterline

--- a/test/unit/archive_tar_test.py
+++ b/test/unit/archive_tar_test.py
@@ -6,7 +6,7 @@ from .test_helper import raises
 
 from kiwi.archive.tar import ArchiveTar
 
-from kiwi.exceptions import KiwiArchiveTarError
+from kiwi.exceptions import KiwiCommandCapabilitiesError
 
 
 class TestArchiveTar(object):
@@ -17,7 +17,7 @@ class TestArchiveTar(object):
         mock_command.return_value = command
         self.archive = ArchiveTar('foo.tar')
 
-    @raises(KiwiArchiveTarError)
+    @raises(KiwiCommandCapabilitiesError)
     @patch('kiwi.archive.tar.Command.run')
     def test_invalid_tar_command_version(self, mock_command):
         command = mock.Mock()

--- a/test/unit/utils_command_capabilities_test.py
+++ b/test/unit/utils_command_capabilities_test.py
@@ -2,7 +2,10 @@ from mock import patch
 from mock import call
 from collections import namedtuple
 
+from .test_helper import raises
+
 from kiwi.utils.command_capabilities import CommandCapabilities
+from kiwi.exceptions import KiwiCommandCapabilitiesError
 
 
 class TestCommandCapabilities(object):
@@ -32,7 +35,21 @@ class TestCommandCapabilities(object):
 
     @patch('kiwi.command.Command.run')
     @patch('kiwi.logger.log.warning')
-    def test_has_option_in_help_command_failure(self, mock_warn, mock_run):
+    def test_has_option_in_help_command_failure_warning(
+        self, mock_warn, mock_run
+    ):
+        def side_effect():
+            raise Exception("Something went wrong")
+
+        mock_run.side_effect = side_effect
+        CommandCapabilities.has_option_in_help(
+            'command_that_fails', '--non-existing-flag', raise_on_error=False
+        )
+        assert mock_warn.called
+
+    @patch('kiwi.command.Command.run')
+    @raises(KiwiCommandCapabilitiesError)
+    def test_has_option_in_help_command_failure_exception(self, mock_run):
         def side_effect():
             raise Exception("Something went wrong")
 
@@ -40,4 +57,58 @@ class TestCommandCapabilities(object):
         CommandCapabilities.has_option_in_help(
             'command_that_fails', '--non-existing-flag'
         )
+
+    @patch('kiwi.command.Command.run')
+    def test_check_version(self, mock_run):
+        command_type = namedtuple('command', ['output'])
+        mock_run.return_value = command_type(
+            output="Dummy line\ncommand v1.2.3\n"
+        )
+        assert CommandCapabilities.check_version('command', (1, 2, 3))
+        assert CommandCapabilities.check_version('command', (1, 1, 3))
+        assert not CommandCapabilities.check_version('command', (1, 3))
+        assert CommandCapabilities.check_version(
+            'command', (1, 2, 3), version_flags=['-v']
+        )
+        assert CommandCapabilities.check_version(
+            'command', (1, 2, 3), version_flags=['-v'], root='root_dir'
+        )
+        mock_run.assert_has_calls([
+            call(['command', '--version']),
+            call(['command', '--version']),
+            call(['command', '--version']),
+            call(['command', '-v']),
+            call(['chroot', 'root_dir', 'command', '-v'])
+        ])
+
+    @patch('kiwi.command.Command.run')
+    @raises(KiwiCommandCapabilitiesError)
+    def test_check_version_no_match(self, mock_run):
+        command_type = namedtuple('command', ['output'])
+        mock_run.return_value = command_type(
+            output="Dummy line\ncommand someother stuff\n"
+        )
+        CommandCapabilities.check_version('command', (1, 2, 3))
+
+    @patch('kiwi.command.Command.run')
+    @patch('kiwi.logger.log.warning')
+    def test_check_version_failure_warning(self, mock_warn, mock_run):
+        def side_effect():
+            raise Exception("Something went wrong")
+
+        mock_run.side_effect = side_effect
+        CommandCapabilities.check_version(
+            'command_that_fails', (1, 2), raise_on_error=False
+        )
         assert mock_warn.called
+
+    @patch('kiwi.command.Command.run')
+    @raises(KiwiCommandCapabilitiesError)
+    def test_check_version_failure_exception(self, mock_run):
+        def side_effect():
+            raise Exception("Something went wrong")
+
+        mock_run.side_effect = side_effect
+        CommandCapabilities.check_version(
+            'command_that_fails', '--non-existing-flag'
+        )


### PR DESCRIPTION
Changes proposed in this pull request:
* CommandCapabilities.check_version method has been included into CommandCapabilities and used to verify the tar command version.
* Also a raise_on_error option has been included into CommandCapabilities.has_option_in_help.

