### PR TITLE
Fixup LOADER_LOCATION in sysconfig/bootloader

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -190,7 +190,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             'LOADER_TYPE':
                 'grub2-efi' if self.firmware.efi_mode() else 'grub2',
             'LOADER_LOCATION':
-                'mbr'
+                'none' if self.firmware.efi_mode() else 'mbr'
         }
         if self.cmdline:
             sysconfig_bootloader_entries['DEFAULT_APPEND'] = '"{0}"'.format(

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -357,7 +357,7 @@ class TestBootLoaderConfigGrub2(object):
         assert sysconfig_bootloader.__setitem__.call_args_list == [
             call('DEFAULT_APPEND', '"some-cmdline"'),
             call('FAILSAFE_APPEND', '"some-failsafe-cmdline"'),
-            call('LOADER_LOCATION', 'mbr'),
+            call('LOADER_LOCATION', 'none'),
             call('LOADER_TYPE', 'grub2-efi')
         ]
 


### PR DESCRIPTION
By default we always set LOADER_LOCATION=mbr which is wrong
if EFI is in use. This patch updates the value to be correct.
It also seems that this variable is only consumed by the
yast2 bootloader module from past days. Thus we consider
it obsolete and on the to be droped list in future releases.
This Fixes #746


