### PR TITLE
The order of the options for mkisofs matters

### DIFF
--- a/kiwi/iso.py
+++ b/kiwi/iso.py
@@ -356,15 +356,15 @@ class Iso(object):
         """
         loader_file = self.boot_path + '/efi'
         if os.path.exists(os.sep.join([self.source_dir, loader_file])):
-            self.iso_loaders += [
-                '-eltorito-alt-boot', '-b', loader_file,
-                '-no-emul-boot', '-joliet-long'
-            ]
+            self.iso_loaders.append('-eltorito-alt-boot')
             iso_tool = self.get_iso_creation_tool()
             if iso_tool and CommandCapabilities.has_option_in_help(
                 iso_tool, '-eltorito-platform', raise_on_error=False
             ):
                 self.iso_loaders += ['-eltorito-platform', 'efi']
+            self.iso_loaders += [
+                '-b', loader_file, '-no-emul-boot', '-joliet-long'
+            ]
             loader_file_512_byte_blocks = os.path.getsize(
                 os.sep.join([self.source_dir, loader_file])
             ) / 512

--- a/test/unit/iso_test.py
+++ b/test/unit/iso_test.py
@@ -145,8 +145,9 @@ class TestIso(object):
         mock_exists.return_value = True
         self.iso.add_efi_loader_parameters()
         assert self.iso.iso_loaders == [
-            '-eltorito-alt-boot', '-b', 'boot/x86_64/efi',
-            '-no-emul-boot', '-joliet-long', '-eltorito-platform', 'efi',
+            '-eltorito-alt-boot', '-eltorito-platform', 'efi',
+            '-b', 'boot/x86_64/efi',
+            '-no-emul-boot', '-joliet-long',
             '-boot-load-size', '8'
         ]
 


### PR DESCRIPTION
Setting -eltorito-platform after -b causes mkisofs to fail

