### PR TITLE
Fixed btrfs search path in earlyboot script

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -652,21 +652,31 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
     def _create_early_boot_script_for_uuid_search(self, filename, uuid):
         with open(filename, 'w') as early_boot:
             early_boot.write(
-                'search --fs-uuid --set=root %s\n' % uuid
+                'set btrfs_relative_path="yes"{0}'.format(os.linesep)
             )
             early_boot.write(
-                'set prefix=($root)%s/%s\n' % (
-                    self.get_boot_path(), self.boot_directory_name
+                'search --fs-uuid --set=root {0}{1}'.format(uuid, os.linesep)
+            )
+            early_boot.write(
+                'set prefix=($root){0}/{1}{2}'.format(
+                    self.get_boot_path(), self.boot_directory_name, os.linesep
                 )
             )
 
     def _create_early_boot_script_for_mbrid_search(self, filename, mbrid):
         with open(filename, 'w') as early_boot:
             early_boot.write(
-                'search --file --set=root /boot/%s\n' % mbrid.get_id()
+                'set btrfs_relative_path="yes"{0}'.format(os.linesep)
             )
             early_boot.write(
-                'set prefix=($root)/boot/%s\n' % self.boot_directory_name
+                'search --file --set=root /boot/{0}{1}'.format(
+                    mbrid.get_id(), os.linesep
+                )
+            )
+            early_boot.write(
+                'set prefix=($root)/boot/{0}{1}'.format(
+                    self.boot_directory_name, os.linesep
+                )
             )
 
     def _get_grub2_boot_path(self):

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -574,6 +574,7 @@ class TestBootLoaderConfigGrub2(object):
             'root_dir/boot/efi/EFI/BOOT/earlyboot.cfg', 'w'
         )
         assert file_mock.write.call_args_list == [
+            call('set btrfs_relative_path="yes"\n'),
             call('search --fs-uuid --set=root 0815\n'),
             call('set prefix=($root)//grub2\n')
         ]
@@ -791,6 +792,7 @@ class TestBootLoaderConfigGrub2(object):
             call('root_dir//EFI/BOOT/earlyboot.cfg', 'w')
         ]
         assert file_mock.write.call_args_list == [
+            call('set btrfs_relative_path="yes"\n'),
             call('search --file --set=root /boot/0xffffffff\n'),
             call('set prefix=($root)/boot/grub2\n')
         ]


### PR DESCRIPTION
If kiwi generates its own efi image for the boot process
it does not setup the btrfs relative path setup in the
earlyboot script embedded into the generated efi image.
This has a bad impact on the file search because the
btrfs setup done in kiwi puts root below the @ volume
which we then need to specify of the relative lookup
is not activated. Fixes bsc#1082155


