### PR TITLE
Delete obsolete ovf format value

### DIFF
--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1416,7 +1416,7 @@ div {
     k.type.format.attribute =
         ## Specifies the format of the virtual disk.
         attribute format {
-            "gce" | "ovf" | "ova" | "qcow2" | "vagrant" | "vmdk" |
+            "gce" | "ova" | "qcow2" | "vagrant" | "vmdk" |
             "vdi" | "vhd" | "vhdx" | "vhd-fixed"
         }
         >> sch:pattern [ id = "format" is-a = "image_type"
@@ -1840,7 +1840,7 @@ div {
 div {
     k.vmdisk.disktype.attribute =
         ## The type of the disk as it is internally handled
-        ## by the VM (ovf only)
+        ## by the VM (ova only)
         attribute disktype { text }
     k.vmdisk.controller.attribute =
         ## The disk controller used for the VM guest (vmdk only)
@@ -2404,11 +2404,17 @@ div {
 #
 div {
     k.machine.ovftype.attribute =
-        ## The OVF configuration type
+        ## The OVF configuration type.
+        ## The Open Virtualization Format is a standard for describing
+        ## virtual appliances and distribute them in an archive also
+        ## called Open Virtual Appliance(OVA). The standard describes
+        ## major components associated with a disk image. The exact
+        ## specification depends on the product using the format
+        ## and is specified in KIWI as the OVF type.
         attribute ovftype { "zvm" | "powervm" | "xen" | "vmware" }
     k.machine.HWversion.attribute =
         ## The virtual HW version number for the VM configuration
-        ## (vmdk and ovf)
+        ## (vmdk and ova)
         attribute HWversion { xsd:integer }
     k.machine.arch.attribute =
         ## the VM architecture type (vmdk only)
@@ -2418,20 +2424,20 @@ div {
         attribute xen_loader { "hvmloader" | "pygrub" | "pvgrub" }
     k.machine.guestOS.attribute =
         ## The virtual guestOS identification string for the VM
-        ## (vmdk and ovf, note the name designation is different for the two
+        ## (vmdk and ova, note the name designation is different for the two
         ## formats)
         attribute guestOS { text }
     k.machine.min_memory.attribute =
-        ## The virtual machine min memory in MB (ovf only)
+        ## The virtual machine min memory in MB (ova only)
         attribute min_memory { xsd:nonNegativeInteger }
     k.machine.max_memory.attribute =
-        ## The virtual machine max memory in MB (ovf only)
+        ## The virtual machine max memory in MB (ova only)
         attribute max_memory { xsd:nonNegativeInteger }
     k.machine.min_cpu.attribute =
-        ## The virtual machine min CPU count (ovf only)
+        ## The virtual machine min CPU count (ova only)
         attribute min_cpu { xsd:nonNegativeInteger }
     k.machine.max_cpu.attribute =
-        ## The virtual machine max CPU count (ovf only)
+        ## The virtual machine max CPU count (ova only)
         attribute max_cpu { xsd:nonNegativeInteger }
     k.machine.memory.attribute =
         ## The memory, in MB, setup for the guest VM (all formats)

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2108,7 +2108,6 @@ a different set of live features.</a:documentation>
         <a:documentation>Specifies the format of the virtual disk.</a:documentation>
         <choice>
           <value>gce</value>
-          <value>ovf</value>
           <value>ova</value>
           <value>qcow2</value>
           <value>vagrant</value>
@@ -2825,7 +2824,7 @@ to the user according to he specifing toolchain behaviour.</a:documentation>
     <define name="k.vmdisk.disktype.attribute">
       <attribute name="disktype">
         <a:documentation>The type of the disk as it is internally handled
-by the VM (ovf only)</a:documentation>
+by the VM (ova only)</a:documentation>
       </attribute>
     </define>
     <define name="k.vmdisk.controller.attribute">
@@ -3736,7 +3735,13 @@ configuration options which are used inside a vagrant box</a:documentation>
   <div>
     <define name="k.machine.ovftype.attribute">
       <attribute name="ovftype">
-        <a:documentation>The OVF configuration type</a:documentation>
+        <a:documentation>The OVF configuration type.
+The Open Virtualization Format is a standard for describing
+virtual appliances and distribute them in an archive also
+called Open Virtual Appliance(OVA). The standard describes
+major components associated with a disk image. The exact
+specification depends on the product using the format
+and is specified in KIWI as the OVF type.</a:documentation>
         <choice>
           <value>zvm</value>
           <value>powervm</value>
@@ -3748,7 +3753,7 @@ configuration options which are used inside a vagrant box</a:documentation>
     <define name="k.machine.HWversion.attribute">
       <attribute name="HWversion">
         <a:documentation>The virtual HW version number for the VM configuration
-(vmdk and ovf)</a:documentation>
+(vmdk and ova)</a:documentation>
         <data type="integer"/>
       </attribute>
     </define>
@@ -3774,31 +3779,31 @@ configuration options which are used inside a vagrant box</a:documentation>
     <define name="k.machine.guestOS.attribute">
       <attribute name="guestOS">
         <a:documentation>The virtual guestOS identification string for the VM
-(vmdk and ovf, note the name designation is different for the two
+(vmdk and ova, note the name designation is different for the two
 formats)</a:documentation>
       </attribute>
     </define>
     <define name="k.machine.min_memory.attribute">
       <attribute name="min_memory">
-        <a:documentation>The virtual machine min memory in MB (ovf only)</a:documentation>
+        <a:documentation>The virtual machine min memory in MB (ova only)</a:documentation>
         <data type="nonNegativeInteger"/>
       </attribute>
     </define>
     <define name="k.machine.max_memory.attribute">
       <attribute name="max_memory">
-        <a:documentation>The virtual machine max memory in MB (ovf only)</a:documentation>
+        <a:documentation>The virtual machine max memory in MB (ova only)</a:documentation>
         <data type="nonNegativeInteger"/>
       </attribute>
     </define>
     <define name="k.machine.min_cpu.attribute">
       <attribute name="min_cpu">
-        <a:documentation>The virtual machine min CPU count (ovf only)</a:documentation>
+        <a:documentation>The virtual machine min CPU count (ova only)</a:documentation>
         <data type="nonNegativeInteger"/>
       </attribute>
     </define>
     <define name="k.machine.max_cpu.attribute">
       <attribute name="max_cpu">
-        <a:documentation>The virtual machine max CPU count (ovf only)</a:documentation>
+        <a:documentation>The virtual machine max CPU count (ova only)</a:documentation>
         <data type="nonNegativeInteger"/>
       </attribute>
     </define>

--- a/kiwi/storage/subformat/__init__.py
+++ b/kiwi/storage/subformat/__init__.py
@@ -86,7 +86,7 @@ class DiskFormat(object):
             return DiskFormatGce(
                 xml_state, root_dir, target_dir, custom_args
             )
-        elif name == 'vmdk' or name == 'ova' or name == 'ovf':
+        elif name == 'vmdk' or name == 'ova':
             vmdisk_section = xml_state.get_build_type_vmdisk_section()
             if vmdisk_section:
                 disk_mode = vmdisk_section.get_diskmode()


### PR DESCRIPTION
Support for ova has been added which makes the ovf format
value obsolete and redundant

