### PR TITLE
Relax runtime check for ISO images using dmsquash

### DIFF
--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -395,7 +395,8 @@ class RuntimeChecker(object):
             <package name="{0}"/>
         ''')
         required_dracut_package = 'dracut-kiwi-live'
-        if self.xml_state.get_build_type_name() == 'iso':
+        if (self.xml_state.get_build_type_name() == 'iso' and
+                self.xml_state.build_type.get_flags() != 'dmsquash'):
             package_names = \
                 self.xml_state.get_bootstrap_packages() + \
                 self.xml_state.get_system_packages()


### PR DESCRIPTION
This commit relaxes the dracut-kiwi-live package requirement if
dmsquash dracut module is selected in flags attribute.
