### PR TITLE
Added runtime check for dracut-kiwi-oem-dump

### DIFF
--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -261,6 +261,42 @@ class RuntimeChecker(object):
                     )
                 )
 
+    def check_dracut_module_for_oem_install_in_package_list(self):
+        """
+        OEM images if configured to use dracut as initrd system
+        and configured with one of the installiso, installstick
+        or installpxe attributes requires the KIWI provided
+        dracut-kiwi-oem-dump module to be installed at the time
+        dracut is called. Thus this runtime check examines if the
+        required package is part of the package list in the
+        image description.
+        """
+        message = dedent('''\n
+            Required dracut module package missing in package list
+
+            The package '{0}' is required to build an installation
+            image for the selected oem image type. Please add the
+            following in your <packages type="image"> section to
+            your system XML description:
+
+            <package name="{0}"/>
+        ''')
+        required_dracut_package = 'dracut-kiwi-oem-dump'
+        initrd_system = self.xml_state.get_initrd_system()
+        build_type = self.xml_state.get_build_type_name()
+        if build_type == 'oem' and initrd_system == 'dracut':
+            install_iso = self.xml_state.build_type.get_installiso()
+            install_stick = self.xml_state.build_type.get_installstick()
+            install_pxe = self.xml_state.build_type.get_installpxe()
+            if install_iso or install_stick or install_pxe:
+                package_names = \
+                    self.xml_state.get_bootstrap_packages() + \
+                    self.xml_state.get_system_packages()
+                if required_dracut_package not in package_names:
+                    raise KiwiRuntimeError(
+                        message.format(required_dracut_package)
+                    )
+
     def check_dracut_module_for_disk_oem_in_package_list(self):
         """
         OEM images if configured to use dracut as initrd system

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -145,6 +145,7 @@ class SystemBuildTask(CliTask):
         self.runtime_checker.check_dracut_module_for_live_iso_in_package_list()
         self.runtime_checker.check_dracut_module_for_disk_overlay_in_package_list()
         self.runtime_checker.check_dracut_module_for_disk_oem_in_package_list()
+        self.runtime_checker.check_dracut_module_for_oem_install_in_package_list()
 
         if self.command_args['--ignore-repos']:
             self.xml_state.delete_repository_sections()

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -131,6 +131,7 @@ class SystemPrepareTask(CliTask):
         self.runtime_checker.check_dracut_module_for_live_iso_in_package_list()
         self.runtime_checker.check_dracut_module_for_disk_overlay_in_package_list()
         self.runtime_checker.check_dracut_module_for_disk_oem_in_package_list()
+        self.runtime_checker.check_dracut_module_for_oem_install_in_package_list()
 
         if self.command_args['--ignore-repos']:
             self.xml_state.delete_repository_sections()

--- a/test/data/example_runtime_checker_config.xml
+++ b/test/data/example_runtime_checker_config.xml
@@ -72,7 +72,7 @@
                 <vmnic driver="e1000" interface="0" mode="bridged"/>
             </machine>
         </type>
-        <type bootloader="grub2" image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="my_edit_boot_install" filesystem="ext4" initrd_system="dracut">
+        <type bootloader="grub2" image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="my_edit_boot_install" filesystem="ext4" initrd_system="dracut" installiso="true">
             <size unit="G" additive="true">1</size>
             <systemdisk name="mydisk">
                 <volume name="root" size="6G" mountpoint="/"/>

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -195,3 +195,11 @@ class TestRuntimeChecker(object):
         )
         runtime_checker = RuntimeChecker(xml_state)
         runtime_checker.check_dracut_module_for_disk_oem_in_package_list()
+
+    @raises(KiwiRuntimeError)
+    def test_check_dracut_module_for_oem_install_in_package_list(self):
+        xml_state = XMLState(
+            self.description.load(), ['vmxFlavour'], 'oem'
+        )
+        runtime_checker = RuntimeChecker(xml_state)
+        runtime_checker.check_dracut_module_for_oem_install_in_package_list()

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -104,6 +104,7 @@ class TestSystemBuildTask(object):
         self.runtime_checker.check_repositories_configured.assert_called_once_with()
         self.runtime_checker.check_dracut_module_for_disk_overlay_in_package_list.assert_called_once_with()
         self.runtime_checker.check_dracut_module_for_disk_oem_in_package_list.assert_called_once_with()
+        self.runtime_checker.check_dracut_module_for_oem_install_in_package_list.assert_called_once_with()
         self.runtime_checker.check_efi_mode_for_disk_overlay_correctly_setup.assert_called_once_with()
         self.system_prepare.setup_repositories.assert_called_once_with(False, None)
         self.system_prepare.install_bootstrap.assert_called_once_with(

--- a/test/unit/tasks_system_prepare_test.py
+++ b/test/unit/tasks_system_prepare_test.py
@@ -96,6 +96,7 @@ class TestSystemPrepareTask(object):
         self.runtime_checker.check_repositories_configured.assert_called_once_with()
         self.runtime_checker.check_dracut_module_for_disk_overlay_in_package_list.assert_called_once_with()
         self.runtime_checker.check_dracut_module_for_disk_oem_in_package_list.assert_called_once_with()
+        self.runtime_checker.check_dracut_module_for_oem_install_in_package_list.assert_called_once_with()
         self.runtime_checker.check_efi_mode_for_disk_overlay_correctly_setup.assert_called_once_with()
         self.system_prepare.setup_repositories.assert_called_once_with(True, None)
         self.system_prepare.install_bootstrap.assert_called_once_with(


### PR DESCRIPTION
The installation of the above mentioned dracut module package
is required for oem images which uses dracut as initrd system
and have the creation of an installation image requested.
This is related to Issue #576


