### PR TITLE
Update tox.ini to use python3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,12 +29,12 @@ whitelist_externals =
     /usr/bin/shellcheck
     /bin/bash
 basepython =
-    {check,doc,doc_travis,doc_travis_deploy}: python3.4
-    unit_py3: python3.4
+    {check,doc,doc_travis,doc_travis_deploy}: python3
+    unit_py3: python3
     unit_py2: python2.7
 envdir =
-    {check,doc,doc_travis,doc_travis_deploy}: {toxworkdir}/3.4
-    unit_py3: {toxworkdir}/3.4
+    {check,doc,doc_travis,doc_travis_deploy}: {toxworkdir}/3
+    unit_py3: {toxworkdir}/3
     unit_py2: {toxworkdir}/2.7
 passenv =
     *


### PR DESCRIPTION
We should be using python3 instead of specific minor version
like python3.4

Fixes tests.
