### PR TITLE
Add support for building OVA images

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -507,7 +507,7 @@ class Defaults(object):
         :rtype: list
         """
         return [
-            'gce', 'qcow2', 'vmdk', 'vmx', 'vhd', 'vhdx',
+            'gce', 'qcow2', 'vmdk', 'ova', 'vmx', 'vhd', 'vhdx',
             'vhdfixed', 'vdi', 'vagrant.libvirt.box'
         ]
 

--- a/kiwi/storage/subformat/__init__.py
+++ b/kiwi/storage/subformat/__init__.py
@@ -21,6 +21,7 @@ from kiwi.storage.subformat.vhd import DiskFormatVhd
 from kiwi.storage.subformat.vhdx import DiskFormatVhdx
 from kiwi.storage.subformat.vhdfixed import DiskFormatVhdFixed
 from kiwi.storage.subformat.vmdk import DiskFormatVmdk
+from kiwi.storage.subformat.ova import DiskFormatOva
 from kiwi.storage.subformat.gce import DiskFormatGce
 from kiwi.storage.subformat.vdi import DiskFormatVdi
 from kiwi.storage.subformat.base import DiskFormatBase
@@ -85,7 +86,7 @@ class DiskFormat(object):
             return DiskFormatGce(
                 xml_state, root_dir, target_dir, custom_args
             )
-        elif name == 'vmdk':
+        elif name == 'vmdk' or name == 'ova' or name == 'ovf':
             vmdisk_section = xml_state.get_build_type_vmdisk_section()
             if vmdisk_section:
                 disk_mode = vmdisk_section.get_diskmode()
@@ -98,9 +99,14 @@ class DiskFormat(object):
                     custom_args.update(
                         {'adapter_type={0}'.format(disk_controller): None}
                     )
-            return DiskFormatVmdk(
-                xml_state, root_dir, target_dir, custom_args
-            )
+            if name == 'vmdk':
+                return DiskFormatVmdk(
+                    xml_state, root_dir, target_dir, custom_args
+                )
+            else:
+                return DiskFormatOva(
+                    xml_state, root_dir, target_dir, custom_args
+                )
         elif name == 'vagrant':
             vagrant_config = xml_state.get_build_type_vagrant_config_section()
             if vagrant_config:

--- a/kiwi/storage/subformat/ova.py
+++ b/kiwi/storage/subformat/ova.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2018 Eaton.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+import os
+import stat
+import re
+
+# project
+from kiwi.storage.subformat.vmdk import DiskFormatVmdk
+from kiwi.command import Command
+from kiwi.exceptions import (
+    KiwiFormatSetupError
+)
+
+
+class DiskFormatOva(DiskFormatVmdk):
+    """
+    Create ova disk format, based on vmdk
+    """
+    def post_init(self, custom_args):
+        """
+        vmdk disk format post initialization method
+
+        Store qemu options as list from custom args dict
+
+        Attributes
+
+        * :attr:`options`
+            qemu format conversion options
+
+        * :attr:`image_format`
+            disk format name: ova
+        """
+        ovftype = self.xml_state.get_build_type_machine_section().get_ovftype()
+        if ovftype is not None and ovftype != 'vmware':
+            raise KiwiFormatSetupError('Unsupported ovftype %s' % ovftype)
+        self.image_format = 'ova'
+        self.options = self.get_qemu_option_list(custom_args)
+
+    def create_image_format(self):
+        # Creates the vmdk disk image and vmx config
+        super(DiskFormatOva, self).create_image_format()
+        # Converts to ova using ovftool
+        vmx = self.get_target_name_for_format('vmx')
+        ova = self.get_target_name_for_format('ova')
+        try:
+            os.unlink(ova)
+        except OSError:
+            pass
+        ovftool_cmd = ['ovftool']
+        ovftool_help = Command.run(['ovftool', '--help'])
+        if re.search(r'--shaAlgorithm\b', ovftool_help.output):
+            ovftool_cmd.append('--shaAlgorithm=SHA1')
+        ovftool_cmd.extend([vmx, ova])
+        Command.run(ovftool_cmd)
+        # ovftool ignores the umask and creates files with 0600 for some reason
+        st = os.stat(vmx)
+        os.chmod(ova, stat.S_IMODE(st.st_mode))
+
+    def store_to_result(self, result):
+        """
+        Store the resulting ova file into the provided result instance.
+
+        :param object result: Instance of Result
+        """
+        result.add(
+            key='disk_format_image',
+            filename=self.get_target_name_for_format('ova'),
+            use_for_bundle=True,
+            compress=False,
+            shasum=True
+        )

--- a/kiwi/storage/subformat/vmdk.py
+++ b/kiwi/storage/subformat/vmdk.py
@@ -65,9 +65,9 @@ class DiskFormatVmdk(DiskFormatBase):
         Command.run(
             [
                 'qemu-img', 'convert', '-f', 'raw', self.diskname,
-                '-O', self.image_format
+                '-O', 'vmdk'
             ] + self.options + [
-                self.get_target_name_for_format(self.image_format)
+                self.get_target_name_for_format('vmdk')
             ]
         )
         self._update_vmdk_descriptor()
@@ -83,18 +83,14 @@ class DiskFormatVmdk(DiskFormatBase):
         """
         result.add(
             key='disk_format_image',
-            filename=self.get_target_name_for_format(
-                self.image_format
-            ),
+            filename=self.get_target_name_for_format('vmdk'),
             use_for_bundle=True,
             compress=False,
             shasum=True
         )
         result.add(
             key='disk_format_machine_settings',
-            filename=self.get_target_name_for_format(
-                'vmx'
-            ),
+            filename=self.get_target_name_for_format('vmx'),
             use_for_bundle=True,
             compress=False,
             shasum=False
@@ -111,7 +107,7 @@ class DiskFormatVmdk(DiskFormatBase):
                 self.xml_state.xml_data.get_displayname() or
                 self.xml_state.xml_data.get_name(),
             'vmdk_file':
-                self.get_target_name_for_format(self.image_format),
+                self.get_target_name_for_format('vmdk'),
             'virtual_hardware_version': '9',
             'guest_os': 'suse-64',
             'disk_id': '0'

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ exclude=xml_parse.py
 # we allow long lines
 ignore = E501
 # we allow a custom complexity level
-max-complexity = 17
+max-complexity = 18
 
 [doc8]
 max-line-length = 90

--- a/test/unit/storage_subformat_ova_test.py
+++ b/test/unit/storage_subformat_ova_test.py
@@ -1,0 +1,119 @@
+from mock import patch
+from mock import call
+import mock
+
+from .test_helper import raises, patch_open
+
+from kiwi.exceptions import (
+    KiwiFormatSetupError
+)
+
+from kiwi.storage.subformat.ova import DiskFormatOva
+
+
+class TestDiskFormatOva(object):
+    @patch('platform.machine')
+    def setup(self, mock_machine):
+        self.context_manager_mock = mock.Mock()
+        self.file_mock = mock.Mock()
+        self.enter_mock = mock.Mock()
+        self.exit_mock = mock.Mock()
+        self.enter_mock.return_value = self.file_mock
+        setattr(self.context_manager_mock, '__enter__', self.enter_mock)
+        setattr(self.context_manager_mock, '__exit__', self.exit_mock)
+        mock_machine.return_value = 'x86_64'
+        xml_data = mock.Mock()
+        xml_data.get_name = mock.Mock(
+            return_value='some-disk-image'
+        )
+        xml_data.get_displayname = mock.Mock(
+            return_value=None
+        )
+        self.xml_state = mock.Mock()
+        self.xml_state.xml_data = xml_data
+        self.xml_state.get_image_version = mock.Mock(
+            return_value='1.2.3'
+        )
+
+        self.machine_setup = mock.Mock()
+        self.xml_state.get_build_type_machine_section = mock.Mock(
+            return_value=self.machine_setup
+        )
+        self.machine_setup.get_HWversion = mock.Mock(
+            return_value='42'
+        )
+        self.machine_setup.get_guestOS = mock.Mock(
+            return_value='suse'
+        )
+        self.machine_setup.get_memory = mock.Mock(
+            return_value='4096'
+        )
+        self.machine_setup.get_ncpus = mock.Mock(
+            return_value='2'
+        )
+
+        self.machine_setup.get_ovftype = mock.Mock(
+            return_value='vmware'
+        )
+
+        self.disk_format = DiskFormatOva(
+            self.xml_state, 'root_dir', 'target_dir'
+        )
+
+    def test_post_init(self):
+        self.disk_format.post_init({})
+
+    @raises(KiwiFormatSetupError)
+    def test_post_init_bad_ovftype(self):
+        self.machine_setup.get_ovftype.return_value = 'foobar'
+        self.disk_format.post_init({})
+
+    def test_store_to_result(self):
+        result = mock.Mock()
+        self.disk_format.store_to_result(result)
+        assert result.add.call_args_list == [
+            call(
+                compress=False,
+                filename='target_dir/some-disk-image.x86_64-1.2.3.ova',
+                key='disk_format_image',
+                shasum=True,
+                use_for_bundle=True
+            )
+        ]
+
+    @patch('kiwi.storage.subformat.ova.Command.run')
+    @patch('os.stat')
+    @patch('os.chmod')
+    @patch_open
+    def test_create_image_format(
+        self, mock_open, mock_chmod, mock_stat, mock_command
+    ):
+        qemu_img_result = mock.Mock()
+        vmtoolsd_result = mock.Mock()
+        vmtoolsd_result.output = \
+            'VMware Tools daemon, version 9.4.6.33107 (build-0815)'
+        dd_result = mock.Mock()
+        dd_result.output = 'dd-out\0\0\0\0\0'
+        ovftool_help_result = mock.Mock()
+        ovftool_help_result.output = """This is a new ovftool
+                it knows options such as --shaAlgorithm and others
+                enjoy"""
+        ovftool_result = mock.Mock()
+
+        command_results = [
+            ovftool_result, ovftool_help_result, dd_result, vmtoolsd_result, qemu_img_result
+        ]
+
+        def side_effect(arg):
+            return command_results.pop()
+
+        mock_command.side_effect = side_effect
+        mock_open.return_value = self.context_manager_mock
+        mock_stat.return_value = mock.Mock(st_mode=0o644)
+        self.disk_format.create_image_format()
+        assert mock_command.call_args_list[-1] == call([
+            'ovftool',
+            '--shaAlgorithm=SHA1',
+            'target_dir/some-disk-image.x86_64-1.2.3.vmx',
+            'target_dir/some-disk-image.x86_64-1.2.3.ova'
+        ])

--- a/test/unit/storage_subformat_test.py
+++ b/test/unit/storage_subformat_test.py
@@ -94,6 +94,24 @@ class TestDiskFormat(object):
             {'adapter_type=controller': None, 'subformat=disk-mode': None}
         )
 
+    @patch('kiwi.storage.subformat.DiskFormatOva')
+    def test_disk_format_ova(self, mock_ova):
+        vmdisk = mock.Mock()
+        vmdisk.get_controller = mock.Mock(
+            return_value='controller'
+        )
+        vmdisk.get_diskmode = mock.Mock(
+            return_value='disk-mode'
+        )
+        self.xml_state.get_build_type_vmdisk_section = mock.Mock(
+            return_value=vmdisk
+        )
+        DiskFormat('ova', self.xml_state, 'root_dir', 'target_dir')
+        mock_ova.assert_called_once_with(
+            self.xml_state, 'root_dir', 'target_dir',
+            {'adapter_type=controller': None, 'subformat=disk-mode': None}
+        )
+
     @patch('kiwi.storage.subformat.DiskFormatVagrantLibVirt')
     def test_disk_format_vagrant_libvirt(self, mock_vagrant):
         vagrant_config = mock.Mock()


### PR DESCRIPTION
Implement support for format="ova" using VMware's ovftool. We use the
vmdk format as a basis and then just call ovftool to convert *.vmdk +
*.vmx to an OVA.