### PR TITLE
Set eltorito-platform for efi

### DIFF
--- a/kiwi/filesystem/isofs.py
+++ b/kiwi/filesystem/isofs.py
@@ -19,9 +19,6 @@
 from kiwi.filesystem.base import FileSystemBase
 from kiwi.command import Command
 from kiwi.iso import Iso
-from kiwi.path import Path
-
-from kiwi.exceptions import KiwiIsoToolError
 
 
 class FileSystemIsoFs(FileSystemBase):
@@ -46,7 +43,7 @@ class FileSystemIsoFs(FileSystemBase):
         iso.add_efi_loader_parameters()
         Command.run(
             [
-                self._find_iso_creation_tool()
+                Iso.get_iso_creation_tool()
             ] + iso.get_iso_creation_parameters() + [
                 '-o', filename, self.root_dir
             ]
@@ -54,7 +51,7 @@ class FileSystemIsoFs(FileSystemBase):
         hybrid_offset = iso.create_header_end_block(filename)
         Command.run(
             [
-                self._find_iso_creation_tool(),
+                Iso.get_iso_creation_tool(),
                 '-hide', iso.header_end_name,
                 '-hide-joliet', iso.header_end_name
             ] + iso.get_iso_creation_parameters() + [
@@ -64,19 +61,3 @@ class FileSystemIsoFs(FileSystemBase):
         iso.relocate_boot_catalog(filename)
         iso.fix_boot_catalog(filename)
         return hybrid_offset
-
-    def _find_iso_creation_tool(self):
-        """
-        There are tools by J.Schilling and tools from the community
-        Depending on what is installed a decision needs to be made
-        """
-        iso_creation_tools = ['mkisofs', 'genisoimage']
-        for tool in iso_creation_tools:
-            tool_found = Path.which(tool)
-            if tool_found:
-                return tool_found
-
-        raise KiwiIsoToolError(
-            'No iso creation tool found, searched for: %s' %
-            iso_creation_tools
-        )

--- a/kiwi/iso.py
+++ b/kiwi/iso.py
@@ -323,7 +323,8 @@ class Iso(object):
         loader_file = self.boot_path + '/efi'
         if os.path.exists(os.sep.join([self.source_dir, loader_file])):
             self.iso_loaders += [
-                '-eltorito-alt-boot', '-b', loader_file,
+                '-eltorito-alt-boot', '-eltorito-platform', 'efi',
+                '-b', loader_file,
                 '-no-emul-boot', '-joliet-long'
             ]
             loader_file_512_byte_blocks = os.path.getsize(

--- a/kiwi/utils/command_capabilities.py
+++ b/kiwi/utils/command_capabilities.py
@@ -55,6 +55,9 @@ class CommandCapabilities(object):
             for line in command.output.splitlines():
                 if flag in line:
                     return True
+            for line in command.error.splitlines():
+                if flag in line:
+                    return True
         except Exception:
             message = 'Could not parse {} output'.format(call)
             if raise_on_error:

--- a/test/unit/filesystem_isofs_test.py
+++ b/test/unit/filesystem_isofs_test.py
@@ -3,10 +3,6 @@ from mock import call
 
 import mock
 
-from .test_helper import raises
-
-from kiwi.exceptions import KiwiIsoToolError
-
 from kiwi.filesystem.isofs import FileSystemIsoFs
 
 
@@ -22,36 +18,19 @@ class TestFileSystemIsoFs(object):
         assert self.isofs.custom_args['mount_options'] == []
         assert self.isofs.custom_args['some_args'] == 'data'
 
-    @raises(KiwiIsoToolError)
     @patch('kiwi.filesystem.isofs.Command.run')
+    @patch('kiwi.filesystem.isofs.Iso.get_iso_creation_tool')
     @patch('kiwi.filesystem.isofs.Iso')
-    @patch('kiwi.filesystem.isofs.Path.which')
-    def test_create_on_file_no_tool_found(
-        self, mock_which, mock_iso, mock_command
-    ):
-        mock_which.return_value = None
-        self.isofs.create_on_file('myimage', None)
-
-    @patch('kiwi.filesystem.isofs.Command.run')
-    @patch('kiwi.filesystem.isofs.Iso')
-    @patch('kiwi.filesystem.isofs.Path.which')
-    def test_create_on_file_mkisofs(
-        self, mock_which, mock_iso, mock_command
+    def test_create_on_file(
+        self, mock_iso, mock_get_iso_creation_tool, mock_command
     ):
         iso = mock.Mock()
         iso.header_end_name = 'header_end'
         iso.get_iso_creation_parameters = mock.Mock(
             return_value=['args']
         )
+        mock_get_iso_creation_tool.return_value = '/usr/bin/mkisofs'
         mock_iso.return_value = iso
-        path_return_values = [
-            '/usr/bin/mkisofs', '/usr/bin/mkisofs'
-        ]
-
-        def side_effect(arg):
-            return path_return_values.pop()
-
-        mock_which.side_effect = side_effect
         self.isofs.create_on_file('myimage', None)
         iso.init_iso_creation_parameters.assert_called_once_with([])
         iso.add_efi_loader_parameters.assert_called_once_with()
@@ -64,49 +43,6 @@ class TestFileSystemIsoFs(object):
             ]),
             call([
                 '/usr/bin/mkisofs', '-hide', 'header_end',
-                '-hide-joliet', 'header_end', 'args', '-o', 'myimage',
-                'root_dir'
-            ])
-        ]
-        iso.relocate_boot_catalog.assert_called_once_with(
-            'myimage'
-        )
-        iso.fix_boot_catalog.assert_called_once_with(
-            'myimage'
-        )
-
-    @patch('kiwi.filesystem.isofs.Command.run')
-    @patch('kiwi.filesystem.isofs.Iso')
-    @patch('kiwi.filesystem.isofs.Path.which')
-    def test_create_on_file_genisoimage(
-        self, mock_which, mock_iso, mock_command
-    ):
-        iso = mock.Mock()
-        iso.header_end_name = 'header_end'
-        iso.get_iso_creation_parameters = mock.Mock(
-            return_value=['args']
-        )
-        mock_iso.return_value = iso
-        path_return_values = [
-            '/usr/bin/genisoimage', None, '/usr/bin/genisoimage', None
-        ]
-
-        def side_effect(arg):
-            return path_return_values.pop()
-
-        mock_which.side_effect = side_effect
-        self.isofs.create_on_file('myimage', None)
-        iso.init_iso_creation_parameters.assert_called_once_with([])
-        iso.add_efi_loader_parameters.assert_called_once_with()
-        iso.create_header_end_block.assert_called_once_with(
-            'myimage'
-        )
-        assert mock_command.call_args_list == [
-            call([
-                '/usr/bin/genisoimage', 'args', '-o', 'myimage', 'root_dir'
-            ]),
-            call([
-                '/usr/bin/genisoimage', '-hide', 'header_end',
                 '-hide-joliet', 'header_end', 'args', '-o', 'myimage',
                 'root_dir'
             ])

--- a/test/unit/iso_test.py
+++ b/test/unit/iso_test.py
@@ -141,7 +141,8 @@ class TestIso(object):
         mock_exists.return_value = True
         self.iso.add_efi_loader_parameters()
         assert self.iso.iso_loaders == [
-            '-eltorito-alt-boot', '-b', 'boot/x86_64/efi',
+            '-eltorito-alt-boot', '-eltorito-platform', 'efi',
+            '-b', 'boot/x86_64/efi',
             '-no-emul-boot', '-joliet-long', '-boot-load-size', '8'
         ]
 
@@ -154,7 +155,8 @@ class TestIso(object):
         mock_exists.return_value = True
         self.iso.add_efi_loader_parameters()
         assert self.iso.iso_loaders == [
-            '-eltorito-alt-boot', '-b', 'boot/x86_64/efi',
+            '-eltorito-alt-boot', '-eltorito-platform', 'efi',
+            '-b', 'boot/x86_64/efi',
             '-no-emul-boot', '-joliet-long'
         ]
 

--- a/test/unit/utils_command_capabilities_test.py
+++ b/test/unit/utils_command_capabilities_test.py
@@ -11,11 +11,13 @@ from kiwi.exceptions import KiwiCommandCapabilitiesError
 class TestCommandCapabilities(object):
     @patch('kiwi.command.Command.run')
     def test_has_option_in_help(self, mock_run):
-        command_type = namedtuple('command', ['output'])
+        command_type = namedtuple('command', ['output', 'error'])
         mock_run.return_value = command_type(
-            output="Dummy line\n\t--some-flag\n\t--some-other-flag"
+            output="Dummy line\n\t--some-flag\n\t--some-other-flag",
+            error="Dummy line\n\t--error-flag\n\t--some-other-flag"
         )
         assert CommandCapabilities.has_option_in_help('command', '--some-flag')
+        assert CommandCapabilities.has_option_in_help('command', '--error-flag')
         assert CommandCapabilities.has_option_in_help(
             'command', '--some-flag', help_flags=['subcommand', '-h']
         )
@@ -27,6 +29,7 @@ class TestCommandCapabilities(object):
             'command', '--non-existing-flag'
         )
         mock_run.assert_has_calls([
+            call(['command', '--help']),
             call(['command', '--help']),
             call(['command', 'subcommand', '-h']),
             call(['chroot', 'root_dir', 'command', 'subcommand', '-h']),


### PR DESCRIPTION
The default eltorito platform is set to "x86_64 PC", however
in an alternative bootloader spec for efi this would be the
wrong platform spec. This patch adds the correct platform
to the alt-boot setup for efi. References #643

