### PR TITLE
Complete GUID change from signed to unsigned

### DIFF
--- a/kiwi/storage/subformat/vhdfixed.py
+++ b/kiwi/storage/subformat/vhdfixed.py
@@ -124,11 +124,11 @@ class DiskFormatVhdFixed(DiskFormatBase):
         )
         # pack second nibble into 2 byte unsigned short type
         binary_tag_part_2 = struct.pack(
-            'h', list(struct.unpack('>H', unhexlify(tag_format.group(2))))[0]
+            'H', list(struct.unpack('>H', unhexlify(tag_format.group(2))))[0]
         )
         # pack third nibble into 2 byte unsigned short type
         binary_tag_part_3 = struct.pack(
-            'h', list(struct.unpack('>H', unhexlify(tag_format.group(3))))[0]
+            'H', list(struct.unpack('>H', unhexlify(tag_format.group(3))))[0]
         )
         # pack fourth nibble into hex
         binary_tag_part_4 = unhexlify(tag_format.group(4))


### PR DESCRIPTION
Follow up fix to complete the binary packing of the GUID
format to use unsigned types. Missed to move short source
from signed to unsigned.

This Fixes bsc#1095267

