### PR TITLE
Kiwi dump hw test fixes

### DIFF
--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -56,6 +56,10 @@ function get_disk_list {
         lsblk -p -n -r -o NAME,SIZE,TYPE | grep disk | tr ' ' ":"
     );do
         disk_device="$(echo "${disk_meta}" | cut -f1 -d:)"
+        if [ "$(blkid "${disk_device}" -s LABEL -o value)" = "INSTALL" ];then
+            # ignore install source device
+            continue
+        fi
         disk_size=$(echo "${disk_meta}" | cut -f2 -d:)
         disk_device_by_id=$(
             get_persistent_device_from_unix_node "${disk_device}" "${disk_id}"

--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -192,7 +192,7 @@ function dump_image {
 
     if [ -z "${kiwi_oemunattended}" ];then
         local ack_dump_text="Destroying ALL data on ${image_target}, continue ?"
-        if ! run_dialog --yesno "\"${ack_dump_text}\"" 5 80; then
+        if ! run_dialog --yesno "\"${ack_dump_text}\"" 7 80; then
             local install_cancel_text="System installation canceled"
             run_dialog --msgbox "\"${install_cancel_text}\"" 5 60
             die "${install_cancel_text}"

--- a/dracut/modules.d/90kiwi-dump/kiwi-installer-device.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-installer-device.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
+type setup_debug >/dev/null 2>&1 || . /lib/kiwi-lib.sh
+
+setup_debug
+
+info "Install Device is $1"

--- a/dracut/modules.d/90kiwi-dump/kiwi-installer-genrules.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-installer-genrules.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+declare root=${root}
+
+case "${root}" in
+    install:/dev/*)
+    {
+        printf 'KERNEL=="%s", RUN+="/sbin/initqueue --settled --onetime --unique /sbin/kiwi-installer-device %s"\n' \
+            "${root#install:/dev/}" "${root#install:}"
+        printf 'SYMLINK=="%s", RUN+="/sbin/initqueue --settled --onetime --unique /sbin/kiwi-installer-device %s"\n' \
+            "${root#install:/dev/}" "${root#install:}"
+    } >> /etc/udev/rules.d/99-installer-kiwi.rules
+    wait_for_dev -n "${root#install:}"
+    ;;
+esac

--- a/dracut/modules.d/90kiwi-dump/module-setup.sh
+++ b/dracut/modules.d/90kiwi-dump/module-setup.sh
@@ -17,7 +17,11 @@ install() {
     inst_multiple \
         tr lsblk dd md5sum head pv kexec basename awk
 
+    inst_hook pre-udev 30 "${moddir}/kiwi-installer-genrules.sh"
     inst_hook pre-udev 60 "${moddir}/kiwi-dump-net-genrules.sh"
+
+    inst_script "${moddir}/kiwi-installer-device.sh" \
+        "/sbin/kiwi-installer-device"
 
     inst_hook cmdline 30 "${moddir}/parse-kiwi-install.sh"
     inst_hook pre-mount 30 "${moddir}/kiwi-dump-image.sh"


### PR DESCRIPTION
This is a series of smaller patches found by testing deployment to real hardware

1. when the target device names gets too long to fit into the dialog window, dialog break up the line but if the vertical space is also limited information gets lost. Thus the size of the dialog has been increased to allow multiple lines to be displayed

2. the dracut kiwi-dump module outlines a timing issue in a way that the pre-mount hook is called before the actual installation source device is ready for access. A udev rule created to wait for this device in pre-udev stage has been added which fixes this problem

3. the installation source device should be excluded from the target disk list. If the install.iso is dumped on e.g a stick and used as disk device, it appeared in the selection list as possible target