### PR TITLE
Adding iso-scan feature to kiwi-live dracut module

### DIFF
--- a/dracut/modules.d/90kiwi-live/module-setup.sh
+++ b/dracut/modules.d/90kiwi-live/module-setup.sh
@@ -23,10 +23,21 @@ installkernel() {
 install() {
     declare moddir=${moddir}
     declare systemdutildir=${systemdutildir}
+    declare dracutbasedir=${dracutbasedir}
+    local dmsquashdir=
     inst_multiple \
         umount dmsetup blockdev blkid lsblk dd losetup \
         isoinfo grep cut partprobe find wc fdisk tail mkfs.ext4 mkfs.xfs \
         checkmedia dialog
+
+    dmsquashdir=$(find "${dracutbasedir}/modules.d" -name "*dmsquash-live")
+    if [ -n "${dmsquashdir}" ] && \
+        [ -f "${dmsquashdir}/parse-iso-scan.sh" ] && \
+        [ -f "${dmsquashdir}/iso-scan.sh" ]; then
+        inst_hook cmdline 31 "${dmsquashdir}/parse-iso-scan.sh"
+        inst_script "${dmsquashdir}/iso-scan.sh" "/sbin/iso-scan"
+    fi
+
     inst_hook cmdline 30 "${moddir}/parse-kiwi-live.sh"
     inst_hook pre-udev 30 "${moddir}/kiwi-live-genrules.sh"
     inst_hook pre-mount 30 "${moddir}/kiwi-live-checkmedia.sh"


### PR DESCRIPTION
This commit adds the iso-scan scripts to kiwi-live module_setup
if the former files are found in the system inside the dmsquash-live
dracut module directory.

Fixes #574 and is related to #521
