### PR TITLE
Fix default initrd_system values

### DIFF
--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -118,10 +118,14 @@ class XMLState(object):
         :return: dracut|kiwi|None
         :rtype: string
         """
-        initrd_system = self.build_type.get_initrd_system() or 'kiwi'
-        if self.get_build_type_name() == 'vmx':
-            # vmx image type always uses dracut as initrd system
+        if self.get_build_type_name() in ['vmx', 'iso']:
+            # vmx and iso image types always use dracut as initrd system
             initrd_system = 'dracut'
+        elif self.get_build_type_name() in ['oem', 'pxe']:
+            # pxe and oem image types default to kiwi if unset
+            initrd_system = self.build_type.get_initrd_system() or 'kiwi'
+        else:
+            initrd_system = self.build_type.get_initrd_system()
         return initrd_system
 
     def get_rpm_excludedocs(self):

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -686,3 +686,9 @@ class TestXMLState(object):
         xml_data = description.load()
         state = XMLState(xml_data, ['vmxFlavour'], 'vmx')
         assert state.get_initrd_system() == 'dracut'
+        state = XMLState(xml_data, ['vmxFlavour'], 'iso')
+        assert state.get_initrd_system() == 'dracut'
+        state = XMLState(xml_data, ['vmxFlavour'], 'docker')
+        assert state.get_initrd_system() is None
+        state = XMLState(xml_data, [], 'oem')
+        assert state.get_initrd_system() == 'kiwi'


### PR DESCRIPTION
This commit fixes the default initrd_system value for some image
types. Since this value is included in profile and potentially
taken into account for some of the config script functions, it is
important to have consistent values even when the image type
has no initrd choice or it doesn't have initrd at all.

Related to #689
