### PR TITLE
Use pytest instead of py.test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,7 @@ deps = {[testenv]deps}
 changedir=test/unit
 commands =
     bash -c 'cd ../../ && ./setup.py develop'
-    py.test --no-cov-on-fail --cov=kiwi \
+    pytest --no-cov-on-fail --cov=kiwi \
         --cov-report=term-missing --cov-fail-under=100 --cov-config .coveragerc
 
 
@@ -78,7 +78,7 @@ deps = {[testenv]deps}
 changedir=test/unit
 commands =
     bash -c 'cd ../../ && ./setup.py develop'
-    py.test --no-cov-on-fail --cov=kiwi \
+    pytest --no-cov-on-fail --cov=kiwi \
         --cov-report=term-missing --cov-fail-under=100 --cov-config .coveragerc
 
 
@@ -96,7 +96,7 @@ deps = {[testenv]deps}
 changedir=test/unit
 commands =
     bash -c 'cd ../../ && ./setup.py develop'
-    py.test --no-cov-on-fail --cov=kiwi \
+    pytest --no-cov-on-fail --cov=kiwi \
         --cov-report=term-missing --cov-fail-under=100 --cov-config .coveragerc
 
 


### PR DESCRIPTION
Changes proposed in this pull request:
* Use `pytest` instead of `py.test` inside `tox.ini`


### Background

From pytest 3.0, it is recommended to use `pytest` as the main command. The use of `py.test` is deprecated and is potentially removed in the future. To be better prepared, I'd recommend to make the switch now.

For more information, see [pytest-dev#1629](https://github.com/pytest-dev/pytest/issues/1629#issue-161422224).


