### PR TITLE
Remove vmdk metadata update procedure

### DIFF
--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -724,13 +724,6 @@ class KiwiVhdTagError(KiwiError):
     """
 
 
-class KiwiVmdkToolsError(KiwiError):
-    """
-    Exception raised if the version information from vmtoolsd does
-    not match the expected output format.
-    """
-
-
 class KiwiVolumeGroupConflict(KiwiError):
     """
     Exception raised if the requested LVM volume group already is

--- a/kiwi/storage/subformat/vmdk.py
+++ b/kiwi/storage/subformat/vmdk.py
@@ -16,23 +16,15 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
-import re
-
-# In python2 bytes is string which is different from
-# the bytes type in python3. The bytes type from the
-# builtins generalizes this type to be bytes always
-from builtins import bytes
 
 # project
 from kiwi.storage.subformat.base import DiskFormatBase
 from kiwi.command import Command
-from kiwi.logger import log
 from kiwi.storage.subformat.template.vmware_settings import (
     VmwareSettingsTemplate
 )
 
 from ...exceptions import (
-    KiwiVmdkToolsError,
     KiwiTemplateError
 )
 
@@ -70,7 +62,6 @@ class DiskFormatVmdk(DiskFormatBase):
                 self.get_target_name_for_format(self.image_format)
             ]
         )
-        self._update_vmdk_descriptor()
         self._create_vmware_settings_file()
 
     def store_to_result(self, result):
@@ -194,82 +185,4 @@ class DiskFormatVmdk(DiskFormatBase):
         except Exception as e:
             raise KiwiTemplateError(
                 '%s: %s' % (type(e).__name__, format(e))
-            )
-
-    def _update_vmdk_descriptor(self):
-        """
-        Update the VMDK descriptor with the VMware tools version
-        and type information. This is done to let VMware's virtualization
-        infrastructure know about the installed VMware tools at boot
-        time of the image within a VMware virtual environment
-        e.g VCloud Air. It's required to have vmtoolsd installed as
-        part of the image. If not found a warning is provided to the
-        user and the VMDK descriptor stays untouched
-        """
-        vmdk_vmtoolsd = self.root_dir + '/usr/bin/vmtoolsd'
-        if not os.path.exists(vmdk_vmtoolsd):
-            log.warning(
-                'Could not find vmtoolsd in image root %s', self.root_dir
-            )
-            log.warning(
-                'Update of VMDK metadata skipped'
-            )
-            return
-        log.info('Updating VMDK metadata')
-        vmdk_tools_install_type = 4
-        vmdk_tools_version = self._get_vmdk_tools_version()
-        vmdk_image_name = self.get_target_name_for_format('vmdk')
-        log.info(
-            '--> Setting tools version: %d', vmdk_tools_version
-        )
-        log.info(
-            '--> Setting tools install type: %d', vmdk_tools_install_type
-        )
-        vmdk_descriptor_call = Command.run(
-            ['dd', 'if=' + vmdk_image_name, 'bs=1', 'count=1024', 'skip=512']
-        )
-        vmdk_descriptor_lines = \
-            vmdk_descriptor_call.output.strip('\0').split('\n')
-        if (vmdk_descriptor_lines[0] != 'encoding="UTF-8"'):
-            vmdk_descriptor_lines.insert(0, 'encoding="UTF-8"')
-        vmdk_descriptor_lines.append(
-            'ddb.toolsInstallType = "%s"' % vmdk_tools_install_type
-        )
-        vmdk_descriptor_lines.append(
-            'ddb.toolsVersion = "%s"' % vmdk_tools_version
-        )
-        with open(vmdk_image_name, 'r+b') as vmdk:
-            vmdk.seek(512, 0)
-            vmdk.write(bytes('\n'.join(vmdk_descriptor_lines), 'utf-8'))
-            vmdk.seek(0, 2)
-
-    def _get_vmdk_tools_version(self):
-        vmdk_tools_version_call = Command.run(
-            ['chroot', self.root_dir, 'vmtoolsd', '--version']
-        )
-        vmdk_tools_version = vmdk_tools_version_call.output
-        vmdk_tools_version_format = re.match(
-            ''.join(
-                [
-                    '^VMware Tools daemon, version ',
-                    '(.*)',
-                    '\.',
-                    '(.*)',
-                    '\.',
-                    '(.*)',
-                    '\.',
-                    '(.*?)',
-                    ' \(.*\)',
-                    '$'
-                ]
-            ), vmdk_tools_version
-        )
-        if vmdk_tools_version_format:
-            return \
-                (int(vmdk_tools_version_format.group(1)) * 1024) + \
-                (int(vmdk_tools_version_format.group(2)) * 32) + \
-                int(vmdk_tools_version_format.group(3))
-        else:
-            raise KiwiVmdkToolsError(
-                'vmtools version %s does not match format' % vmdk_tools_version
             )


### PR DESCRIPTION
This commit removes the method _update_vmdk_descriptor from
DiskFormatVmdk class. The code part causes vmdk format issues
in current up to date hipervisors such as VMWarePlayer 14 or
Virtualbox 5.2. Removing this code does not produce any failure,
at most can only imply loosing some features provided by open-vm-tools
package.

Fixes #591