### PR TITLE
Fixed truncation of image when writing vhd tag

### DIFF
--- a/kiwi/storage/subformat/vhdfixed.py
+++ b/kiwi/storage/subformat/vhdfixed.py
@@ -155,14 +155,14 @@ class DiskFormatVhdFixed(DiskFormatBase):
         binary_tag = self._pack_net_guid_tag(tag)
         vhd_fixed_image = self.get_target_file_path_for_format('vhdfixed')
         # seek to 64k offset and zero out 512 byte
-        with open(vhd_fixed_image, 'wb') as vhd_fixed:
+        with open(vhd_fixed_image, 'r+b') as vhd_fixed:
             with open('/dev/null', 'rb') as null:
                 vhd_fixed.seek(65536, 0)
                 vhd_fixed.write(null.read(512))
                 vhd_fixed.seek(0, 2)
 
         # seek to 64k offset and write tag
-        with open(vhd_fixed_image, 'wb') as vhd_fixed:
+        with open(vhd_fixed_image, 'r+b') as vhd_fixed:
             vhd_fixed.seek(65536, 0)
             vhd_fixed.write(binary_tag)
             vhd_fixed.seek(0, 2)

--- a/test/unit/storage_subformat_vhdfixed_test.py
+++ b/test/unit/storage_subformat_vhdfixed_test.py
@@ -69,9 +69,9 @@ class TestDiskFormatVhdFixed(object):
             ]
         )
         assert mock_open.call_args_list == [
-            call('target_dir/some-disk-image.x86_64-1.2.3.vhdfixed', 'wb'),
+            call('target_dir/some-disk-image.x86_64-1.2.3.vhdfixed', 'r+b'),
             call('/dev/null', 'rb'),
-            call('target_dir/some-disk-image.x86_64-1.2.3.vhdfixed', 'wb')
+            call('target_dir/some-disk-image.x86_64-1.2.3.vhdfixed', 'r+b')
         ]
         assert file_mock.write.call_args_list[0] == call(
             'dev_null_data'


### PR DESCRIPTION
When writing the vhd tag into a vhdfixed formatted image
the image was opened with the wrong open bits 'wb' and
thus was truncated at the 64k offset. This patch fixes
the open bits to allow in-place tag writing. This
Fixes bsc#1077096


