### PR TITLE
Disable multipath support when kiwi-oem-repar is active

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -650,7 +650,7 @@ class DiskBuilder(object):
             'dracut_rescue_image="no"'
         ]
         dracut_modules = []
-        dracut_modules_omit = ['kiwi-live', 'kiwi-dump']
+        dracut_modules_omit = ['kiwi-live', 'kiwi-dump', 'multipath']
         if self.root_filesystem_is_overlay:
             dracut_modules.append('kiwi-overlay')
         else:

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -467,7 +467,7 @@ class TestDiskBuilder(object):
             call('dracut_rescue_image="no"\n'),
             # before dracut is called, image dracut setup
             call('add_dracutmodules+=" kiwi-lib kiwi-repart "\n'),
-            call('omit_dracutmodules+=" kiwi-live kiwi-dump kiwi-overlay "\n'),
+            call('omit_dracutmodules+=" kiwi-live kiwi-dump multipath kiwi-overlay "\n'),
             # after dracut was called, system dracut setup
             call('omit_dracutmodules+=" kiwi-live kiwi-dump kiwi-repart kiwi-overlay "\n'),
             call('boot_cmdline\n'),
@@ -539,7 +539,7 @@ class TestDiskBuilder(object):
             call('dracut_rescue_image="no"\n'),
             # before dracut is called, image dracut setup
             call('add_dracutmodules+=" kiwi-overlay kiwi-lib kiwi-repart "\n'),
-            call('omit_dracutmodules+=" kiwi-live kiwi-dump "\n'),
+            call('omit_dracutmodules+=" kiwi-live kiwi-dump multipath "\n'),
             # after dracut was called, system dracut setup
             call('add_dracutmodules+=" kiwi-overlay "\n'),
             call('omit_dracutmodules+=" kiwi-live kiwi-dump kiwi-repart "\n'),


### PR DESCRIPTION
This commit fixes #645. With this commit there is no interction between
multipathd service and kiwi-oem-repart module, this way there are no
issues with devices appearing and disappearing. This this commit during
firstboot there will not be multipath support.
