### PR TITLE
Use /dev/zero to really write a zero byte

### DIFF
--- a/build-tests/x86/test-image-azure/appliance.kiwi
+++ b/build-tests/x86/test-image-azure/appliance.kiwi
@@ -7,7 +7,7 @@
         <specification>azure test build</specification>
     </description>
     <preferences>
-        <type image="vmx" filesystem="ext4" boottimeout="1" kernelcmdline="console=ttyS0 rootdelay=300 net.ifnames=0" devicepersistency="by-uuid" format="vhd-fixed" formatoptions="force_size" bootloader="grub2" bootpartition="true" bootpartsize="1024">
+        <type image="vmx" filesystem="xfs" bootloader="grub2" kernelcmdline="USE_BY_UUID_DEVICE_NAMES=1 earlyprintk=ttyS0 console=ttyS0 rootdelay=300 net.ifnames=0 dis_ucode_ldr" devicepersistency="by-uuid" formatoptions="force_size" format="vhd-fixed" vhdfixedtag="22222222-3333-4444-5555-666666666666" bootpartition="true" bootpartsize="1024" bootloader_console="serial">
             <size unit="M">30720</size>
         </type>
         <version>1.0.5</version>

--- a/kiwi/storage/subformat/vhdfixed.py
+++ b/kiwi/storage/subformat/vhdfixed.py
@@ -154,7 +154,7 @@ class DiskFormatVhdFixed(DiskFormatBase):
         vhd_fixed_image = self.get_target_file_path_for_format('vhdfixed')
         # seek to 64k offset and zero out 512 byte
         with open(vhd_fixed_image, 'r+b') as vhd_fixed:
-            with open('/dev/null', 'rb') as null:
+            with open('/dev/zero', 'rb') as null:
                 vhd_fixed.seek(65536, 0)
                 vhd_fixed.write(null.read(512))
                 vhd_fixed.seek(0, 2)

--- a/test/unit/storage_subformat_vhdfixed_test.py
+++ b/test/unit/storage_subformat_vhdfixed_test.py
@@ -56,7 +56,7 @@ class TestDiskFormatVhdFixed(object):
         enter_mock.return_value = file_mock
         setattr(context_manager_mock, '__enter__', enter_mock)
         setattr(context_manager_mock, '__exit__', exit_mock)
-        file_mock.read.return_value = 'dev_null_data'
+        file_mock.read.return_value = 'dev_zero_data'
 
         self.disk_format.create_image_format()
 
@@ -70,11 +70,11 @@ class TestDiskFormatVhdFixed(object):
         )
         assert mock_open.call_args_list == [
             call('target_dir/some-disk-image.x86_64-1.2.3.vhdfixed', 'r+b'),
-            call('/dev/null', 'rb'),
+            call('/dev/zero', 'rb'),
             call('target_dir/some-disk-image.x86_64-1.2.3.vhdfixed', 'r+b')
         ]
         assert file_mock.write.call_args_list[0] == call(
-            'dev_null_data'
+            'dev_zero_data'
         )
         if sys.byteorder == 'little':
             # on little endian machines


### PR DESCRIPTION
The cleanup of the 512 byte block for the vhdfixed tag
was based on reading from /dev/null which does effectively
nothing. As the block should be filled with zero bytes
this patch changes the source from /dev/null to /dev/zero
This was found by tests to reproduce the issue reported
in bsc#1090953 but is not causing it

