### PR TITLE
Fixed check for volume group in use

### DIFF
--- a/kiwi/volume_manager/lvm.py
+++ b/kiwi/volume_manager/lvm.py
@@ -286,12 +286,19 @@ class VolumeManagerLVM(VolumeManagerBase):
 
     def _volume_group_in_use_on_host_system(self, volume_group_name):
         vgs_call = Command.run(
-            ['vgs', '--noheadings', '-o', 'vg_name']
+            [
+                'vgs', '--noheadings',
+                '--select', 'vg_name={0}'.format(volume_group_name)
+            ]
         )
-        for host_volume_group_name in vgs_call.output.split('\n'):
-            if volume_group_name in host_volume_group_name:
-                return True
-        return False
+        if vgs_call.output:
+            # if vgs returned some information on the selected volume
+            # group name, this indicates the group is in use
+            return True
+        else:
+            # if vgs returned no information on the selected volume
+            # group name, it is considered to be not used
+            return False
 
     def __del__(self):
         if self.volume_group:

--- a/test/unit/volume_manager_lvm_test.py
+++ b/test/unit/volume_manager_lvm_test.py
@@ -87,11 +87,16 @@ class TestVolumeManagerLVM(object):
     @patch('kiwi.volume_manager.base.mkdtemp')
     def test_setup(self, mock_mkdtemp, mock_command):
         mock_mkdtemp.return_value = 'tmpdir'
+        command = mock.Mock()
+        # no output for commands to mock empty information for
+        # vgs command, indicating the volume group is not in use
+        command.output = ''
+        mock_command.return_value = command
         self.volume_manager.setup('volume_group')
         call = mock_command.call_args_list[0]
         assert mock_command.call_args_list[0] == \
             call([
-                'vgs', '--noheadings', '-o', 'vg_name'
+                'vgs', '--noheadings', '--select', 'vg_name=volume_group'
             ])
         call = mock_command.call_args_list[1]
         assert mock_command.call_args_list[1] == \
@@ -115,7 +120,7 @@ class TestVolumeManagerLVM(object):
     @patch('kiwi.volume_manager.lvm.Command.run')
     def test_setup_volume_group_host_conflict(self, mock_command):
         command = mock.Mock()
-        command.output = 'volume_group'
+        command.output = 'some_data_about_volume_group'
         mock_command.return_value = command
         self.volume_manager.setup('volume_group')
 


### PR DESCRIPTION
The former implementation evaluates the output of the vgs command and set the volume group as in use if one of the listed volume groups on the host contains the group name set by the image description.

This would also match if the group name set in the image description is e.g 'System' and a volume group on the host with name 'SystemVG' exists. However a conflict only exists on _exact_ match of the name.

The proposed fix is to use the --select feature from vgs and let it show information on exact match of the vg_name field. The code in kiwi then just evaluates if the selection by vgs has a value or not.

Fixes #721

