### PR TITLE
Do not require multipath in dracut dump module

### DIFF
--- a/build-tests/x86/test-image-oem/appliance.kiwi
+++ b/build-tests/x86/test-image-oem/appliance.kiwi
@@ -20,6 +20,7 @@
             <oemconfig>
                 <oem-unattended>true</oem-unattended>
                 <oem-swapsize>1024</oem-swapsize>
+                <oem-multipath-scan>false</oem-multipath-scan>
             </oemconfig>
             <systemdisk>
                 <volume name="home"/>

--- a/dracut/modules.d/90kiwi-dump/module-setup.sh
+++ b/dracut/modules.d/90kiwi-dump/module-setup.sh
@@ -2,7 +2,7 @@
 
 # called by dracut
 depends() {
-    echo dmraid multipath network rootfs-block dm kiwi-lib
+    echo dmraid network rootfs-block dm kiwi-lib
     return 0
 }
 

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -105,13 +105,8 @@ class DiskBuilder(object):
         self.bootloader = xml_state.build_type.get_bootloader()
         self.initrd_system = xml_state.get_initrd_system()
         self.target_removable = xml_state.build_type.get_target_removable()
-
-        self.root_filesystem_is_multipath = False
-        self.oemconfig = self.xml_state.get_build_type_oemconfig_section()
-        if self.oemconfig and self.oemconfig.get_oem_multipath_scan():
-            self.root_filesystem_is_multipath = \
-                self.oemconfig.get_oem_multipath_scan()[0]
-
+        self.root_filesystem_is_multipath = \
+            xml_state.get_oemconfig_oem_multipath_scan()
         self.disk_setup = DiskSetup(
             xml_state, root_dir
         )
@@ -658,7 +653,7 @@ class DiskBuilder(object):
         ]
         dracut_modules = []
         dracut_modules_omit = ['kiwi-live', 'kiwi-dump']
-        if not self.root_filesystem_is_multipath:
+        if self.root_filesystem_is_multipath is False:
             dracut_modules_omit.append('multipath')
         if self.root_filesystem_is_overlay:
             dracut_modules.append('kiwi-overlay')

--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -105,6 +105,13 @@ class DiskBuilder(object):
         self.bootloader = xml_state.build_type.get_bootloader()
         self.initrd_system = xml_state.get_initrd_system()
         self.target_removable = xml_state.build_type.get_target_removable()
+
+        self.root_filesystem_is_multipath = False
+        self.oemconfig = self.xml_state.get_build_type_oemconfig_section()
+        if self.oemconfig and self.oemconfig.get_oem_multipath_scan():
+            self.root_filesystem_is_multipath = \
+                self.oemconfig.get_oem_multipath_scan()[0]
+
         self.disk_setup = DiskSetup(
             xml_state, root_dir
         )
@@ -651,6 +658,8 @@ class DiskBuilder(object):
         ]
         dracut_modules = []
         dracut_modules_omit = ['kiwi-live', 'kiwi-dump']
+        if not self.root_filesystem_is_multipath:
+            dracut_modules_omit.append('multipath')
         if self.root_filesystem_is_overlay:
             dracut_modules.append('kiwi-overlay')
         else:

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -74,6 +74,13 @@ class InstallImageBuilder(object):
         self.target_dir = target_dir
         self.boot_image_task = boot_image_task
         self.xml_state = xml_state
+
+        self.root_filesystem_is_multipath = False
+        self.oemconfig = self.xml_state.get_build_type_oemconfig_section()
+        if self.oemconfig and self.oemconfig.get_oem_multipath_scan():
+            self.root_filesystem_is_multipath = \
+                self.oemconfig.get_oem_multipath_scan()[0]
+
         self.initrd_system = xml_state.get_initrd_system()
         self.firmware = FirmWare(xml_state)
         self.diskname = ''.join(
@@ -433,6 +440,8 @@ class InstallImageBuilder(object):
         ]
         dracut_modules = ['kiwi-lib', 'kiwi-dump']
         dracut_modules_omit = ['kiwi-overlay', 'kiwi-live', 'kiwi-repart']
+        if not self.root_filesystem_is_multipath:
+            dracut_modules_omit.append('multipath')
         dracut_config.append(
             'add_dracutmodules+=" {0} "'.format(' '.join(dracut_modules))
         )

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -74,13 +74,8 @@ class InstallImageBuilder(object):
         self.target_dir = target_dir
         self.boot_image_task = boot_image_task
         self.xml_state = xml_state
-
-        self.root_filesystem_is_multipath = False
-        self.oemconfig = self.xml_state.get_build_type_oemconfig_section()
-        if self.oemconfig and self.oemconfig.get_oem_multipath_scan():
-            self.root_filesystem_is_multipath = \
-                self.oemconfig.get_oem_multipath_scan()[0]
-
+        self.root_filesystem_is_multipath = \
+            xml_state.get_oemconfig_oem_multipath_scan()
         self.initrd_system = xml_state.get_initrd_system()
         self.firmware = FirmWare(xml_state)
         self.diskname = ''.join(
@@ -440,7 +435,7 @@ class InstallImageBuilder(object):
         ]
         dracut_modules = ['kiwi-lib', 'kiwi-dump']
         dracut_modules_omit = ['kiwi-overlay', 'kiwi-live', 'kiwi-repart']
-        if not self.root_filesystem_is_multipath:
+        if self.root_filesystem_is_multipath is False:
             dracut_modules_omit.append('multipath')
         dracut_config.append(
             'add_dracutmodules+=" {0} "'.format(' '.join(dracut_modules))

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -617,6 +617,18 @@ class XMLState(object):
         if oemconfig_sections:
             return oemconfig_sections[0]
 
+    def get_oemconfig_oem_multipath_scan(self):
+        """
+        State value to activate multipath maps. Returns a boolean
+        value if specified or None
+
+        :return: oem-multipath-scan value
+        :rtype: bool or None
+        """
+        oemconfig = self.get_build_type_oemconfig_section()
+        if oemconfig and oemconfig.get_oem_multipath_scan():
+            return oemconfig.get_oem_multipath_scan()[0]
+
     def get_build_type_containerconfig_section(self):
         """
         First containerconfig section from the build type section

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -104,7 +104,6 @@ Requires(postun): update-alternatives
 Requires:       grub2-x86_64-efi
 %endif
 Requires:       qemu-tools
-Requires:       multipath-tools
 Requires:       squashfs
 Requires:       gptfdisk
 %endif
@@ -114,7 +113,6 @@ Requires(post):   chkconfig
 Requires(postun): chkconfig
 Requires:       qemu-img
 Requires:       squashfs-tools
-Requires:       device-mapper-multipath
 Requires:       gdisk
 Requires:       yum
 Provides:       kiwi-packagemanager:yum
@@ -131,7 +129,6 @@ Provides:       kiwi-packagemanager:zypper
 Requires:       debootstrap
 Requires:       qemu-utils
 Requires:       squashfs-tools
-Requires:       multipath-tools
 Requires:       gdisk
 %endif
 Requires:       dosfstools
@@ -187,7 +184,6 @@ Requires(postun): update-alternatives
 Requires:       grub2-x86_64-efi
 %endif
 Requires:       qemu-tools
-Requires:       multipath-tools
 Requires:       squashfs
 Requires:       gptfdisk
 %endif
@@ -197,7 +193,6 @@ Requires(post):   chkconfig
 Requires(postun): chkconfig
 Requires:       qemu-img
 Requires:       squashfs-tools
-Requires:       device-mapper-multipath
 Requires:       gdisk
 %endif
 %if 0%{?rhel} && 0%{?rhel} < 8

--- a/test/data/example_disk_config.xml
+++ b/test/data/example_disk_config.xml
@@ -18,7 +18,11 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" installiso="true" bootloader="grub2" kernelcmdline="splash" firmware="efi" btrfs_root_is_snapshot="true" btrfs_root_is_readonly_snapshot="true"/>
+        <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" installiso="true" bootloader="grub2" kernelcmdline="splash" firmware="efi" btrfs_root_is_snapshot="true" btrfs_root_is_readonly_snapshot="true">
+            <oemconfig>
+                <oem-multipath-scan>false</oem-multipath-scan>
+            </oemconfig>
+        </type>
     </preferences>
     <repository type="yast2">
         <source path="obs://13.2/repo/oss"/>

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -467,7 +467,7 @@ class TestDiskBuilder(object):
             call('dracut_rescue_image="no"\n'),
             # before dracut is called, image dracut setup
             call('add_dracutmodules+=" kiwi-lib kiwi-repart "\n'),
-            call('omit_dracutmodules+=" kiwi-live kiwi-dump kiwi-overlay "\n'),
+            call('omit_dracutmodules+=" kiwi-live kiwi-dump multipath kiwi-overlay "\n'),
             # after dracut was called, system dracut setup
             call('omit_dracutmodules+=" kiwi-live kiwi-dump kiwi-repart kiwi-overlay "\n'),
             call('boot_cmdline\n'),
@@ -539,7 +539,7 @@ class TestDiskBuilder(object):
             call('dracut_rescue_image="no"\n'),
             # before dracut is called, image dracut setup
             call('add_dracutmodules+=" kiwi-overlay kiwi-lib kiwi-repart "\n'),
-            call('omit_dracutmodules+=" kiwi-live kiwi-dump "\n'),
+            call('omit_dracutmodules+=" kiwi-live kiwi-dump multipath "\n'),
             # after dracut was called, system dracut setup
             call('add_dracutmodules+=" kiwi-overlay "\n'),
             call('omit_dracutmodules+=" kiwi-live kiwi-dump kiwi-repart "\n'),

--- a/test/unit/builder_install_test.py
+++ b/test/unit/builder_install_test.py
@@ -73,6 +73,13 @@ class TestInstallImageBuilder(object):
         self.xml_state.build_type.get_kernelcmdline = mock.Mock(
             return_value='custom_kernel_options'
         )
+        oemconfig = mock.Mock()
+        oemconfig.get_oem_multipath_scan = mock.Mock(
+            return_value=[False]
+        )
+        self.xml_state.get_build_type_oemconfig_section = mock.Mock(
+            return_value=oemconfig
+        )
         self.boot_image_task = mock.Mock()
         self.boot_image_task.boot_root_directory = 'initrd_dir'
         self.boot_image_task.initrd_filename = 'initrd'
@@ -99,6 +106,9 @@ class TestInstallImageBuilder(object):
         )
         xml_state.build_type.get_kernelcmdline = mock.Mock(
             return_value='custom_kernel_options'
+        )
+        xml_state.get_build_type_oemconfig_section = mock.Mock(
+            return_value=None
         )
         install_image = InstallImageBuilder(
             xml_state, 'root_dir', 'target_dir', mock.Mock()
@@ -210,7 +220,7 @@ class TestInstallImageBuilder(object):
             call('hostonly="no"\n'),
             call('dracut_rescue_image="no"\n'),
             call('add_dracutmodules+=" kiwi-lib kiwi-dump "\n'),
-            call('omit_dracutmodules+=" kiwi-overlay kiwi-live kiwi-repart "\n')
+            call('omit_dracutmodules+=" kiwi-overlay kiwi-live kiwi-repart multipath "\n')
         ]
 
     @patch('kiwi.builder.install.mkdtemp')
@@ -376,7 +386,7 @@ class TestInstallImageBuilder(object):
             call('hostonly="no"\n'),
             call('dracut_rescue_image="no"\n'),
             call('add_dracutmodules+=" kiwi-lib kiwi-dump "\n'),
-            call('omit_dracutmodules+=" kiwi-overlay kiwi-live kiwi-repart "\n')
+            call('omit_dracutmodules+=" kiwi-overlay kiwi-live kiwi-repart multipath "\n')
         ]
 
     @patch('kiwi.builder.install.Path.wipe')

--- a/test/unit/builder_install_test.py
+++ b/test/unit/builder_install_test.py
@@ -73,12 +73,8 @@ class TestInstallImageBuilder(object):
         self.xml_state.build_type.get_kernelcmdline = mock.Mock(
             return_value='custom_kernel_options'
         )
-        oemconfig = mock.Mock()
-        oemconfig.get_oem_multipath_scan = mock.Mock(
-            return_value=[False]
-        )
-        self.xml_state.get_build_type_oemconfig_section = mock.Mock(
-            return_value=oemconfig
+        self.xml_state.get_oemconfig_oem_multipath_scan = mock.Mock(
+            return_value=False
         )
         self.boot_image_task = mock.Mock()
         self.boot_image_task.boot_root_directory = 'initrd_dir'


### PR DESCRIPTION
The presence of multipath in the initrd seems to expect
a multipath based rootfs environment and causes conflicts
to the device setup if this is not the case. Thus a generic
module requirement can not be done in the kiwi dump
module. Customers need to explicitly add the module in
an overlay dracut.conf file if they plan to provide the
rootfs via multipath


