### PR TITLE
Fixed creation of machine settings file

### DIFF
--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -633,6 +633,8 @@ class XMLState(object):
         machine_section = self.get_build_type_machine_section()
         if machine_section:
             return machine_section.get_vmnic()
+        else:
+            return []
 
     def get_build_type_vmdvd_section(self):
         """

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -199,6 +199,7 @@ class TestXMLState(object):
     def test_get_build_type_vmnic_entries(self):
         assert self.state.get_build_type_vmnic_entries()[0].get_interface() \
             == ''
+        assert self.boot_state.get_build_type_vmnic_entries() == []
 
     def test_get_build_type_vmdvd_section(self):
         assert self.state.get_build_type_vmdvd_section().get_id() == 0


### PR DESCRIPTION
If no vmnic setup is present a request to iterator over
a NoneType object is attempted and failed. This Fixes #710

