### PR TITLE
Remove xml_parse.py shebang in spec

### DIFF
--- a/package/python-kiwi-rpmlintrc
+++ b/package/python-kiwi-rpmlintrc
@@ -9,9 +9,6 @@ addFilter("no-manual-page-for-binary kiwi-ng")
 addFilter("suse-filelist-empty .*")
 addFilter("explicit-lib-dependency .*")
 
-# don't blame on auto generated code
-addFilter("non-executable-script .*/xml_parse.py.*")
-
 # don't check uid for tftpboot
 addFilter("non-standard-uid .*")
 

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -422,6 +422,10 @@ Provides manual pages to describe the kiwi commands
 %prep
 %setup -q -n kiwi-%{version}
 
+# Drop shebang for kiwi/xml_parse.py, as we don't intend to use it
+# as an independent script
+sed -e "s|#!/usr/bin/env python||" -i kiwi/xml_parse.py
+
 %build
 # Build Python 2 version
 python2 setup.py build --cflags="${RPM_OPT_FLAGS}"


### PR DESCRIPTION
It removes the shebang from the autogenerated file and also removes
the exception in rpmlint to ignore non-executable-script warning.

Fixes #666
