### PR TITLE
Delete obsolete hybrid attribute

### DIFF
--- a/build-tests/arm/test-image-panda-oem/appliance.kiwi
+++ b/build-tests/arm/test-image-panda-oem/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="openSUSE-Tumbleweed-ARM-JeOS-panda">
+<image schemaversion="6.9" name="openSUSE-Tumbleweed-ARM-JeOS-panda">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/s390/test-image-oem/appliance.kiwi
+++ b/build-tests/s390/test-image-oem/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="LimeJeOS-DASD-ECKD-SLE12-Community">
+<image schemaversion="6.9" name="LimeJeOS-DASD-ECKD-SLE12-Community">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/test-image-azure/appliance.kiwi
+++ b/build-tests/x86/test-image-azure/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="Azure-openSUSE-Tumbleweed">
+<image schemaversion="6.9" name="Azure-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/test-image-docker/appliance.kiwi
+++ b/build-tests/x86/test-image-docker/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="Docker-openSUSE-Tumbleweed">
+<image schemaversion="6.9" name="Docker-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/test-image-ec2/appliance.kiwi
+++ b/build-tests/x86/test-image-ec2/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="EC2-openSUSE-Tumbleweed">
+<image schemaversion="6.9" name="EC2-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/test-image-fedora-vmx/appliance.kiwi
+++ b/build-tests/x86/test-image-fedora-vmx/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="VMX-Fedora-25.0">
+<image schemaversion="6.9" name="VMX-Fedora-25.0">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/test-image-iso/appliance.kiwi
+++ b/build-tests/x86/test-image-iso/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="ISO-openSUSE-Tumbleweed">
+<image schemaversion="6.9" name="ISO-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -16,7 +16,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="iso" flags="overlay" hybrid="true" firmware="efi" kernelcmdline="console=ttyS0 splash" hybridpersistent_filesystem="ext4" hybridpersistent="true" mediacheck="true"/>
+        <type image="iso" flags="overlay" firmware="efi" kernelcmdline="console=ttyS0 splash" hybridpersistent_filesystem="ext4" hybridpersistent="true" mediacheck="true"/>
     </preferences>
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>

--- a/build-tests/x86/test-image-oem/appliance.kiwi
+++ b/build-tests/x86/test-image-oem/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="OEM-openSUSE-Tumbleweed">
+<image schemaversion="6.9" name="OEM-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/test-image-orthos-oem/appliance.kiwi
+++ b/build-tests/x86/test-image-orthos-oem/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="factory-kiwi">
+<image schemaversion="6.9" name="factory-kiwi">
     <description type="system">
         <author>Julian Wolf</author>
         <contact>juwolf@suse.de</contact>

--- a/build-tests/x86/test-image-pxe/appliance.kiwi
+++ b/build-tests/x86/test-image-pxe/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="PXE-openSUSE-Tumbleweed">
+<image schemaversion="6.9" name="PXE-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/test-image-vmx/appliance.kiwi
+++ b/build-tests/x86/test-image-vmx/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="VMX-openSUSE-Tumbleweed">
+<image schemaversion="6.9" name="VMX-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -255,7 +255,6 @@ class BootImageBase(object):
             'filesystem',
             'firmware',
             'fsmountoptions',
-            'hybrid',
             'hybridpersistent',
             'hybridpersistent_filesystem',
             'initrd_system',

--- a/kiwi/config/strip.xml
+++ b/kiwi/config/strip.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="initrd-strip-metadata">
+<image schemaversion="6.9" name="initrd-strip-metadata">
     <description type="boot">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -57,7 +57,7 @@ div {
         attribute xsi:schemaLocation { xsd:anyURI }
     k.image.schemaversion.attribute =
         ## The allowed Schema version (fixed value)
-        attribute schemaversion { "6.8" }
+        attribute schemaversion { "6.9" }
     k.image.id =
         ## An identification number which is represented in a file
         ## named /etc/ImageID
@@ -1481,16 +1481,6 @@ div {
         ## Specifies the filesystem mount options which also ends up in fstab
         ## The string given here is passed as value to the -o option of mount
         attribute fsmountoptions { text }
-    k.type.hybrid.attribute =
-        ## Specifies that the ISO file will be turned into a hybrid image.
-        ## hybrid means the ISO image can be used as CD/DVD image and as a
-        ## disk image if the iso is e.g dumped on a USB stick. In both cases
-        ## the result is a bootable system.
-        attribute hybrid { xsd:boolean }
-        >> sch:pattern [ id = "hybrid" is-a = "image_type"
-            sch:param [ name = "attr" value = "hybrid" ]
-            sch:param [ name = "types" value = "iso pxe" ]
-        ]
     k.type.hybridpersistent.attribute =
         ## Will trigger the creation of a partition for a COW file
         ## to keep data persistent over a reboot
@@ -1737,7 +1727,6 @@ div {
         k.type.formatoptions.attribute? &
         k.type.fsmountoptions.attribute? &
         k.type.gcelicense.attribute? &
-        k.type.hybrid.attribute? &
         k.type.hybridpersistent.attribute? &
         k.type.hybridpersistent_filesystem.attribute? &
         k.type.gpt_hybrid_mbr.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -105,7 +105,7 @@ second the location of the XSD Schema
     <define name="k.image.schemaversion.attribute">
       <attribute name="schemaversion">
         <a:documentation>The allowed Schema version (fixed value)</a:documentation>
-        <value>6.8</value>
+        <value>6.9</value>
       </attribute>
     </define>
     <define name="k.image.id">
@@ -2205,19 +2205,6 @@ partitions</a:documentation>
 The string given here is passed as value to the -o option of mount</a:documentation>
       </attribute>
     </define>
-    <define name="k.type.hybrid.attribute">
-      <attribute name="hybrid">
-        <a:documentation>Specifies that the ISO file will be turned into a hybrid image.
-hybrid means the ISO image can be used as CD/DVD image and as a
-disk image if the iso is e.g dumped on a USB stick. In both cases
-the result is a bootable system.</a:documentation>
-        <data type="boolean"/>
-      </attribute>
-      <sch:pattern id="hybrid" is-a="image_type">
-        <sch:param name="attr" value="hybrid"/>
-        <sch:param name="types" value="iso pxe"/>
-      </sch:pattern>
-    </define>
     <define name="k.type.hybridpersistent.attribute">
       <attribute name="hybridpersistent">
         <a:documentation>Will trigger the creation of a partition for a COW file
@@ -2603,9 +2590,6 @@ default.</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.gcelicense.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.type.hybrid.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.hybridpersistent.attribute"/>

--- a/kiwi/system/profile.py
+++ b/kiwi/system/profile.py
@@ -282,8 +282,6 @@ class Profile(object):
             type_section.get_boottimeout()
         self.dot_profile['kiwi_wwid_wait_timeout'] = \
             type_section.get_wwid_wait_timeout()
-        self.dot_profile['kiwi_hybrid'] = \
-            type_section.get_hybrid()
         self.dot_profile['kiwi_hybridpersistent'] = \
             type_section.get_hybridpersistent()
         self.dot_profile['kiwi_hybridpersistent_filesystem'] = \

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Generated  by generateDS.py version 2.29.9.
+# Generated  by generateDS.py version 2.29.11.
 # Python 3.4.6 (default, Mar 22 2017, 12:26:13) [GCC]
 #
 # Command line options:
@@ -16,7 +16,7 @@
 #   kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Command line:
-#   /home/david/workspaces/kiwi/.env3/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
+#   /home/ms/Project/kiwi/.env3/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -2717,7 +2717,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, gcelicense=None, hybrid=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, containerconfig=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, boottimeout=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, containerconfig=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2744,7 +2744,6 @@ class type_(GeneratedsSuper):
         self.formatoptions = _cast(None, formatoptions)
         self.fsmountoptions = _cast(None, fsmountoptions)
         self.gcelicense = _cast(None, gcelicense)
-        self.hybrid = _cast(bool, hybrid)
         self.hybridpersistent = _cast(bool, hybridpersistent)
         self.hybridpersistent_filesystem = _cast(None, hybridpersistent_filesystem)
         self.gpt_hybrid_mbr = _cast(bool, gpt_hybrid_mbr)
@@ -2900,8 +2899,6 @@ class type_(GeneratedsSuper):
     def set_fsmountoptions(self, fsmountoptions): self.fsmountoptions = fsmountoptions
     def get_gcelicense(self): return self.gcelicense
     def set_gcelicense(self, gcelicense): self.gcelicense = gcelicense
-    def get_hybrid(self): return self.hybrid
-    def set_hybrid(self, hybrid): self.hybrid = hybrid
     def get_hybridpersistent(self): return self.hybridpersistent
     def set_hybridpersistent(self, hybridpersistent): self.hybridpersistent = hybridpersistent
     def get_hybridpersistent_filesystem(self): return self.hybridpersistent_filesystem
@@ -3095,9 +3092,6 @@ class type_(GeneratedsSuper):
         if self.gcelicense is not None and 'gcelicense' not in already_processed:
             already_processed.add('gcelicense')
             outfile.write(' gcelicense=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.gcelicense), input_name='gcelicense')), ))
-        if self.hybrid is not None and 'hybrid' not in already_processed:
-            already_processed.add('hybrid')
-            outfile.write(' hybrid="%s"' % self.gds_format_boolean(self.hybrid, input_name='hybrid'))
         if self.hybridpersistent is not None and 'hybridpersistent' not in already_processed:
             already_processed.add('hybridpersistent')
             outfile.write(' hybridpersistent="%s"' % self.gds_format_boolean(self.hybridpersistent, input_name='hybridpersistent'))
@@ -3363,15 +3357,6 @@ class type_(GeneratedsSuper):
         if value is not None and 'gcelicense' not in already_processed:
             already_processed.add('gcelicense')
             self.gcelicense = value
-        value = find_attr_value_('hybrid', node)
-        if value is not None and 'hybrid' not in already_processed:
-            already_processed.add('hybrid')
-            if value in ('true', '1'):
-                self.hybrid = True
-            elif value in ('false', '0'):
-                self.hybrid = False
-            else:
-                raise_parse_error(node, 'Bad boolean attribute')
         value = find_attr_value_('hybridpersistent', node)
         if value is not None and 'hybridpersistent' not in already_processed:
             already_processed.add('hybridpersistent')

--- a/kiwi/xsl/convert68to69.xsl
+++ b/kiwi/xsl/convert68to69.xsl
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv68to69">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv68to69"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<!-- remove kiwirevision attribute from image -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>6.8</literal> to <literal>6.9</literal>.
+</para>
+<xsl:template match="image" mode="conv68to69">
+    <xsl:choose>
+        <!-- nothing to do if already at 6.9 -->
+        <xsl:when test="@schemaversion > 6.8">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="6.9">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion' and local-name() != 'kiwirevision']"/>
+                <xsl:apply-templates  mode="conv68to69"/>  
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- delete hybrid attribute from type -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Delete hybrid attribute from type
+</para>
+<xsl:template match="type" mode="conv68to69">
+    <type>
+        <xsl:copy-of select="@*[not(local-name(.) = 'hybrid')]"/>
+        <xsl:apply-templates mode="conv68to69"/>
+    </type>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/kiwi/xsl/master.xsl
+++ b/kiwi/xsl/master.xsl
@@ -39,6 +39,7 @@
 <xsl:import href="convert65to66.xsl"/>
 <xsl:import href="convert66to67.xsl"/>
 <xsl:import href="convert67to68.xsl"/>
+<xsl:import href="convert68to69.xsl"/>
 <xsl:import href="pretty.xsl"/>
 
 
@@ -181,8 +182,12 @@
         <xsl:apply-templates select="exslt:node-set($v67)" mode="conv67to68"/>
     </xsl:variable>
 
+    <xsl:variable name="v69">
+        <xsl:apply-templates select="exslt:node-set($v68)" mode="conv68to69"/>
+    </xsl:variable>
+
     <xsl:apply-templates
-        select="exslt:node-set($v68)" mode="pretty"
+        select="exslt:node-set($v69)" mode="pretty"
     />
 </xsl:template>
 

--- a/test/data/example_arm_disk_size_config.xml
+++ b/test/data/example_arm_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_btrfs_config.xml
+++ b/test/data/example_btrfs_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
     <drivers>
         <file name="crypto/*"/>
         <file name="drivers/acpi/*"/>

--- a/test/data/example_disk_config.xml
+++ b/test/data/example_disk_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_config.xml
+++ b/test/data/example_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_empty_vol_config.xml
+++ b/test/data/example_disk_size_empty_vol_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_oem_volume_config.xml
+++ b/test/data/example_disk_size_oem_volume_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_vol_root_config.xml
+++ b/test/data/example_disk_size_vol_root_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_volume_config.xml
+++ b/test/data/example_disk_size_volume_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_dot_profile_config.xml
+++ b/test/data/example_dot_profile_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="LimeJeOS-openSUSE-13.2" displayname="schäfer">
+<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2" displayname="schäfer">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_default_config.xml
+++ b/test/data/example_lvm_default_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_no_root_config.xml
+++ b/test/data/example_lvm_no_root_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_no_root_full_usr_config.xml
+++ b/test/data/example_lvm_no_root_full_usr_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_preferred_config.xml
+++ b/test/data/example_lvm_preferred_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_multiple_users_config.xml
+++ b/test/data/example_multiple_users_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_no_default_type.xml
+++ b/test/data/example_no_default_type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_no_image_packages_config.xml
+++ b/test/data/example_no_image_packages_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_no_imageinclude_config.xml
+++ b/test/data/example_no_imageinclude_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_ppc_disk_size_config.xml
+++ b/test/data/example_ppc_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_pxe_config.xml
+++ b/test/data/example_pxe_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_runtime_checker_boot_desc_not_found.xml
+++ b/test/data/example_runtime_checker_boot_desc_not_found.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="JeOS">
+<image schemaversion="6.9" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_runtime_checker_config.xml
+++ b/test/data/example_runtime_checker_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
     <drivers>
         <file name="crypto/*"/>
         <file name="drivers/acpi/*"/>

--- a/test/data/example_runtime_checker_no_boot_reference.xml
+++ b/test/data/example_runtime_checker_no_boot_reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="JeOS">
+<image schemaversion="6.9" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/isoboot/example-distribution-no-delete-section/config.xml
+++ b/test/data/isoboot/example-distribution-no-delete-section/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="initrd-isoboot-suse-13.2">
+<image schemaversion="6.9" name="initrd-isoboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/data/isoboot/example-distribution/config.xml
+++ b/test/data/isoboot/example-distribution/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="initrd-isoboot-suse-13.2">
+<image schemaversion="6.9" name="initrd-isoboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/data/oemboot/example-distribution/config.xml
+++ b/test/data/oemboot/example-distribution/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.8" name="initrd-oemboot-suse-13.2">
+<image schemaversion="6.9" name="initrd-oemboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/unit/system_profile_test.py
+++ b/test/unit/system_profile_test.py
@@ -45,7 +45,6 @@ class TestProfile(object):
             'kiwi_drivers': '',
             'kiwi_firmware': 'efi',
             'kiwi_fsmountoptions': None,
-            'kiwi_hybrid': None,
             'kiwi_hybridpersistent_filesystem': None,
             'kiwi_hybridpersistent': None,
             'kiwi_iname': 'LimeJeOS-openSUSE-13.2',


### PR DESCRIPTION
Any iso image we create will be a hybrid image. That was already the default for any install iso image and was a configuration option for live images. The optional selection only existed for systems which do not provide tools to make an iso hybrid. All distributions kiwi supports provides this capabilities and there is no good reason why a live or install iso should not be hybrid and bootable as iso and as disk. Also the boot in disk mode became the preferred boot method for the majority of our users which requires to provide a hybrid iso