### PR TITLE
Add config-cdroot to description import list

### DIFF
--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -93,6 +93,7 @@ class SystemSetup(object):
 
         self._import_custom_scripts()
         self._import_custom_archives()
+        self._import_cdroot_archive()
 
     def cleanup(self):
         """
@@ -684,6 +685,19 @@ class SystemSetup(object):
                 '--> Inplace recovery requested, deleting archive'
             )
             Path.wipe(metadata['archive_name'] + '.gz')
+
+    def _import_cdroot_archive(self):
+        glob_match = self.description_dir + '/config-cdroot.tar*'
+        for cdroot_archive in glob.iglob(glob_match):
+            log.info(
+                '--> Importing {0} archive as /image/{0}'.format(
+                    cdroot_archive
+                )
+            )
+            Command.run(
+                ['cp', cdroot_archive, self.root_dir + '/image/']
+            )
+            break
 
     def _import_custom_archives(self):
         """

--- a/test/unit/system_setup_test.py
+++ b/test/unit/system_setup_test.py
@@ -73,10 +73,17 @@ class TestSystemSetup(object):
     @patch('kiwi.command.Command.run')
     @patch_open
     @patch('os.path.exists')
-    def test_import_description(self, mock_path, mock_open, mock_command):
+    @patch('kiwi.system.setup.glob.iglob')
+    def test_import_description(
+        self, mock_iglob, mock_path, mock_open, mock_command
+    ):
+        mock_iglob.return_value = ['config-cdroot.tar.xz']
         mock_path.return_value = True
         self.setup_with_real_xml.import_description()
 
+        mock_iglob.assert_called_once_with(
+            '../data/config-cdroot.tar*'
+        )
         assert mock_command.call_args_list == [
             call(['mkdir', '-p', 'root_dir/image']),
             call(['cp', '../data/config.sh', 'root_dir/image/config.sh']),
@@ -94,7 +101,9 @@ class TestSystemSetup(object):
                 'root_dir/.kconfig'
             ]),
             call(['cp', '/absolute/path/to/image.tgz', 'root_dir/image/']),
-            call(['cp', '../data/bootstrap.tgz', 'root_dir/image/'])]
+            call(['cp', '../data/bootstrap.tgz', 'root_dir/image/']),
+            call(['cp', 'config-cdroot.tar.xz', 'root_dir/image/'])
+        ]
 
     @patch('kiwi.command.Command.run')
     @patch_open


### PR DESCRIPTION
During the prepare step the image description and mandatory
files needed in the create step are copied into the image
root system below the image/ directory. In case of the
optional config-cdroot archive this copy action was missing
which lead to the problem that the archive was not present
if the kiwi system create command is sequence is used.
This Fixes #756


