### PR TITLE
Fixed kiwi dracut config for the final system

### DIFF
--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -104,7 +104,7 @@ class InstallImageBuilder(object):
             ]
         )
         self.dracut_config_file = ''.join(
-            [self.root_dir, '/etc/dracut.conf.d/02-kiwi.conf']
+            [self.root_dir, Defaults.get_dracut_conf_name()]
         )
         self.squashed_diskname = ''.join(
             [xml_state.xml_data.get_name(), '.raw']
@@ -432,7 +432,7 @@ class InstallImageBuilder(object):
             'dracut_rescue_image="no"'
         ]
         dracut_modules = ['kiwi-lib', 'kiwi-dump']
-        dracut_modules_omit = ['kiwi-overlay', 'kiwi-repart']
+        dracut_modules_omit = ['kiwi-overlay', 'kiwi-live', 'kiwi-repart']
         dracut_config.append(
             'add_dracutmodules+=" {0} "'.format(' '.join(dracut_modules))
         )

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -713,6 +713,10 @@ class Defaults(object):
         return 'overlay'
 
     @classmethod
+    def get_dracut_conf_name(self):
+        return '/etc/dracut.conf.d/02-kiwi.conf'
+
+    @classmethod
     def get_live_dracut_module_from_flag(self, flag_name):
         """
         Implements flag_name to dracut module name map

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -455,6 +455,7 @@ class TestDiskBuilder(object):
             call('boot_dir/config.partids', 'w'),
             call('root_dir/boot/mbrid', 'w'),
             call('root_dir/etc/dracut.conf.d/02-kiwi.conf', 'w'),
+            call('root_dir/etc/dracut.conf.d/02-kiwi.conf', 'w'),
             call('boot_dir/config.bootoptions', 'w'),
             call('/dev/some-loop', 'wb')
         ]
@@ -464,8 +465,11 @@ class TestDiskBuilder(object):
             call('0x0f0f0f0f\n'),
             call('hostonly="no"\n'),
             call('dracut_rescue_image="no"\n'),
+            # before dracut is called, image dracut setup
             call('add_dracutmodules+=" kiwi-lib kiwi-repart "\n'),
-            call('omit_dracutmodules+=" kiwi-dump "\n'),
+            call('omit_dracutmodules+=" kiwi-live kiwi-dump kiwi-overlay "\n'),
+            # after dracut was called, system dracut setup
+            call('omit_dracutmodules+=" kiwi-live kiwi-dump kiwi-repart kiwi-overlay "\n'),
             call('boot_cmdline\n'),
             call(bytes(b'\x0f\x0f\x0f\x0f'))
         ]
@@ -479,7 +483,6 @@ class TestDiskBuilder(object):
         self.setup.export_package_verification.assert_called_once_with(
             'target_dir'
         )
-        print(self.boot_image_task.include_file.call_args_list)
         assert self.boot_image_task.include_file.call_args_list == [
             call('/config.partids'),
             call('/recovery.partition.size')
@@ -534,8 +537,12 @@ class TestDiskBuilder(object):
             call('0x0f0f0f0f\n'),
             call('hostonly="no"\n'),
             call('dracut_rescue_image="no"\n'),
+            # before dracut is called, image dracut setup
             call('add_dracutmodules+=" kiwi-overlay kiwi-lib kiwi-repart "\n'),
-            call('omit_dracutmodules+=" kiwi-dump "\n'),
+            call('omit_dracutmodules+=" kiwi-live kiwi-dump "\n'),
+            # after dracut was called, system dracut setup
+            call('add_dracutmodules+=" kiwi-overlay "\n'),
+            call('omit_dracutmodules+=" kiwi-live kiwi-dump kiwi-repart "\n'),
             call('boot_cmdline\n'),
             call(b'\x0f\x0f\x0f\x0f')
         ]

--- a/test/unit/builder_install_test.py
+++ b/test/unit/builder_install_test.py
@@ -210,7 +210,7 @@ class TestInstallImageBuilder(object):
             call('hostonly="no"\n'),
             call('dracut_rescue_image="no"\n'),
             call('add_dracutmodules+=" kiwi-lib kiwi-dump "\n'),
-            call('omit_dracutmodules+=" kiwi-overlay kiwi-repart "\n')
+            call('omit_dracutmodules+=" kiwi-overlay kiwi-live kiwi-repart "\n')
         ]
 
     @patch('kiwi.builder.install.mkdtemp')
@@ -376,7 +376,7 @@ class TestInstallImageBuilder(object):
             call('hostonly="no"\n'),
             call('dracut_rescue_image="no"\n'),
             call('add_dracutmodules+=" kiwi-lib kiwi-dump "\n'),
-            call('omit_dracutmodules+=" kiwi-overlay kiwi-repart "\n')
+            call('omit_dracutmodules+=" kiwi-overlay kiwi-live kiwi-repart "\n')
         ]
 
     @patch('kiwi.builder.install.Path.wipe')


### PR DESCRIPTION
Once the image has been deployed on the target and the
system is up and running some of the kiwi dracut modules
used for deployment are no longer needed and should not be
taken into account when another dracut call happens on the
system.

