### PR TITLE
- Image name generation for GCE images

### DIFF
--- a/kiwi/storage/subformat/gce.py
+++ b/kiwi/storage/subformat/gce.py
@@ -106,7 +106,7 @@ class DiskFormatGce(DiskFormatBase):
             format_name = 'tar.gz'
         return ''.join(
             [
-                self.xml_state.get_distribution_name_from_boot_attribute(),
+                self.xml_state.xml_data.get_name(),
                 '-guest-gce-',
                 self.xml_state.get_image_version(),
                 '.' + format_name

--- a/test/unit/storage_subformat_gce_test.py
+++ b/test/unit/storage_subformat_gce_test.py
@@ -15,9 +15,6 @@ class TestDiskFormatGce(object):
         )
         self.xml_state = mock.Mock()
         self.xml_state.xml_data = xml_data
-        self.xml_state.get_distribution_name_from_boot_attribute = mock.Mock(
-            return_value='distribution'
-        )
         self.xml_state.get_image_version = mock.Mock(
             return_value='0.8.15'
         )
@@ -64,11 +61,11 @@ class TestDiskFormatGce(object):
             call('{"licenses": ["gce-license"]}')
         ]
         mock_archive.assert_called_once_with(
-            filename='target_dir/distribution-guest-gce-0.8.15.tar',
+            filename='target_dir/some-disk-image-guest-gce-0.8.15.tar',
             file_list=['manifest.json', 'disk.raw']
         )
         archive.create_gnu_gzip_compressed.assert_called_once_with(
             'tmpdir'
         )
         assert self.disk_format.get_target_name_for_format('gce') == \
-            'distribution-guest-gce-0.8.15.tar.gz'
+            'some-disk-image-guest-gce-0.8.15.tar.gz'


### PR DESCRIPTION
  + Fix the name generation for GCE images. The implementation assumed that
    GCE images are of a type that use a kiwi generated initrd, looking for
    image name components based on the boot attribute in the type element.
    This assumption is not correct, use the name provided in the XML to
    compose the image name.


