### PR TITLE
Fixup move_to_root method

### DIFF
--- a/kiwi/system/root_bind.py
+++ b/kiwi/system/root_bind.py
@@ -170,7 +170,9 @@ class RootBind(object):
         for element in elements:
             normalized_element = os.path.normpath(element)
             result.append(
-                normalized_element.replace(os.path.normpath(self.root_dir), '/')
+                normalized_element.replace(
+                    os.path.normpath(self.root_dir), os.sep
+                ).replace('{0}{0}'.format(os.sep), os.sep)
             )
         return result
 

--- a/test/unit/system_root_bind_test.py
+++ b/test/unit/system_root_bind_test.py
@@ -175,4 +175,4 @@ class TestRootBind(object):
     def test_move_to_root(self):
         assert self.bind_root.move_to_root(
             [self.bind_root.root_dir + '/argument']
-        ) == ['//argument']
+        ) == ['/argument']


### PR DESCRIPTION
move_to_root is called to check each element of a given list
and changes any path specification to a valid path if the given
root path would be it's root(/). This tranformation implied the
creation of paths containing double slashes like //foo which
was considered harmless. However it has turned out that the dnf
package manager makes a difference here which requires to fix
the resulting paths. This Fixes #761

