### PR TITLE
omit multipath module in live iso initrd

### DIFF
--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -290,7 +290,7 @@ class LiveImageBuilder(object):
     def _create_dracut_live_iso_config(self):
         live_config_file = self.root_dir + '/etc/dracut.conf.d/02-livecd.conf'
         omit_modules = [
-            'kiwi-dump', 'kiwi-overlay', 'kiwi-repart', 'kiwi-lib'
+            'kiwi-dump', 'kiwi-overlay', 'kiwi-repart', 'kiwi-lib', 'multipath'
         ]
         live_config = [
             'add_dracutmodules+=" {0} pollcdrom "'.format(

--- a/test/unit/builder_live_test.py
+++ b/test/unit/builder_live_test.py
@@ -213,7 +213,7 @@ class TestLiveImageBuilder(object):
             call('add_dracutmodules+=" kiwi-live pollcdrom "\n'),
             call(
                 'omit_dracutmodules+=" '
-                'kiwi-dump kiwi-overlay kiwi-repart kiwi-lib "\n'
+                'kiwi-dump kiwi-overlay kiwi-repart kiwi-lib multipath "\n'
             ),
             call('hostonly="no"\n'),
             call('dracut_rescue_image="no"\n')


### PR DESCRIPTION
The multipath module creates device maps which puts the device
in a busy state and prevents the creation of a persistent write
partition. As multipath seems never useful for the root of a live
iso image we generally omit this module from being included

