### PR TITLE
Switch to xorriso

### DIFF
--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -225,11 +225,12 @@ class InstallImageBuilder(object):
         )
         iso_header_offset = iso_image.create_on_file(self.isoname)
 
-        # make it hybrid
-        Iso.create_hybrid(
-            iso_header_offset, self.mbrid, self.isoname,
-            self.firmware.efi_mode()
-        )
+        # make it hybrid if not already done by iso tool
+        if iso_header_offset:
+            Iso.create_hybrid(
+                iso_header_offset, self.mbrid, self.isoname,
+                self.firmware.efi_mode()
+            )
 
     def create_install_pxe_archive(self):
         """

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -255,8 +255,8 @@ class LiveImageBuilder(object):
         )
         iso_header_offset = iso_image.create_on_file(self.isoname)
 
-        # make it hybrid
-        if self.hybrid:
+        # make it hybrid if not already done by iso tool
+        if self.hybrid and iso_header_offset:
             Iso.create_hybrid(
                 iso_header_offset, self.mbrid, self.isoname,
                 self.firmware.efi_mode()

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -893,6 +893,13 @@ class Defaults(object):
         return os.sep.join(['boot', arch])
 
     @classmethod
+    def get_iso_tool_category(self):
+        """
+        Returns default iso tool category
+        """
+        return 'xorriso'
+
+    @classmethod
     def set_python_default_encoding_to_utf8(self):
         """
         Set python default encoding to utf-8 if not already done

--- a/kiwi/filesystem/isofs.py
+++ b/kiwi/filesystem/isofs.py
@@ -50,12 +50,11 @@ class FileSystemIsoFs(FileSystemBase):
 
         iso_tool.create_iso(filename)
 
-        hybrid_offset = iso.create_header_end_block(filename)
-
-        iso_tool.create_iso(
-            filename, hidden_files=[iso.header_end_name]
-        )
-
-        iso.relocate_boot_catalog(filename)
-        iso.fix_boot_catalog(filename)
-        return hybrid_offset
+        if not iso_tool.has_iso_hybrid_capability():
+            hybrid_offset = iso.create_header_end_block(filename)
+            iso_tool.create_iso(
+                filename, hidden_files=[iso.header_end_name]
+            )
+            iso.relocate_boot_catalog(filename)
+            iso.fix_boot_catalog(filename)
+            return hybrid_offset

--- a/kiwi/filesystem/isofs.py
+++ b/kiwi/filesystem/isofs.py
@@ -18,7 +18,7 @@
 # project
 from kiwi.filesystem.base import FileSystemBase
 from kiwi.iso_tools.iso import Iso
-from kiwi.iso_tools.cdrtools import IsoToolsCdrTools
+from kiwi.iso_tools import IsoTools
 
 
 class FileSystemIsoFs(FileSystemBase):
@@ -36,7 +36,7 @@ class FileSystemIsoFs(FileSystemBase):
         :param string label: unused
         :param string exclude: unused
         """
-        iso_tool = IsoToolsCdrTools(self.root_dir)
+        iso_tool = IsoTools(self.root_dir)
 
         iso = Iso(self.root_dir)
         iso.setup_isolinux_boot_path()

--- a/kiwi/iso_tools/__init__.py
+++ b/kiwi/iso_tools/__init__.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2015 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+# project
+from kiwi.iso_tools.cdrtools import IsoToolsCdrTools
+from kiwi.iso_tools.xorriso import IsoToolsXorrIso
+from kiwi.runtime_config import RuntimeConfig
+
+
+class IsoTools(object):
+    """
+    IsoTools factory
+    """
+    def __new__(self, source_dir):
+        runtime_config = RuntimeConfig()
+        if runtime_config.get_iso_tool_category() == 'cdrtools':
+            return IsoToolsCdrTools(source_dir)
+        else:
+            return IsoToolsXorrIso(source_dir)

--- a/kiwi/iso_tools/base.py
+++ b/kiwi/iso_tools/base.py
@@ -92,3 +92,13 @@ class IsoToolsBase(object):
         :param string isofile: unused
         """
         raise NotImplementedError
+
+    def has_iso_hybrid_capability(self):
+        """
+        Indicate if the iso tool has the capability to embed
+        a partition table into the iso such that it can be
+        used as both; an iso and a disk
+
+        Implementation in specialized tool class
+        """
+        raise NotImplementedError

--- a/kiwi/iso_tools/cdrtools.py
+++ b/kiwi/iso_tools/cdrtools.py
@@ -36,6 +36,14 @@ class IsoToolsCdrTools(IsoToolsBase):
     the cdrkit/cdrtools projects. Addressed here are the option
     compatible tools mkisofs and genisoimage
     """
+    def has_iso_hybrid_capability(self):
+        """
+        Indicate if the iso tool has the capability to embed a
+        partition table into the iso such that it can be
+        used as both; an iso and a disk
+        """
+        return False
+
     def get_tool_name(self):
         """
         There are tools by J.Schilling and tools from the community

--- a/kiwi/iso_tools/iso.py
+++ b/kiwi/iso_tools/iso.py
@@ -174,7 +174,10 @@ class Iso(object):
                         new_boot_catalog_sector = sector + 1
                         break
 
-            if iso_metadata.boot_catalog_sector != new_boot_catalog_sector:
+            if (
+                new_boot_catalog_sector and
+                iso_metadata.boot_catalog_sector != new_boot_catalog_sector
+            ):
                 new_boot_catalog = Iso._read_iso_sector(
                     new_boot_catalog_sector, iso
                 )

--- a/kiwi/iso_tools/xorriso.py
+++ b/kiwi/iso_tools/xorriso.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2015 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+import os
+
+# project
+from kiwi.iso_tools.base import IsoToolsBase
+from kiwi.path import Path
+from kiwi.command import Command
+from kiwi.exceptions import KiwiIsoToolError
+
+
+class IsoToolsXorrIso(IsoToolsBase):
+    """
+    Implementation of Parameter API for iso creation tools using
+    the libburnia project. Addressed here is the tool xorriso
+    """
+    def has_iso_hybrid_capability(self):
+        """
+        Indicate if the iso tool has the capability to embed a
+        partition table into the iso such that it can be
+        used as both; an iso and a disk
+        """
+        return True
+
+    def get_tool_name(self):
+        """
+        Lookup xorriso in search path
+        """
+        xorriso = Path.which('xorriso')
+        if xorriso:
+            return xorriso
+
+        raise KiwiIsoToolError('xorriso tool not found')
+
+    def init_iso_creation_parameters(self, sortfile, custom_args=None):
+        """
+        Create a set of standard parameters
+
+        :param string sortfile: unused
+        :param list custom_args: custom ISO creation args
+        """
+        if custom_args:
+            custom_args_dict = dict(zip(custom_args[0::2], custom_args[1::2]))
+            if '-A' in custom_args_dict:
+                self.iso_parameters += [
+                    '-application_id', custom_args_dict['-A']
+                ]
+            if '-p' in custom_args_dict:
+                self.iso_parameters += [
+                    '-preparer_id', custom_args_dict['-p']
+                ]
+            if '-V' in custom_args_dict:
+                self.iso_parameters += [
+                    '-volid', custom_args_dict['-V']
+                ]
+        catalog_file = self.boot_path + '/boot.catalog'
+        self.iso_parameters += [
+            '-joliet', 'on', '-padding', '0'
+        ]
+        loader_file = self.boot_path + '/loader/isolinux.bin'
+
+        syslinux_lookup_paths = [
+            '/usr/share/syslinux', '/usr/lib/syslinux/modules/bios'
+        ]
+        mbr_file = Path.which('isohdpfx.bin', syslinux_lookup_paths)
+        if not mbr_file:
+            raise KiwiIsoToolError(
+                'isohdpfx.bin not found in {0}'.format(syslinux_lookup_paths)
+            )
+
+        self.iso_loaders += [
+            '-boot_image', 'any', 'partition_offset=16',
+            '-boot_image', 'isolinux', 'bin_path={0}'.format(loader_file),
+            '-boot_image', 'isolinux', 'system_area={0}'.format(mbr_file),
+            '-boot_image', 'isolinux', 'partition_table=on',
+            '-boot_image', 'any', 'cat_path={0}'.format(catalog_file),
+            '-boot_image', 'any', 'cat_hidden=on',
+            '-boot_image', 'any', 'boot_info_table=on',
+            '-boot_image', 'any', 'platform_id=0x00',
+            '-boot_image', 'any', 'emul_type=no_emulation',
+            '-boot_image', 'any', 'load_size=2048'
+        ]
+
+    def add_efi_loader_parameters(self):
+        """
+        Add ISO creation parameters to embed the EFI loader
+
+        In order to boot the ISO from EFI, the EFI binary is added as
+        alternative loader to the ISO creation parameter list. The
+        EFI binary must be included into a fat filesystem in order
+        to become recognized by the firmware. For details about this
+        file refer to _create_embedded_fat_efi_image() from
+        bootloader/config/grub2.py
+        """
+        loader_file = os.sep.join([self.source_dir, self.boot_path, 'efi'])
+        if os.path.exists(loader_file):
+            self.iso_loaders += [
+                '-append_partition', '2', '0xef', loader_file,
+                '-boot_image', 'any', 'next',
+                '-boot_image', 'any',
+                'efi_path=--interval:appended_partition_2:all::',
+                '-boot_image', 'any', 'platform_id=0xef',
+                '-boot_image', 'any', 'emul_type=no_emulation'
+            ]
+
+    def create_iso(self, filename, hidden_files=None):
+        hidden_files_parameters = []
+        if hidden_files:
+            for hidden_file in hidden_files:
+                hidden_files_parameters += [
+                    '--', '-find', hidden_file, '-exec', 'hide', 'on'
+                ]
+        Path.wipe(filename)
+        Command.run(
+            [
+                self.get_tool_name()
+            ] + self.iso_parameters + [
+                '-outdev', filename, '-map', self.source_dir, '/'
+            ] + self.iso_loaders + hidden_files_parameters
+        )

--- a/kiwi/runtime_config.py
+++ b/kiwi/runtime_config.py
@@ -97,6 +97,33 @@ class RuntimeConfig(object):
         xz_options = self._get_attribute(element='xz', attribute='options')
         return xz_options.split() if xz_options else None
 
+    def get_iso_tool_category(self):
+        """
+        Return tool category which should be used to build iso images
+
+        iso:
+          - tool_category: cdrtools|xorriso
+
+        if no or invalid configuration exists the default tool category
+        from the Defaults class is returned
+
+        :rtype: string
+        """
+        iso_tool_category = self._get_attribute(
+            element='iso', attribute='tool_category'
+        )
+        if not iso_tool_category:
+            return Defaults.get_iso_tool_category()
+        elif 'cdrtools' in iso_tool_category or 'xorriso' in iso_tool_category:
+            return iso_tool_category
+        else:
+            log.warning(
+                'Skipping invalid iso tool category: {0}'.format(
+                    iso_tool_category
+                )
+            )
+            return Defaults.get_iso_tool_category()
+
     def get_max_size_constraint(self):
         """
         Returns the maximum allowed size of the built image. The value is

--- a/test/data/.config/kiwi/config.yml
+++ b/test/data/.config/kiwi/config.yml
@@ -4,3 +4,6 @@ xz:
 obs:
   - download_url: http://example.com
   - public: true
+
+iso:
+  - tool_category: cdrtools

--- a/test/unit/filesystem_isofs_test.py
+++ b/test/unit/filesystem_isofs_test.py
@@ -18,7 +18,7 @@ class TestFileSystemIsoFs(object):
         assert self.isofs.custom_args['mount_options'] == []
         assert self.isofs.custom_args['some_args'] == 'data'
 
-    @patch('kiwi.filesystem.isofs.IsoToolsCdrTools')
+    @patch('kiwi.filesystem.isofs.IsoTools')
     @patch('kiwi.filesystem.isofs.Iso')
     def test_create_on_file(self, mock_iso, mock_cdrtools):
         iso_tool = mock.Mock()

--- a/test/unit/filesystem_isofs_test.py
+++ b/test/unit/filesystem_isofs_test.py
@@ -22,6 +22,9 @@ class TestFileSystemIsoFs(object):
     @patch('kiwi.filesystem.isofs.Iso')
     def test_create_on_file(self, mock_iso, mock_cdrtools):
         iso_tool = mock.Mock()
+        iso_tool.has_iso_hybrid_capability = mock.Mock(
+            return_value=False
+        )
         iso_tool.get_tool_name = mock.Mock(
             return_value='/usr/bin/mkisofs'
         )

--- a/test/unit/iso_tools_base_test.py
+++ b/test/unit/iso_tools_base_test.py
@@ -29,3 +29,7 @@ class TestIsoToolsBase(object):
     @raises(NotImplementedError)
     def test_add_efi_loader_parameters(self):
         self.iso_tool.add_efi_loader_parameters()
+
+    @raises(NotImplementedError)
+    def test_has_iso_hybrid_capability(self):
+        self.iso_tool.has_iso_hybrid_capability()

--- a/test/unit/iso_tools_cdrtools_test.py
+++ b/test/unit/iso_tools_cdrtools_test.py
@@ -105,3 +105,6 @@ class TestIsoToolsCdrTools(object):
     def test_list_iso_no_tool_found(self, mock_exists):
         mock_exists.return_value = False
         self.iso_tool.list_iso('some-iso')
+
+    def test_has_iso_hybrid_capability(self):
+        assert self.iso_tool.has_iso_hybrid_capability() is False

--- a/test/unit/iso_tools_test.py
+++ b/test/unit/iso_tools_test.py
@@ -1,0 +1,30 @@
+from mock import patch
+import mock
+
+from kiwi.iso_tools import IsoTools
+
+
+class TestIsoTools(object):
+    def setup(self):
+        self.runtime_config = mock.Mock()
+        self.runtime_config.get_iso_tool_category = mock.Mock()
+
+    @patch('kiwi.iso_tools.IsoToolsCdrTools')
+    @patch('kiwi.iso_tools.RuntimeConfig')
+    def test_iso_tools_cdrtools(
+        self, mock_RuntimeConfig, mock_IsoToolsCdrTools
+    ):
+        self.runtime_config.get_iso_tool_category.return_value = 'cdrtools'
+        mock_RuntimeConfig.return_value = self.runtime_config
+        IsoTools('root-dir')
+        mock_IsoToolsCdrTools.assert_called_once_with('root-dir')
+
+    @patch('kiwi.iso_tools.IsoToolsXorrIso')
+    @patch('kiwi.iso_tools.RuntimeConfig')
+    def test_iso_tools_xorriso(
+        self, mock_RuntimeConfig, mock_IsoToolsXorrIso
+    ):
+        self.runtime_config.get_iso_tool_category.return_value = 'xorriso'
+        mock_RuntimeConfig.return_value = self.runtime_config
+        IsoTools('root-dir')
+        mock_IsoToolsXorrIso.assert_called_once_with('root-dir')

--- a/test/unit/iso_tools_xorriso_test.py
+++ b/test/unit/iso_tools_xorriso_test.py
@@ -1,0 +1,89 @@
+from mock import patch
+from .test_helper import raises
+
+from kiwi.iso_tools.xorriso import IsoToolsXorrIso
+from kiwi.exceptions import KiwiIsoToolError
+
+
+class TestIsoToolsXorrIso(object):
+    @patch('platform.machine')
+    def setup(self, mock_machine):
+        mock_machine.return_value = 'x86_64'
+        self.iso_tool = IsoToolsXorrIso('source-dir')
+
+    @patch('kiwi.iso_tools.xorriso.Path.which')
+    def test_get_tool_name(self, mock_which):
+        mock_which.return_value = 'tool_found'
+        assert self.iso_tool.get_tool_name() == 'tool_found'
+
+    @raises(KiwiIsoToolError)
+    @patch('os.path.exists')
+    def test_get_tool_name_raises(self, mock_exists):
+        mock_exists.return_value = False
+        self.iso_tool.get_tool_name()
+
+    @raises(KiwiIsoToolError)
+    @patch('kiwi.iso_tools.xorriso.Path.which')
+    def test_init_iso_creation_parameters_no_isohdpfx(self, mock_which):
+        mock_which.return_value = None
+        self.iso_tool.init_iso_creation_parameters('sortfile')
+
+    @patch('kiwi.iso_tools.xorriso.Path.which')
+    def test_init_iso_creation_parameters(self, mock_which):
+        mock_which.return_value = '/usr/share/syslinux/isohdpfx.bin'
+        self.iso_tool.init_iso_creation_parameters(
+            'sortfile', ['-A', 'app_id', '-p', 'preparer', '-V', 'vol_id']
+        )
+        assert self.iso_tool.iso_parameters == [
+            '-application_id', 'app_id',
+            '-preparer_id', 'preparer',
+            '-volid', 'vol_id',
+            '-joliet', 'on',
+            '-padding', '0'
+        ]
+        assert self.iso_tool.iso_loaders == [
+            '-boot_image', 'any', 'partition_offset=16',
+            '-boot_image', 'isolinux',
+            'bin_path=boot/x86_64/loader/isolinux.bin',
+            '-boot_image', 'isolinux',
+            'system_area=/usr/share/syslinux/isohdpfx.bin',
+            '-boot_image', 'isolinux', 'partition_table=on',
+            '-boot_image', 'any', 'cat_path=boot/x86_64/boot.catalog',
+            '-boot_image', 'any', 'cat_hidden=on',
+            '-boot_image', 'any', 'boot_info_table=on',
+            '-boot_image', 'any', 'platform_id=0x00',
+            '-boot_image', 'any', 'emul_type=no_emulation',
+            '-boot_image', 'any', 'load_size=2048'
+        ]
+
+    @patch('os.path.exists')
+    def test_add_efi_loader_parameters(self, mock_exists):
+        mock_exists.return_value = True
+        self.iso_tool.add_efi_loader_parameters()
+        assert self.iso_tool.iso_loaders == [
+            '-append_partition', '2', '0xef', 'source-dir/boot/x86_64/efi',
+            '-boot_image', 'any', 'next',
+            '-boot_image', 'any',
+            'efi_path=--interval:appended_partition_2:all::',
+            '-boot_image', 'any', 'platform_id=0xef',
+            '-boot_image', 'any', 'emul_type=no_emulation'
+        ]
+
+    @patch('kiwi.iso_tools.xorriso.Command.run')
+    @patch('kiwi.iso_tools.xorriso.Path.wipe')
+    @patch('kiwi.iso_tools.xorriso.Path.which')
+    def test_create_iso(self, mock_which, mock_wipe, mock_command):
+        mock_which.return_value = '/usr/bin/xorriso'
+        self.iso_tool.create_iso('myiso', hidden_files=['hide_me'])
+        mock_wipe.assert_called_once_with('myiso')
+        mock_command.assert_called_once_with(
+            [
+                '/usr/bin/xorriso',
+                '-outdev', 'myiso',
+                '-map', 'source-dir', '/',
+                '--', '-find', 'hide_me', '-exec', 'hide', 'on'
+            ]
+        )
+
+    def test_has_iso_hybrid_capability(self):
+        assert self.iso_tool.has_iso_hybrid_capability() is True

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -37,3 +37,22 @@ class TestRuntimeConfig(object):
             runtime_config = RuntimeConfig()
             assert runtime_config.get_obs_download_server_url() == \
                 Defaults.get_obs_download_server_url()
+
+    def test_get_iso_tool_category(self):
+        assert self.runtime_config.get_iso_tool_category() == 'cdrtools'
+
+    def test_get_iso_tool_category_default(self):
+        with patch.dict('os.environ', {'HOME': './'}):
+            runtime_config = RuntimeConfig()
+            assert runtime_config.get_iso_tool_category() == 'xorriso'
+
+    @patch.object(RuntimeConfig, '_get_attribute')
+    @patch('kiwi.logger.log.warning')
+    def test_get_iso_tool_category_invalid(
+        self, mock_warning, mock_get_attribute
+    ):
+        mock_get_attribute.return_value = 'foo'
+        assert self.runtime_config.get_iso_tool_category() == 'xorriso'
+        mock_warning.assert_called_once_with(
+            'Skipping invalid iso tool category: foo'
+        )


### PR DESCRIPTION
* Added IsoToolsXorrIso class
  As an alternative to mkisofs/genisoimage there is now the
  IsoToolsXorrIso class which implements the IsoTools interface
  by using xorriso. This Fixes #635

* Allow to configure iso tool category
  Switch to xorriso by default but allow to setup cdrtools
  in the runtime configuration file