### PR TITLE
Create compatible boot options

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -147,9 +147,14 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             'rd.live.image'
         ]
         self.install_boot_options = [
-            'root=install:CDLABEL={0}'.format(Defaults.get_install_volume_id()),
             'loglevel=0'
         ]
+        if self.xml_state.get_initrd_system() == 'dracut':
+            self.install_boot_options.append(
+                'root=install:CDLABEL={0}'.format(
+                    Defaults.get_install_volume_id()
+                )
+            )
         if self.xml_state.build_type.get_hybridpersistent():
             self.live_boot_options += \
                 Defaults.get_live_iso_persistent_boot_options(

--- a/kiwi/bootloader/config/isolinux.py
+++ b/kiwi/bootloader/config/isolinux.py
@@ -99,9 +99,14 @@ class BootLoaderConfigIsoLinux(BootLoaderConfigBase):
             'rd.live.image'
         ]
         self.install_boot_options = [
-            'root=install:CDLABEL={0}'.format(Defaults.get_install_volume_id()),
             'loglevel=0'
         ]
+        if self.xml_state.get_initrd_system() == 'dracut':
+            self.install_boot_options.append(
+                'root=install:CDLABEL={0}'.format(
+                    Defaults.get_install_volume_id()
+                )
+            )
 
         if self.xml_state.build_type.get_hybridpersistent():
             self.live_boot_options += \

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -175,6 +175,9 @@ class TestBootLoaderConfigGrub2(object):
     @patch('platform.machine')
     def test_post_init_ix86_platform(self, mock_machine):
         xml_state = mock.MagicMock()
+        xml_state.get_initrd_system = mock.Mock(
+            return_value='dracut'
+        )
         xml_state.build_type.get_firmware = mock.Mock(
             return_value=None
         )

--- a/test/unit/bootloader_config_isolinux_test.py
+++ b/test/unit/bootloader_config_isolinux_test.py
@@ -44,6 +44,9 @@ class TestBootLoaderConfigIsoLinux(object):
         self.state.build_type.get_boottimeout = mock.Mock(
             return_value=None
         )
+        self.state.get_initrd_system = mock.Mock(
+            return_value='dracut'
+        )
         self.state.build_type.get_kernelcmdline = mock.Mock(
             return_value='splash'
         )


### PR DESCRIPTION
The boot option root=install:CDLABEL= is mandatory for install
images which uses the dracut initrd system. But for the custom
kiwi oemboot descriptions this is causing a problem when detecting
the install device. Thus the above boot option is only applied
for the initrd system which actually makes use of it

