### PR TITLE
Add efiparttable type attribute

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -670,6 +670,16 @@ class Defaults(object):
         return Defaults().defaults['kiwi_startsector']
 
     @classmethod
+    def get_default_efi_partition_table_type(self):
+        """
+        Implements the default partition table type for efi firmwares.
+
+        :return: partition table type
+        :rtype: string
+        """
+        return 'gpt'
+
+    @classmethod
     def get_default_inode_size(self):
         """
         Implements default size of inodes in bytes. This is only

--- a/kiwi/firmware.py
+++ b/kiwi/firmware.py
@@ -50,6 +50,7 @@ class FirmWare(object):
         self.zipl_target_type = xml_state.build_type.get_zipl_targettype()
         self.firmware = xml_state.build_type.get_firmware()
         self.efipart_mbytes = xml_state.build_type.get_efipartsize()
+        self.efi_partition_table = xml_state.build_type.get_efiparttable()
 
         if not self.firmware:
             self.firmware = Defaults.get_default_firmware(self.arch)
@@ -82,7 +83,10 @@ class FirmWare(object):
             else:
                 return 'msdos'
         elif self.efi_mode():
-            return 'gpt'
+            return (
+                self.efi_partition_table or
+                Defaults.get_default_efi_partition_table_type()
+            )
         else:
             return 'msdos'
 

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1307,6 +1307,15 @@ div {
             sch:param [ name = "attr" value = "efipartsize" ]
             sch:param [ name = "types" value = "oem vmx" ]
         ]
+    k.type.efiparttable.attribute =
+        ## For images with an EFI firmware specifies the partition
+        ## table type to use. If not set defaults to gpt partition 
+        ## table type.
+        attribute efiparttable { "msdos" | "gpt" }
+        >> sch:pattern [ id = "efiparttable" is-a = "image_type"
+            sch:param [ name = "attr" value = "efiparttable" ]
+            sch:param [ name = "types" value = "oem vmx" ]
+        ]
     k.type.bootprofile.attribute =
         ## Specifies the boot profile defined in the boot image
         ## description. When kiwi builds the boot image the
@@ -1713,6 +1722,7 @@ div {
         k.type.bootpartition.attribute? &
         k.type.bootpartsize.attribute? &
         k.type.efipartsize.attribute? &
+        k.type.efiparttable.attribute? &
         k.type.bootprofile.attribute? &
         k.type.boottimeout.attribute? &
         k.type.btrfs_root_is_snapshot.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -1957,6 +1957,21 @@ size is set to 20 MB</a:documentation>
         <sch:param name="types" value="oem vmx"/>
       </sch:pattern>
     </define>
+    <define name="k.type.efiparttable.attribute">
+      <attribute name="efiparttable">
+        <a:documentation>For images with an EFI firmware specifies the partition
+table type to use. If not set defaults to gpt partition 
+table type.</a:documentation>
+        <choice>
+          <value>msdos</value>
+          <value>gpt</value>
+        </choice>
+      </attribute>
+      <sch:pattern id="efiparttable" is-a="image_type">
+        <sch:param name="attr" value="efiparttable"/>
+        <sch:param name="types" value="oem vmx"/>
+      </sch:pattern>
+    </define>
     <define name="k.type.bootprofile.attribute">
       <attribute name="bootprofile">
         <a:documentation>Specifies the boot profile defined in the boot image
@@ -2543,6 +2558,9 @@ default.</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.efipartsize.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.efiparttable.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.bootprofile.attribute"/>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2717,7 +2717,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, efipartsize=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, gcelicense=None, hybrid=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, containerconfig=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, gcelicense=None, hybrid=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, containerconfig=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2729,6 +2729,7 @@ class type_(GeneratedsSuper):
         self.bootpartition = _cast(bool, bootpartition)
         self.bootpartsize = _cast(int, bootpartsize)
         self.efipartsize = _cast(int, efipartsize)
+        self.efiparttable = _cast(None, efiparttable)
         self.bootprofile = _cast(None, bootprofile)
         self.boottimeout = _cast(int, boottimeout)
         self.btrfs_root_is_snapshot = _cast(bool, btrfs_root_is_snapshot)
@@ -2869,6 +2870,8 @@ class type_(GeneratedsSuper):
     def set_bootpartsize(self, bootpartsize): self.bootpartsize = bootpartsize
     def get_efipartsize(self): return self.efipartsize
     def set_efipartsize(self, efipartsize): self.efipartsize = efipartsize
+    def get_efiparttable(self): return self.efiparttable
+    def set_efiparttable(self, efiparttable): self.efiparttable = efiparttable
     def get_bootprofile(self): return self.bootprofile
     def set_bootprofile(self, bootprofile): self.bootprofile = bootprofile
     def get_boottimeout(self): return self.boottimeout
@@ -3047,6 +3050,9 @@ class type_(GeneratedsSuper):
         if self.efipartsize is not None and 'efipartsize' not in already_processed:
             already_processed.add('efipartsize')
             outfile.write(' efipartsize="%s"' % self.gds_format_integer(self.efipartsize, input_name='efipartsize'))
+        if self.efiparttable is not None and 'efiparttable' not in already_processed:
+            already_processed.add('efiparttable')
+            outfile.write(' efiparttable=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.efiparttable), input_name='efiparttable')), ))
         if self.bootprofile is not None and 'bootprofile' not in already_processed:
             already_processed.add('bootprofile')
             outfile.write(' bootprofile=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.bootprofile), input_name='bootprofile')), ))
@@ -3272,6 +3278,11 @@ class type_(GeneratedsSuper):
                 raise_parse_error(node, 'Bad integer attribute: %s' % exp)
             if self.efipartsize < 0:
                 raise_parse_error(node, 'Invalid NonNegativeInteger')
+        value = find_attr_value_('efiparttable', node)
+        if value is not None and 'efiparttable' not in already_processed:
+            already_processed.add('efiparttable')
+            self.efiparttable = value
+            self.efiparttable = ' '.join(self.efiparttable.split())
         value = find_attr_value_('bootprofile', node)
         if value is not None and 'bootprofile' not in already_processed:
             already_processed.add('bootprofile')

--- a/test/unit/firmware_test.py
+++ b/test/unit/firmware_test.py
@@ -17,9 +17,15 @@ class TestFirmWare(object):
         xml_state.build_type.get_firmware.return_value = 'bios'
         self.firmware_bios = FirmWare(xml_state)
 
+        xml_state.build_type.get_efiparttable.return_value = None
         xml_state.build_type.get_efipartsize.return_value = None
         xml_state.build_type.get_firmware.return_value = 'efi'
         self.firmware_efi = FirmWare(xml_state)
+
+        xml_state.build_type.get_efiparttable.return_value = 'msdos'
+        xml_state.build_type.get_efipartsize.return_value = None
+        xml_state.build_type.get_firmware.return_value = 'efi'
+        self.firmware_efi_mbr = FirmWare(xml_state)
 
         xml_state.build_type.get_efipartsize.return_value = 42
         self.firmware_efi_custom_efi_part = FirmWare(xml_state)
@@ -59,6 +65,7 @@ class TestFirmWare(object):
     def test_get_partition_table_type(self):
         assert self.firmware_bios.get_partition_table_type() == 'msdos'
         assert self.firmware_efi.get_partition_table_type() == 'gpt'
+        assert self.firmware_efi_mbr.get_partition_table_type() == 'msdos'
         assert self.firmware_s390_ldl.get_partition_table_type() == 'dasd'
         assert self.firmware_s390_cdl.get_partition_table_type() == 'dasd'
         assert self.firmware_s390_scsi.get_partition_table_type() == 'msdos'


### PR DESCRIPTION
This commit allows to choose the partition table type for efi firmwares
using the efiparttable type attribute.

Fixes #638
