### PR TITLE
Tell plymouth to quit only if a dialog is called

### DIFF
--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -363,8 +363,6 @@ initialize
 
 udev_pending
 
-stop_plymouth
-
 image_target=$(get_selected_disk)
 
 if getargbool 0 rd.kiwi.install.pxe; then

--- a/dracut/modules.d/99kiwi-lib/kiwi-dialog-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-dialog-lib.sh
@@ -9,6 +9,7 @@ function run_dialog {
     # output of the dialog call is stored in a file and can be
     # one time read via the get_dialog_result function
     # """
+    stop_plymouth
     local dialog_result=/tmp/dialog_result
     local dialog_exit_code=/tmp/dialog_code
     {
@@ -55,7 +56,9 @@ function get_dialog_result {
 }
 
 function stop_plymouth {
-    plymouth --quit --wait
+    if command -v plymouth &>/dev/null;then
+        plymouth --quit --wait
+    fi
 }
 
 #=========================================


### PR DESCRIPTION
In case of a dialog kiwi uses the dialog program which conflicts
with the plymouth splash system. Thus we tell plymouth to stop
This patch changes the request to be send to plymouth prior to
a dialog call and not in general


