### PR TITLE
Update build-test descriptions for Kanku

### DIFF
--- a/build-tests/x86/test-image-fedora-vmx/appliance.kiwi
+++ b/build-tests/x86/test-image-fedora-vmx/appliance.kiwi
@@ -15,7 +15,7 @@
         <keytable>us</keytable>
         <timezone>UTC</timezone>
         <rpm-check-signatures>false</rpm-check-signatures>
-        <type image="vmx" filesystem="ext3" bootloader="grub2" kernelcmdline="splash"/>
+        <type image="vmx" filesystem="ext3" bootloader="grub2" kernelcmdline="console=ttyS0 splash"/>
     </preferences>
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>

--- a/build-tests/x86/test-image-iso/appliance.kiwi
+++ b/build-tests/x86/test-image-iso/appliance.kiwi
@@ -16,7 +16,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="iso" flags="overlay" hybrid="true" firmware="efi" kernelcmdline="splash" hybridpersistent_filesystem="ext4" hybridpersistent="true" mediacheck="true"/>
+        <type image="iso" flags="overlay" hybrid="true" firmware="efi" kernelcmdline="console=ttyS0 splash" hybridpersistent_filesystem="ext4" hybridpersistent="true" mediacheck="true"/>
     </preferences>
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>

--- a/build-tests/x86/test-image-oem/appliance.kiwi
+++ b/build-tests/x86/test-image-oem/appliance.kiwi
@@ -16,7 +16,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="btrfs" initrd_system="dracut" bootloader="grub2" kernelcmdline="splash" firmware="efi" installiso="true" bootpartition="false" btrfs_root_is_snapshot="true">
+        <type image="oem" filesystem="btrfs" initrd_system="dracut" bootloader="grub2" kernelcmdline="console=ttyS0 splash" firmware="efi" installiso="true" bootpartition="false" btrfs_root_is_snapshot="true">
             <systemdisk>
                 <volume name="home"/>
             </systemdisk>

--- a/build-tests/x86/test-image-vmx/appliance.kiwi
+++ b/build-tests/x86/test-image-vmx/appliance.kiwi
@@ -16,7 +16,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="vmx" filesystem="ext3" bootloader="grub2" kernelcmdline="splash" firmware="uefi" format="vmdk"/>
+        <type image="vmx" filesystem="ext3" bootloader="grub2" kernelcmdline="console=ttyS0 splash" firmware="uefi" format="vmdk"/>
     </preferences>
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>


### PR DESCRIPTION
As part of the buildservice there is now also a CI system called Kanku
which allows for image boot/run tests. The only requirement on the image
level which is missing in our build test descriptions is the setup of
the serial console. This patch updates those image descriptions which
could be tested by kanku to provide a serial console at boot time.

The plan is that our build-test images automatically gets boot tested
by the Kanku CI. This should include boot, console-login, reboot,
console login, shutdown. The required job description to do this
needs to be worked out together with the Kanku team

