### PR TITLE
APT: Run debootstrap with --variant=minbase

### DIFF
--- a/kiwi/package_manager/apt.py
+++ b/kiwi/package_manager/apt.py
@@ -54,6 +54,7 @@ class PackageManagerApt(PackageManagerBase):
         self.custom_args = custom_args
         if not custom_args:
             self.custom_args = []
+        self.deboostrap_minbase = True
 
         runtime_config = self.repository.runtime_config()
         self.apt_get_args = runtime_config['apt_get_args']
@@ -139,12 +140,13 @@ class PackageManagerApt(PackageManagerBase):
                     'provided key will only be used inside the chroot '
                     'environment'
                 )
-            Command.run(
-                [
-                    'debootstrap', '--no-check-gpg', '--variant=minbase',
-                    self.distribution, bootstrap_dir, self.distribution_path
-                ], self.command_env
-            )
+            cmd = ['debootstrap', '--no-check-gpg']
+            if self.deboostrap_minbase:
+                cmd.append('--variant=minbase')
+            cmd.extend([
+                self.distribution, bootstrap_dir, self.distribution_path
+            ])
+            Command.run(cmd, self.command_env)
             data = DataSync(
                 bootstrap_dir + '/', self.root_dir
             )
@@ -223,6 +225,7 @@ class PackageManagerApt(PackageManagerBase):
         """
         if '--no-install-recommends' not in self.custom_args:
             self.custom_args.append('--no-install-recommends')
+        self.deboostrap_minbase = True
 
     def process_plus_recommended(self):
         """
@@ -230,6 +233,7 @@ class PackageManagerApt(PackageManagerBase):
         """
         if '--no-install-recommends' in self.custom_args:
             self.custom_args.remove('--no-install-recommends')
+        self.deboostrap_minbase = False
 
     def match_package_installed(self, package_name, apt_get_output):
         """

--- a/kiwi/package_manager/apt.py
+++ b/kiwi/package_manager/apt.py
@@ -141,8 +141,8 @@ class PackageManagerApt(PackageManagerBase):
                 )
             Command.run(
                 [
-                    'debootstrap', '--no-check-gpg', self.distribution,
-                    bootstrap_dir, self.distribution_path
+                    'debootstrap', '--no-check-gpg', '--variant=minbase',
+                    self.distribution, bootstrap_dir, self.distribution_path
                 ], self.command_env
             )
             data = DataSync(

--- a/test/unit/package_manager_apt_test.py
+++ b/test/unit/package_manager_apt_test.py
@@ -101,8 +101,8 @@ class TestPackageManagerApt(object):
         assert mock_run.call_args_list == [
             call(command=['mountpoint', 'root-dir/dev'], raise_on_error=False),
             call([
-                'debootstrap', '--no-check-gpg', 'xenial',
-                'root-dir.debootstrap', 'xenial_path'],
+                'debootstrap', '--no-check-gpg', '--variant=minbase',
+                'xenial', 'root-dir.debootstrap', 'xenial_path'],
                 ['env']),
             call([
                 'chroot', 'root-dir', 'apt-key', 'add', 'key-file.asc'


### PR DESCRIPTION
This selects only packages with Priority: required, which is more in
line with what the other package managers are doing. A patch for
kiwi-descriptions has been submitted to adapt to this new behavior.