### PR TITLE
Added system cleanup methods

### DIFF
--- a/kiwi/config/functions.sh
+++ b/kiwi/config/functions.sh
@@ -1158,6 +1158,33 @@ function baseSetRunlevel {
 }
 
 #======================================
+# baseCleanup
+#--------------------------------------
+function baseCleanup {
+    # /.../
+    # Delete files from the system which are considered
+    # one time initialization files to be re-created on
+    # the final target system
+    # ----
+    # systemd random seed
+    rm -f /var/lib/systemd/random-seed
+}
+
+#======================================
+# suseCleanup
+#--------------------------------------
+function suseCleanup {
+    # /.../
+    # Delete files from a SUSE system which are considered
+    # one time initialization files to be re-created on
+    # the final target system
+    # ----
+    baseCleanup
+    # zypper id
+    rm -f /var/lib/zypp/AnonymousUniqueId
+}
+
+#======================================
 # suseRemovePackagesMarkedForDeletion
 #--------------------------------------
 function suseRemovePackagesMarkedForDeletion {


### PR DESCRIPTION
Some files in the system gets created by services like
systemd or zypper and are meant to be created once on the
target system. However in the image they might be unwanted.
Thus this commit adds convenience methods to delete files
which gets automatically re-created by the services on
startup. Whether or not the methods are used is in the
responsibility of the author of the image descripion.
This Fixes bsc#1098535

