### PR TITLE
Added true module to grub image list

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -348,7 +348,8 @@ class Defaults(object):
             'xfs',
             'btrfs',
             'lvm',
-            'test'
+            'test',
+            'true'
         ]
         if multiboot:
             modules.append('multiboot')

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -546,7 +546,7 @@ class TestBootLoaderConfigGrub2(object):
                 'search_label', 'search_fs_file', 'search', 'search_fs_uuid',
                 'ls', 'normal', 'gzio', 'png', 'fat', 'gettext', 'font',
                 'minicmd', 'gfxterm', 'gfxmenu', 'video', 'video_fb', 'xfs',
-                'btrfs', 'lvm', 'test', 'multiboot', 'part_gpt',
+                'btrfs', 'lvm', 'test', 'true', 'multiboot', 'part_gpt',
                 'part_msdos', 'efi_gop', 'efi_uga', 'linuxefi'
             ])
         ]
@@ -604,8 +604,8 @@ class TestBootLoaderConfigGrub2(object):
                 'search_label', 'search_fs_file', 'search', 'search_fs_uuid',
                 'ls', 'normal', 'gzio', 'png', 'fat', 'gettext', 'font',
                 'minicmd', 'gfxterm', 'gfxmenu', 'video', 'video_fb', 'xfs',
-                'btrfs', 'lvm', 'test', 'part_gpt', 'part_msdos', 'efi_gop',
-                'efi_uga', 'linuxefi'
+                'btrfs', 'lvm', 'test', 'true', 'part_gpt', 'part_msdos',
+                'efi_gop', 'efi_uga', 'linuxefi'
             ])
         ]
         assert mock_sync.call_args_list == [
@@ -822,8 +822,8 @@ class TestBootLoaderConfigGrub2(object):
                 'search_label', 'search_fs_file', 'search', 'search_fs_uuid',
                 'ls', 'normal', 'gzio', 'png', 'fat', 'gettext', 'font',
                 'minicmd', 'gfxterm', 'gfxmenu', 'video', 'video_fb', 'xfs',
-                'btrfs', 'lvm', 'test', 'part_gpt', 'part_msdos', 'efi_gop',
-                'efi_uga', 'linuxefi'
+                'btrfs', 'lvm', 'test', 'true', 'part_gpt', 'part_msdos',
+                'efi_gop', 'efi_uga', 'linuxefi'
             ])
         ]
         assert mock_sync.call_args_list == [


### PR DESCRIPTION
When kiwi creates a grub image a list of modules are embedded.
For the purpose of snapshot boot the true module seems to be
used but was not included at build time when kiwi created
the grub image. This Fixes bsc#1093917


