### PR TITLE
Added chapter for live-fat-stick deployment

### DIFF
--- a/doc/source/building/build_live_iso.rst
+++ b/doc/source/building/build_live_iso.rst
@@ -38,4 +38,5 @@ openSUSE Leap:
       $ qemu -cdrom LimeJeOS-Leap-42.3.x86_64-1.42.3.iso -m 4096
 
 After the test was successful, the image is complete and ready to use.
-See :ref:`iso_to_usb_stick` for further information.
+See :ref:`iso_to_usb_stick` and :ref:`iso_as_file_to_usb_stick`
+for further information.

--- a/doc/source/building/working_with_images.rst
+++ b/doc/source/building/working_with_images.rst
@@ -8,6 +8,7 @@ different image types.
    :maxdepth: 1
 
    working_with_images/iso_to_usb_stick_deployment
+   working_with_images/iso_to_usb_stick_file_based_deployment.rst
    working_with_images/vmx_setup_for_ec2
    working_with_images/vmx_setup_for_azure
    working_with_images/vmx_setup_for_google

--- a/doc/source/building/working_with_images/iso_to_usb_stick_file_based_deployment.rst
+++ b/doc/source/building/working_with_images/iso_to_usb_stick_file_based_deployment.rst
@@ -64,29 +64,29 @@ to setup the USB stick with `live-fat-stick`:
    By default, the SYSLINUX configuration does not use the "iso-scan"
    feature. Thus this information needs to be added as follows:
 
-   * Mount the FAT32 partition of the USB Stick. This must be the
-     same device as used in the `live-fat-stick` command call:
+   1. Mount the FAT32 partition of the USB Stick. This must be the
+      same device as used in the `live-fat-stick` command call:
 
-     .. code:: bash
+      .. code:: bash
 
-         $ sudo mount /dev/sdz1 /mnt
+          $ sudo mount /dev/sdz1 /mnt
 
-   * Edit the :file:`/mnt/boot/syslinux/syslinux.cfg` and include the
-     following parameters to the existing **append** line:
+   #. Edit the file :file:`/mnt/boot/syslinux/syslinux.cfg` and include the
+      following parameters to the existing **append** line:
 
-     .. code:: bash
+      .. code:: bash
 
-         iso-scan/filename=/LimeJeOS-Leap-42.3.x86_64-1.42.3.iso root=live:CDLABEL=CDROM
+          iso-scan/filename=/LimeJeOS-Leap-42.3.x86_64-1.42.3.iso root=live:CDLABEL=CDROM
 
-   * Unmount the FAT32 partition:
+   #. Unmount the FAT32 partition:
 
-     .. code:: bash
+      .. code:: bash
 
-         $ sudo umount /mnt
+          $ sudo umount /mnt
 
 5. Boot from your USB Stick
 
    Activate booting from USB in your BIOS/UEFI. As many firmware has different
    procedures on how to do it, look into your user manual.
    Many firmware offers a boot menu which can be activated at boot time.
-   Usually this can be reached by :kbd:`Esc` or :kbd:`F12`.
+   Usually this can be reached by pressing the :kbd:`Esc` or :kbd:`F12` keys.

--- a/doc/source/building/working_with_images/iso_to_usb_stick_file_based_deployment.rst
+++ b/doc/source/building/working_with_images/iso_to_usb_stick_file_based_deployment.rst
@@ -1,6 +1,6 @@
 .. _iso_as_file_to_usb_stick:
 
-Deploy ISO Image as file on a FAT32 formated USB Stick
+Deploy ISO Image as File on a FAT32 Formated USB Stick
 ======================================================
 
 .. sidebar:: Abstract
@@ -11,31 +11,31 @@ Deploy ISO Image as file on a FAT32 formated USB Stick
 
    * :ref:`hybrid_iso`
 
-In KIWI all generated ISO images are created to be hybrid. This means,
+In KIWI, all generated ISO images are created to be hybrid. This means,
 the image can be used as a CD/DVD or as a disk. The deployment of such
 an image onto a disk like an USB stick normally destroys all existing
 data on this device. Most USB sticks are pre-formatted with a FAT32
 Windows File System and to keep the existing data on the stick untouched
 a different deployment needs to be used.
 
-The following deployment process just copies the ISO image as an
+The following deployment process copies the ISO image as an
 additional file to the USB stick and makes the USB stick bootable.
-The ability to boot from the stick is configured through a grub
+The ability to boot from the stick is configured through a GRUB v2
 feature which allows to loopback mount an ISO file and boot the
 kernel and initrd directly from the ISO file.
 
 The initrd loaded in this process must also be able to loopback
 mount the ISO file to access the root filesystem and boot the
 live system. The dracut initrd system used by KIWI provides this
-feature upstream called as `iso-scan`. Therefore all KIWI generated
+feature upstream called as "iso-scan". Therefore all KIWI generated
 live ISO images supports this deployment mode.
 
 For copying the ISO file on the USB stick and the setup of the
-grub bootloader to make use of the `iso-scan` feature an extra tool
+GRUB v2 bootloader to make use of the "iso-scan" feature an extra tool
 named `live-fat-stick` exists. The following procedure shows how
-to setup the USB stick with `live-fat-stick`
+to setup the USB stick with `live-fat-stick`:
 
-1. Install the `live-fat-stick` package
+1. Install the `live-fat-stick` package:
 
    The package is available for openSUSE at:
    https://software.opensuse.org/package/live-fat-stick
@@ -43,7 +43,7 @@ to setup the USB stick with `live-fat-stick`
 2. Plug in a USB stick
 
    Once plugged in, check which Unix device name the stick was assigned
-   to. The following command provides an overview about all linux
+   to. The following command provides an overview about all Linux
    storage devices:
 
    .. code:: bash
@@ -61,3 +61,4 @@ to setup the USB stick with `live-fat-stick`
    Activate booting from USB in your BIOS/UEFI. As many firmware has different
    procedures on how to do it, look into your user manual.
    Many firmware offers a boot menu which can be activated at boot time.
+   Usually this can be reached by :kbd:`Esc` or :kbd:`F12`.

--- a/doc/source/building/working_with_images/iso_to_usb_stick_file_based_deployment.rst
+++ b/doc/source/building/working_with_images/iso_to_usb_stick_file_based_deployment.rst
@@ -20,7 +20,7 @@ a different deployment needs to be used.
 
 The following deployment process copies the ISO image as an
 additional file to the USB stick and makes the USB stick bootable.
-The ability to boot from the stick is configured through a GRUB v2
+The ability to boot from the stick is configured through a SYSLINUX
 feature which allows to loopback mount an ISO file and boot the
 kernel and initrd directly from the ISO file.
 
@@ -31,7 +31,7 @@ feature upstream called as "iso-scan". Therefore all KIWI generated
 live ISO images supports this deployment mode.
 
 For copying the ISO file on the USB stick and the setup of the
-GRUB v2 bootloader to make use of the "iso-scan" feature an extra tool
+SYSLINUX bootloader to make use of the "iso-scan" feature an extra tool
 named `live-fat-stick` exists. The following procedure shows how
 to setup the USB stick with `live-fat-stick`:
 
@@ -42,21 +42,49 @@ to setup the USB stick with `live-fat-stick`:
 
 2. Plug in a USB stick
 
-   Once plugged in, check which Unix device name the stick was assigned
-   to. The following command provides an overview about all Linux
-   storage devices:
+   Once plugged in, check which Unix device name the FAT32 partition
+   was assigned to. The following command provides an overview about all
+   storage devices and their filesystems:
 
    .. code:: bash
 
-      $ lsblk
+      $ sudo lsblk --fs
 
 3. Call the `live-fat-stick` command as follows:
 
+   Assuming "/dev/sdz1" was the FAT32 partition selected from the
+   output of the `lsblk` command:
+
    .. code:: bash
 
-      $ live-fat-stick LimeJeOS-Leap-42.3.x86_64-1.42.3.iso /dev/<stickdevice>
+      $ sudo live-fat-stick LimeJeOS-Leap-42.3.x86_64-1.42.3.iso /dev/sdz1
 
-4. Boot from your USB Stick
+4. Update the SYSLINUX configuration on the USB Stick
+
+   By default, the SYSLINUX configuration does not use the "iso-scan"
+   feature. Thus this information needs to be added as follows:
+
+   * Mount the FAT32 partition of the USB Stick. This must be the
+     same device as used in the `live-fat-stick` command call:
+
+     .. code:: bash
+
+         $ sudo mount /dev/sdz1 /mnt
+
+   * Edit the :file:`/mnt/boot/syslinux/syslinux.cfg` and include the
+     following parameters to the existing **append** line:
+
+     .. code:: bash
+
+         iso-scan/filename=/LimeJeOS-Leap-42.3.x86_64-1.42.3.iso root=live:CDLABEL=CDROM
+
+   * Unmount the FAT32 partition:
+
+     .. code:: bash
+
+         $ sudo umount /mnt
+
+5. Boot from your USB Stick
 
    Activate booting from USB in your BIOS/UEFI. As many firmware has different
    procedures on how to do it, look into your user manual.

--- a/doc/source/building/working_with_images/iso_to_usb_stick_file_based_deployment.rst
+++ b/doc/source/building/working_with_images/iso_to_usb_stick_file_based_deployment.rst
@@ -1,0 +1,63 @@
+.. _iso_as_file_to_usb_stick:
+
+Deploy ISO Image as file on a FAT32 formated USB Stick
+======================================================
+
+.. sidebar:: Abstract
+
+   This page provides further information for handling
+   ISO images built with KIWI and references the following
+   articles:
+
+   * :ref:`hybrid_iso`
+
+In KIWI all generated ISO images are created to be hybrid. This means,
+the image can be used as a CD/DVD or as a disk. The deployment of such
+an image onto a disk like an USB stick normally destroys all existing
+data on this device. Most USB sticks are pre-formatted with a FAT32
+Windows File System and to keep the existing data on the stick untouched
+a different deployment needs to be used.
+
+The following deployment process just copies the ISO image as an
+additional file to the USB stick and makes the USB stick bootable.
+The ability to boot from the stick is configured through a grub
+feature which allows to loopback mount an ISO file and boot the
+kernel and initrd directly from the ISO file.
+
+The initrd loaded in this process must also be able to loopback
+mount the ISO file to access the root filesystem and boot the
+live system. The dracut initrd system used by KIWI provides this
+feature upstream called as `iso-scan`. Therefore all KIWI generated
+live ISO images supports this deployment mode.
+
+For copying the ISO file on the USB stick and the setup of the
+grub bootloader to make use of the `iso-scan` feature an extra tool
+named `live-fat-stick` exists. The following procedure shows how
+to setup the USB stick with `live-fat-stick`
+
+1. Install the `live-fat-stick` package
+
+   The package is available for openSUSE at:
+   https://software.opensuse.org/package/live-fat-stick
+
+2. Plug in a USB stick
+
+   Once plugged in, check which Unix device name the stick was assigned
+   to. The following command provides an overview about all linux
+   storage devices:
+
+   .. code:: bash
+
+      $ lsblk
+
+3. Call the `live-fat-stick` command as follows:
+
+   .. code:: bash
+
+      $ live-fat-stick LimeJeOS-Leap-42.3.x86_64-1.42.3.iso /dev/<stickdevice>
+
+4. Boot from your USB Stick
+
+   Activate booting from USB in your BIOS/UEFI. As many firmware has different
+   procedures on how to do it, look into your user manual.
+   Many firmware offers a boot menu which can be activated at boot time.


### PR DESCRIPTION
With the support for the iso-scan feature in KIWI live
ISO image, also the ability to deploy file based on
FAT32 usb sticks via the live-fat-stick tool exists.
This chapter describes how to do it and Fixes #521


