### PR TITLE
Add '--add-container-label' flag

### DIFF
--- a/kiwi/container/oci.py
+++ b/kiwi/container/oci.py
@@ -129,7 +129,7 @@ class ContainerImageOCI(object):
         # specific build. Thus disturl label only exists inside the
         # buildservice.
         if Defaults.is_buildservice_worker():
-            bs_label = 'org.openbuildservice'
+            bs_label = 'org.openbuildservice.disturl'
             # Do not label anything if any build service label is
             # already present
             if not [label for label in self.labels if bs_label in label]:

--- a/kiwi/container/oci.py
+++ b/kiwi/container/oci.py
@@ -73,8 +73,8 @@ class ContainerImageOCI(object):
         self.oci_dir = None
         self.oci_root_dir = None
 
-        self.container_name = 'kiwi-container'
-        self.container_tag = 'latest'
+        self.container_name = Defaults.get_default_container_name()
+        self.container_tag = Defaults.get_default_container_tag()
         self.additional_tags = []
         self.entry_command = []
         self.entry_subcommand = []
@@ -129,7 +129,11 @@ class ContainerImageOCI(object):
         # specific build. Thus disturl label only exists inside the
         # buildservice.
         if Defaults.is_buildservice_worker():
-            self._append_buildservice_disturl_label()
+            bs_label = 'org.openbuildservice'
+            # Do not label anything if any build service label is
+            # already present
+            if not [label for label in self.labels if bs_label in label]:
+                self._append_buildservice_disturl_label()
 
         if not custom_args or 'container_name' not in custom_args:
             log.info(
@@ -247,8 +251,7 @@ class ContainerImageOCI(object):
                     if disturl:
                         self.labels.append(
                             ''.join([
-                                '--config.label='
-                                'org.openbuildservice.disturl=',
+                                '--config.label=org.openbuildservice.disturl=',
                                 disturl
                             ])
                         )

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1105,6 +1105,28 @@ class Defaults(object):
         return 'xz'
 
     @classmethod
+    def get_default_container_name(self):
+        """
+        Provides the default container name.
+
+        :return: name
+
+        :rtype: str
+        """
+        return 'kiwi-container'
+
+    @classmethod
+    def get_default_container_tag(self):
+        """
+        Provides the default container tag.
+
+        :return: tag
+
+        :rtype: str
+        """
+        return 'latest'
+
+    @classmethod
     def set_python_default_encoding_to_utf8(self):
         """
         Set python default encoding to utf-8 if not already done

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -28,6 +28,7 @@ usage: kiwi system build -h | --help
            [--delete-package=<name>...]
            [--set-container-derived-from=<uri>]
            [--set-container-tag=<name>]
+           [--add-container-label=<label>...]
            [--signing-key=<key-file>...]
        kiwi system build help
 
@@ -71,6 +72,10 @@ options:
         overwrite the container tag in the container configuration.
         The setting is only effective if the container configuraiton
         provides an initial tag value
+    --add-container-label=<name=value>
+        add a container label in the container configuration metadata. It
+        overwrites the label with the provided key-value pair in case it was
+        already defined in the XML description
     --set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck>
         overwrite the first XML listed repository source, type, alias,
         priority, the imageinclude flag and the package_gpgcheck flag
@@ -164,6 +169,14 @@ class SystemBuildTask(CliTask):
             self.xml_state.set_container_config_tag(
                 self.command_args['--set-container-tag']
             )
+
+        if self.command_args['--add-container-label']:
+            for add_label in self.command_args['--add-container-label']:
+                if '=' in add_label:
+                    label_value_pair = add_label.split('=', maxsplit=1)
+                    self.xml_state.add_container_config_label(
+                        label_value_pair[0], label_value_pair[1]
+                    )
 
         if self.command_args['--set-container-derived-from']:
             self.xml_state.set_derived_from_image_uri(

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -172,10 +172,13 @@ class SystemBuildTask(CliTask):
 
         if self.command_args['--add-container-label']:
             for add_label in self.command_args['--add-container-label']:
-                if '=' in add_label:
-                    label_value_pair = add_label.split('=', maxsplit=1)
-                    self.xml_state.add_container_config_label(
-                        label_value_pair[0], label_value_pair[1]
+                try:
+                    (name, value) = add_label.split('=', 1)
+                    self.xml_state.add_container_config_label(name, value)
+                except Exception:
+                    log.warning(
+                        'Container label {0} ignored. Invalid format: '
+                        'expected labelname=value'.format(add_label)
                     )
 
         if self.command_args['--set-container-derived-from']:

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -28,6 +28,7 @@ usage: kiwi system prepare -h | --help
            [--delete-package=<name>...]
            [--set-container-derived-from=<uri>]
            [--set-container-tag=<name>]
+           [--add-container-label=<label>...]
            [--signing-key=<key-file>...]
        kiwi system prepare help
 
@@ -71,6 +72,10 @@ options:
         overwrite the container tag in the container configuration.
         The setting is only effective if the container configuraiton
         provides an initial tag value
+    --add-container-label=<name=value>
+        add a container label in the container configuration metadata. It
+        overwrites the label with the provided key-value pair in case it was
+        already defined in the XML description
     --set-repo=<source,type,alias,priority,imageinclude,package_gpgcheck>
         overwrite the first XML listed repository source, type, alias,
         priority, the imageinclude flag and the package_gpgcheck flag
@@ -152,6 +157,14 @@ class SystemPrepareTask(CliTask):
                 self.command_args['--set-container-tag']
             )
 
+        if self.command_args['--add-container-label']:
+            for add_label in self.command_args['--add-container-label']:
+                if '=' in add_label:
+                    label_value_pair = add_label.split('=', maxsplit=1)
+                    self.xml_state.add_container_config_label(
+                        label_value_pair[0], label_value_pair[1]
+                    )
+
         if self.command_args['--set-container-derived-from']:
             self.xml_state.set_derived_from_image_uri(
                 self.command_args['--set-container-derived-from']
@@ -207,6 +220,7 @@ class SystemPrepareTask(CliTask):
         # make sure manager instance is cleaned up now
         del manager
 
+        log.info('Preparing repos')
         # setup permanent image repositories after cleanup
         setup.import_repositories_marked_as_imageinclude()
         setup.call_config_script()

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -159,10 +159,13 @@ class SystemPrepareTask(CliTask):
 
         if self.command_args['--add-container-label']:
             for add_label in self.command_args['--add-container-label']:
-                if '=' in add_label:
-                    label_value_pair = add_label.split('=', maxsplit=1)
-                    self.xml_state.add_container_config_label(
-                        label_value_pair[0], label_value_pair[1]
+                try:
+                    (name, value) = add_label.split('=', 1)
+                    self.xml_state.add_container_config_label(name, value)
+                except Exception:
+                    log.warning(
+                        'Container label {0} ignored. Invalid format: '
+                        'expected labelname=value'.format(add_label)
                     )
 
         if self.command_args['--set-container-derived-from']:
@@ -220,7 +223,6 @@ class SystemPrepareTask(CliTask):
         # make sure manager instance is cleaned up now
         del manager
 
-        log.info('Preparing repos')
         # setup permanent image repositories after cleanup
         setup.import_repositories_marked_as_imageinclude()
         setup.call_config_script()

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -966,7 +966,7 @@ class XMLState(object):
 
         * name: name of the volume
         * size: size of the volume
-        * realpath: system h to lookup volume data. If no mountpoint
+        * realpath: system path to lookup volume data. If no mountpoint
           is set the volume name is used as data path.
         * mountpoint: volume mount point and volume data path
         * fullsize: takes all space True|False

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -915,6 +915,49 @@ class XMLState(object):
             ''')
             log.warning(message.format(tag))
 
+    def add_container_config_label(self, label_name, value):
+        """
+        Adds a new label in the containerconfig section, if a label with the
+        same name is already defined in containerconfig it gets overwritten by
+        this method.
+
+        :param str label_name: the string representing the label name
+        :param str value: the value of the label
+        """
+        if self.get_build_type_name() not in ['docker', 'oci']:
+            message = dedent('''\n
+                Labels can only be configured for container image types
+                docker and oci.
+            ''')
+            log.warning(message)
+            return
+
+        container_config_section = self.get_build_type_containerconfig_section()
+        if not container_config_section:
+            container_config_section = xml_parse.containerconfig(
+                name=Defaults.get_default_container_name(),
+                tag=Defaults.get_default_container_tag()
+            )
+            self.build_type.set_containerconfig([container_config_section])
+
+        labels = container_config_section.get_labels()
+        if not labels:
+            labels = [xml_parse.labels()]
+
+        label_names = []
+        for label in labels[0].get_label():
+            label_names.append(label.get_name())
+
+        if label_name in label_names:
+            labels[0].replace_label_at(
+                label_names.index(label_name),
+                xml_parse.label(label_name, value)
+            )
+        else:
+            labels[0].add_label(xml_parse.label(label_name, value))
+
+        container_config_section.set_labels(labels)
+
     def get_volumes(self):
         """
         List of configured systemdisk volumes.
@@ -923,7 +966,7 @@ class XMLState(object):
 
         * name: name of the volume
         * size: size of the volume
-        * realpath: system path to lookup volume data. If no mountpoint
+        * realpath: system h to lookup volume data. If no mountpoint
           is set the volume name is used as data path.
         * mountpoint: volume mount point and volume data path
         * fullsize: takes all space True|False

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -81,6 +81,7 @@
                 <oem-swap>true</oem-swap>
             </oemconfig>
         </type>
+        <type image="docker"/>
     </preferences>
     <preferences profiles="vmxFlavour">
         <type image="vmx" filesystem="ext3" format="vmdk" bootloader="grub2" kernelcmdline="splash" bootpartition="false">

--- a/test/unit/cli_test.py
+++ b/test/unit/cli_test.py
@@ -48,6 +48,7 @@ class TestCli(object):
             '--delete-package': [],
             '--set-container-derived-from': None,
             '--set-container-tag': None,
+            '--add-container-label': [],
             '--signing-key': [],
             '-h': False,
             'help': False,

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -178,11 +178,24 @@ class TestSystemBuildTask(object):
         self, mock_log, mock_add_container_label
     ):
         self._init_command_args()
-        self.task.command_args['--add-container-label'] = ['newLabel=value']
+        self.task.command_args['--add-container-label'] = [
+            'newLabel=value', 'anotherLabel=my=crazy value'
+        ]
         self.task.process()
-        mock_add_container_label.assert_called_once_with(
-            'newLabel', 'value'
-        )
+        mock_add_container_label.assert_has_calls([
+            call('newLabel', 'value'),
+            call('anotherLabel', 'my=crazy value')
+        ])
+
+    @patch('kiwi.logger.log.warning')
+    @patch('kiwi.logger.Logger.set_logfile')
+    def test_process_system_build_add_container_label_invalid_format(
+        self, mock_logger, mock_log_warn
+    ):
+        self._init_command_args()
+        self.task.command_args['--add-container-label'] = ['newLabel:value']
+        self.task.process()
+        assert mock_log_warn.called
 
     @patch('kiwi.xml_state.XMLState.set_derived_from_image_uri')
     @patch('kiwi.logger.Logger.set_logfile')

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -87,6 +87,7 @@ class TestSystemBuildTask(object):
         self.task.command_args['--ignore-repos-used-for-build'] = False
         self.task.command_args['--set-container-derived-from'] = None
         self.task.command_args['--set-container-tag'] = None
+        self.task.command_args['--add-container-label'] = []
         self.task.command_args['--clear-cache'] = False
         self.task.command_args['--signing-key'] = None
 
@@ -169,6 +170,18 @@ class TestSystemBuildTask(object):
         self.task.process()
         mock_set_container_tag.assert_called_once_with(
             'new_tag'
+        )
+
+    @patch('kiwi.xml_state.XMLState.add_container_config_label')
+    @patch('kiwi.logger.Logger.set_logfile')
+    def test_process_system_build_add_container_label(
+        self, mock_log, mock_add_container_label
+    ):
+        self._init_command_args()
+        self.task.command_args['--add-container-label'] = ['newLabel=value']
+        self.task.process()
+        mock_add_container_label.assert_called_once_with(
+            'newLabel', 'value'
         )
 
     @patch('kiwi.xml_state.XMLState.set_derived_from_image_uri')

--- a/test/unit/tasks_system_prepare_test.py
+++ b/test/unit/tasks_system_prepare_test.py
@@ -78,6 +78,7 @@ class TestSystemPrepareTask(object):
         self.task.command_args['--clear-cache'] = False
         self.task.command_args['--set-container-derived-from'] = None
         self.task.command_args['--set-container-tag'] = None
+        self.task.command_args['--add-container-label'] = []
         self.task.command_args['--signing-key'] = None
 
     def test_process_system_prepare(self):
@@ -153,6 +154,17 @@ class TestSystemPrepareTask(object):
         self.task.process()
         mock_set_container_tag.assert_called_once_with(
             'new_tag'
+        )
+
+    @patch('kiwi.xml_state.XMLState.add_container_config_label')
+    def test_process_system_prepare_add_container_label(
+        self, mock_add_container_label
+    ):
+        self._init_command_args()
+        self.task.command_args['--add-container-label'] = ['newLabel=value']
+        self.task.process()
+        mock_add_container_label.assert_called_once_with(
+            'newLabel', 'value'
         )
 
     @patch('kiwi.xml_state.XMLState.set_derived_from_image_uri')

--- a/test/unit/tasks_system_prepare_test.py
+++ b/test/unit/tasks_system_prepare_test.py
@@ -167,6 +167,15 @@ class TestSystemPrepareTask(object):
             'newLabel', 'value'
         )
 
+    @patch('kiwi.logger.log.warning')
+    def test_process_system_prepare_add_container_label_invalid_format(
+        self, mock_log_warn
+    ):
+        self._init_command_args()
+        self.task.command_args['--add-container-label'] = ['newLabel:value']
+        self.task.process()
+        assert mock_log_warn.called
+
     @patch('kiwi.xml_state.XMLState.set_derived_from_image_uri')
     def test_process_system_prepare_set_derived_from_uri(
         self, mock_set_derived_from_uri

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -588,6 +588,36 @@ class TestXMLState(object):
         config = state.get_container_config()
         assert config['container_tag'] == 'new_tag'
 
+    def test_add_container_label(self):
+        xml_data = self.description.load()
+        state = XMLState(xml_data, ['vmxFlavour'], 'docker')
+        state.add_container_config_label('somelabel', 'overwrittenvalue')
+        state.add_container_config_label('new_label', 'new value')
+        config = state.get_container_config()
+        assert config['labels'] == [
+            '--config.label=somelabel=overwrittenvalue',
+            '--config.label=someotherlabel=anotherlabelvalue',
+            '--config.label=new_label=new value'
+        ]
+
+    def test_add_container_label_without_contianerconfig(self):
+        xml_data = self.description.load()
+        state = XMLState(xml_data, ['xenFlavour'], 'docker')
+        state.add_container_config_label('somelabel', 'newlabelvalue')
+        config = state.get_container_config()
+        assert config['labels'] == [
+            '--config.label=somelabel=newlabelvalue'
+        ]
+
+    @patch('kiwi.logger.log.warning')
+    def test_add_container_label_no_contianer_image_type(self, mock_log_warn):
+        xml_data = self.description.load()
+        state = XMLState(xml_data, ['vmxFlavour'], 'vmx')
+        state.add_container_config_label('somelabel', 'newlabelvalue')
+        config = state.get_container_config()
+        assert not config
+        assert mock_log_warn.called
+
     @patch('kiwi.logger.log.warning')
     def test_set_container_tag_not_applied(self, mock_log_warn):
         self.state.set_container_config_tag('new_tag')


### PR DESCRIPTION
This commits adds a command line flag to add a label for container image
types. The flag can be used multiple times.

Fixes #770
