### PR TITLE
Fixed detection of disk node in live iso images

### DIFF
--- a/dracut/modules.d/90kiwi-live/module-setup.sh
+++ b/dracut/modules.d/90kiwi-live/module-setup.sh
@@ -27,7 +27,7 @@ install() {
     local dmsquashdir=
     inst_multiple \
         umount dmsetup blockdev blkid lsblk dd losetup \
-        isoinfo grep cut partprobe find wc fdisk tail mkfs.ext4 mkfs.xfs \
+        grep cut partprobe find wc fdisk tail mkfs.ext4 mkfs.xfs \
         checkmedia dialog
 
     dmsquashdir=$(find "${dracutbasedir}/modules.d" -name "*dmsquash-live")


### PR DESCRIPTION
If the live iso is booted as disk the initrd code needs to find the correct disk node pointing to the iso image. This was formerly done by checking if the populated disk devices contains an iso header with an application id. The information was obtained using the isoinfo tool. isoinfo is a tool provided by the obsolete and xorriso replaced cdrtools kit. In addition the lookup was unsafe because any iso with an application id would have been valid.

Thus this patch changes the detection mechanism to use the volume id as it is used in the root assignment on the cmdline. The volume id is populated as device label for the assigned block device and can therefore be used as a unique id. The volume id itself is a configuration option in the image
XML description. If not set the default is 'CDROM'. The information can be obtained via blkid and therefore also eliminates the isoinfo requirement


