### PR TITLE
Fixed yum vs. yum-deprecated binary lookup

### DIFF
--- a/kiwi/package_manager/yum.py
+++ b/kiwi/package_manager/yum.py
@@ -90,14 +90,24 @@ class PackageManagerYum(PackageManagerBase):
         """
         self.exclude_requests.append(name)
 
-    def _get_yum_binary_name(self):
+    def _get_yum_binary_name(self, root=None):
         """
         Identify whether yum is 'yum' or 'yum-deprecated'
+
+        :param string root: lookup binary name below this root directory
 
         :return: name of yum command
         """
         yum_binary = 'yum'
-        if Path.which(filename='yum-deprecated', access_mode=os.X_OK):
+        yum_search_env = {
+            'PATH': os.sep.join([root, 'usr', 'bin'])
+        } if root else None
+
+        if Path.which(
+            filename='yum-deprecated',
+            custom_env=yum_search_env,
+            access_mode=os.X_OK
+        ):
             yum_binary = 'yum-deprecated'
         return yum_binary
 
@@ -129,7 +139,7 @@ class PackageManagerYum(PackageManagerBase):
         """
         Process package install requests for image phase (chroot)
         """
-        yum = self._get_yum_binary_name()
+        yum = self._get_yum_binary_name(root=self.root_dir)
         if self.exclude_requests:
             # For Yum, excluding a package means removing it from
             # the solver operation. This is done by adding --exclude
@@ -190,7 +200,7 @@ class PackageManagerYum(PackageManagerBase):
         """
         Process package update requests (chroot)
         """
-        yum = self._get_yum_binary_name()
+        yum = self._get_yum_binary_name(root=self.root_dir)
         chroot_yum_args = self.root_bind.move_to_root(
             self.yum_args
         )

--- a/test/unit/package_manager_yum_test.py
+++ b/test/unit/package_manager_yum_test.py
@@ -45,11 +45,20 @@ class TestPackageManagerYum(object):
         assert self.manager.exclude_requests == ['name']
 
     @patch('kiwi.path.Path.which')
-    def test_get_yum_binary_name(self, mock_exists):
-        mock_exists.return_value = '/usr/bin/yum-deprecated'
+    def test_get_yum_binary_name(self, mock_which):
+        mock_which.return_value = '/usr/bin/yum-deprecated'
         assert self.manager._get_yum_binary_name() == 'yum-deprecated'
-        mock_exists.return_value = None
-        assert self.manager._get_yum_binary_name() == 'yum'
+        mock_which.assert_called_once_with(
+            access_mode=1, custom_env=None,
+            filename='yum-deprecated'
+        )
+        mock_which.return_value = None
+        mock_which.reset_mock()
+        assert self.manager._get_yum_binary_name(root='/some/root') == 'yum'
+        mock_which.assert_called_once_with(
+            access_mode=1, custom_env={'PATH': '/some/root/usr/bin'},
+            filename='yum-deprecated'
+        )
 
     @patch('kiwi.path.Path.which')
     @patch('kiwi.command.Command.call')


### PR DESCRIPTION
When using the yum package manager it could be either provided
as yum or yum-deprecated binary. Because of this the search
method to find the binary needs to know the context from which
the call is performed. This could be either the host system
or the created image root. This Fixes #624

