### PR TITLE
Iso tool api

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -23,6 +23,7 @@ graft kiwi/schema
 graft kiwi/config
 graft kiwi/tasks
 graft kiwi/solver
+graft kiwi/iso_tools
 graft package
 
 include Makefile

--- a/doc/source/development/api/kiwi.iso_tools.rst
+++ b/doc/source/development/api/kiwi.iso_tools.rst
@@ -1,0 +1,35 @@
+kiwi.iso_tools Package
+======================
+
+Submodules
+----------
+
+`kiwi.iso_tools.base` Module
+----------------------------
+.. automodule:: kiwi.iso_tools.base
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+`kiwi.iso_tools.cdrtools` Module
+--------------------------------
+.. automodule:: kiwi.iso_tools.cdrtools
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+`kiwi.iso_tools.iso` Module
+----------------------------
+.. automodule:: kiwi.iso_tools.iso
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module Contents
+---------------
+
+.. automodule:: kiwi.iso_tools
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/development/api/kiwi.rst
+++ b/doc/source/development/api/kiwi.rst
@@ -14,6 +14,7 @@ Subpackages
     kiwi.builder
     kiwi.container
     kiwi.filesystem
+    kiwi.iso_tools
     kiwi.package_manager
     kiwi.partitioner
     kiwi.repository
@@ -91,14 +92,6 @@ Submodules
     :undoc-members:
     :show-inheritance:
 
-`kiwi.iso` Module
------------------
-
-.. automodule:: kiwi.iso
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 `kiwi.kiwi` Module
 ------------------
 
@@ -135,6 +128,22 @@ Submodules
 ------------------------
 
 .. automodule:: kiwi.privileges
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+`kiwi.runtime_checker` Module
+-----------------------------
+
+.. automodule:: kiwi.runtime_checker
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+`kiwi.runtime_config` Module
+----------------------------
+
+.. automodule:: kiwi.runtime_config
     :members:
     :undoc-members:
     :show-inheritance:

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -32,7 +32,7 @@ from kiwi.defaults import Defaults
 from kiwi.utils.checksum import Checksum
 from kiwi.logger import log
 from kiwi.system.kernel import Kernel
-from kiwi.iso import Iso
+from kiwi.iso_tools.iso import Iso
 from kiwi.utils.compress import Compress
 from kiwi.archive.tar import ArchiveTar
 

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -34,7 +34,7 @@ from kiwi.firmware import FirmWare
 from kiwi.defaults import Defaults
 from kiwi.path import Path
 from kiwi.system.result import Result
-from kiwi.iso import Iso
+from kiwi.iso_tools.iso import Iso
 from kiwi.system.identifier import SystemIdentifier
 from kiwi.system.kernel import Kernel
 from kiwi.logger import log

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -883,6 +883,16 @@ class Defaults(object):
         return os.sep.join([root_dir, 'image', 'imported_root'])
 
     @classmethod
+    def get_iso_boot_path(self):
+        """
+        Returns relative path to boot files on kiwi iso filesystems
+        """
+        arch = platform.machine()
+        if arch == 'i686' or arch == 'i586':
+            arch = 'ix86'
+        return os.sep.join(['boot', arch])
+
+    @classmethod
     def set_python_default_encoding_to_utf8(self):
         """
         Set python default encoding to utf-8 if not already done

--- a/kiwi/filesystem/isofs.py
+++ b/kiwi/filesystem/isofs.py
@@ -18,7 +18,7 @@
 # project
 from kiwi.filesystem.base import FileSystemBase
 from kiwi.command import Command
-from kiwi.iso import Iso
+from kiwi.iso_tools.iso import Iso
 
 
 class FileSystemIsoFs(FileSystemBase):

--- a/kiwi/filesystem/isofs.py
+++ b/kiwi/filesystem/isofs.py
@@ -17,7 +17,6 @@
 #
 # project
 from kiwi.filesystem.base import FileSystemBase
-from kiwi.command import Command
 from kiwi.iso_tools.iso import Iso
 from kiwi.iso_tools.cdrtools import IsoToolsCdrTools
 
@@ -38,7 +37,6 @@ class FileSystemIsoFs(FileSystemBase):
         :param string exclude: unused
         """
         iso_tool = IsoToolsCdrTools(self.root_dir)
-        iso_tool_name = iso_tool.get_tool_name()
 
         iso = Iso(self.root_dir)
         iso.setup_isolinux_boot_path()
@@ -50,24 +48,12 @@ class FileSystemIsoFs(FileSystemBase):
         )
         iso_tool.add_efi_loader_parameters()
 
-        Command.run(
-            [
-                iso_tool_name
-            ] + iso_tool.get_iso_creation_parameters() + [
-                '-o', filename, self.root_dir
-            ]
-        )
+        iso_tool.create_iso(filename)
 
         hybrid_offset = iso.create_header_end_block(filename)
 
-        Command.run(
-            [
-                iso_tool_name,
-                '-hide', iso.header_end_name,
-                '-hide-joliet', iso.header_end_name
-            ] + iso_tool.get_iso_creation_parameters() + [
-                '-o', filename, self.root_dir
-            ]
+        iso_tool.create_iso(
+            filename, hidden_files=[iso.header_end_name]
         )
 
         iso.relocate_boot_catalog(filename)

--- a/kiwi/filesystem/isofs.py
+++ b/kiwi/filesystem/isofs.py
@@ -19,6 +19,7 @@
 from kiwi.filesystem.base import FileSystemBase
 from kiwi.command import Command
 from kiwi.iso_tools.iso import Iso
+from kiwi.iso_tools.cdrtools import IsoToolsCdrTools
 
 
 class FileSystemIsoFs(FileSystemBase):
@@ -36,28 +37,39 @@ class FileSystemIsoFs(FileSystemBase):
         :param string label: unused
         :param string exclude: unused
         """
+        iso_tool = IsoToolsCdrTools(self.root_dir)
+        iso_tool_name = iso_tool.get_tool_name()
+
         iso = Iso(self.root_dir)
-        iso.init_iso_creation_parameters(
-            self.custom_args['create_options']
+        iso.setup_isolinux_boot_path()
+
+        iso.create_header_end_marker()
+
+        iso_tool.init_iso_creation_parameters(
+            iso.create_sortfile(), self.custom_args['create_options']
         )
-        iso.add_efi_loader_parameters()
+        iso_tool.add_efi_loader_parameters()
+
         Command.run(
             [
-                Iso.get_iso_creation_tool()
-            ] + iso.get_iso_creation_parameters() + [
+                iso_tool_name
+            ] + iso_tool.get_iso_creation_parameters() + [
                 '-o', filename, self.root_dir
             ]
         )
+
         hybrid_offset = iso.create_header_end_block(filename)
+
         Command.run(
             [
-                Iso.get_iso_creation_tool(),
+                iso_tool_name,
                 '-hide', iso.header_end_name,
                 '-hide-joliet', iso.header_end_name
-            ] + iso.get_iso_creation_parameters() + [
+            ] + iso_tool.get_iso_creation_parameters() + [
                 '-o', filename, self.root_dir
             ]
         )
+
         iso.relocate_boot_catalog(filename)
         iso.fix_boot_catalog(filename)
         return hybrid_offset

--- a/kiwi/iso_tools/base.py
+++ b/kiwi/iso_tools/base.py
@@ -75,11 +75,12 @@ class IsoToolsBase(object):
         """
         raise NotImplementedError
 
-    def get_iso_creation_parameters(self):
+    def create_iso(self, filename, hidden_files=None):
         """
-        Return current list of ISO creation parameters
+        Create iso file
 
-        :return: tool specific parameters
-        :rtype: list
+        Implementation in specialized tool class
+
+        :param string filename: unused
         """
-        return self.iso_parameters + self.iso_loaders
+        raise NotImplementedError

--- a/kiwi/iso_tools/base.py
+++ b/kiwi/iso_tools/base.py
@@ -84,3 +84,11 @@ class IsoToolsBase(object):
         :param string filename: unused
         """
         raise NotImplementedError
+
+    def list_iso(self, isofile):
+        """
+        List contents of an ISO image
+
+        :param string isofile: unused
+        """
+        raise NotImplementedError

--- a/kiwi/iso_tools/base.py
+++ b/kiwi/iso_tools/base.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2015 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+# project
+from kiwi.defaults import Defaults
+
+
+class IsoToolsBase(object):
+    """
+    Base Class for Parameter API for iso creation tools
+
+    Attributes
+
+    * :attr:`boot_path`
+        architecture specific boot path on the ISO
+
+    * :attr:`iso_parameters`
+        list of ISO creation parameters
+
+    * :attr:`iso_loaders`
+        list of ISO loaders to embed
+    """
+    def __init__(self, source_dir):
+        """
+        Initialize setup data for later iso creation tool
+
+        :param string source_dir: data source dir, usually root_dir
+        """
+        self.source_dir = source_dir
+
+        self.boot_path = Defaults.get_iso_boot_path()
+        self.iso_parameters = []
+        self.iso_loaders = []
+
+    def get_tool_name(self):
+        """
+        Return caller name for iso creation tool
+
+        Implementation in specialized tool class
+
+        :return: tool name
+        """
+        raise NotImplementedError
+
+    def init_iso_creation_parameters(self, sortfile, custom_args=None):
+        """
+        Create a set of standard parameters for the main isolinux loader
+
+        Implementation in specialized tool class
+
+        :param string sortfile: unused
+        :param list custom_args: unused
+        """
+        raise NotImplementedError
+
+    def add_efi_loader_parameters(self):
+        """
+        Add ISO creation parameters to embed the EFI loader
+
+        Implementation in specialized tool class
+        """
+        raise NotImplementedError
+
+    def get_iso_creation_parameters(self):
+        """
+        Return current list of ISO creation parameters
+
+        :return: tool specific parameters
+        :rtype: list
+        """
+        return self.iso_parameters + self.iso_loaders

--- a/kiwi/iso_tools/cdrtools.py
+++ b/kiwi/iso_tools/cdrtools.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2015 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+import os
+
+# project
+from kiwi.iso_tools.base import IsoToolsBase
+from kiwi.utils.command_capabilities import CommandCapabilities
+from kiwi.path import Path
+from kiwi.exceptions import KiwiIsoToolError
+
+
+class IsoToolsCdrTools(IsoToolsBase):
+    """
+    Implementation of Parameter API for iso creation tools using
+    the cdrkit/cdrtools projects. Addressed here are the option
+    compatible tools mkisofs and genisoimage
+    """
+    def get_tool_name(self):
+        """
+        There are tools by J.Schilling and tools from the community
+        Depending on what is installed a decision needs to be made.
+        mkisofs is preferred over genisoimage
+        """
+        iso_creation_tools = ['mkisofs', 'genisoimage']
+        for tool in iso_creation_tools:
+            tool_found = Path.which(tool)
+            if tool_found:
+                return tool_found
+
+        raise KiwiIsoToolError(
+            'No iso creation tool found, searched for: %s'.format(
+                iso_creation_tools
+            )
+        )
+
+    def init_iso_creation_parameters(self, sortfile, custom_args=None):
+        """
+        Create a set of standard parameters
+
+        :param string sortfile: file path name
+        :param list custom_args: custom ISO creation args
+        """
+        if custom_args:
+            self.iso_parameters = custom_args
+        catalog_file = self.boot_path + '/boot.catalog'
+        self.iso_parameters += [
+            '-R', '-J', '-f', '-pad', '-joliet-long',
+            '-sort', sortfile,
+            '-no-emul-boot', '-boot-load-size', '4', '-boot-info-table',
+            '-hide', catalog_file,
+            '-hide-joliet', catalog_file,
+        ]
+        loader_file = self.boot_path + '/loader/isolinux.bin'
+        self.iso_loaders += [
+            '-b', loader_file, '-c', catalog_file
+        ]
+
+    def add_efi_loader_parameters(self):
+        """
+        Add ISO creation parameters to embed the EFI loader
+
+        In order to boot the ISO from EFI, the EFI binary is added as
+        alternative loader to the ISO creation parameter list. The
+        EFI binary must be included into a fat filesystem in order
+        to become recognized by the firmware. For details about this
+        file refer to _create_embedded_fat_efi_image() from
+        bootloader/config/grub2.py
+        """
+        loader_file = self.boot_path + '/efi'
+        if os.path.exists(os.sep.join([self.source_dir, loader_file])):
+            self.iso_loaders.append('-eltorito-alt-boot')
+            iso_tool = self.get_tool_name()
+            if iso_tool and CommandCapabilities.has_option_in_help(
+                iso_tool, '-eltorito-platform', raise_on_error=False
+            ):
+                self.iso_loaders += ['-eltorito-platform', 'efi']
+            self.iso_loaders += [
+                '-b', loader_file, '-no-emul-boot', '-joliet-long'
+            ]
+            loader_file_512_byte_blocks = os.path.getsize(
+                os.sep.join([self.source_dir, loader_file])
+            ) / 512
+            # boot-load-size is stored in a 16bit range, thus we only
+            # set the value if it fits into that range
+            if loader_file_512_byte_blocks <= 0xffff:
+                self.iso_loaders.append(
+                    '-boot-load-size'
+                )
+                self.iso_loaders.append(
+                    format(int(loader_file_512_byte_blocks))
+                )

--- a/kiwi/iso_tools/cdrtools.py
+++ b/kiwi/iso_tools/cdrtools.py
@@ -21,6 +21,7 @@ import os
 from kiwi.iso_tools.base import IsoToolsBase
 from kiwi.utils.command_capabilities import CommandCapabilities
 from kiwi.path import Path
+from kiwi.command import Command
 from kiwi.exceptions import KiwiIsoToolError
 
 
@@ -104,3 +105,20 @@ class IsoToolsCdrTools(IsoToolsBase):
                 self.iso_loaders.append(
                     format(int(loader_file_512_byte_blocks))
                 )
+
+    def create_iso(self, filename, hidden_files=None):
+        hidden_files_parameters = []
+        if hidden_files:
+            for hidden_file in hidden_files:
+                hidden_files_parameters.append('-hide')
+                hidden_files_parameters.append(hidden_file)
+                hidden_files_parameters.append('-hide-joliet')
+                hidden_files_parameters.append(hidden_file)
+        Command.run(
+            [
+                self.get_tool_name()
+            ] + hidden_files_parameters +
+            self.iso_parameters + self.iso_loaders + [
+                '-o', filename, self.source_dir
+            ]
+        )

--- a/kiwi/iso_tools/iso.py
+++ b/kiwi/iso_tools/iso.py
@@ -19,7 +19,6 @@ import os
 import re
 import struct
 import collections
-import platform
 from tempfile import NamedTemporaryFile
 from collections import namedtuple
 
@@ -29,8 +28,8 @@ from collections import namedtuple
 from builtins import bytes
 
 # project
-from kiwi.utils.command_capabilities import CommandCapabilities
 from kiwi.logger import log
+from kiwi.defaults import Defaults
 from kiwi.path import Path
 from kiwi.command import Command
 from kiwi.exceptions import (
@@ -46,9 +45,6 @@ class Iso(object):
     Implements helper methods around the creation of ISO filesystems
 
     Attributes
-
-    * :attr:`arch`
-        system architecture
 
     * :attr:`header_id`
         static identifier string for self written headers
@@ -67,25 +63,14 @@ class Iso(object):
 
     * :attr:`iso_sortfile`
         named temporary file used as ISO sortfile
-
-    * :attr:`iso_parameters`
-        list of ISO creation parameters
-
-    * :attr:`iso_loaders`
-        list of ISO loaders to embed
     """
     def __init__(self, source_dir):
-        self.arch = platform.machine()
-        if self.arch == 'i686' or self.arch == 'i586':
-            self.arch = 'ix86'
         self.source_dir = source_dir
         self.header_id = '7984fc91-a43f-4e45-bf27-6d3aa08b24cf'
         self.header_end_name = 'header_end'
         self.header_end_file = self.source_dir + '/' + self.header_end_name
-        self.boot_path = 'boot/' + self.arch
+        self.boot_path = Defaults.get_iso_boot_path()
         self.iso_sortfile = NamedTemporaryFile()
-        self.iso_parameters = []
-        self.iso_loaders = []
 
     @classmethod
     def create_hybrid(self, offset, mbrid, isofile, efi_mode=False):
@@ -186,9 +171,11 @@ class Iso(object):
                     new_volume_id = Iso._sub_string(
                         data=new_volume_descriptor, length=7
                     )
-                    if bytes(b'TEA01') in new_volume_id or sector + 1 == ref_sector:
+                    if (bytes(b'TEA01') in new_volume_id or
+                            sector + 1 == ref_sector):
                         new_boot_catalog_sector = sector + 1
                         break
+
             if iso_metadata.boot_catalog_sector != new_boot_catalog_sector:
                 new_boot_catalog = Iso._read_iso_sector(
                     new_boot_catalog_sector, iso
@@ -273,119 +260,17 @@ class Iso(object):
                 )
             log.debug('Fixed iso catalog contents')
 
-    @classmethod
-    def get_iso_creation_tool(self):
+    def create_header_end_marker(self):
         """
-        There are tools by J.Schilling and tools from the community
-        Depending on what is installed a decision needs to be made
+        Prepare iso file to become a hybrid iso image.
+
+        To do this the offest address of the end of the first iso
+        block is required. To lookup this address a reference(marker)
+        file named 'header_end' is created and will show up as last
+        file in the block.
         """
-        iso_creation_tools = ['mkisofs', 'genisoimage']
-        for tool in iso_creation_tools:
-            tool_found = Path.which(tool)
-            if tool_found:
-                return tool_found
-
-        raise KiwiIsoToolError(
-            'No iso creation tool found, searched for: %s' %
-            iso_creation_tools
-        )
-
-    @classmethod
-    def get_isoinfo_tool(self):
-        """
-        There are tools by J.Schilling and tools from the community
-        Depending on what is installed a decision needs to be done
-        """
-        alternative_lookup_paths = ['/usr/lib/genisoimage']
-        isoinfo = Path.which('isoinfo', alternative_lookup_paths)
-        if isoinfo:
-            return isoinfo
-
-        raise KiwiIsoToolError(
-            'No isoinfo tool found, searched in PATH: %s and %s' %
-            (os.environ.get('PATH'), alternative_lookup_paths)
-        )
-
-    def init_iso_creation_parameters(self, custom_args=None):
-        """
-        Create a set of standard parameters for the main isolinux loader
-
-        In addition a sort file with the contents of the iso is created.
-        The kiwi iso file is also prepared to become a hybrid iso image.
-        In order to do this the offest address of the end of the first iso
-        block is required. In order to lookup the address a reference file
-        named 'header_end' is created and will show up as last file in
-        the block.
-
-        :param list custom_args: custom ISO creation args
-        """
-        loader_file = self.boot_path + '/loader/isolinux.bin'
-        catalog_file = self.boot_path + '/boot.catalog'
         with open(self.header_end_file, 'w') as marker:
             marker.write('%s\n' % self.header_id)
-        if not os.path.exists(self.source_dir + '/' + loader_file):
-            raise KiwiIsoLoaderError(
-                'No isolinux loader found in %s' %
-                self.source_dir + '/loader'
-            )
-        if custom_args:
-            self.iso_parameters = custom_args
-        self.iso_parameters += [
-            '-R', '-J', '-f', '-pad', '-joliet-long',
-            '-sort', self.iso_sortfile.name,
-            '-no-emul-boot', '-boot-load-size', '4', '-boot-info-table',
-            '-hide', catalog_file,
-            '-hide-joliet', catalog_file,
-        ]
-        self.iso_loaders += [
-            '-b', loader_file, '-c', catalog_file
-        ]
-        self._setup_isolinux_boot_path()
-        self._create_sortfile()
-
-    def add_efi_loader_parameters(self):
-        """
-        Add ISO creation parameters to embed the EFI loader
-
-        In order to boot the ISO from EFI, the EFI binary is added as
-        alternative loader to the ISO creation parameter list. The
-        EFI binary must be included into a fat filesystem in order
-        to become recognized by the firmware. For details about this
-        file refer to _create_embedded_fat_efi_image() from
-        bootloader/config/grub2.py
-        """
-        loader_file = self.boot_path + '/efi'
-        if os.path.exists(os.sep.join([self.source_dir, loader_file])):
-            self.iso_loaders.append('-eltorito-alt-boot')
-            iso_tool = self.get_iso_creation_tool()
-            if iso_tool and CommandCapabilities.has_option_in_help(
-                iso_tool, '-eltorito-platform', raise_on_error=False
-            ):
-                self.iso_loaders += ['-eltorito-platform', 'efi']
-            self.iso_loaders += [
-                '-b', loader_file, '-no-emul-boot', '-joliet-long'
-            ]
-            loader_file_512_byte_blocks = os.path.getsize(
-                os.sep.join([self.source_dir, loader_file])
-            ) / 512
-            # boot-load-size is stored in a 16bit range, thus we only
-            # set the value if it fits into that range
-            if loader_file_512_byte_blocks <= 0xffff:
-                self.iso_loaders.append(
-                    '-boot-load-size'
-                )
-                self.iso_loaders.append(
-                    format(int(loader_file_512_byte_blocks))
-                )
-
-    def get_iso_creation_parameters(self):
-        """
-        Return current list of ISO creation parameters
-
-        :return: genisoimage args
-        :rtype: list
-        """
-        return self.iso_parameters + self.iso_loaders
 
     def create_header_end_block(self, isofile):
         """
@@ -445,7 +330,7 @@ class Iso(object):
             'listing_type', ['name', 'filetype', 'start']
         )
         listing = Command.run(
-            [self.get_isoinfo_tool(), '-R', '-l', '-i', isofile]
+            [self._get_isoinfo_tool(), '-R', '-l', '-i', isofile]
         )
         listing_result = {}
         for line in listing.output.split('\n'):
@@ -465,14 +350,18 @@ class Iso(object):
             sorted(listing_result.items())
         )
 
-    def _setup_isolinux_boot_path(self):
+    def setup_isolinux_boot_path(self):
         """
-        Write the isolinux base boot path into the loader
+        Write the base boot path into the isolinux loader binary
         """
         loader_base_directory = self.boot_path + '/loader'
         loader_file = '/'.join(
             [self.source_dir, self.boot_path, 'loader/isolinux.bin']
         )
+        if not os.path.exists(loader_file):
+            raise KiwiIsoLoaderError(
+                'No isolinux loader %s found'.format(loader_file)
+            )
         try:
             Command.run(
                 [
@@ -497,7 +386,10 @@ class Iso(object):
                 ['bash', '-c', bash_command]
             )
 
-    def _create_sortfile(self):
+    def create_sortfile(self):
+        """
+        Create isolinux sort file
+        """
         catalog_file = \
             self.source_dir + '/' + self.boot_path + '/boot.catalog'
         loader_file = \
@@ -520,6 +412,7 @@ class Iso(object):
             sortfile.write(
                 '%s/%s 1000000\n' % (self.source_dir, self.header_end_name)
             )
+        return self.iso_sortfile.name
 
     @staticmethod
     def _read_iso_metadata(isofile):
@@ -608,6 +501,22 @@ class Iso(object):
                 '%s: no boot catalog found' %
                 iso_header.isofile
             )
+
+    def _get_isoinfo_tool(self):
+        """
+        There are tools by J.Schilling and tools from the community
+        This method searches in all paths which could provide an
+        isoinfo tool. The first match makes the decision
+        """
+        alternative_lookup_paths = ['/usr/lib/genisoimage']
+        isoinfo = Path.which('isoinfo', alternative_lookup_paths)
+        if isoinfo:
+            return isoinfo
+
+        raise KiwiIsoToolError(
+            'No isoinfo tool found, searched in PATH: %s and %s' %
+            (os.environ.get('PATH'), alternative_lookup_paths)
+        )
 
     @staticmethod
     def _read_iso_sector(sector, handle):

--- a/kiwi/iso_tools/iso.py
+++ b/kiwi/iso_tools/iso.py
@@ -16,9 +16,7 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
-import re
 import struct
-import collections
 from tempfile import NamedTemporaryFile
 from collections import namedtuple
 
@@ -28,6 +26,7 @@ from collections import namedtuple
 from builtins import bytes
 
 # project
+from kiwi.iso_tools.cdrtools import IsoToolsCdrTools
 from kiwi.logger import log
 from kiwi.defaults import Defaults
 from kiwi.path import Path
@@ -35,7 +34,6 @@ from kiwi.command import Command
 from kiwi.exceptions import (
     KiwiIsoLoaderError,
     KiwiIsoMetaDataError,
-    KiwiIsoToolError,
     KiwiCommandError
 )
 
@@ -287,8 +285,9 @@ class Iso(object):
         file_count = 0
         offset = 0
         found_id = False
+        iso_tool = IsoToolsCdrTools(self.source_dir)
         with open(isofile, 'rb') as iso:
-            for start in self.isols(isofile):
+            for start in iso_tool.list_iso(isofile):
                 if file_count >= 8:  # check only the first 8 files
                     break
                 file_count += 1
@@ -316,39 +315,6 @@ class Iso(object):
                     'Header ID not found in iso file %s' % isofile
                 )
             return offset * 4
-
-    def isols(self, isofile):
-        """
-        List contents of an ISO image
-
-        :param string isofile: path to the ISO file
-
-        :return: formatted isoinfo result
-        :rtype: dict
-        """
-        listing_type = namedtuple(
-            'listing_type', ['name', 'filetype', 'start']
-        )
-        listing = Command.run(
-            [self._get_isoinfo_tool(), '-R', '-l', '-i', isofile]
-        )
-        listing_result = {}
-        for line in listing.output.split('\n'):
-            iso_entry = re.search(
-                '.*(-[-rwx]{9}).*\s\[\s*(\d+)(\s+\d+)?\]\s+(.*?)\s*$', line
-            )
-            if iso_entry:
-                entry_type = iso_entry.group(1)
-                entry_name = iso_entry.group(4)
-                entry_addr = int(iso_entry.group(2))
-                listing_result[entry_addr] = listing_type(
-                    name=entry_name,
-                    filetype=entry_type,
-                    start=entry_addr
-                )
-        return collections.OrderedDict(
-            sorted(listing_result.items())
-        )
 
     def setup_isolinux_boot_path(self):
         """
@@ -501,22 +467,6 @@ class Iso(object):
                 '%s: no boot catalog found' %
                 iso_header.isofile
             )
-
-    def _get_isoinfo_tool(self):
-        """
-        There are tools by J.Schilling and tools from the community
-        This method searches in all paths which could provide an
-        isoinfo tool. The first match makes the decision
-        """
-        alternative_lookup_paths = ['/usr/lib/genisoimage']
-        isoinfo = Path.which('isoinfo', alternative_lookup_paths)
-        if isoinfo:
-            return isoinfo
-
-        raise KiwiIsoToolError(
-            'No isoinfo tool found, searched in PATH: %s and %s' %
-            (os.environ.get('PATH'), alternative_lookup_paths)
-        )
 
     @staticmethod
     def _read_iso_sector(sector, handle):

--- a/kiwi/iso_tools/iso.py
+++ b/kiwi/iso_tools/iso.py
@@ -29,11 +29,11 @@ from collections import namedtuple
 from builtins import bytes
 
 # project
-from .utils.command_capabilities import CommandCapabilities
-from .logger import log
-from .path import Path
-from .command import Command
-from .exceptions import (
+from kiwi.utils.command_capabilities import CommandCapabilities
+from kiwi.logger import log
+from kiwi.path import Path
+from kiwi.command import Command
+from kiwi.exceptions import (
     KiwiIsoLoaderError,
     KiwiIsoMetaDataError,
     KiwiIsoToolError,

--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -466,7 +466,7 @@ class RuntimeChecker(object):
     def check_grub_efi_installed_for_efi_firmware(self):
         """
         If the image is being built with efi or uefi firmware setting
-        we need a grub(2)-*-efi package installed. The check is not 100%
+        we need a grub(2)-...-efi package installed. The check is not 100%
         as every distribution has different names and different requirement
         but it is a reasonable approximation on the safe side meaning the
         user may still get an error but should not receive a false positive

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -79,3 +79,10 @@ class TestDefaults(object):
             'kiwi-live'
         assert Defaults.get_live_dracut_module_from_flag('dmsquash') == \
             'dmsquash-live'
+
+    @patch('platform.machine')
+    def test_get_iso_boot_path(self, mock_machine):
+        mock_machine.return_value = 'i686'
+        assert Defaults.get_iso_boot_path() == 'boot/ix86'
+        mock_machine.return_value = 'x86_64'
+        assert Defaults.get_iso_boot_path() == 'boot/x86_64'

--- a/test/unit/filesystem_isofs_test.py
+++ b/test/unit/filesystem_isofs_test.py
@@ -19,21 +19,31 @@ class TestFileSystemIsoFs(object):
         assert self.isofs.custom_args['some_args'] == 'data'
 
     @patch('kiwi.filesystem.isofs.Command.run')
-    @patch('kiwi.filesystem.isofs.Iso.get_iso_creation_tool')
+    @patch('kiwi.filesystem.isofs.IsoToolsCdrTools')
     @patch('kiwi.filesystem.isofs.Iso')
-    def test_create_on_file(
-        self, mock_iso, mock_get_iso_creation_tool, mock_command
-    ):
+    def test_create_on_file(self, mock_iso, mock_cdrtools, mock_command):
+        iso_tool = mock.Mock()
+        iso_tool.get_tool_name = mock.Mock(
+            return_value='/usr/bin/mkisofs'
+        )
         iso = mock.Mock()
         iso.header_end_name = 'header_end'
-        iso.get_iso_creation_parameters = mock.Mock(
+        iso_tool.get_iso_creation_parameters = mock.Mock(
             return_value=['args']
         )
-        mock_get_iso_creation_tool.return_value = '/usr/bin/mkisofs'
+        mock_cdrtools.return_value = iso_tool
         mock_iso.return_value = iso
         self.isofs.create_on_file('myimage', None)
-        iso.init_iso_creation_parameters.assert_called_once_with([])
-        iso.add_efi_loader_parameters.assert_called_once_with()
+
+        iso_tool.get_tool_name.assert_called_once_with()
+
+        iso.setup_isolinux_boot_path.assert_called_once_with()
+        iso.create_header_end_marker.assert_called_once_with()
+
+        iso_tool.init_iso_creation_parameters.assert_called_once_with(
+            iso.create_sortfile.return_value, []
+        )
+        iso_tool.add_efi_loader_parameters.assert_called_once_with()
         iso.create_header_end_block.assert_called_once_with(
             'myimage'
         )

--- a/test/unit/filesystem_isofs_test.py
+++ b/test/unit/filesystem_isofs_test.py
@@ -18,24 +18,18 @@ class TestFileSystemIsoFs(object):
         assert self.isofs.custom_args['mount_options'] == []
         assert self.isofs.custom_args['some_args'] == 'data'
 
-    @patch('kiwi.filesystem.isofs.Command.run')
     @patch('kiwi.filesystem.isofs.IsoToolsCdrTools')
     @patch('kiwi.filesystem.isofs.Iso')
-    def test_create_on_file(self, mock_iso, mock_cdrtools, mock_command):
+    def test_create_on_file(self, mock_iso, mock_cdrtools):
         iso_tool = mock.Mock()
         iso_tool.get_tool_name = mock.Mock(
             return_value='/usr/bin/mkisofs'
         )
         iso = mock.Mock()
         iso.header_end_name = 'header_end'
-        iso_tool.get_iso_creation_parameters = mock.Mock(
-            return_value=['args']
-        )
         mock_cdrtools.return_value = iso_tool
         mock_iso.return_value = iso
         self.isofs.create_on_file('myimage', None)
-
-        iso_tool.get_tool_name.assert_called_once_with()
 
         iso.setup_isolinux_boot_path.assert_called_once_with()
         iso.create_header_end_marker.assert_called_once_with()
@@ -44,19 +38,13 @@ class TestFileSystemIsoFs(object):
             iso.create_sortfile.return_value, []
         )
         iso_tool.add_efi_loader_parameters.assert_called_once_with()
-        iso.create_header_end_block.assert_called_once_with(
-            'myimage'
-        )
-        assert mock_command.call_args_list == [
-            call([
-                '/usr/bin/mkisofs', 'args', '-o', 'myimage', 'root_dir'
-            ]),
-            call([
-                '/usr/bin/mkisofs', '-hide', 'header_end',
-                '-hide-joliet', 'header_end', 'args', '-o', 'myimage',
-                'root_dir'
-            ])
+
+        iso.create_header_end_block.assert_called_once_with('myimage')
+
+        assert iso_tool.create_iso.call_args_list == [
+            call('myimage'), call('myimage', hidden_files=['header_end'])
         ]
+
         iso.relocate_boot_catalog.assert_called_once_with(
             'myimage'
         )

--- a/test/unit/iso_tools_base_test.py
+++ b/test/unit/iso_tools_base_test.py
@@ -15,6 +15,10 @@ class TestIsoToolsBase(object):
         self.iso_tool.create_iso('filename')
 
     @raises(NotImplementedError)
+    def test_list_iso(self):
+        self.iso_tool.list_iso('isofile')
+
+    @raises(NotImplementedError)
     def test_get_tool_name(self):
         self.iso_tool.get_tool_name()
 

--- a/test/unit/iso_tools_base_test.py
+++ b/test/unit/iso_tools_base_test.py
@@ -1,0 +1,26 @@
+from mock import patch
+from .test_helper import raises
+
+from kiwi.iso_tools.base import IsoToolsBase
+
+
+class TestIsoToolsBase(object):
+    @patch('platform.machine')
+    def setup(self, mock_machine):
+        mock_machine.return_value = 'x86_64'
+        self.iso_tool = IsoToolsBase('source-dir')
+
+    def test_get_iso_creation_parameters(self):
+        assert self.iso_tool.get_iso_creation_parameters() == []
+
+    @raises(NotImplementedError)
+    def test_get_tool_name(self):
+        self.iso_tool.get_tool_name()
+
+    @raises(NotImplementedError)
+    def test_init_iso_creation_parameters(self):
+        self.iso_tool.init_iso_creation_parameters('sortfile')
+
+    @raises(NotImplementedError)
+    def test_add_efi_loader_parameters(self):
+        self.iso_tool.add_efi_loader_parameters()

--- a/test/unit/iso_tools_base_test.py
+++ b/test/unit/iso_tools_base_test.py
@@ -10,8 +10,9 @@ class TestIsoToolsBase(object):
         mock_machine.return_value = 'x86_64'
         self.iso_tool = IsoToolsBase('source-dir')
 
-    def test_get_iso_creation_parameters(self):
-        assert self.iso_tool.get_iso_creation_parameters() == []
+    @raises(NotImplementedError)
+    def test_create_iso(self):
+        self.iso_tool.create_iso('filename')
 
     @raises(NotImplementedError)
     def test_get_tool_name(self):

--- a/test/unit/iso_tools_cdrtools_test.py
+++ b/test/unit/iso_tools_cdrtools_test.py
@@ -75,3 +75,14 @@ class TestIsoToolsCdrTools(object):
             '-eltorito-alt-boot', '-b', 'boot/x86_64/efi',
             '-no-emul-boot', '-joliet-long'
         ]
+
+    @patch('kiwi.iso_tools.cdrtools.Command.run')
+    def test_create_iso(self, mock_command):
+        self.iso_tool.create_iso('myiso', hidden_files=['hide_me'])
+        mock_command.assert_called_once_with(
+            [
+                '/usr/bin/mkisofs',
+                '-hide', 'hide_me', '-hide-joliet', 'hide_me',
+                '-o', 'myiso', 'source-dir'
+            ]
+        )

--- a/test/unit/iso_tools_cdrtools_test.py
+++ b/test/unit/iso_tools_cdrtools_test.py
@@ -1,0 +1,77 @@
+from mock import patch, call
+from .test_helper import raises
+
+from kiwi.iso_tools.cdrtools import IsoToolsCdrTools
+from kiwi.exceptions import KiwiIsoToolError
+
+
+class TestIsoToolsCdrTools(object):
+    @patch('platform.machine')
+    def setup(self, mock_machine):
+        mock_machine.return_value = 'x86_64'
+        self.iso_tool = IsoToolsCdrTools('source-dir')
+
+    @patch('kiwi.iso_tools.cdrtools.Path.which')
+    def test_get_tool_name(self, mock_which):
+        path_search_return_values = ['tool_found', None]
+
+        def path_search(tool):
+            return path_search_return_values.pop()
+
+        mock_which.side_effect = path_search
+        assert self.iso_tool.get_tool_name() == 'tool_found'
+        assert mock_which.call_args_list == [
+            call('mkisofs'), call('genisoimage')
+        ]
+
+    @raises(KiwiIsoToolError)
+    @patch('os.path.exists')
+    def test_get_tool_name_raises(self, mock_exists):
+        mock_exists.return_value = False
+        self.iso_tool.get_tool_name()
+
+    def test_init_iso_creation_parameters(self):
+        self.iso_tool.init_iso_creation_parameters('sortfile', ['custom_arg'])
+        assert self.iso_tool.iso_parameters == [
+            'custom_arg', '-R', '-J', '-f', '-pad', '-joliet-long',
+            '-sort', 'sortfile', '-no-emul-boot', '-boot-load-size', '4',
+            '-boot-info-table',
+            '-hide', 'boot/x86_64/boot.catalog',
+            '-hide-joliet', 'boot/x86_64/boot.catalog',
+        ]
+        assert self.iso_tool.iso_loaders == [
+            '-b', 'boot/x86_64/loader/isolinux.bin',
+            '-c', 'boot/x86_64/boot.catalog'
+        ]
+
+    @patch('os.path.exists')
+    @patch('os.path.getsize')
+    @patch('kiwi.iso_tools.cdrtools.CommandCapabilities.has_option_in_help')
+    def test_add_efi_loader_parameters(
+        self, mock_has_option_in_help, mock_getsize, mock_exists
+    ):
+        mock_has_option_in_help.return_value = True
+        mock_getsize.return_value = 4096
+        mock_exists.return_value = True
+        self.iso_tool.add_efi_loader_parameters()
+        assert self.iso_tool.iso_loaders == [
+            '-eltorito-alt-boot', '-eltorito-platform', 'efi',
+            '-b', 'boot/x86_64/efi',
+            '-no-emul-boot', '-joliet-long',
+            '-boot-load-size', '8'
+        ]
+
+    @patch('os.path.exists')
+    @patch('os.path.getsize')
+    @patch('kiwi.iso_tools.cdrtools.CommandCapabilities.has_option_in_help')
+    def test_add_efi_loader_parameters_big_loader(
+        self, mock_has_option_in_help, mock_getsize, mock_exists
+    ):
+        mock_has_option_in_help.return_value = False
+        mock_getsize.return_value = 33554432
+        mock_exists.return_value = True
+        self.iso_tool.add_efi_loader_parameters()
+        assert self.iso_tool.iso_loaders == [
+            '-eltorito-alt-boot', '-b', 'boot/x86_64/efi',
+            '-no-emul-boot', '-joliet-long'
+        ]

--- a/test/unit/iso_tools_cdrtools_test.py
+++ b/test/unit/iso_tools_cdrtools_test.py
@@ -1,4 +1,5 @@
 from mock import patch, call
+from collections import namedtuple
 from .test_helper import raises
 
 from kiwi.iso_tools.cdrtools import IsoToolsCdrTools
@@ -86,3 +87,21 @@ class TestIsoToolsCdrTools(object):
                 '-o', 'myiso', 'source-dir'
             ]
         )
+
+    @patch('kiwi.iso_tools.cdrtools.Command.run')
+    @patch('os.path.exists')
+    def test_list_iso(self, mock_exists, mock_command):
+        mock_exists.return_value = True
+        output_type = namedtuple('output_type', ['output'])
+        output_data = ''
+        with open('../data/iso_listing.txt') as iso:
+            output_data = iso.read()
+        mock_command.return_value = output_type(output=output_data)
+        result = self.iso_tool.list_iso('some-iso')
+        assert result[2158].name == 'header_end'
+
+    @raises(KiwiIsoToolError)
+    @patch('os.path.exists')
+    def test_list_iso_no_tool_found(self, mock_exists):
+        mock_exists.return_value = False
+        self.iso_tool.list_iso('some-iso')

--- a/test/unit/iso_tools_iso_test.py
+++ b/test/unit/iso_tools_iso_test.py
@@ -39,28 +39,57 @@ class TestIso(object):
         self.iso = Iso('source-dir')
 
     @patch_open
-    @patch('os.path.exists')
-    @raises(KiwiIsoLoaderError)
-    def test_init_iso_creation_parameters_no_loader(
-        self, mock_exists, mock_open
-    ):
-        mock_exists.return_value = False
-        self.iso.init_iso_creation_parameters()
+    def test_create_header_end_marker(self, mock_open):
+        mock_open.return_value = self.context_manager_mock
+        self.iso.create_header_end_marker()
+        assert self.file_mock.write.called_once_with(
+            'source-dir/header_end 1000000\n'
+        )
 
-    @patch('kiwi.iso_tools.iso.NamedTemporaryFile')
-    @patch('platform.machine')
-    def test_init_for_ix86_platform(self, mock_machine, mock_tempfile):
-        mock_machine.return_value = 'i686'
-        iso = Iso('source-dir')
-        assert iso.arch == 'ix86'
+    @raises(KiwiIsoLoaderError)
+    @patch('os.path.exists')
+    def test_setup_isolinux_boot_path_raises(self, mock_exists):
+        mock_exists.return_value = False
+        self.iso.setup_isolinux_boot_path()
+
+    @patch('os.path.exists')
+    @patch('kiwi.iso_tools.iso.Command.run')
+    def test_setup_isolinux_boot_path(self, mock_command, mock_exists):
+        mock_exists.return_value = True
+        self.iso.setup_isolinux_boot_path()
+        mock_command.assert_called_once_with(
+            [
+                'isolinux-config', '--base', 'boot/x86_64/loader',
+                'source-dir/boot/x86_64/loader/isolinux.bin'
+            ]
+        )
+
+    @patch('kiwi.iso_tools.iso.Command.run')
+    @patch('kiwi.iso_tools.iso.Path.create')
+    @patch('os.path.exists')
+    def test_setup_isolinux_boot_path_failed_isolinux_config(
+        self, mock_exists, mock_path, mock_command
+    ):
+        mock_exists.return_value = True
+        command_raises = [False, True]
+
+        def side_effect(arg):
+            if command_raises.pop():
+                raise Exception
+
+        mock_command.side_effect = side_effect
+        self.iso.setup_isolinux_boot_path()
+        mock_path.assert_called_once_with('source-dir/isolinux')
+        assert mock_command.call_args_list[1] == call(
+            [
+                'bash', '-c',
+                'ln source-dir/boot/x86_64/loader/* source-dir/isolinux'
+            ]
+        )
 
     @patch_open
-    @patch('kiwi.iso_tools.iso.Command.run')
-    @patch('os.path.exists')
     @patch('os.walk')
-    def test_init_iso_creation_parameters(
-        self, mock_walk, mock_exists, mock_command, mock_open
-    ):
+    def test_create_sortfile(self, mock_walk, mock_open):
         mock_walk_results = [
             [('source-dir', ('EFI',), ())],
             [('source-dir', ('bar', 'baz'), ('efi', 'eggs'))]
@@ -70,15 +99,11 @@ class TestIso(object):
             return mock_walk_results.pop()
 
         mock_walk.side_effect = side_effect
-
-        mock_exists.return_value = True
         mock_open.return_value = self.context_manager_mock
 
-        self.iso.init_iso_creation_parameters(['custom_arg'])
+        self.iso.create_sortfile()
 
-        print(self.file_mock.write.call_args_list)
         assert self.file_mock.write.call_args_list == [
-            call('7984fc91-a43f-4e45-bf27-6d3aa08b24cf\n'),
             call('source-dir/boot/x86_64/boot.catalog 3\n'),
             call('source-dir/boot/x86_64/loader/isolinux.bin 2\n'),
             call('source-dir/efi 1000001\n'),
@@ -88,94 +113,6 @@ class TestIso(object):
             call('source-dir/EFI 1\n'),
             call('source-dir/header_end 1000000\n')
         ]
-        assert self.iso.iso_parameters == [
-            'custom_arg', '-R', '-J', '-f', '-pad', '-joliet-long',
-            '-sort', 'sortfile', '-no-emul-boot', '-boot-load-size', '4',
-            '-boot-info-table',
-            '-hide', 'boot/x86_64/boot.catalog',
-            '-hide-joliet', 'boot/x86_64/boot.catalog',
-        ]
-        assert self.iso.iso_loaders == [
-            '-b', 'boot/x86_64/loader/isolinux.bin',
-            '-c', 'boot/x86_64/boot.catalog'
-        ]
-        mock_command.assert_called_once_with(
-            [
-                'isolinux-config', '--base', 'boot/x86_64/loader',
-                'source-dir/boot/x86_64/loader/isolinux.bin'
-            ]
-        )
-
-    @patch_open
-    @patch('kiwi.iso_tools.iso.Command.run')
-    @patch('kiwi.iso_tools.iso.Path.create')
-    @patch('os.path.exists')
-    @patch('os.walk')
-    def test_init_iso_creation_parameters_failed_isolinux_config(
-        self, mock_walk, mock_exists, mock_path, mock_command, mock_open
-    ):
-        mock_exists.return_value = True
-        mock_open.return_value = self.context_manager_mock
-        command_raises = [False, True]
-
-        def side_effect(arg):
-            if command_raises.pop():
-                raise Exception
-
-        mock_command.side_effect = side_effect
-
-        self.iso.init_iso_creation_parameters(['custom_arg'])
-
-        mock_path.assert_called_once_with('source-dir/isolinux')
-        assert mock_command.call_args_list[1] == call(
-            [
-                'bash', '-c',
-                'ln source-dir/boot/x86_64/loader/* source-dir/isolinux'
-            ]
-        )
-
-    @patch('os.path.exists')
-    @patch('os.path.getsize')
-    @patch('kiwi.iso_tools.iso.CommandCapabilities.has_option_in_help')
-    def test_add_efi_loader_parameters(
-        self, mock_has_option_in_help, mock_getsize, mock_exists
-    ):
-        mock_has_option_in_help.return_value = True
-        mock_getsize.return_value = 4096
-        mock_exists.return_value = True
-        self.iso.add_efi_loader_parameters()
-        assert self.iso.iso_loaders == [
-            '-eltorito-alt-boot', '-eltorito-platform', 'efi',
-            '-b', 'boot/x86_64/efi',
-            '-no-emul-boot', '-joliet-long',
-            '-boot-load-size', '8'
-        ]
-
-    @patch('os.path.exists')
-    @patch('os.path.getsize')
-    @patch('kiwi.iso_tools.iso.CommandCapabilities.has_option_in_help')
-    def test_add_efi_loader_parameters_big_loader(
-        self, mock_has_option_in_help, mock_getsize, mock_exists
-    ):
-        mock_has_option_in_help.return_value = False
-        mock_getsize.return_value = 33554432
-        mock_exists.return_value = True
-        self.iso.add_efi_loader_parameters()
-        assert self.iso.iso_loaders == [
-            '-eltorito-alt-boot', '-b', 'boot/x86_64/efi',
-            '-no-emul-boot', '-joliet-long'
-        ]
-
-    def test_get_iso_creation_parameters(self):
-        self.iso.iso_parameters = ['a']
-        self.iso.iso_loaders = ['b']
-        assert self.iso.get_iso_creation_parameters() == ['a', 'b']
-
-    @raises(KiwiIsoToolError)
-    @patch('os.path.exists')
-    def test_get_iso_creation_tool_no_tool_found(self, mock_exists):
-        mock_exists.return_value = False
-        self.iso.get_iso_creation_tool()
 
     @raises(KiwiIsoToolError)
     @patch('os.path.exists')

--- a/test/unit/iso_tools_iso_test.py
+++ b/test/unit/iso_tools_iso_test.py
@@ -7,7 +7,6 @@ from builtins import bytes
 
 from kiwi.exceptions import (
     KiwiIsoLoaderError,
-    KiwiIsoToolError,
     KiwiIsoMetaDataError,
     KiwiCommandError
 )
@@ -113,62 +112,6 @@ class TestIso(object):
             call('source-dir/EFI 1\n'),
             call('source-dir/header_end 1000000\n')
         ]
-
-    @raises(KiwiIsoToolError)
-    @patch('os.path.exists')
-    def test_isols_no_tool_found(self, mock_exists):
-        mock_exists.return_value = False
-        self.iso.isols('some-iso')
-
-    @patch('os.path.exists')
-    @patch('kiwi.iso_tools.iso.Command.run')
-    @patch('kiwi.iso_tools.iso.Path.which')
-    @patch_open
-    def test_isols_usr_bin_isoinfo_used(
-        self, mock_open, mock_which, mock_command, mock_exists
-    ):
-        mock_which.return_value = '/usr/bin/isoinfo'
-        exists_results = [False, True]
-
-        def side_effect(self):
-            return exists_results.pop()
-
-        mock_exists.side_effect = side_effect
-        self.iso.isols('some-iso')
-        mock_command.assert_called_once_with(
-            ['/usr/bin/isoinfo', '-R', '-l', '-i', 'some-iso']
-        )
-
-    @patch('os.path.exists')
-    @patch('kiwi.iso_tools.iso.Command.run')
-    @patch('kiwi.iso_tools.iso.Path.which')
-    @patch_open
-    def test_isols_usr_lib_genisoimage_isoinfo_used(
-        self, mock_open, mock_which, mock_command, mock_exists
-    ):
-        mock_which.return_value = '/usr/lib/genisoimage/isoinfo'
-        exists_results = [True, False]
-
-        def side_effect(self):
-            return exists_results.pop()
-
-        mock_exists.side_effect = side_effect
-        self.iso.isols('some-iso')
-        mock_command.assert_called_once_with(
-            ['/usr/lib/genisoimage/isoinfo', '-R', '-l', '-i', 'some-iso']
-        )
-
-    @patch('kiwi.iso_tools.iso.Command.run')
-    @patch('os.path.exists')
-    def test_isols(self, mock_exists, mock_command):
-        mock_exists.return_value = True
-        output_type = namedtuple('output_type', ['output'])
-        output_data = ''
-        with open('../data/iso_listing.txt') as iso:
-            output_data = iso.read()
-        mock_command.return_value = output_type(output=output_data)
-        result = self.iso.isols('some-iso')
-        assert result[2158].name == 'header_end'
 
     def test_create_header_end_block(self):
         temp_file = NamedTemporaryFile()

--- a/test/unit/iso_tools_iso_test.py
+++ b/test/unit/iso_tools_iso_test.py
@@ -12,13 +12,13 @@ from kiwi.exceptions import (
     KiwiCommandError
 )
 
-from kiwi.iso import Iso
+from kiwi.iso_tools.iso import Iso
 from collections import namedtuple
 from tempfile import NamedTemporaryFile
 
 
 class TestIso(object):
-    @patch('kiwi.iso.NamedTemporaryFile')
+    @patch('kiwi.iso_tools.iso.NamedTemporaryFile')
     @patch('platform.machine')
     def setup(self, mock_machine, mock_tempfile):
         temp_type = namedtuple(
@@ -47,7 +47,7 @@ class TestIso(object):
         mock_exists.return_value = False
         self.iso.init_iso_creation_parameters()
 
-    @patch('kiwi.iso.NamedTemporaryFile')
+    @patch('kiwi.iso_tools.iso.NamedTemporaryFile')
     @patch('platform.machine')
     def test_init_for_ix86_platform(self, mock_machine, mock_tempfile):
         mock_machine.return_value = 'i686'
@@ -55,7 +55,7 @@ class TestIso(object):
         assert iso.arch == 'ix86'
 
     @patch_open
-    @patch('kiwi.iso.Command.run')
+    @patch('kiwi.iso_tools.iso.Command.run')
     @patch('os.path.exists')
     @patch('os.walk')
     def test_init_iso_creation_parameters(
@@ -107,8 +107,8 @@ class TestIso(object):
         )
 
     @patch_open
-    @patch('kiwi.iso.Command.run')
-    @patch('kiwi.iso.Path.create')
+    @patch('kiwi.iso_tools.iso.Command.run')
+    @patch('kiwi.iso_tools.iso.Path.create')
     @patch('os.path.exists')
     @patch('os.walk')
     def test_init_iso_creation_parameters_failed_isolinux_config(
@@ -136,7 +136,7 @@ class TestIso(object):
 
     @patch('os.path.exists')
     @patch('os.path.getsize')
-    @patch('kiwi.iso.CommandCapabilities.has_option_in_help')
+    @patch('kiwi.iso_tools.iso.CommandCapabilities.has_option_in_help')
     def test_add_efi_loader_parameters(
         self, mock_has_option_in_help, mock_getsize, mock_exists
     ):
@@ -153,7 +153,7 @@ class TestIso(object):
 
     @patch('os.path.exists')
     @patch('os.path.getsize')
-    @patch('kiwi.iso.CommandCapabilities.has_option_in_help')
+    @patch('kiwi.iso_tools.iso.CommandCapabilities.has_option_in_help')
     def test_add_efi_loader_parameters_big_loader(
         self, mock_has_option_in_help, mock_getsize, mock_exists
     ):
@@ -184,8 +184,8 @@ class TestIso(object):
         self.iso.isols('some-iso')
 
     @patch('os.path.exists')
-    @patch('kiwi.iso.Command.run')
-    @patch('kiwi.iso.Path.which')
+    @patch('kiwi.iso_tools.iso.Command.run')
+    @patch('kiwi.iso_tools.iso.Path.which')
     @patch_open
     def test_isols_usr_bin_isoinfo_used(
         self, mock_open, mock_which, mock_command, mock_exists
@@ -203,8 +203,8 @@ class TestIso(object):
         )
 
     @patch('os.path.exists')
-    @patch('kiwi.iso.Command.run')
-    @patch('kiwi.iso.Path.which')
+    @patch('kiwi.iso_tools.iso.Command.run')
+    @patch('kiwi.iso_tools.iso.Path.which')
     @patch_open
     def test_isols_usr_lib_genisoimage_isoinfo_used(
         self, mock_open, mock_which, mock_command, mock_exists
@@ -221,7 +221,7 @@ class TestIso(object):
             ['/usr/lib/genisoimage/isoinfo', '-R', '-l', '-i', 'some-iso']
         )
 
-    @patch('kiwi.iso.Command.run')
+    @patch('kiwi.iso_tools.iso.Command.run')
     @patch('os.path.exists')
     def test_isols(self, mock_exists, mock_command):
         mock_exists.return_value = True
@@ -248,7 +248,7 @@ class TestIso(object):
             '../data/iso_no_marker.iso'
         )
 
-    @patch('kiwi.iso.Command.run')
+    @patch('kiwi.iso_tools.iso.Command.run')
     def test_create_hybrid(self, mock_command):
         mbrid = mock.Mock()
         mbrid.get_id = mock.Mock(
@@ -267,7 +267,7 @@ class TestIso(object):
         )
 
     @raises(KiwiCommandError)
-    @patch('kiwi.iso.Command.run')
+    @patch('kiwi.iso_tools.iso.Command.run')
     def test_create_hybrid_with_error(self, mock_command):
         mbrid = mock.Mock()
         mbrid.get_id = mock.Mock(
@@ -279,7 +279,7 @@ class TestIso(object):
         Iso.create_hybrid(42, mbrid, 'some-iso', 'efi')
 
     @raises(KiwiCommandError)
-    @patch('kiwi.iso.Command.run')
+    @patch('kiwi.iso_tools.iso.Command.run')
     def test_create_hybrid_with_multiple_errors(self, mock_command):
         mbrid = mock.Mock()
         mbrid.get_id = mock.Mock(
@@ -293,7 +293,7 @@ class TestIso(object):
         mock_command.return_value = command
         Iso.create_hybrid(42, mbrid, 'some-iso', 'efi')
 
-    @patch('kiwi.iso.Command.run')
+    @patch('kiwi.iso_tools.iso.Command.run')
     def test_create_hybrid_with_cylinders_warning(self, mock_command):
         mbrid = mock.Mock()
         mbrid.get_id = mock.Mock(
@@ -313,7 +313,7 @@ class TestIso(object):
             ]
         )
 
-    @patch('kiwi.iso.Command.run')
+    @patch('kiwi.iso_tools.iso.Command.run')
     def test_set_media_tag(self, mock_command):
         Iso.set_media_tag('foo')
         mock_command.assert_called_once_with(


### PR DESCRIPTION
Refactor Iso class api

In kiwi we have an abstraction layer for calling the iso filesystem creation tools. However this layer assumes we are option compatible with all tools we use. This is not correct if we consider support for
xorriso. Thus a refactoring is required first before we can think about xorriso

This patch is two fold

1. Cleanup Iso class to only provide generic helper methods around the creation of an iso
2. Provide an own namespace for the cdrtools (mkisofs/genisoimage)
3. Update the filesystem/isofs code to make use of the changed api

It touches quite some code but it should change nothing in the end. I have not tested intensively but will do the next days. So this is open for review to get your thoughts and ideas

Thanks