### PR TITLE
Update etc/default/grub setup

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -524,13 +524,13 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         * GRUB_USE_LINUXEFI
         * GRUB_USE_INITRDEFI
         * GRUB_SERIAL_COMMAND
-        * GRUB_CMDLINE_LINUX
+        * GRUB_CMDLINE_LINUX_DEFAULT
         """
         grub_default_entries = {
             'GRUB_TIMEOUT': self.timeout
         }
         if self.cmdline:
-            grub_default_entries['GRUB_CMDLINE_LINUX'] = '"{0}"'.format(
+            grub_default_entries['GRUB_CMDLINE_LINUX_DEFAULT'] = '"{0}"'.format(
                 self.cmdline
             )
         if self.terminal and self.terminal == 'serial':

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -321,7 +321,7 @@ class TestBootLoaderConfigGrub2(object):
         grub_default.write.assert_called_once_with()
         assert grub_default.__setitem__.call_args_list == [
             call('GRUB_BACKGROUND', '/boot/grub2/themes/openSUSE/background.png'),
-            call('GRUB_CMDLINE_LINUX', '"some-cmdline"'),
+            call('GRUB_CMDLINE_LINUX_DEFAULT', '"some-cmdline"'),
             call('GRUB_SERIAL_COMMAND', '"serial --speed=38400 --unit=0 --word=8 --parity=no --stop=1"'),
             call('GRUB_THEME', '/boot/grub2/themes/openSUSE/theme.txt'),
             call('GRUB_TIMEOUT', 10),


### PR DESCRIPTION
kiwi writes optional grub boot parameters to the GRUB_CMDLINE_LINUX
variable in default/grub. This information is then picked up by
grub2-mkconfig and written to grub.cfg However there is also another
variable named GRUB_CMDLINE_LINUX_DEFAULT which according to the
documentation should be used preferably. While it does not seem to
matter for grub it matters for yast. Thus this patch changes the
configuration variable and fixes bsc#1084117


