### PR TITLE
Cleanup hybrid call and use of iso tool options

### DIFF
--- a/kiwi/filesystem/base.py
+++ b/kiwi/filesystem/base.py
@@ -88,6 +88,9 @@ class FileSystemBase(object):
         if 'create_options' not in self.custom_args:
             self.custom_args['create_options'] = []
 
+        if 'meta_data' not in self.custom_args:
+            self.custom_args['meta_data'] = {}
+
         if 'mount_options' not in self.custom_args:
             self.custom_args['mount_options'] = []
 

--- a/kiwi/iso_tools/base.py
+++ b/kiwi/iso_tools/base.py
@@ -56,13 +56,12 @@ class IsoToolsBase(object):
         """
         raise NotImplementedError
 
-    def init_iso_creation_parameters(self, sortfile, custom_args=None):
+    def init_iso_creation_parameters(self, custom_args=None):
         """
         Create a set of standard parameters for the main isolinux loader
 
         Implementation in specialized tool class
 
-        :param string sortfile: unused
         :param list custom_args: unused
         """
         raise NotImplementedError

--- a/kiwi/iso_tools/xorriso.py
+++ b/kiwi/iso_tools/xorriso.py
@@ -47,26 +47,28 @@ class IsoToolsXorrIso(IsoToolsBase):
 
         raise KiwiIsoToolError('xorriso tool not found')
 
-    def init_iso_creation_parameters(self, sortfile, custom_args=None):
+    def init_iso_creation_parameters(self, custom_args=None):
         """
         Create a set of standard parameters
 
-        :param string sortfile: unused
-        :param list custom_args: custom ISO creation args
+        :param list custom_args: custom ISO meta data
         """
         if custom_args:
-            custom_args_dict = dict(zip(custom_args[0::2], custom_args[1::2]))
-            if '-A' in custom_args_dict:
+            if 'mbr_id' in custom_args:
                 self.iso_parameters += [
-                    '-application_id', custom_args_dict['-A']
+                    '-application_id', custom_args['mbr_id']
                 ]
-            if '-p' in custom_args_dict:
+            if 'publisher' in custom_args:
                 self.iso_parameters += [
-                    '-preparer_id', custom_args_dict['-p']
+                    '-publisher', custom_args['publisher']
                 ]
-            if '-V' in custom_args_dict:
+            if 'preparer' in custom_args:
                 self.iso_parameters += [
-                    '-volid', custom_args_dict['-V']
+                    '-preparer_id', custom_args['preparer']
+                ]
+            if 'volume_id' in custom_args:
+                self.iso_parameters += [
+                    '-volid', custom_args['volume_id']
                 ]
         catalog_file = self.boot_path + '/boot.catalog'
         self.iso_parameters += [

--- a/test/unit/builder_install_test.py
+++ b/test/unit/builder_install_test.py
@@ -115,10 +115,9 @@ class TestInstallImageBuilder(object):
     @patch('kiwi.builder.install.mkdtemp')
     @patch_open
     @patch('kiwi.builder.install.Command.run')
-    @patch('kiwi.builder.install.Iso.create_hybrid')
     @patch('kiwi.builder.install.Defaults.get_grub_boot_directory_name')
     def test_create_install_iso(
-        self, mock_grub_dir, mock_hybrid, mock_command, mock_open,
+        self, mock_grub_dir, mock_command, mock_open,
         mock_dtemp, mock_copy
     ):
         tmpdir_name = ['temp-squashfs', 'temp_media_dir']
@@ -191,10 +190,6 @@ class TestInstallImageBuilder(object):
         ]
         self.iso_image.create_on_file.assert_called_once_with(
             'target_dir/result-image.x86_64-1.2.3.install.iso'
-        )
-        mock_hybrid.assert_called_once_with(
-            42, self.mbrid, 'target_dir/result-image.x86_64-1.2.3.install.iso',
-            'uefi'
         )
 
         tmpdir_name = ['temp-squashfs', 'temp_media_dir']

--- a/test/unit/filesystem_isofs_test.py
+++ b/test/unit/filesystem_isofs_test.py
@@ -14,7 +14,7 @@ class TestFileSystemIsoFs(object):
 
     def test_post_init(self):
         self.isofs.post_init({'some_args': 'data'})
-        assert self.isofs.custom_args['create_options'] == []
+        assert self.isofs.custom_args['meta_data'] == {}
         assert self.isofs.custom_args['mount_options'] == []
         assert self.isofs.custom_args['some_args'] == 'data'
 
@@ -37,9 +37,7 @@ class TestFileSystemIsoFs(object):
         iso.setup_isolinux_boot_path.assert_called_once_with()
         iso.create_header_end_marker.assert_called_once_with()
 
-        iso_tool.init_iso_creation_parameters.assert_called_once_with(
-            iso.create_sortfile.return_value, []
-        )
+        iso_tool.init_iso_creation_parameters.assert_called_once_with({})
         iso_tool.add_efi_loader_parameters.assert_called_once_with()
 
         iso.create_header_end_block.assert_called_once_with('myimage')
@@ -53,4 +51,8 @@ class TestFileSystemIsoFs(object):
         )
         iso.fix_boot_catalog.assert_called_once_with(
             'myimage'
+        )
+        iso.create_hybrid.assert_called_once_with(
+            iso.create_header_end_block.return_value,
+            '0xffffffff', 'myimage', False
         )

--- a/test/unit/iso_tools_base_test.py
+++ b/test/unit/iso_tools_base_test.py
@@ -24,7 +24,7 @@ class TestIsoToolsBase(object):
 
     @raises(NotImplementedError)
     def test_init_iso_creation_parameters(self):
-        self.iso_tool.init_iso_creation_parameters('sortfile')
+        self.iso_tool.init_iso_creation_parameters()
 
     @raises(NotImplementedError)
     def test_add_efi_loader_parameters(self):

--- a/test/unit/iso_tools_xorriso_test.py
+++ b/test/unit/iso_tools_xorriso_test.py
@@ -32,10 +32,16 @@ class TestIsoToolsXorrIso(object):
     def test_init_iso_creation_parameters(self, mock_which):
         mock_which.return_value = '/usr/share/syslinux/isohdpfx.bin'
         self.iso_tool.init_iso_creation_parameters(
-            'sortfile', ['-A', 'app_id', '-p', 'preparer', '-V', 'vol_id']
+            {
+                'mbr_id': 'app_id',
+                'publisher': 'org',
+                'preparer': 'preparer',
+                'volume_id': 'vol_id'
+            }
         )
         assert self.iso_tool.iso_parameters == [
             '-application_id', 'app_id',
+            '-publisher', 'org',
             '-preparer_id', 'preparer',
             '-volid', 'vol_id',
             '-joliet', 'on',


### PR DESCRIPTION
The extra isohybrid call is only needed if the mkisofs
tool category is used. Thus it should be only visible
at the place where the isofs is created and not as an
extra step in the builder tasks. Additionally the handling
of extra options was mkisofs specific and should be
better done as a common meta_data record. The tool
specific options should only appear in the tool specific
class implementations


