### PR TITLE
Prevent building custom efi image

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -643,11 +643,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 efi_boot_config, mbrid
             )
         with open(efi_boot_config, 'a') as config:
-            config.write(
-                'configfile ($root)/boot/{0}/grub.cfg{1}'.format(
-                    self.boot_directory_name, os.linesep
-                )
-            )
+            config.write('normal{0}'.format(os.linesep))
 
     def _create_early_boot_script_for_uuid_search(self, filename, uuid):
         with open(filename, 'w') as early_boot:

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -481,6 +481,29 @@ class Defaults(object):
                 return shim_file
 
     @classmethod
+    def get_unsigned_grub_loader(self, root_path):
+        """
+        Provides unsigned grub efi loader file path
+
+        Searches distribution specific locations to find grub.efi
+        below the given root path
+
+        :param string root_path: image root path
+
+        :return: file path or None
+
+        :rtype: str
+        """
+        unsigned_grub_file_patterns = [
+            '/usr/lib/grub*/*-efi/grub.efi'
+        ]
+        for unsigned_grub_file_pattern in unsigned_grub_file_patterns:
+            for unsigned_grub_file in glob.iglob(
+                root_path + unsigned_grub_file_pattern
+            ):
+                return unsigned_grub_file
+
+    @classmethod
     def get_signed_grub_loader(self, root_path):
         """
         Provides shim signed grub loader file path

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -649,7 +649,7 @@ class TestBootLoaderConfigGrub2(object):
             call('set btrfs_relative_path="yes"\n'),
             call('search --fs-uuid --set=root 0815\n'),
             call('set prefix=($root)//grub2\n'),
-            call('configfile ($root)/boot/grub2/grub.cfg\n')
+            call('normal\n')
         ]
         assert mock_open.call_args_list == [
             call('root_dir/boot/efi/EFI/BOOT/grub.cfg', 'w'),
@@ -896,7 +896,7 @@ class TestBootLoaderConfigGrub2(object):
             call('set btrfs_relative_path="yes"\n'),
             call('search --file --set=root /boot/0xffffffff\n'),
             call('set prefix=($root)/boot/grub2\n'),
-            call('configfile ($root)/boot/grub2/grub.cfg\n')
+            call('normal\n')
         ]
         assert mock_open.call_args_list == [
             call('root_dir//EFI/BOOT/grub.cfg', 'w'),

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -509,14 +509,17 @@ class TestBootLoaderConfigGrub2(object):
         mock_command.side_effect = Exception
         self.bootloader.setup_disk_boot_images('0815')
 
+    @patch('kiwi.bootloader.config.grub2.Defaults.get_unsigned_grub_loader')
     @patch('kiwi.bootloader.config.grub2.Command.run')
     @patch('kiwi.bootloader.config.grub2.DataSync')
     @patch_open
     @patch('os.path.exists')
     @patch('platform.machine')
     def test_setup_disk_boot_images_xen_guest_efi_image_needs_multiboot(
-        self, mock_machine, mock_exists, mock_open, mock_sync, mock_command
+        self, mock_machine, mock_exists, mock_open, mock_sync,
+        mock_command, mock_get_unsigned_grub_loader
     ):
+        mock_get_unsigned_grub_loader.return_value = None
         mock_machine.return_value = 'x86_64'
         self.firmware.efi_mode = mock.Mock(
             return_value='efi'
@@ -551,14 +554,17 @@ class TestBootLoaderConfigGrub2(object):
             ])
         ]
 
+    @patch('kiwi.bootloader.config.grub2.Defaults.get_unsigned_grub_loader')
     @patch('kiwi.bootloader.config.grub2.Command.run')
     @patch('kiwi.bootloader.config.grub2.DataSync')
     @patch_open
     @patch('os.path.exists')
     @patch('platform.machine')
     def test_setup_disk_boot_images_bios_plus_efi(
-        self, mock_machine, mock_exists, mock_open, mock_sync, mock_command
+        self, mock_machine, mock_exists, mock_open, mock_sync,
+        mock_command, mock_get_unsigned_grub_loader
     ):
+        mock_get_unsigned_grub_loader.return_value = None
         data = mock.Mock()
         mock_sync.return_value = data
         mock_machine.return_value = 'x86_64'
@@ -621,6 +627,33 @@ class TestBootLoaderConfigGrub2(object):
         assert data.sync_data.call_args_list == [
             call(exclude=['*.module'], options=['-z', '-a']),
             call(exclude=['*.module'], options=['-z', '-a'])
+        ]
+
+        mock_get_unsigned_grub_loader.return_value = 'custom_grub_image'
+        mock_command.reset_mock()
+        file_mock.write.reset_mock()
+        mock_open.reset_mock()
+        self.bootloader.setup_disk_boot_images('0815')
+
+        assert mock_command.call_args_list == [
+            call([
+                'cp', 'root_dir/usr/share/grub2/unicode.pf2',
+                'root_dir/boot/unicode.pf2'
+            ]),
+            call([
+                'cp', 'custom_grub_image',
+                'root_dir/boot/efi/EFI/BOOT/bootx64.efi'
+            ])
+        ]
+        assert file_mock.write.call_args_list == [
+            call('set btrfs_relative_path="yes"\n'),
+            call('search --fs-uuid --set=root 0815\n'),
+            call('set prefix=($root)//grub2\n'),
+            call('configfile ($root)/boot/grub2/grub.cfg\n')
+        ]
+        assert mock_open.call_args_list == [
+            call('root_dir/boot/efi/EFI/BOOT/grub.cfg', 'w'),
+            call('root_dir/boot/efi/EFI/BOOT/grub.cfg', 'a')
         ]
 
     @patch('kiwi.bootloader.config.grub2.Command.run')
@@ -768,14 +801,17 @@ class TestBootLoaderConfigGrub2(object):
         ]
         assert mock_log.called
 
+    @patch('kiwi.bootloader.config.grub2.Defaults.get_unsigned_grub_loader')
     @patch('kiwi.bootloader.config.grub2.Command.run')
     @patch('kiwi.bootloader.config.grub2.DataSync')
     @patch_open
     @patch('os.path.exists')
     @patch('platform.machine')
     def test_setup_install_boot_images_efi(
-        self, mock_machine, mock_exists, mock_open, mock_sync, mock_command
+        self, mock_machine, mock_exists, mock_open, mock_sync,
+        mock_command, mock_get_unsigned_grub_loader
     ):
+        mock_get_unsigned_grub_loader.return_value = None
         data = mock.Mock()
         mock_sync.return_value = data
         mock_machine.return_value = 'x86_64'
@@ -839,6 +875,32 @@ class TestBootLoaderConfigGrub2(object):
         assert data.sync_data.call_args_list == [
             call(exclude=['*.module'], options=['-z', '-a']),
             call(exclude=['*.module'], options=['-z', '-a'])
+        ]
+
+        mock_get_unsigned_grub_loader.return_value = 'custom_grub_image'
+        mock_command.reset_mock()
+        file_mock.write.reset_mock()
+        mock_open.reset_mock()
+        self.bootloader.setup_install_boot_images(self.mbrid)
+
+        assert mock_command.call_args_list == [
+            call([
+                'cp', 'root_dir/usr/share/grub2/unicode.pf2',
+                'root_dir/boot/unicode.pf2'
+            ]),
+            call([
+                'cp', 'custom_grub_image', 'root_dir//EFI/BOOT/bootx64.efi'
+            ])
+        ]
+        assert file_mock.write.call_args_list == [
+            call('set btrfs_relative_path="yes"\n'),
+            call('search --file --set=root /boot/0xffffffff\n'),
+            call('set prefix=($root)/boot/grub2\n'),
+            call('configfile ($root)/boot/grub2/grub.cfg\n')
+        ]
+        assert mock_open.call_args_list == [
+            call('root_dir//EFI/BOOT/grub.cfg', 'w'),
+            call('root_dir//EFI/BOOT/grub.cfg', 'a')
         ]
 
     @patch('kiwi.bootloader.config.grub2.Command.run')

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -86,3 +86,10 @@ class TestDefaults(object):
         assert Defaults.get_iso_boot_path() == 'boot/ix86'
         mock_machine.return_value = 'x86_64'
         assert Defaults.get_iso_boot_path() == 'boot/x86_64'
+
+    @patch('kiwi.defaults.glob.iglob')
+    def test_get_unsigned_grub_loader(self, mock_glob):
+        mock_glob.return_value = ['/usr/lib/grub2/x86_64-efi/grub.efi']
+        assert Defaults.get_unsigned_grub_loader('root') == \
+            mock_glob.return_value.pop()
+        mock_glob.assert_called_once_with('root/usr/lib/grub*/*-efi/grub.efi')


### PR DESCRIPTION
If the distribution provides a prebuilt efi image kiwi
should use it instead of building its own image.


