### PR TITLE
Add service dependencies in generators

### DIFF
--- a/dracut/modules.d/90kiwi-live/kiwi-generator.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-generator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 
@@ -36,9 +36,11 @@ ROOTFLAGS="$(getarg rootflags)"
     _dev=LiveOS_rootfs
 } > "$GENERATOR_DIR"/sysroot.mount
 
-mkdir -p "$GENERATOR_DIR"/initrd-root-fs.target.requires
-ln -s "$GENERATOR_DIR"/sysroot.mount \
-    "$GENERATOR_DIR"/initrd-root-fs.target.requires/sysroot.mount
+if [ ! -e "$GENERATOR_DIR/initrd-root-fs.target.requires/sysroot.mount" ]; then
+    mkdir -p "$GENERATOR_DIR"/initrd-root-fs.target.requires
+    ln -s "$GENERATOR_DIR"/sysroot.mount \
+        "$GENERATOR_DIR"/initrd-root-fs.target.requires/sysroot.mount
+fi
 
 mkdir -p "$GENERATOR_DIR/$_dev.device.d"
 {

--- a/dracut/modules.d/90kiwi-live/kiwi-generator.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-generator.sh
@@ -36,6 +36,10 @@ ROOTFLAGS="$(getarg rootflags)"
     _dev=LiveOS_rootfs
 } > "$GENERATOR_DIR"/sysroot.mount
 
+mkdir -p "$GENERATOR_DIR"/initrd-root-fs.target.requires
+ln -s "$GENERATOR_DIR"/sysroot.mount \
+    "$GENERATOR_DIR"/initrd-root-fs.target.requires/sysroot.mount
+
 mkdir -p "$GENERATOR_DIR/$_dev.device.d"
 {
     echo "[Unit]"

--- a/dracut/modules.d/90kiwi-overlay/kiwi-generator.sh
+++ b/dracut/modules.d/90kiwi-overlay/kiwi-generator.sh
@@ -36,6 +36,10 @@ ROOTFLAGS="$(getarg rootflags)"
     _dev=OverlayOS_rootfs
 } > "$GENERATOR_DIR"/sysroot.mount
 
+mkdir -p "$GENERATOR_DIR"/initrd-root-fs.target.requires
+ln -s "$GENERATOR_DIR"/sysroot.mount \
+    "$GENERATOR_DIR"/initrd-root-fs.target.requires/sysroot.mount
+
 mkdir -p "$GENERATOR_DIR/$_dev.device.d"
 {
     echo "[Unit]"

--- a/dracut/modules.d/90kiwi-overlay/kiwi-generator.sh
+++ b/dracut/modules.d/90kiwi-overlay/kiwi-generator.sh
@@ -36,9 +36,11 @@ ROOTFLAGS="$(getarg rootflags)"
     _dev=OverlayOS_rootfs
 } > "$GENERATOR_DIR"/sysroot.mount
 
-mkdir -p "$GENERATOR_DIR"/initrd-root-fs.target.requires
-ln -s "$GENERATOR_DIR"/sysroot.mount \
-    "$GENERATOR_DIR"/initrd-root-fs.target.requires/sysroot.mount
+if [ ! -e "$GENERATOR_DIR/initrd-root-fs.target.requires/sysroot.mount" ]; then
+    mkdir -p "$GENERATOR_DIR"/initrd-root-fs.target.requires
+    ln -s "$GENERATOR_DIR"/sysroot.mount \
+        "$GENERATOR_DIR"/initrd-root-fs.target.requires/sysroot.mount
+fi
 
 mkdir -p "$GENERATOR_DIR/$_dev.device.d"
 {


### PR DESCRIPTION
Correctly adding the initrd-root-fs.target service dependency to
auto generated sysroot.mount for kiwi-live and kiwi-overlay dracut
modules.

Fixes #741