### PR TITLE
Make sure profile env is included in live images

### DIFF
--- a/dracut/modules.d/90kiwi-live/kiwi-live-lib.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-live-lib.sh
@@ -28,6 +28,11 @@ function setupDebugMode {
     fi
 }
 
+function initialize {
+    local profile=/.profile
+    test -f ${profile} && cat ${profile}
+}
+
 function loadKernelModules {
     modprobe squashfs
 }

--- a/dracut/modules.d/90kiwi-live/kiwi-live-root.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-live-root.sh
@@ -8,6 +8,9 @@ PATH=/usr/sbin:/usr/bin:/sbin:/bin
 # init debug log file if wanted
 setupDebugMode
 
+# initialize profile environment
+initialize
+
 # device nodes and types
 initGlobalDevices "$1"
 

--- a/dracut/modules.d/90kiwi-live/module-setup.sh
+++ b/dracut/modules.d/90kiwi-live/module-setup.sh
@@ -28,7 +28,7 @@ install() {
     inst_multiple \
         umount dmsetup blockdev blkid lsblk dd losetup \
         grep cut partprobe find wc fdisk tail mkfs.ext4 mkfs.xfs \
-        checkmedia dialog
+        checkmedia dialog cat
 
     dmsquashdir=$(find "${dracutbasedir}/modules.d" -name "*dmsquash-live")
     if [ -n "${dmsquashdir}" ] && \

--- a/kiwi/builder/live.py
+++ b/kiwi/builder/live.py
@@ -230,6 +230,9 @@ class LiveImageBuilder(object):
             working_directory=self.root_dir
         )
 
+        # prepare dracut initrd call
+        self.boot_image.prepare()
+
         # create dracut initrd for live image
         log.info('Creating live ISO boot image')
         self._create_dracut_live_iso_config()

--- a/test/unit/builder_live_test.py
+++ b/test/unit/builder_live_test.py
@@ -241,6 +241,7 @@ class TestLiveImageBuilder(object):
             call(mbrid=self.mbrid)
         assert self.bootloader.write.call_args_list[1] == call()
 
+        self.boot_image_task.prepare.assert_called_once_with()
         self.boot_image_task.create_initrd.assert_called_once_with(
             self.mbrid
         )


### PR DESCRIPTION
For all images which boots via dracut the .profile file is included
except for live iso's because no information is needed from that file
to boot or customize the boot. However the .profile contains the
kiwi_revision information which is useful for any image type.
This Fixes #755

