### PR TITLE
Fix setup of LOADER_TYPE in sysconfig/bootloader

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -187,8 +187,10 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         * FAILSAFE_APPEND
         """
         sysconfig_bootloader_entries = {
-            'LOADER_TYPE': self.boot_directory_name,
-            'LOADER_LOCATION': 'mbr'
+            'LOADER_TYPE':
+                'grub2-efi' if self.firmware.efi_mode() else 'grub2',
+            'LOADER_LOCATION':
+                'mbr'
         }
         if self.cmdline:
             sysconfig_bootloader_entries['DEFAULT_APPEND'] = '"{0}"'.format(

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -349,6 +349,17 @@ class TestBootLoaderConfigGrub2(object):
             call('LOADER_LOCATION', 'mbr'),
             call('LOADER_TYPE', 'grub2')
         ]
+        self.firmware.efi_mode = mock.Mock(
+            return_value=True
+        )
+        sysconfig_bootloader.__setitem__.reset_mock()
+        self.bootloader.setup_sysconfig_bootloader()
+        assert sysconfig_bootloader.__setitem__.call_args_list == [
+            call('DEFAULT_APPEND', '"some-cmdline"'),
+            call('FAILSAFE_APPEND', '"some-failsafe-cmdline"'),
+            call('LOADER_LOCATION', 'mbr'),
+            call('LOADER_TYPE', 'grub2-efi')
+        ]
 
     def test_setup_live_image_config_multiboot(self):
         self.bootloader.multiboot = True


### PR DESCRIPTION
LOADER_TYPE value for the grub2 bootloader depends on
the use of EFI. This Fixes bsc#1094883


