### PR TITLE
Added support for config-cdroot archive

### DIFF
--- a/doc/source/overview/workflow.rst
+++ b/doc/source/overview/workflow.rst
@@ -235,6 +235,15 @@ These are the optional components of an image description:
    after all the packages included in the :file:`config.xml` file
    have been installed. Any already present file is overwritten.
 
+#. CD root user data
+
+   For live ISO images and install ISO images an optional cdroot archive
+   is supported. This is a tar archive matching the name
+   :file:`config-cdroot.tar[.compression_postfix]`. If present it will
+   be unpacked as user data on the ISO image. This is mostly useful to
+   add e.g license files or user documentation on the CD/DVD which
+   can be read directly without booting from the media.
+
 #. Archives included in the :file:`config.xml` file.
 
    The archives that are included in the `<packages>` using the `<archive>`

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -34,6 +34,7 @@ from kiwi.logger import log
 from kiwi.system.kernel import Kernel
 from kiwi.utils.compress import Compress
 from kiwi.archive.tar import ArchiveTar
+from kiwi.system.setup import SystemSetup
 
 from kiwi.exceptions import (
     KiwiInstallBootImageError
@@ -66,6 +67,9 @@ class InstallImageBuilder(object):
             xml_state.get_oemconfig_oem_multipath_scan()
         self.initrd_system = xml_state.get_initrd_system()
         self.firmware = FirmWare(xml_state)
+        self.setup = SystemSetup(
+            self.xml_state, self.root_dir
+        )
         self.diskname = ''.join(
             [
                 target_dir, '/',
@@ -126,6 +130,9 @@ class InstallImageBuilder(object):
         self.media_dir = mkdtemp(
             prefix='kiwi_install_media.', dir=self.target_dir
         )
+        # unpack cdroot user files to media dir
+        self.setup.import_cdroot_files(self.media_dir)
+
         # custom iso metadata
         self.custom_iso_args = {
             'meta_data': {

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -117,6 +117,10 @@ class LiveImageBuilder(object):
         self.media_dir = mkdtemp(
             prefix='live-media.', dir=self.target_dir
         )
+
+        # unpack cdroot user files to media dir
+        self.system_setup.import_cdroot_files(self.media_dir)
+
         rootsize = SystemSize(self.media_dir)
 
         # custom iso metadata

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+import glob
 import os
 import platform
 from collections import OrderedDict
@@ -157,6 +158,25 @@ class SystemSetup(object):
             for line in profile_environment:
                 profile.write(line + '\n')
                 log.debug('--> %s', line)
+
+    def import_cdroot_files(self, target_dir):
+        """
+        Copy cdroot files from the image description to the
+        specified target directory. Supported is a tar
+        archive named config-cdroot.tar[.compression-postfix]
+
+        :param str target_dir: directory to unpack archive to
+        """
+        glob_match = self.description_dir + '/config-cdroot.tar*'
+        for cdroot_archive in glob.iglob(glob_match):
+            log.info(
+                'Extracting ISO user config archive: {0} to: {1}'.format(
+                    cdroot_archive, target_dir
+                )
+            )
+            archive = ArchiveTar(cdroot_archive)
+            archive.extract(target_dir)
+            break
 
     def import_overlay_files(
         self, follow_links=False, preserve_owner_group=False

--- a/test/unit/builder_install_test.py
+++ b/test/unit/builder_install_test.py
@@ -20,6 +20,10 @@ class TestInstallImageBuilder(object):
             'boot_names_type', ['kernel_name', 'initrd_name']
         )
         mock_machine.return_value = 'x86_64'
+        self.setup = mock.Mock()
+        kiwi.builder.install.SystemSetup = mock.Mock(
+            return_value=self.setup
+        )
         self.firmware = mock.Mock()
         self.firmware.efi_mode = mock.Mock(
             return_value='uefi'
@@ -136,6 +140,8 @@ class TestInstallImageBuilder(object):
         setattr(context_manager_mock, '__exit__', exit_mock)
 
         self.install_image.create_install_iso()
+
+        self.setup.import_cdroot_files.assert_called_once_with('temp_media_dir')
 
         self.checksum.md5.assert_called_once_with(
             'temp-squashfs/result-image.md5'

--- a/test/unit/builder_live_test.py
+++ b/test/unit/builder_live_test.py
@@ -175,6 +175,8 @@ class TestLiveImageBuilder(object):
 
         self.live_image.create()
 
+        self.setup.import_cdroot_files.assert_called_once_with('temp_media_dir')
+
         assert kiwi.builder.live.FileSystem.call_args_list == [
             call(
                 custom_args={'mount_options': 'async'},

--- a/test/unit/system_setup_test.py
+++ b/test/unit/system_setup_test.py
@@ -183,6 +183,17 @@ class TestSystemSetup(object):
         mock_open.assert_called_once_with('root_dir/.profile', 'w')
         self.file_mock.write.assert_called_once_with('a\n')
 
+    @patch('kiwi.system.setup.ArchiveTar')
+    @patch('kiwi.system.setup.glob.iglob')
+    def test_import_cdroot_files(self, mock_iglob, mock_ArchiveTar):
+        archive = mock.Mock()
+        mock_ArchiveTar.return_value = archive
+        mock_iglob.return_value = ['config-cdroot.tar.xz']
+        self.setup.import_cdroot_files('target_dir')
+        mock_iglob.assert_called_once_with('description_dir/config-cdroot.tar*')
+        mock_ArchiveTar.assert_called_once_with('config-cdroot.tar.xz')
+        archive.extract.assert_called_once_with('target_dir')
+
     @patch('kiwi.command.Command.run')
     @patch('kiwi.system.setup.DataSync')
     @patch('os.path.exists')


### PR DESCRIPTION
The image description now allows an optional file named:
config-cdroot.tar[.compression_postfix]. The file gets
unpacked as user data for live and install ISO images.
This allows users to add e.g license files or reference
documentation to the ISO image. This Fixes #737

