### PR TITLE
Add uninstall packages type

### DIFF
--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -360,6 +360,13 @@ class KiwiInstallPhaseFailed(KiwiError):
     """
 
 
+class KiwiPackagesDeletePhaseFailed(KiwiError):
+    """
+    Exception raised if the packages deletion phase in system prepare
+    fails.
+    """
+
+
 class KiwiIsoLoaderError(KiwiError):
     """
     Exception raised if no isolinux loader file could be found.

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -2537,7 +2537,8 @@ div {
         ## packages are only installed if this build type is requested.
         attribute type {
             "bootstrap" | "delete" | "docker" | "image" |
-            "iso" | "oem" | "pxe" | "vmx" | "oci"
+            "iso" | "oem" | "pxe" | "vmx" | "oci" |
+            "uninstall"
         }
     k.packages.profiles.attribute = k.profiles.attribute
     k.packages.patternType.attribute =

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -3981,6 +3981,7 @@ packages are only installed if this build type is requested.</a:documentation>
           <value>pxe</value>
           <value>vmx</value>
           <value>oci</value>
+          <value>uninstall</value>
         </choice>
       </attribute>
     </define>

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -216,15 +216,13 @@ class SystemBuildTask(CliTask):
         setup.setup_plymouth_splash()
         setup.setup_timezone()
 
-        system.pinch_system(
-            manager=manager, force=True
-        )
         # make sure manager instance is cleaned up now
         del manager
 
         # setup permanent image repositories after cleanup
         setup.import_repositories_marked_as_imageinclude()
         setup.call_config_script()
+        system.pinch_system()
 
         # make sure system instance is cleaned up now
         del system

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -222,8 +222,14 @@ class SystemBuildTask(CliTask):
         # setup permanent image repositories after cleanup
         setup.import_repositories_marked_as_imageinclude()
         setup.call_config_script()
-        system.pinch_system(manager=None, force=False)
-        system.pinch_system(manager=None, force=True)
+
+        # handle uninstall package requests, gracefully uninstall
+        # with dependency cleanup
+        system.pinch_system(force=False)
+
+        # handle delete package requests, forced uninstall without
+        # any dependency resolution
+        system.pinch_system(force=True)
 
         # make sure system instance is cleaned up now
         del system

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -173,12 +173,6 @@ class SystemBuildTask(CliTask):
         self.runtime_checker.check_repositories_configured()
         self.runtime_checker.check_image_include_repos_publicly_resolvable()
 
-        package_requests = False
-        if self.command_args['--add-package']:
-            package_requests = True
-        if self.command_args['--delete-package']:
-            package_requests = True
-
         log.info('Preparing new root system')
         system = SystemPrepare(
             self.xml_state,
@@ -193,15 +187,14 @@ class SystemBuildTask(CliTask):
         system.install_system(
             manager
         )
-        if package_requests:
-            if self.command_args['--add-package']:
-                system.install_packages(
-                    manager, self.command_args['--add-package']
-                )
-            if self.command_args['--delete-package']:
-                system.delete_packages(
-                    manager, self.command_args['--delete-package']
-                )
+        if self.command_args['--add-package']:
+            system.install_packages(
+                manager, self.command_args['--add-package']
+            )
+        if self.command_args['--delete-package']:
+            system.delete_packages(
+                manager, self.command_args['--delete-package']
+            )
 
         profile = Profile(self.xml_state)
 

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -222,7 +222,8 @@ class SystemBuildTask(CliTask):
         # setup permanent image repositories after cleanup
         setup.import_repositories_marked_as_imageinclude()
         setup.call_config_script()
-        system.pinch_system()
+        system.pinch_system(manager=None, force=False)
+        system.pinch_system(manager=None, force=True)
 
         # make sure system instance is cleaned up now
         del system

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -204,16 +204,13 @@ class SystemPrepareTask(CliTask):
         setup.setup_plymouth_splash()
         setup.setup_timezone()
 
-        system.pinch_system(
-            manager=manager, force=True
-        )
-
         # make sure manager instance is cleaned up now
         del manager
 
         # setup permanent image repositories after cleanup
         setup.import_repositories_marked_as_imageinclude()
         setup.call_config_script()
+        system.pinch_system()
 
         # make sure system instance is cleaned up now
         del system

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -160,12 +160,6 @@ class SystemPrepareTask(CliTask):
         self.runtime_checker.check_repositories_configured()
         self.runtime_checker.check_image_include_repos_publicly_resolvable()
 
-        package_requests = False
-        if self.command_args['--add-package']:
-            package_requests = True
-        if self.command_args['--delete-package']:
-            package_requests = True
-
         log.info('Preparing system')
         system = SystemPrepare(
             self.xml_state,
@@ -180,15 +174,15 @@ class SystemPrepareTask(CliTask):
         system.install_system(
             manager
         )
-        if package_requests:
-            if self.command_args['--add-package']:
-                system.install_packages(
-                    manager, self.command_args['--add-package']
-                )
-            if self.command_args['--delete-package']:
-                system.delete_packages(
-                    manager, self.command_args['--delete-package']
-                )
+
+        if self.command_args['--add-package']:
+            system.install_packages(
+                manager, self.command_args['--add-package']
+            )
+        if self.command_args['--delete-package']:
+            system.delete_packages(
+                manager, self.command_args['--delete-package']
+            )
 
         profile = Profile(self.xml_state)
 

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -210,8 +210,14 @@ class SystemPrepareTask(CliTask):
         # setup permanent image repositories after cleanup
         setup.import_repositories_marked_as_imageinclude()
         setup.call_config_script()
-        system.pinch_system(manager=None, force=False)
-        system.pinch_system(manager=None, force=True)
+
+        # handle uninstall package requests, gracefully uninstall
+        # with dependency cleanup
+        system.pinch_system(force=False)
+
+        # handle delete package requests, forced uninstall without
+        # any dependency resolution
+        system.pinch_system(force=True)
 
         # make sure system instance is cleaned up now
         del system

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -210,7 +210,8 @@ class SystemPrepareTask(CliTask):
         # setup permanent image repositories after cleanup
         setup.import_repositories_marked_as_imageinclude()
         setup.call_config_script()
-        system.pinch_system()
+        system.pinch_system(manager=None, force=False)
+        system.pinch_system(manager=None, force=True)
 
         # make sure system instance is cleaned up now
         del system

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -277,6 +277,26 @@ class XMLState(object):
                 result.append(package.package_section.get_name())
         return sorted(list(set(result)))
 
+    def get_to_become_uninstalled_packages(self):
+        """
+        List of package names from the type="uninstall" packages section(s)
+
+        :return: package names
+
+        :rtype: list
+        """
+        result = []
+        to_become_uninstalled_packages_sections = self.get_packages_sections(
+            ['uninstall']
+        )
+        package_list = self.get_package_sections(
+            to_become_uninstalled_packages_sections
+        )
+        if package_list:
+            for package in package_list:
+                result.append(package.package_section.get_name())
+        return sorted(list(set(result)))
+
     def get_bootstrap_packages_sections(self):
         """
         List of packages sections matching type="bootstrap"

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -257,9 +257,13 @@ class XMLState(object):
                             )
         return result
 
-    def get_to_become_deleted_packages(self):
+    def get_to_become_deleted_packages(self, force=True):
         """
-        List of package names from the type="delete" packages section(s)
+        List of package names from the type="delete" or type="uninstall"
+        packages section(s)
+
+        :param bool force: return "delete" type if True, "uninstall" type
+            otherwise
 
         :return: package names
 
@@ -267,30 +271,10 @@ class XMLState(object):
         """
         result = []
         to_become_deleted_packages_sections = self.get_packages_sections(
-            ['delete']
+            ['delete' if force else 'uninstall']
         )
         package_list = self.get_package_sections(
             to_become_deleted_packages_sections
-        )
-        if package_list:
-            for package in package_list:
-                result.append(package.package_section.get_name())
-        return sorted(list(set(result)))
-
-    def get_to_become_uninstalled_packages(self):
-        """
-        List of package names from the type="uninstall" packages section(s)
-
-        :return: package names
-
-        :rtype: list
-        """
-        result = []
-        to_become_uninstalled_packages_sections = self.get_packages_sections(
-            ['uninstall']
-        )
-        package_list = self.get_package_sections(
-            to_become_uninstalled_packages_sections
         )
         if package_list:
             for package in package_list:

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -196,4 +196,7 @@
     <packages type="delete">
         <package name="kernel-debug"/>
     </packages>
+    <packages type="uninstall">
+        <package name="shadow"/>
+    </packages>
 </image>

--- a/test/unit/system_prepare_test.py
+++ b/test/unit/system_prepare_test.py
@@ -9,7 +9,8 @@ from kiwi.exceptions import (
     KiwiSystemUpdateFailed,
     KiwiSystemInstallPackagesFailed,
     KiwiSystemDeletePackagesFailed,
-    KiwiInstallPhaseFailed
+    KiwiInstallPhaseFailed,
+    KiwiPackagesDeletePhaseFailed
 )
 
 from kiwi.system.prepare import SystemPrepare
@@ -139,12 +140,6 @@ class TestSystemPrepare(object):
     def test_install_system_archives_raises(self, mock_tar, mock_poll):
         mock_tar.side_effect = KiwiInstallPhaseFailed
         self.system.install_system(self.manager)
-
-    @raises(KiwiInstallPhaseFailed)
-    @patch('kiwi.system.prepare.CommandProcess.poll_show_progress')
-    def test_pinch_system_raises(self, mock_poll):
-        mock_poll.side_effect = Exception
-        self.system.pinch_system(self.manager)
 
     @raises(KiwiSystemDeletePackagesFailed)
     @patch('kiwi.system.prepare.CommandProcess.poll_show_progress')
@@ -332,14 +327,6 @@ class TestSystemPrepare(object):
         tar.extract.assert_called_once_with('root_dir')
 
     @patch('kiwi.system.prepare.CommandProcess.poll_show_progress')
-    def test_pinch_system(self, mock_poll):
-        self.system.pinch_system(self.manager)
-        self.manager.request_package.assert_any_call(
-            'kernel-debug'
-        )
-        self.manager.process_delete_requests.assert_called_once_with(False)
-
-    @patch('kiwi.system.prepare.CommandProcess.poll_show_progress')
     def test_install_packages(self, mock_poll):
         self.system.install_packages(self.manager, ['foo'])
         self.manager.request_package.assert_called_once_with('foo')
@@ -348,6 +335,26 @@ class TestSystemPrepare(object):
     def test_delete_packages(self, mock_poll):
         self.system.delete_packages(self.manager, ['foo'])
         self.manager.request_package.assert_called_once_with('foo')
+
+    @patch('kiwi.package_manager.PackageManagerZypper.process_delete_requests')
+    @patch('kiwi.system.prepare.Repository')
+    @patch('kiwi.system.prepare.CommandProcess.poll_show_progress')
+    def test_pinch_system(
+        self, mock_poll, mock_repo, mock_deleterequests
+    ):
+        self.system.pinch_system()
+        mock_deleterequests.assert_has_calls([call(False), call(True)])
+
+    @raises(KiwiPackagesDeletePhaseFailed)
+    @patch('kiwi.package_manager.PackageManagerZypper.process_delete_requests')
+    @patch('kiwi.system.prepare.Repository')
+    @patch('kiwi.system.prepare.CommandProcess.poll_show_progress')
+    def test_pinch_system_raises(
+        self, mock_poll, mock_repo, mock_deleterequests
+    ):
+        mock_poll.side_effect = Exception
+        self.system.pinch_system()
+        mock_deleterequests.assert_called_once_with()
 
     @patch('kiwi.system.prepare.CommandProcess.poll')
     def test_update_system(self, mock_poll):

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -129,9 +129,7 @@ class TestSystemBuildTask(object):
         self.setup.setup_locale.assert_called_once_with()
         self.setup.setup_plymouth_splash.assert_called_once_with()
         self.setup.setup_timezone.assert_called_once_with()
-        self.system_prepare.pinch_system.assert_called_once_with(
-            manager=self.manager, force=True
-        )
+        self.system_prepare.pinch_system.assert_called_once_with()
         self.setup.call_image_script.assert_called_once_with()
         self.builder.create.assert_called_once_with()
         self.result.print_results.assert_called_once_with()

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -130,7 +130,7 @@ class TestSystemBuildTask(object):
         self.setup.setup_plymouth_splash.assert_called_once_with()
         self.setup.setup_timezone.assert_called_once_with()
         self.system_prepare.pinch_system.assert_has_calls(
-            [call(manager=None, force=False), call(manager=None, force=True)]
+            [call(force=False), call(force=True)]
         )
         self.setup.call_image_script.assert_called_once_with()
         self.builder.create.assert_called_once_with()

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -2,7 +2,7 @@ import sys
 import mock
 import os
 
-from mock import patch
+from mock import patch, call
 
 import kiwi
 
@@ -129,7 +129,9 @@ class TestSystemBuildTask(object):
         self.setup.setup_locale.assert_called_once_with()
         self.setup.setup_plymouth_splash.assert_called_once_with()
         self.setup.setup_timezone.assert_called_once_with()
-        self.system_prepare.pinch_system.assert_called_once_with()
+        self.system_prepare.pinch_system.assert_has_calls(
+            [call(manager=None, force=False), call(manager=None, force=True)]
+        )
         self.setup.call_image_script.assert_called_once_with()
         self.builder.create.assert_called_once_with()
         self.result.print_results.assert_called_once_with()

--- a/test/unit/tasks_system_prepare_test.py
+++ b/test/unit/tasks_system_prepare_test.py
@@ -123,7 +123,7 @@ class TestSystemPrepareTask(object):
         self.setup.setup_timezone.assert_called_once_with()
 
         self.system_prepare.pinch_system.assert_has_calls(
-            [call(manager=None, force=False), call(manager=None, force=True)]
+            [call(force=False), call(force=True)]
         )
 
     def test_process_system_prepare_add_package(self):

--- a/test/unit/tasks_system_prepare_test.py
+++ b/test/unit/tasks_system_prepare_test.py
@@ -2,7 +2,7 @@ import sys
 import mock
 import os
 
-from mock import patch
+from mock import patch, call
 
 import kiwi
 
@@ -122,7 +122,9 @@ class TestSystemPrepareTask(object):
         self.setup.setup_plymouth_splash.assert_called_once_with()
         self.setup.setup_timezone.assert_called_once_with()
 
-        self.system_prepare.pinch_system.assert_called_once_with()
+        self.system_prepare.pinch_system.assert_has_calls(
+            [call(manager=None, force=False), call(manager=None, force=True)]
+        )
 
     def test_process_system_prepare_add_package(self):
         self._init_command_args()

--- a/test/unit/tasks_system_prepare_test.py
+++ b/test/unit/tasks_system_prepare_test.py
@@ -122,9 +122,7 @@ class TestSystemPrepareTask(object):
         self.setup.setup_plymouth_splash.assert_called_once_with()
         self.setup.setup_timezone.assert_called_once_with()
 
-        self.system_prepare.pinch_system.assert_called_once_with(
-            manager=self.manager, force=True
-        )
+        self.system_prepare.pinch_system.assert_called_once_with()
 
     def test_process_system_prepare_add_package(self):
         self._init_command_args()


### PR DESCRIPTION
This PR adds a new `uninstall` type for packages. Packages listed
with this type will be removed by the package manager cleaning also any
unneeded dependency. The removal is executed after running `config.sh`.

Also in this commit `delete` type for packages is now executed after
`uninstall` packages, meaing it also happens after `config.sh`.

Fixes #625