### PR TITLE
Fix initrd names

### DIFF
--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -122,6 +122,9 @@ class BootImageBase(object):
     def enable_cleanup(self):
         self.call_destructor = True
 
+    def get_boot_names(self):
+        raise NotImplementedError
+
     def prepare(self):
         """
         Prepare new root system to create initrd from. Implementation

--- a/kiwi/boot/image/builtin_kiwi.py
+++ b/kiwi/boot/image/builtin_kiwi.py
@@ -17,6 +17,7 @@
 #
 import os
 from tempfile import mkdtemp
+from collections import namedtuple
 
 from kiwi.defaults import Defaults
 from kiwi.utils.sync import DataSync
@@ -176,3 +177,12 @@ class BootImageKiwi(BootImageBase):
                 ['--check=crc32', '--lzma2=dict=1MiB', '--threads=0']
             )
             self.initrd_filename = compress.compressed_filename
+
+    def get_boot_names(self):
+        boot_names_type = namedtuple(
+            'boot_names_type', ['kernel_name', 'initrd_name']
+        )
+        return boot_names_type(
+            kernel_name='linux.vmx',
+            initrd_name='initrd.vmx'
+        )

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -283,7 +283,10 @@ class InstallImageBuilder(object):
 
         # the kexec required system image initrd is stored for dracut kiwi-dump
         if self.initrd_system == 'dracut':
-            system_image_initrd = self.root_dir + '/boot/initrd'
+            boot_names = self.boot_image_task.get_boot_names()
+            system_image_initrd = os.sep.join(
+                [self.root_dir, 'boot', boot_names.initrd_name]
+            )
             target_initrd_name = '{0}/{1}.initrd'.format(
                 self.pxe_dir, self.xml_state.xml_data.get_name()
             )
@@ -404,7 +407,10 @@ class InstallImageBuilder(object):
         )
 
     def _copy_system_image_initrd_to_iso_image(self):
-        system_image_initrd = self.root_dir + '/boot/initrd'
+        boot_names = self.boot_image_task.get_boot_names()
+        system_image_initrd = os.sep.join(
+            [self.root_dir, 'boot', boot_names.initrd_name]
+        )
         shutil.copy(
             system_image_initrd, self.media_dir + '/initrd.system_image'
         )

--- a/test/unit/boot_image_base_test.py
+++ b/test/unit/boot_image_base_test.py
@@ -114,3 +114,7 @@ class TestBootImageBase(object):
     def test_load_boot_xml_description(self, mock_boot_dir):
         mock_boot_dir.return_value = None
         self.boot_image.load_boot_xml_description()
+
+    @raises(NotImplementedError)
+    def test_get_boot_names(self):
+        self.boot_image.get_boot_names()

--- a/test/unit/boot_image_builtin_kiwi_test.py
+++ b/test/unit/boot_image_builtin_kiwi_test.py
@@ -2,6 +2,7 @@ import mock
 
 from mock import patch
 from mock import call
+from collections import namedtuple
 
 import kiwi
 
@@ -154,3 +155,11 @@ class TestBootImageKiwi(object):
         mock_path.return_value = True
         self.boot_image.__del__()
         mock_wipe.assert_called_once_with('boot-root-directory')
+
+    def test_boot_names(self):
+        boot_names_type = namedtuple(
+            'boot_names_type', ['kernel_name', 'initrd_name']
+        )
+        assert self.boot_image.get_boot_names() == boot_names_type(
+            kernel_name='linux.vmx', initrd_name='initrd.vmx'
+        )


### PR DESCRIPTION
Provide a get_boot_names method in boot classes
    
The naming schema for an initrd file name depends on the boot image type as well as on the underlaying initrd creation toolkit. In order to encapsulate that in a clear  interface the code to know about the correct names has  been moved into the classes which are responsible for  it and out of the builder/disk class

Fixed installation image builder
    
Use get_boot_names from BootImage instance to ask for the name of the initrd instead of constructing this information from static values.
