### PR TITLE
kiwi_inode_size value is no longer hardcoded in more than one place

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -678,7 +678,7 @@ class Defaults(object):
         :return: bytesize
         :rtype: int
         """
-        return 256
+        return Defaults().defaults['kiwi_inode_size']
 
     @classmethod
     def get_archive_image_types(self):


### PR DESCRIPTION
Just nit-picking, if found it while coding #662 and preferred to fix it in a separate PR.