### PR TITLE
Prepare test-image-oem build test for Kanku

### DIFF
--- a/build-tests/x86/test-image-oem/appliance.kiwi
+++ b/build-tests/x86/test-image-oem/appliance.kiwi
@@ -16,7 +16,11 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="btrfs" initrd_system="dracut" bootloader="grub2" kernelcmdline="console=ttyS0 splash" firmware="efi" installiso="true" bootpartition="false" btrfs_root_is_snapshot="true">
+        <type image="oem" filesystem="btrfs" initrd_system="dracut" bootloader="grub2" kernelcmdline="console=ttyS0 splash" firmware="efi" installiso="true" bootpartition="false" btrfs_root_is_snapshot="true" installboot="install">
+            <oemconfig>
+                <oem-unattended>true</oem-unattended>
+                <oem-swapsize>1024</oem-swapsize>
+            </oemconfig>
             <systemdisk>
                 <volume name="home"/>
             </systemdisk>


### PR DESCRIPTION
Activate unattended mode and preselect the installation target
Also specify a fixed swapsize value to be independent of the
host main memory which is used to calculate swap if no size
is specified

