### PR TITLE
Do not create static dev nodes in root init

### DIFF
--- a/kiwi/system/root_init.py
+++ b/kiwi/system/root_init.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
-import stat
 from pwd import getpwnam
 from tempfile import mkdtemp
 from shutil import rmtree
@@ -79,7 +78,6 @@ class RootInit(object):
         Path.create(self.root_dir)
         try:
             self._create_base_directories(root)
-            self._create_device_nodes(root)
             self._create_base_links(root)
             self._setup_config_templates(root)
             data = DataSync(root + '/', self.root_dir)
@@ -108,30 +106,6 @@ class RootInit(object):
             Command.run(['cp', passwd_template, root + '/etc/passwd'])
         if os.path.exists(proxy_template):
             Command.run(['cp', proxy_template, root + '/etc/sysconfig/proxy'])
-
-    def _create_device_nodes(self, root):
-        """
-        Create minimum set of device nodes for a new root system
-
-        :param str root: path to the new root
-        """
-        mknod_data = [
-            (0o666, 'dev/null', stat.S_IFCHR, (1, 3)),
-            (0o666, 'dev/zero', stat.S_IFCHR, (1, 5)),
-            (0o622, 'dev/full', stat.S_IFCHR, (1, 7)),
-            (0o666, 'dev/random', stat.S_IFCHR, (1, 8)),
-            (0o644, 'dev/urandom', stat.S_IFCHR, (1, 9)),
-            (0o666, 'dev/tty', stat.S_IFCHR, (5, 0)),
-            (0o666, 'dev/ptmx', stat.S_IFCHR, (5, 2)),
-            (0o640, 'dev/loop0', stat.S_IFBLK, (7, 0)),
-            (0o640, 'dev/loop1', stat.S_IFBLK, (7, 1)),
-            (0o640, 'dev/loop2', stat.S_IFBLK, (7, 2)),
-            (0o666, 'dev/loop3', stat.S_IFBLK, (7, 3)),
-            (0o666, 'dev/loop4', stat.S_IFBLK, (7, 4))
-        ]
-        for d_mode, d_path, d_type, d_dev in mknod_data:
-            root_path = os.sep.join([root, d_path])
-            os.mknod(root_path, d_mode | d_type, os.makedev(*d_dev))
 
     def _create_base_directories(self, root):
         """

--- a/test/unit/system_root_init_test.py
+++ b/test/unit/system_root_init_test.py
@@ -23,7 +23,6 @@ class TestRootInit(object):
     @patch('os.path.exists')
     @patch('os.makedirs')
     @patch('os.chown')
-    @patch('os.mknod')
     @patch('os.symlink')
     @patch('shutil.rmtree')
     @patch('kiwi.system.root_init.DataSync')
@@ -31,7 +30,7 @@ class TestRootInit(object):
     @patch('kiwi.system.root_init.Command.run')
     def test_create_raises_error(
         self, mock_command, mock_temp, mock_data_sync, mock_rmtree,
-        mock_symlink, mock_mknod, mock_chwon, mock_makedirs, mock_path
+        mock_symlink, mock_chwon, mock_makedirs, mock_path
     ):
         mock_path.return_value = False
         mock_temp.return_value = 'tmpdir'
@@ -42,7 +41,6 @@ class TestRootInit(object):
     @patch('os.path.exists')
     @patch('os.makedirs')
     @patch('os.chown')
-    @patch('os.mknod')
     @patch('os.symlink')
     @patch('os.makedev')
     @patch('kiwi.system.root_init.copy')
@@ -52,7 +50,7 @@ class TestRootInit(object):
     @patch('kiwi.system.root_init.Command.run')
     def test_create(
         self, mock_command, mock_temp, mock_data_sync, mock_rmtree, mock_copy,
-        mock_makedev, mock_symlink, mock_mknod, mock_chwon, mock_makedirs,
+        mock_makedev, mock_symlink, mock_chwon, mock_makedirs,
         mock_path
     ):
         data_sync = mock.Mock()
@@ -88,20 +86,6 @@ class TestRootInit(object):
             call('tmpdir/run', 0, 0),
             call('tmpdir/sys', 0, 0),
             call('tmpdir/var', 0, 0)
-        ]
-        assert mock_mknod.call_args_list == [
-            call('tmpdir/dev/null', 8630, 'makedev'),
-            call('tmpdir/dev/zero', 8630, 'makedev'),
-            call('tmpdir/dev/full', 8594, 'makedev'),
-            call('tmpdir/dev/random', 8630, 'makedev'),
-            call('tmpdir/dev/urandom', 8612, 'makedev'),
-            call('tmpdir/dev/tty', 8630, 'makedev'),
-            call('tmpdir/dev/ptmx', 8630, 'makedev'),
-            call('tmpdir/dev/loop0', 24992, 'makedev'),
-            call('tmpdir/dev/loop1', 24992, 'makedev'),
-            call('tmpdir/dev/loop2', 24992, 'makedev'),
-            call('tmpdir/dev/loop3', 25014, 'makedev'),
-            call('tmpdir/dev/loop4', 25014, 'makedev')
         ]
         assert mock_symlink.call_args_list == [
             call('/proc/self/fd', 'tmpdir/dev/fd'),


### PR DESCRIPTION
For compatibility reasons kiwi created a set of static device
nodes when initializing a new image root system. With the
presence of devtmpfs this should no longer be needed. In addition
the static dev node setup now also causes problems on filesystems
like btrfs which was the reason to delete this code now.
This Fixes bsc#1087104

