### PR TITLE
Fixed use of stat result in os.chmod

### DIFF
--- a/kiwi/utils/sync.py
+++ b/kiwi/utils/sync.py
@@ -71,7 +71,7 @@ class DataSync(object):
                 exclude_options.append(
                     '/' + item
                 )
-        target_entry_permissions = oct(os.stat(self.target_dir)[ST_MODE])
+        target_entry_permissions = os.stat(self.target_dir)[ST_MODE]
         Command.run(
             ['rsync'] + rsync_options + exclude_options + [
                 self.source_dir, self.target_dir

--- a/test/unit/utils_sync_test.py
+++ b/test/unit/utils_sync_test.py
@@ -1,4 +1,5 @@
 import os
+from stat import ST_MODE
 from mock import patch
 
 from kiwi.utils.sync import DataSync
@@ -29,7 +30,7 @@ class TestDataSync(object):
             ]
         )
         mock_chmod.assert_called_once_with(
-            'target_dir', oct(mock_stat.return_value)
+            'target_dir', mock_stat.return_value[ST_MODE]
         )
         assert mock_warn.called
 


### PR DESCRIPTION
oct method returns a string representation which was mistakenly
used in a subsequent os.chmod call. This Fixes #564 

This completes the backport for bsc#1077619
