### PR TITLE
Update boot description search path

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -791,12 +791,12 @@ class Defaults(object):
     @classmethod
     def get_boot_image_description_path(self):
         """
-        Implements bootloader path for ISO images
+        Implements path to find custom kiwi boot descriptions
 
         :return: directory path
         :rtype: string
         """
-        return Defaults.project_file('boot/arch/' + platform.machine())
+        return '/usr/share/kiwi/custom_boot'
 
     @classmethod
     def get_boot_image_strip_file(self):

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -130,6 +130,7 @@ class SystemBuildTask(CliTask):
             self.command_args['--description']
         )
         self.runtime_checker.check_efi_mode_for_disk_overlay_correctly_setup()
+        self.runtime_checker.check_boot_description_exists()
         self.runtime_checker.check_consistent_kernel_in_boot_and_system_image()
         self.runtime_checker.check_docker_tool_chain_installed()
         self.runtime_checker.check_volume_setup_has_no_root_definition()

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -117,6 +117,7 @@ class SystemPrepareTask(CliTask):
 
         self.runtime_checker.check_efi_mode_for_disk_overlay_correctly_setup()
         self.runtime_checker.check_grub_efi_installed_for_efi_firmware()
+        self.runtime_checker.check_boot_description_exists()
         self.runtime_checker.check_consistent_kernel_in_boot_and_system_image()
         self.runtime_checker.check_docker_tool_chain_installed()
         self.runtime_checker.check_volume_setup_has_no_root_definition()

--- a/test/data/example_runtime_checker_boot_desc_not_found.xml
+++ b/test/data/example_runtime_checker_boot_desc_not_found.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="6.8" name="JeOS">
+    <description type="system">
+        <author>Marcus Schäfer</author>
+        <contact>ms@suse.com</contact>
+        <specification>JeOS</specification>
+    </description>
+    <preferences>
+        <version>1.1.0</version>
+        <packagemanager>zypper</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us.map.gz</keytable>
+        <timezone>Europe/Berlin</timezone>
+        <rpm-excludedocs>true</rpm-excludedocs>
+        <rpm-check-signatures>false</rpm-check-signatures>
+        <bootsplash-theme>openSUSE</bootsplash-theme>
+        <bootloader-theme>openSUSE</bootloader-theme>
+        <type image="oem" initrd_system="kiwi" filesystem="ext3" boot="oemboot/foo"/>
+    </preferences>
+    <repository type="yast2">
+        <source path="obs://13.2/repo/oss"/>
+    </repository>
+    <packages type="image">
+        <package name="patterns-openSUSE-base"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="udev"/>
+        <package name="filesystem"/>
+        <package name="glibc-locale"/>
+    </packages>
+</image>

--- a/test/data/example_runtime_checker_no_boot_reference.xml
+++ b/test/data/example_runtime_checker_no_boot_reference.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="6.8" name="JeOS">
+    <description type="system">
+        <author>Marcus Schäfer</author>
+        <contact>ms@suse.com</contact>
+        <specification>JeOS</specification>
+    </description>
+    <preferences>
+        <version>1.1.0</version>
+        <packagemanager>zypper</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us.map.gz</keytable>
+        <timezone>Europe/Berlin</timezone>
+        <rpm-excludedocs>true</rpm-excludedocs>
+        <rpm-check-signatures>false</rpm-check-signatures>
+        <bootsplash-theme>openSUSE</bootsplash-theme>
+        <bootloader-theme>openSUSE</bootloader-theme>
+        <type image="oem" initrd_system="kiwi" filesystem="ext3"/>
+    </preferences>
+    <repository type="yast2">
+        <source path="obs://13.2/repo/oss"/>
+    </repository>
+    <packages type="image">
+        <package name="patterns-openSUSE-base"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="udev"/>
+        <package name="filesystem"/>
+        <package name="glibc-locale"/>
+    </packages>
+</image>

--- a/test/unit/boot_image_base_test.py
+++ b/test/unit/boot_image_base_test.py
@@ -103,11 +103,9 @@ class TestBootImageBase(object):
         assert self.xml_state.copy_machine_section.called
         assert self.xml_state.copy_oemconfig_section.called
 
-    @patch('kiwi.defaults.Defaults.get_boot_image_description_path')
-    def test_get_boot_description_directory(self, boot_path):
-        boot_path.return_value = 'boot_path'
+    def test_get_boot_description_directory(self):
         assert self.boot_image.get_boot_description_directory() == \
-            'boot_path/oemboot/suse-13.2'
+            '/usr/share/kiwi/custom_boot/oemboot/suse-13.2'
 
     @raises(KiwiConfigFileNotFound)
     @patch('kiwi.boot.image.base.BootImageBase.get_boot_description_directory')

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -108,6 +108,24 @@ class TestRuntimeChecker(object):
         runtime_checker.check_consistent_kernel_in_boot_and_system_image()
 
     @raises(KiwiRuntimeError)
+    def test_check_boot_description_exists_no_boot_ref(self):
+        description = XMLDescription(
+            '../data/example_runtime_checker_no_boot_reference.xml'
+        )
+        xml_state = XMLState(description.load())
+        runtime_checker = RuntimeChecker(xml_state)
+        runtime_checker.check_boot_description_exists()
+
+    @raises(KiwiRuntimeError)
+    def test_check_boot_description_exists_does_not_exist(self):
+        description = XMLDescription(
+            '../data/example_runtime_checker_boot_desc_not_found.xml'
+        )
+        xml_state = XMLState(description.load())
+        runtime_checker = RuntimeChecker(xml_state)
+        runtime_checker.check_boot_description_exists()
+
+    @raises(KiwiRuntimeError)
     def test_check_grub_efi_installed_for_efi_firmware_is_efi(self):
         self.xml_state.build_type.get_firmware = mock.Mock(
             return_value='efi'

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -94,6 +94,7 @@ class TestSystemBuildTask(object):
         self._init_command_args()
         self.task.command_args['build'] = True
         self.task.process()
+        self.runtime_checker.check_boot_description_exists.assert_called_once_with()
         self.runtime_checker.check_consistent_kernel_in_boot_and_system_image.assert_called_once_with()
         self.runtime_checker.check_docker_tool_chain_installed.assert_called_once_with()
         self.runtime_checker.check_volume_setup_has_no_root_definition.assert_called_once_with()

--- a/test/unit/tasks_system_prepare_test.py
+++ b/test/unit/tasks_system_prepare_test.py
@@ -84,6 +84,7 @@ class TestSystemPrepareTask(object):
         self.task.command_args['prepare'] = True
         self.task.command_args['--clear-cache'] = True
         self.task.process()
+        self.runtime_checker.check_boot_description_exists.assert_called_once_with()
         self.runtime_checker.check_consistent_kernel_in_boot_and_system_image.assert_called_once_with()
         self.runtime_checker.check_docker_tool_chain_installed.assert_called_once_with()
         self.runtime_checker.check_volume_setup_has_no_root_definition.assert_called_once_with()


### PR DESCRIPTION
With the move of the boot descriptions in its own package
the kiwi search path needs to be adapted to look for boot
descriptions in /usr/share/kiwi/custom_boot. In addition
a runtime check to exit early if the boot description could
not be found or is not specified will be provided. Related
to Issue #576

