### PR TITLE
Fix zypper add lock operations

### DIFF
--- a/kiwi/package_manager/zypper.py
+++ b/kiwi/package_manager/zypper.py
@@ -130,11 +130,8 @@ class PackageManagerZypper(PackageManagerBase):
                 Path.create(metadata_dir)
             for package in self.exclude_requests:
                 Command.run(
-                    [
-                        'chroot', self.root_dir, 'zypper'
-                    ] + self.chroot_zypper_args + [
-                        'al'
-                    ] + self.custom_args + [package],
+                    ['chroot', self.root_dir, 'zypper'] +
+                    self.chroot_zypper_args + ['al'] + [package],
                     self.chroot_command_env
                 )
         return Command.call(


### PR DESCRIPTION
This commit fixes the arguments passed to zypper in add lock
operations.
