### PR TITLE
Change variable quoting for Rm/Rpm shell helpers

### DIFF
--- a/kiwi/config/functions.sh
+++ b/kiwi/config/functions.sh
@@ -453,7 +453,7 @@ function Rm {
     # delete files & anounce it to log
     # ----
     Debug "rm $*"
-    rm "$*"
+    rm "$@"
 }
 
 #======================================
@@ -464,7 +464,7 @@ function Rpm {
     # all rpm function & anounce it to log
     # ----
     Debug "rpm $*"
-    rpm "$*"
+    rpm "$@"
 }
 #======================================
 # Echo


### PR DESCRIPTION
The two methods exists to overlay their call with a logging
facility. Thus it is ok and expected that the caller can
pass arguments for the program e.g (Rm -rf foo) which resulted
in (rm '-rf foo') leading to a runtime error.

Problem found and fixed by Rüdiger Oertel