### PR TITLE
Fixed kernel version check for zImage

### DIFF
--- a/kiwi/system/kernel.py
+++ b/kiwi/system/kernel.py
@@ -53,8 +53,21 @@ class Kernel(object):
         for kernel_name in self.kernel_names:
             kernel_file = self.root_dir + '/boot/' + kernel_name
             if os.path.exists(kernel_file):
+                kernel_file_to_check = kernel_file
+                if 'zImage' in kernel_file_to_check:
+                    # kernels build as zImage contains the decompressor code
+                    # as part of the kernel image and could be therefore
+                    # compressed by any possible compression algorithm.
+                    # In this case we assume/hope that there is also a
+                    # standard gz compressed vmlinux version of the kernel
+                    # available and check this one instead of the zImage
+                    # variant
+                    kernel_file_to_check = kernel_file_to_check.replace(
+                        'zImage', 'vmlinux'
+                    ) + '.gz'
                 version = Command.run(
-                    command=['kversion', kernel_file], raise_on_error=False
+                    command=['kversion', kernel_file_to_check],
+                    raise_on_error=False
                 ).output
                 if not version:
                     version = 'no-version-found'

--- a/test/unit/system_kernel_test.py
+++ b/test/unit/system_kernel_test.py
@@ -54,6 +54,27 @@ class TestKernel(object):
         assert data.name == 'vmlinux-realpath'
 
     @patch('os.path.exists')
+    @patch('os.path.realpath')
+    @patch('kiwi.command.Command.run')
+    def test_get_kernel_from_zImage(self, mock_run, mock_realpath, mock_os):
+        self.kernel.kernel_names = ['zImage-1.2.3-default']
+        run = namedtuple(
+            'run', ['output']
+        )
+        result = run(output='42')
+        mock_os.return_value = True
+        mock_run.return_value = result
+        mock_realpath.return_value = 'zImage-realpath'
+        data = self.kernel.get_kernel()
+        mock_run.assert_called_once_with(
+            command=['kversion', 'root-dir/boot/vmlinux-1.2.3-default.gz'],
+            raise_on_error=False
+        )
+        assert data.filename == 'root-dir/boot/zImage-1.2.3-default'
+        assert data.version == '42'
+        assert data.name == 'zImage-realpath'
+
+    @patch('os.path.exists')
     @patch('kiwi.command.Command.run')
     def test_get_kernel_no_version(self, mock_run, mock_os):
         run = namedtuple(


### PR DESCRIPTION
kernels build as zImage contains the decompressor code
as part of the kernel image and could be therefore
compressed by any possible compression algorithm.
In this case we assume/hope that there is also a
standard gz compressed vmlinux version of the kernel
available and check this one instead of the zImage
variant. Fixes #587

