### PR TITLE
Fixup creation of vmware settings file

### DIFF
--- a/kiwi/storage/subformat/vmdk.py
+++ b/kiwi/storage/subformat/vmdk.py
@@ -132,21 +132,14 @@ class DiskFormatVmdk(DiskFormatBase):
             template_record['iso_id'] = iso_setup.get_id()
 
         # Network setup
-        network_setup = self.xml_state.get_build_type_vmnic_section()
-        network_driver = None
-        network_connection_type = None
-        network_mac = 'generated'
-        if network_setup:
-            network_driver = network_setup.get_driver()
-            network_connection_type = network_setup.get_mode()
-            network_mac = network_setup.get_mac() or network_mac
-            template_record['nic_id'] = network_setup.get_interface() or '0'
-            template_record['mac_address'] = \
-                network_mac
-            template_record['network_connection_type'] = \
-                network_connection_type
-            template_record['network_driver'] = \
-                network_driver
+        network_entries = self.xml_state.get_build_type_vmnic_entries()
+        network_setup = {}
+        for network_entry in network_entries:
+            network_setup[network_entry.get_interface() or '0'] = {
+                'driver': network_entry.get_driver(),
+                'connection_type': network_entry.get_mode(),
+                'mac': network_entry.get_mac() or 'generated',
+            }
 
         # Disk setup
         disk_setup = self.xml_state.get_build_type_vmdisk_section()
@@ -169,10 +162,7 @@ class DiskFormatVmdk(DiskFormatBase):
             network_setup,
             iso_setup,
             disk_controller,
-            iso_controller,
-            network_mac,
-            network_driver,
-            network_connection_type
+            iso_controller
         )
         try:
             settings_file = self.get_target_file_path_for_format('vmx')

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -564,19 +564,17 @@ class XMLState(object):
             if vmdisk_sections:
                 return vmdisk_sections[0]
 
-    def get_build_type_vmnic_section(self):
+    def get_build_type_vmnic_entries(self):
         """
-        First vmnic section from the first machine section in the
+        vmnic section(s) from the first machine section in the
         build type section
 
-        :return: <vmnic>
-        :rtype: xml_parse::vmnic instance
+        :return: xml_parse::vmnic instances
+        :rtype: list
         """
         machine_section = self.get_build_type_machine_section()
         if machine_section:
-            vmnic_sections = machine_section.get_vmnic()
-            if vmnic_sections:
-                return vmnic_sections[0]
+            return machine_section.get_vmnic()
 
     def get_build_type_vmdvd_section(self):
         """

--- a/test/unit/storage_subformat_template_vmware_settings_test.py
+++ b/test/unit/storage_subformat_template_vmware_settings_test.py
@@ -18,15 +18,13 @@ class TestVmwareSettingsTempla(object):
 
     def test_get_template_with_periphery(self):
         assert self.vmware.get_template(
-            memory_setup=True, cpu_setup=True, network_setup=True,
-            iso_setup=True
+            memory_setup=True, cpu_setup=True, iso_setup=True
         ).substitute(
             virtual_hardware_version='8',
             display_name='some-display-name',
             guest_os='suse',
             disk_id='0',
             vmdk_file='myimage.vmdk',
-            nic_id='0',
             memory_size='4096',
             number_of_cpus='2',
             iso_id='0'
@@ -58,16 +56,22 @@ class TestVmwareSettingsTempla(object):
 
     def test_get_template_custom_network(self):
         assert self.vmware.get_template(
-            network_setup=True, network_mac='custom',
-            network_connection_type='link', network_driver='foo'
+            network_setup={
+                '0': {
+                    'driver': 'foo',
+                    'connection_type': 'link',
+                    'mac': '98:90:96:a0:3c:58'
+                },
+                '1': {
+                    'driver': 'foo',
+                    'connection_type': 'link',
+                    'mac': 'generated'
+                }
+            }
         ).substitute(
             virtual_hardware_version='8',
             display_name='some-display-name',
             guest_os='suse',
             disk_id='0',
-            vmdk_file='myimage.vmdk',
-            nic_id='0',
-            mac_address='98:90:96:a0:3c:58',
-            network_connection_type='link',
-            network_driver='foo'
+            vmdk_file='myimage.vmdk'
         )

--- a/test/unit/storage_subformat_vmdk_test.py
+++ b/test/unit/storage_subformat_vmdk_test.py
@@ -68,20 +68,20 @@ class TestDiskFormatVmdk(object):
             return_value='0'
         )
 
-        self.network_setup = mock.Mock()
-        self.xml_state.get_build_type_vmnic_section = mock.Mock(
+        self.network_setup = [mock.Mock()]
+        self.xml_state.get_build_type_vmnic_entries = mock.Mock(
             return_value=self.network_setup
         )
-        self.network_setup.get_interface = mock.Mock(
+        self.network_setup[0].get_interface = mock.Mock(
             return_value='0'
         )
-        self.network_setup.get_mac = mock.Mock(
+        self.network_setup[0].get_mac = mock.Mock(
             return_value='98:90:96:a0:3c:58'
         )
-        self.network_setup.get_mode = mock.Mock(
+        self.network_setup[0].get_mode = mock.Mock(
             return_value='bridged'
         )
-        self.network_setup.get_driver = mock.Mock(
+        self.network_setup[0].get_driver = mock.Mock(
             return_value='e1000'
         )
 

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -196,8 +196,9 @@ class TestXMLState(object):
     def test_get_build_type_vmdisk_section(self):
         assert self.state.get_build_type_vmdisk_section().get_id() == 0
 
-    def test_get_build_type_vmnic_section(self):
-        assert self.state.get_build_type_vmnic_section().get_interface() == ''
+    def test_get_build_type_vmnic_entries(self):
+        assert self.state.get_build_type_vmnic_entries()[0].get_interface() \
+            == ''
 
     def test_get_build_type_vmdvd_section(self):
         assert self.state.get_build_type_vmdvd_section().get_id() == 0


### PR DESCRIPTION
The kiwi schema allows for multiple vmnic sections but kiwi
only took the primary one into account. This patch uses all
configured vmnic sections. This Fixes #688

