### PR TITLE
Container compression configurable

### DIFF
--- a/kiwi/archive/tar.py
+++ b/kiwi/archive/tar.py
@@ -70,6 +70,7 @@ class ArchiveTar(object):
                 '-c', '-f', self.filename
             ] + self._get_archive_items(source_dir, exclude)
         )
+        return self.filename
 
     def append_files(self, source_dir, files_to_append, options=None):
         """
@@ -88,6 +89,7 @@ class ArchiveTar(object):
             ] + options +
             self.xattrs_options + files_to_append
         )
+        return self.filename
 
     def create_xz_compressed(
         self, source_dir, exclude=None, options=None, xz_options=None
@@ -114,6 +116,7 @@ class ArchiveTar(object):
             '>', self.filename + '.xz'
         ]
         Command.run(['bash', '-c', ' '.join(bash_command)])
+        return self.filename + '.xz'
 
     def create_gnu_gzip_compressed(self, source_dir, exclude=None):
         """
@@ -128,6 +131,7 @@ class ArchiveTar(object):
                 '--format=gnu', '-cSz', '-f', self.filename + '.gz'
             ] + self._get_archive_items(source_dir, exclude)
         )
+        return self.filename + '.gz'
 
     def extract(self, dest_dir):
         """

--- a/kiwi/builder/container.py
+++ b/kiwi/builder/container.py
@@ -82,7 +82,7 @@ class ContainerBuilder(object):
                 xml_state.xml_data.get_name(),
                 '.' + platform.machine(),
                 '-' + xml_state.get_image_version(),
-                '.', self.requested_container_type, '.tar.xz'
+                '.', self.requested_container_type, '.tar'
             ]
         )
         self.result = Result(xml_state)
@@ -125,7 +125,7 @@ class ContainerBuilder(object):
         container_image = ContainerImage(
             self.requested_container_type, self.root_dir, self.container_config
         )
-        container_image.create(
+        self.filename = container_image.create(
             self.filename, self.base_image
         )
         self.result.verify_image_size(

--- a/kiwi/container/docker.py
+++ b/kiwi/container/docker.py
@@ -34,23 +34,26 @@ class ContainerImageDocker(ContainerImageOCI):
 
         :param string filename: file name of the resulting packed image
         """
-        docker_tarfile = filename.replace('.xz', '')
         oci_image = os.sep.join([
             self.oci_dir, ':'.join(['umoci_layout', self.container_tag])
         ])
 
-        # make sure the target tar file does not exist
+        # make sure the target archive file does not exist
         # skopeo doesn't support force overwrite
-        Path.wipe(docker_tarfile)
+        Path.wipe(filename)
         Command.run(
             [
                 'skopeo', 'copy', 'oci:{0}'.format(
                     oci_image
                 ),
                 'docker-archive:{0}:{1}:{2}'.format(
-                    docker_tarfile, self.container_name, self.container_tag
+                    filename, self.container_name, self.container_tag
                 )
             ]
         )
-        compressor = Compress(docker_tarfile)
-        compressor.xz(self.xz_options)
+        container_compressor = self.runtime_config.get_container_compression()
+        if container_compressor:
+            compressor = Compress(filename)
+            return compressor.xz(self.runtime_config.get_xz_options())
+        else:
+            return filename

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1071,6 +1071,17 @@ class Defaults(object):
         return 'xorriso'
 
     @classmethod
+    def get_container_compression(self):
+        """
+        Provides default container compression algorithm
+
+        :return: name
+
+        :rtype: str
+        """
+        return 'xz'
+
+    @classmethod
     def set_python_default_encoding_to_utf8(self):
         """
         Set python default encoding to utf-8 if not already done

--- a/kiwi/runtime_config.py
+++ b/kiwi/runtime_config.py
@@ -108,6 +108,37 @@ class RuntimeConfig(object):
         xz_options = self._get_attribute(element='xz', attribute='options')
         return xz_options.split() if xz_options else None
 
+    def get_container_compression(self):
+        """
+        Return compression algorithm to use for compression of container images
+
+        container:
+          - compress: xz|none
+
+        if no or invalid configuration data is provided, the default
+        compression algorithm from the Defaults class is returned
+
+        :return: A name
+
+        :rtype: str
+        """
+        container_compression = self._get_attribute(
+            element='container', attribute='compress'
+        )
+        if not container_compression:
+            return Defaults.get_container_compression()
+        elif 'xz' in container_compression:
+            return container_compression
+        elif 'none' in container_compression:
+            return None
+        else:
+            log.warning(
+                'Skipping invalid container compression: {0}'.format(
+                    container_compression
+                )
+            )
+            return Defaults.get_container_compression()
+
     def get_iso_tool_category(self):
         """
         Return tool category which should be used to build iso images

--- a/kiwi/system/root_import/docker.py
+++ b/kiwi/system/root_import/docker.py
@@ -34,8 +34,11 @@ class RootImportDocker(RootImportOCI):
         """
         if not self.unknown_uri:
             compressor = Compress(self.image_file)
-            compressor.uncompress(True)
-            self.uncompressed_image = compressor.uncompressed_filename
+            if compressor.get_format():
+                compressor.uncompress(True)
+                self.uncompressed_image = compressor.uncompressed_filename
+            else:
+                self.uncompressed_image = self.image_file
             skopeo_uri = 'docker-archive:{0}'.format(self.uncompressed_image)
         else:
             log.warning('Bypassing base image URI to skopeo tool')

--- a/kiwi/system/root_import/oci.py
+++ b/kiwi/system/root_import/oci.py
@@ -31,7 +31,7 @@ from kiwi.defaults import Defaults
 class RootImportOCI(RootImportBase):
     """
     Implements the base class for importing a root system from
-    a oci image compressed tarball file.
+    a oci image tarball file.
     """
     def post_init(self, image_uri):
         """
@@ -73,8 +73,8 @@ class RootImportOCI(RootImportBase):
 
     def extract_oci_image(self):
         """
-        Extract the image from the provided image file to a temporary
-        location to KIWI can work with it.
+        Extract the contents from the provided image file to a temporary
+        location KIWI can work with.
         """
         if not self.unknown_uri:
             tar = ArchiveTar(self.image_file)

--- a/kiwi/utils/compress.py
+++ b/kiwi/utils/compress.py
@@ -67,6 +67,7 @@ class Compress(object):
             ['xz', '-f'] + options + [self.source_filename]
         )
         self.compressed_filename = self.source_filename + '.xz'
+        return self.compressed_filename
 
     def gzip(self):
         """
@@ -81,6 +82,7 @@ class Compress(object):
             ['gzip', '-f'] + options + [self.source_filename]
         )
         self.compressed_filename = self.source_filename + '.gz'
+        return self.compressed_filename
 
     def uncompress(self, temporary=False):
         """
@@ -109,6 +111,7 @@ class Compress(object):
             ]
             Command.run(['bash', '-c', ' '.join(bash_command)])
             self.uncompressed_filename = self.temp_file.name
+        return self.uncompressed_filename
 
     def get_format(self):
         """

--- a/test/data/.config/kiwi/config.yml
+++ b/test/data/.config/kiwi/config.yml
@@ -7,3 +7,6 @@ obs:
 
 iso:
   - tool_category: cdrtools
+
+container:
+  - compress: none

--- a/test/unit/archive_tar_test.py
+++ b/test/unit/archive_tar_test.py
@@ -36,7 +36,7 @@ class TestArchiveTar(object):
     @patch('os.listdir')
     def test_create(self, mock_os_dir, mock_command):
         mock_os_dir.return_value = ['foo', 'bar']
-        self.archive.create('source-dir')
+        assert self.archive.create('source-dir') == 'foo.tar'
         mock_command.assert_called_once_with(
             [
                 'tar', '-C', 'source-dir',
@@ -47,7 +47,8 @@ class TestArchiveTar(object):
 
     @patch('kiwi.archive.tar.Command.run')
     def test_append_files(self, mock_command):
-        self.archive.append_files('source-dir', ['foo', 'bar'])
+        assert self.archive.append_files('source-dir', ['foo', 'bar']) \
+            == 'foo.tar'
         mock_command.assert_called_once_with(
             [
                 'tar', '-C', 'source-dir', '-r',
@@ -61,9 +62,9 @@ class TestArchiveTar(object):
     @patch('os.listdir')
     def test_create_with_options(self, mock_os_dir, mock_command):
         mock_os_dir.return_value = ['foo', 'bar']
-        self.archive.create('source-dir', options=[
+        assert self.archive.create('source-dir', options=[
             '--fake-option', 'fake_arg'
-        ])
+        ]) == 'foo.tar'
         mock_command.assert_called_once_with(
             [
                 'tar', '-C', 'source-dir',
@@ -81,7 +82,7 @@ class TestArchiveTar(object):
         mock_command.return_value = command
         archive = ArchiveTar('foo.tar')
         mock_os_dir.return_value = ['foo', 'bar']
-        archive.create('source-dir')
+        assert archive.create('source-dir') == 'foo.tar'
         calls = [
             call(['tar', '--version']),
             call(
@@ -100,7 +101,7 @@ class TestArchiveTar(object):
         command.output = 'version 1.27.0'
         mock_command.return_value = command
         archive = ArchiveTar('foo.tar', False)
-        archive.create('source-dir', ['foo', 'bar'])
+        assert archive.create('source-dir', ['foo', 'bar']) == 'foo.tar'
         calls = [
             call(['tar', '--version']),
             call(
@@ -118,7 +119,7 @@ class TestArchiveTar(object):
     @patch('os.listdir')
     def test_create_xz_compressed(self, mock_os_dir, mock_command):
         mock_os_dir.return_value = ['foo', 'bar']
-        self.archive.create_xz_compressed('source-dir')
+        assert self.archive.create_xz_compressed('source-dir') == 'foo.tar.xz'
         mock_command.assert_called_once_with(
             [
                 'bash', '-c',
@@ -137,7 +138,9 @@ class TestArchiveTar(object):
         self, mock_os_dir, mock_command
     ):
         mock_os_dir.return_value = ['foo', 'bar']
-        self.archive.create_xz_compressed('source-dir', xz_options=['-a', '-b'])
+        assert self.archive.create_xz_compressed(
+            'source-dir', xz_options=['-a', '-b']
+        ) == 'foo.tar.xz'
         mock_command.assert_called_once_with(
             [
                 'bash', '-c',
@@ -154,7 +157,8 @@ class TestArchiveTar(object):
     @patch('os.listdir')
     def test_create_gnu_gzip_compressed(self, mock_os_dir, mock_command):
         mock_os_dir.return_value = ['foo', 'bar']
-        self.archive.create_gnu_gzip_compressed('source-dir')
+        assert self.archive.create_gnu_gzip_compressed('source-dir') \
+            == 'foo.tar.gz'
         mock_command.assert_called_once_with(
             [
                 'tar', '-C', 'source-dir',
@@ -166,7 +170,7 @@ class TestArchiveTar(object):
     @patch('os.listdir')
     def test_create_exclude(self, mock_os_dir, mock_command):
         mock_os_dir.return_value = ['foo', 'bar']
-        self.archive.create('source-dir', ['foo'])
+        assert self.archive.create('source-dir', ['foo']) == 'foo.tar'
         mock_command.assert_called_once_with(
             [
                 'tar', '-C', 'source-dir', '--xattrs', '--xattrs-include=*',

--- a/test/unit/builder_container_test.py
+++ b/test/unit/builder_container_test.py
@@ -110,6 +110,9 @@ class TestContainerBuilder(object):
         container_setup = mock.Mock()
         mock_setup.return_value = container_setup
         container_image = mock.Mock()
+        container_image.create = mock.Mock(
+            return_value='target_dir/image_name.x86_64-1.2.3.docker.tar.xz'
+        )
         mock_image.return_value = container_image
         self.setup.export_package_verification.return_value = '.verified'
         self.setup.export_package_list.return_value = '.packages'
@@ -123,7 +126,7 @@ class TestContainerBuilder(object):
             'docker', 'root_dir', self.container_config
         )
         container_image.create.assert_called_once_with(
-            'target_dir/image_name.x86_64-1.2.3.docker.tar.xz', None
+            'target_dir/image_name.x86_64-1.2.3.docker.tar', None
         )
         assert self.container.result.add.call_args_list == [
             call(
@@ -167,6 +170,12 @@ class TestContainerBuilder(object):
 
         mock_exists.side_effect = side_effect
 
+        container_image = mock.Mock()
+        container_image.create = mock.Mock(
+            return_value='target_dir/image_name.x86_64-1.2.3.docker.tar.xz'
+        )
+        mock_image.return_value = container_image
+
         container = ContainerBuilder(
             self.xml_state, 'target_dir', 'root_dir'
         )
@@ -178,8 +187,6 @@ class TestContainerBuilder(object):
         )
         mock_checksum.return_value = checksum
 
-        container_image = mock.Mock()
-        mock_image.return_value = container_image
         self.setup.export_package_verification.return_value = '.verified'
         self.setup.export_package_list.return_value = '.packages'
 
@@ -194,7 +201,7 @@ class TestContainerBuilder(object):
             'docker', 'root_dir', self.container_config
         )
         container_image.create.assert_called_once_with(
-            'target_dir/image_name.x86_64-1.2.3.docker.tar.xz',
+            'target_dir/image_name.x86_64-1.2.3.docker.tar',
             'root_dir/image/imported_root'
         )
         assert container.result.add.call_args_list == [

--- a/test/unit/container_image_docker_test.py
+++ b/test/unit/container_image_docker_test.py
@@ -1,17 +1,29 @@
-from mock import call
-from mock import patch
+from mock import (
+    call, patch, Mock
+)
 
 from kiwi.container.docker import ContainerImageDocker
 
 
 class TestContainerImageDocker(object):
-
     @patch('kiwi.container.docker.Compress')
     @patch('kiwi.container.oci.Command.run')
-    def test_pack_image_to_file(self, mock_command, mock_compress):
+    @patch('kiwi.container.oci.RuntimeConfig')
+    def test_pack_image_to_file(
+        self, mock_RuntimeConfig, mock_command, mock_compress
+    ):
+        compressor = Mock()
+        compressor.xz = Mock(
+            return_value='result.tar.xz'
+        )
+        mock_compress.return_value = compressor
         docker = ContainerImageDocker('root_dir', {'container_name': 'foo/bar'})
         docker.oci_dir = 'kiwi_oci_dir'
-        docker.pack_image_to_file('result.tar.xz')
+        docker.runtime_config.get_container_compression = Mock(
+            return_value='xz'
+        )
+
+        assert docker.pack_image_to_file('result.tar') == 'result.tar.xz'
 
         assert mock_command.call_args_list == [
             call(['rm', '-r', '-f', 'result.tar']),
@@ -21,3 +33,12 @@ class TestContainerImageDocker(object):
             ])
         ]
         mock_compress.assert_called_once_with('result.tar')
+        compressor.xz.assert_called_once_with(
+            docker.runtime_config.get_xz_options.return_value
+        )
+
+        docker.runtime_config.get_container_compression = Mock(
+            return_value=None
+        )
+
+        assert docker.pack_image_to_file('result.tar') == 'result.tar'

--- a/test/unit/container_image_oci_test.py
+++ b/test/unit/container_image_oci_test.py
@@ -9,7 +9,8 @@ from kiwi.container.oci import ContainerImageOCI
 
 
 class TestContainerImageOCI(object):
-    def setup(self):
+    @patch('kiwi.container.oci.RuntimeConfig')
+    def setup(self, mock_RuntimeConfig):
         self.oci = ContainerImageOCI(
             'root_dir', {
                 'container_name': 'foo/bar'
@@ -46,8 +47,7 @@ class TestContainerImageOCI(object):
             'labels': [
                 '--config.label=a=value',
                 '--config.label=b=value'
-            ],
-            'xz_options': ['-a', '-b']
+            ]
         }
         container = ContainerImageOCI(
             'root_dir', custom_args
@@ -63,7 +63,6 @@ class TestContainerImageOCI(object):
         assert container.volumes == custom_args['volumes']
         assert container.environment == custom_args['environment']
         assert container.labels == custom_args['labels']
-        assert container.xz_options == custom_args['xz_options']
 
     def test_init_without_custom_args(self):
         container = ContainerImageOCI('root_dir')
@@ -117,6 +116,8 @@ class TestContainerImageOCI(object):
         self, mock_cache, mock_mkdtemp,
         mock_sync, mock_command, mock_tar, mock_datetime
     ):
+        oci_tarfile = mock.Mock()
+        mock_tar.return_value = oci_tarfile
         strftime = mock.Mock()
         strftime.strftime = mock.Mock(return_value='current_date')
         mock_datetime.utcnow = mock.Mock(
@@ -133,7 +134,11 @@ class TestContainerImageOCI(object):
 
         mock_mkdtemp.side_effect = call_mkdtemp
 
-        self.oci.create('result.tar.xz', None)
+        self.oci.runtime_config.get_container_compression = mock.Mock(
+            return_value='xz'
+        )
+
+        self.oci.create('result.tar', None)
 
         assert mock_command.call_args_list == [
             call([
@@ -170,8 +175,22 @@ class TestContainerImageOCI(object):
             ],
             options=['-a', '-H', '-X', '-A', '--delete']
         )
+        mock_tar.assert_called_once_with('result.tar')
+        oci_tarfile.create_xz_compressed.assert_called_once_with(
+            'kiwi_oci_dir/umoci_layout',
+            xz_options=self.oci.runtime_config.get_xz_options.return_value
+        )
 
-        mock_tar.called_once_with('result.tar.xz')
+        tmpdirs = ['kiwi_oci_root_dir', 'kiwi_oci_dir']
+        self.oci.runtime_config.get_container_compression = mock.Mock(
+            return_value=None
+        )
+
+        self.oci.create('result.tar', None)
+
+        oci_tarfile.create.assert_called_once_with(
+            'kiwi_oci_dir/umoci_layout'
+        )
 
     @patch('kiwi.container.oci.datetime')
     @patch('kiwi.container.oci.ArchiveTar')
@@ -200,7 +219,7 @@ class TestContainerImageOCI(object):
 
         mock_mkdtemp.side_effect = call_mkdtemp
 
-        self.oci.create('result.tar.xz', 'root_dir/image/image_file')
+        self.oci.create('result.tar', 'root_dir/image/image_file')
 
         mock_create.assert_called_once_with('kiwi_oci_dir/umoci_layout')
 
@@ -235,6 +254,6 @@ class TestContainerImageOCI(object):
             ],
             options=['-a', '-H', '-X', '-A', '--delete']
         )
-        mock_tar.call_args_list == [
-            call('root_dir/image/image_file'), call('result.tar.xz')
+        assert mock_tar.call_args_list == [
+            call('root_dir/image/image_file'), call('result.tar')
         ]

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -38,6 +38,30 @@ class TestRuntimeConfig(object):
             assert runtime_config.get_obs_download_server_url() == \
                 Defaults.get_obs_download_server_url()
 
+    def test_get_container_compression(self):
+        assert self.runtime_config.get_container_compression() is None
+
+    def test_get_container_compression_default(self):
+        with patch.dict('os.environ', {'HOME': './'}):
+            runtime_config = RuntimeConfig()
+            assert runtime_config.get_container_compression() == 'xz'
+
+    @patch.object(RuntimeConfig, '_get_attribute')
+    @patch('kiwi.logger.log.warning')
+    def test_get_container_compression_invalid(
+        self, mock_warning, mock_get_attribute
+    ):
+        mock_get_attribute.return_value = 'foo'
+        assert self.runtime_config.get_container_compression() == 'xz'
+        mock_warning.assert_called_once_with(
+            'Skipping invalid container compression: foo'
+        )
+
+    @patch.object(RuntimeConfig, '_get_attribute')
+    def test_get_container_compression_xz(self, mock_get_attribute):
+        mock_get_attribute.return_value = 'xz'
+        assert self.runtime_config.get_container_compression() == 'xz'
+
     def test_get_iso_tool_category(self):
         assert self.runtime_config.get_iso_tool_category() == 'cdrtools'
 

--- a/test/unit/system_root_import_docker_test.py
+++ b/test/unit/system_root_import_docker_test.py
@@ -6,20 +6,22 @@ from kiwi.system.root_import.docker import RootImportDocker
 
 
 class TestRootImportDocker(object):
-
     @patch('os.path.exists')
     @patch('kiwi.command.Command.run')
     @patch('kiwi.system.root_import.docker.Compress')
     @patch('kiwi.system.root_import.oci.mkdtemp')
     @patch('kiwi.system.uri.Defaults.is_buildservice_worker')
-    def test_extract_oci_image(
+    def test_extract_compressed_oci_image(
         self, mock_buildservice, mock_mkdtemp, mock_compress,
         mock_run, mock_exists
     ):
         mock_buildservice.return_value = False
         mock_exists.return_value = True
         uncompress = mock.Mock()
-        uncompress.uncompressed_filename = 'tmp_uncompressed'
+        uncompress.get_format = mock.Mock(
+            return_value='xz'
+        )
+        uncompress.uncompressed_filename = 'tmp_uncompressed.tar'
         mock_compress.return_value = uncompress
         tmpdirs = ['kiwi_unpack_dir', 'kiwi_layout_dir']
 
@@ -36,7 +38,41 @@ class TestRootImportDocker(object):
         mock_compress.assert_called_once_with('/image.tar.xz')
         uncompress.uncompress.assert_called_once_with(True)
         mock_run.assert_called_once_with([
-            'skopeo', 'copy', 'docker-archive:tmp_uncompressed',
+            'skopeo', 'copy', 'docker-archive:tmp_uncompressed.tar',
+            'oci:kiwi_layout_dir:base_layer'
+        ])
+
+    @patch('os.path.exists')
+    @patch('kiwi.command.Command.run')
+    @patch('kiwi.system.root_import.docker.Compress')
+    @patch('kiwi.system.root_import.oci.mkdtemp')
+    @patch('kiwi.system.uri.Defaults.is_buildservice_worker')
+    def test_extract_uncompressed_oci_image(
+        self, mock_buildservice, mock_mkdtemp, mock_compress,
+        mock_run, mock_exists
+    ):
+        mock_buildservice.return_value = False
+        mock_exists.return_value = True
+        uncompress = mock.Mock()
+        uncompress.get_format = mock.Mock(
+            return_value=None
+        )
+        mock_compress.return_value = uncompress
+        tmpdirs = ['kiwi_unpack_dir', 'kiwi_layout_dir']
+
+        def call_mkdtemp(prefix):
+            return tmpdirs.pop()
+
+        mock_mkdtemp.side_effect = call_mkdtemp
+
+        with patch.dict('os.environ', {'HOME': '../data'}):
+            docker_import = RootImportDocker(
+                'root_dir', Uri('file:///image.tar')
+            )
+        docker_import.extract_oci_image()
+        mock_compress.assert_called_once_with('/image.tar')
+        mock_run.assert_called_once_with([
+            'skopeo', 'copy', 'docker-archive:/image.tar',
             'oci:kiwi_layout_dir:base_layer'
         ])
 

--- a/test/unit/utils_compress_test.py
+++ b/test/unit/utils_compress_test.py
@@ -23,7 +23,7 @@ class TestCompress(object):
 
     @patch('kiwi.command.Command.run')
     def test_xz(self, mock_command):
-        self.compress.xz()
+        assert self.compress.xz() == 'some-file.xz'
         mock_command.assert_called_once_with(
             [
                 'xz', '-f', '--threads=0', '--keep',
@@ -34,7 +34,7 @@ class TestCompress(object):
 
     @patch('kiwi.command.Command.run')
     def test_xz_with_custom_options(self, mock_command):
-        self.compress.xz(options=['foo', 'bar'])
+        assert self.compress.xz(options=['foo', 'bar']) == 'some-file.xz'
         mock_command.assert_called_once_with(
             [
                 'xz', '-f', 'foo', 'bar', '--keep',
@@ -45,7 +45,7 @@ class TestCompress(object):
 
     @patch('kiwi.command.Command.run')
     def test_gzip(self, mock_command):
-        self.compress.gzip()
+        assert self.compress.gzip() == 'some-file.gz'
         mock_command.assert_called_once_with(
             ['gzip', '-f', '-9', '--keep', 'some-file']
         )


### PR DESCRIPTION
__Make container compression a configuration option__
    
Change the ContainerBuilder class to evaluate on the configuration options to decide if the container archive should be compressed or not. By default the archive will be compressed, thus there is no change to the former behavior but can be setup in ~/.config/kiwi/config.yml as follows:
    
```yaml

container:
   - compress: none|xz
```

This Fixes #725

__Allow docker root import from uncompressed file__
    
Check the given file name for its compression format and only uncompress if a supported format could be detected. This Fixes #730