### PR TITLE
Enable no forced deletion for dnf, yum and apt package managers

### DIFF
--- a/kiwi/package_manager/dnf.py
+++ b/kiwi/package_manager/dnf.py
@@ -164,14 +164,22 @@ class PackageManagerDnf(PackageManagerBase):
             raise KiwiRequestError(
                 'None of the requested packages to delete are installed'
             )
-        delete_options = ['--nodeps', '--allmatches', '--noscripts']
         self.cleanup_requests()
-        return Command.call(
-            [
-                'chroot', self.root_dir, 'rpm', '-e'
-            ] + delete_options + delete_items,
-            self.command_env
-        )
+        if force:
+            delete_options = ['--nodeps', '--allmatches', '--noscripts']
+            return Command.call(
+                [
+                    'chroot', self.root_dir, 'rpm', '-e'
+                ] + delete_options + delete_items,
+                self.command_env
+            )
+        else:
+            chroot_dnf_args = self.root_bind.move_to_root(self.dnf_args)
+            return Command.call(
+                ['chroot', self.root_dir, 'dnf'] + chroot_dnf_args +
+                self.custom_args + ['remove'] + delete_items,
+                self.command_env
+            )
 
     def update(self):
         """

--- a/kiwi/package_manager/dnf.py
+++ b/kiwi/package_manager/dnf.py
@@ -177,7 +177,7 @@ class PackageManagerDnf(PackageManagerBase):
             chroot_dnf_args = self.root_bind.move_to_root(self.dnf_args)
             return Command.call(
                 ['chroot', self.root_dir, 'dnf'] + chroot_dnf_args +
-                self.custom_args + ['remove'] + delete_items,
+                self.custom_args + ['autoremove'] + delete_items,
                 self.command_env
             )
 

--- a/kiwi/package_manager/yum.py
+++ b/kiwi/package_manager/yum.py
@@ -173,9 +173,6 @@ class PackageManagerYum(PackageManagerBase):
         """
         Process package delete requests (chroot)
 
-        Note: yum erase does not delete unneeded dependencies it only
-        makes sure no dependencies are broken.
-
         :param bool force: force deletion: true|false
         """
         delete_items = []
@@ -205,7 +202,7 @@ class PackageManagerYum(PackageManagerBase):
                 [
                     'chroot', self.root_dir, self._get_yum_binary_name()
                 ] + chroot_yum_args + self.custom_args + [
-                    'erase'
+                    'autoremove'
                 ] + delete_items,
                 self.command_env
             )

--- a/kiwi/package_manager/yum.py
+++ b/kiwi/package_manager/yum.py
@@ -173,6 +173,9 @@ class PackageManagerYum(PackageManagerBase):
         """
         Process package delete requests (chroot)
 
+        Note: yum erase does not delete unneeded dependencies it only
+        makes sure no dependencies are broken.
+
         :param bool force: force deletion: true|false
         """
         delete_items = []
@@ -187,14 +190,25 @@ class PackageManagerYum(PackageManagerBase):
             raise KiwiRequestError(
                 'None of the requested packages to delete are installed'
             )
-        delete_options = ['--nodeps', '--allmatches', '--noscripts']
         self.cleanup_requests()
-        return Command.call(
-            [
-                'chroot', self.root_dir, 'rpm', '-e'
-            ] + delete_options + delete_items,
-            self.command_env
-        )
+        if force:
+            delete_options = ['--nodeps', '--allmatches', '--noscripts']
+            return Command.call(
+                [
+                    'chroot', self.root_dir, 'rpm', '-e'
+                ] + delete_options + delete_items,
+                self.command_env
+            )
+        else:
+            chroot_yum_args = self.root_bind.move_to_root(self.yum_args)
+            return Command.call(
+                [
+                    'chroot', self.root_dir, self._get_yum_binary_name()
+                ] + chroot_yum_args + self.custom_args + [
+                    'erase'
+                ] + delete_items,
+                self.command_env
+            )
 
     def update(self):
         """

--- a/kiwi/repository/template/apt.py
+++ b/kiwi/repository/template/apt.py
@@ -51,18 +51,11 @@ class PackageManagerTemplateAptGet(object):
             };
         ''').strip() + os.linesep
 
-        self.dpkg = dedent('''
-            DPkg::Options {
-                "--force-all";
-            };
-        ''').strip() + os.linesep
-
         self.dpkg_exclude_docs = dedent('''
             DPkg::Options {
                 "--path-exclude=/usr/share/man/*";
                 "--path-exclude=/usr/share/doc/*";
                 "--path-include=/usr/share/doc/*/copyright";
-                "--force-all";
             };
         ''').strip() + os.linesep
 
@@ -76,8 +69,6 @@ class PackageManagerTemplateAptGet(object):
         template_data = self.host_header + self.apt
         if exclude_docs:
             template_data += self.dpkg_exclude_docs
-        else:
-            template_data += self.dpkg
 
         return Template(template_data)
 
@@ -91,7 +82,5 @@ class PackageManagerTemplateAptGet(object):
         template_data = self.image_header + self.apt
         if exclude_docs:
             template_data += self.dpkg_exclude_docs
-        else:
-            template_data += self.dpkg
 
         return Template(template_data)

--- a/test/unit/package_manager_dnf_test.py
+++ b/test/unit/package_manager_dnf_test.py
@@ -106,7 +106,7 @@ class TestPackageManagerDnf(object):
         mock_call.assert_called_once_with(
             [
                 'chroot', 'root-dir', 'dnf',
-                'root-moved-arguments', 'remove', 'vim'
+                'root-moved-arguments', 'autoremove', 'vim'
             ],
             ['env']
         )

--- a/test/unit/package_manager_dnf_test.py
+++ b/test/unit/package_manager_dnf_test.py
@@ -87,7 +87,7 @@ class TestPackageManagerDnf(object):
     @patch('kiwi.command.Command.run')
     def test_process_delete_requests_force(self, mock_run, mock_call):
         self.manager.request_package('vim')
-        self.manager.process_delete_requests()
+        self.manager.process_delete_requests(True)
         mock_call.assert_called_once_with(
             [
                 'chroot', 'root-dir', 'rpm', '-e',
@@ -96,6 +96,19 @@ class TestPackageManagerDnf(object):
             [
                 'env'
             ]
+        )
+
+    @patch('kiwi.command.Command.call')
+    @patch('kiwi.command.Command.run')
+    def test_process_delete_requests_no_force(self, mock_run, mock_call):
+        self.manager.request_package('vim')
+        self.manager.process_delete_requests()
+        mock_call.assert_called_once_with(
+            [
+                'chroot', 'root-dir', 'dnf',
+                'root-moved-arguments', 'remove', 'vim'
+            ],
+            ['env']
         )
 
     @patch('kiwi.command.Command.run')

--- a/test/unit/package_manager_yum_test.py
+++ b/test/unit/package_manager_yum_test.py
@@ -127,7 +127,7 @@ class TestPackageManagerYum(object):
         mock_call.assert_called_once_with(
             [
                 'chroot', 'root-dir', 'yum', 'root-moved-arguments',
-                'erase', 'vim'
+                'autoremove', 'vim'
             ], ['env']
         )
 

--- a/test/unit/package_manager_yum_test.py
+++ b/test/unit/package_manager_yum_test.py
@@ -108,7 +108,7 @@ class TestPackageManagerYum(object):
     @patch('kiwi.command.Command.run')
     def test_process_delete_requests_force(self, mock_run, mock_call):
         self.manager.request_package('vim')
-        self.manager.process_delete_requests()
+        self.manager.process_delete_requests(True)
         mock_call.assert_called_once_with(
             [
                 'chroot', 'root-dir', 'rpm', '-e',
@@ -117,6 +117,18 @@ class TestPackageManagerYum(object):
             [
                 'env'
             ]
+        )
+
+    @patch('kiwi.command.Command.call')
+    @patch('kiwi.command.Command.run')
+    def test_process_delete_requests_no_force(self, mock_run, mock_call):
+        self.manager.request_package('vim')
+        self.manager.process_delete_requests()
+        mock_call.assert_called_once_with(
+            [
+                'chroot', 'root-dir', 'yum', 'root-moved-arguments',
+                'erase', 'vim'
+            ], ['env']
         )
 
     @patch('kiwi.command.Command.run')


### PR DESCRIPTION
This commit makes apt, yum and dnf support equivalent to zypper in terms of
being capable to delete packages using the package manger tools
(implies dependencies deletion is handled by the package manager)
or deleting explicitly only listed packages using packager tools
even if this implies breaking dependencies.