### PR TITLE
Support label attribute in volumes

### DIFF
--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -102,6 +102,39 @@ class RuntimeChecker(object):
                 message % (target_dir, shared_cache_location)
             )
 
+    def check_volume_label_used_with_lvm(self):
+        """
+        The optional volume label in a systemdisk setup is only
+        effective if the LVM, logical volume manager system is
+        used. In any other case where the filesystem itself offers
+        volume management capabilities there are no extra filesystem
+        labels which can be applied per volume
+        """
+        message = dedent('''\n
+            Custom volume label setup used without LVM
+
+            The optional volume label in a systemdisk setup is only
+            effective if the LVM, logical volume manager system is
+            used. Your setup uses the {0} filesystem which itself
+            offers volume management capabilities. Extra filesystem
+            labels cannot be applied in this case.
+
+            If you want to force LVM over the {0} volume management
+            system you can do so by specifying the following in
+            your KIWI XML description:
+
+            <systemdisk ... preferlvm="true">
+                <volume .../>
+            </systemdisk>
+        ''')
+        volume_management = self.xml_state.get_volume_management()
+        if volume_management != 'lvm':
+            for volume in self.xml_state.get_volumes():
+                if volume.label:
+                    raise KiwiRuntimeError(
+                        message.format(volume_management)
+                    )
+
     def check_volume_setup_has_no_root_definition(self):
         """
         The root volume in a systemdisk setup is handled in a special

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -2031,10 +2031,14 @@ div {
     k.volume.copy_on_write.attribute =
         ## Apply the filesystem copy-on-write attribute for this volume
         attribute copy_on_write { xsd:boolean }
+    k.volume.label.attribute =
+        ## filesystem label name of the volume.
+        attribute label { text }
     k.volume.attlist =
         k.volume.copy_on_write.attribute? &
         k.volume.freespace.attribute? &
         k.volume.mountpoint.attribute? &
+        k.volume.label.attribute? &
         k.volume.name.attribute &
         k.volume.size.attribute?
     k.volume =

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -3131,6 +3131,11 @@ add "M" and/or "G" as postfix</a:documentation>
         <data type="boolean"/>
       </attribute>
     </define>
+    <define name="k.volume.label.attribute">
+      <attribute name="label">
+        <a:documentation>filesystem label name of the volume.</a:documentation>
+      </attribute>
+    </define>
     <define name="k.volume.attlist">
       <interleave>
         <optional>
@@ -3141,6 +3146,9 @@ add "M" and/or "G" as postfix</a:documentation>
         </optional>
         <optional>
           <ref name="k.volume.mountpoint.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.volume.label.attribute"/>
         </optional>
         <ref name="k.volume.name.attribute"/>
         <optional>

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -139,6 +139,7 @@ class SystemBuildTask(CliTask):
         self.runtime_checker.check_consistent_kernel_in_boot_and_system_image()
         self.runtime_checker.check_docker_tool_chain_installed()
         self.runtime_checker.check_volume_setup_has_no_root_definition()
+        self.runtime_checker.check_volume_label_used_with_lvm()
         self.runtime_checker.check_xen_uniquely_setup_as_server_or_guest()
         self.runtime_checker.check_target_directory_not_in_shared_cache(
             abs_target_dir_path

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -126,6 +126,7 @@ class SystemPrepareTask(CliTask):
         self.runtime_checker.check_consistent_kernel_in_boot_and_system_image()
         self.runtime_checker.check_docker_tool_chain_installed()
         self.runtime_checker.check_volume_setup_has_no_root_definition()
+        self.runtime_checker.check_volume_label_used_with_lvm()
         self.runtime_checker.check_xen_uniquely_setup_as_server_or_guest()
         self.runtime_checker.check_target_directory_not_in_shared_cache(
             abs_root_path

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -4206,11 +4206,12 @@ class volume(GeneratedsSuper):
     """Specify which parts of the filesystem should be on an extra volume."""
     subclass = None
     superclass = None
-    def __init__(self, copy_on_write=None, freespace=None, mountpoint=None, name=None, size=None):
+    def __init__(self, copy_on_write=None, freespace=None, mountpoint=None, label=None, name=None, size=None):
         self.original_tagname_ = None
         self.copy_on_write = _cast(bool, copy_on_write)
         self.freespace = _cast(None, freespace)
         self.mountpoint = _cast(None, mountpoint)
+        self.label = _cast(None, label)
         self.name = _cast(None, name)
         self.size = _cast(None, size)
     def factory(*args_, **kwargs_):
@@ -4230,6 +4231,8 @@ class volume(GeneratedsSuper):
     def set_freespace(self, freespace): self.freespace = freespace
     def get_mountpoint(self): return self.mountpoint
     def set_mountpoint(self, mountpoint): self.mountpoint = mountpoint
+    def get_label(self): return self.label
+    def set_label(self, label): self.label = label
     def get_name(self): return self.name
     def set_name(self, name): self.name = name
     def get_size(self): return self.size
@@ -4278,6 +4281,9 @@ class volume(GeneratedsSuper):
         if self.mountpoint is not None and 'mountpoint' not in already_processed:
             already_processed.add('mountpoint')
             outfile.write(' mountpoint=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.mountpoint), input_name='mountpoint')), ))
+        if self.label is not None and 'label' not in already_processed:
+            already_processed.add('label')
+            outfile.write(' label=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.label), input_name='label')), ))
         if self.name is not None and 'name' not in already_processed:
             already_processed.add('name')
             outfile.write(' name=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.name), input_name='name')), ))
@@ -4313,6 +4319,10 @@ class volume(GeneratedsSuper):
         if value is not None and 'mountpoint' not in already_processed:
             already_processed.add('mountpoint')
             self.mountpoint = value
+        value = find_attr_value_('label', node)
+        if value is not None and 'label' not in already_processed:
+            already_processed.add('label')
+            self.label = value
         value = find_attr_value_('name', node)
         if value is not None and 'name' not in already_processed:
             already_processed.add('name')

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -978,13 +978,16 @@ class XMLState(object):
             .. code:: python
 
                 [
-                    volume_type(name=volume_name,
-                    size=volume_size,
-                    realpath=path,
-                    mountpoint=path,
-                    fullsize=True,
-                    attributes=['no-copy-on-write']
-                )
+                    volume_type(
+                        name=volume_name,
+                        size=volume_size,
+                        realpath=path,
+                        mountpoint=path,
+                        fullsize=True,
+                        label=volume_label,
+                        attributes=['no-copy-on-write']
+                    )
+                ]
 
         :rtype: list
         """
@@ -1000,6 +1003,7 @@ class XMLState(object):
                 'realpath',
                 'mountpoint',
                 'fullsize',
+                'label',
                 'attributes'
             ]
         )
@@ -1017,6 +1021,7 @@ class XMLState(object):
                 size = volume.get_size()
                 freespace = volume.get_freespace()
                 fullsize = False
+                label = volume.get_label()
                 attributes = []
 
                 if volume.get_copy_on_write() is False:
@@ -1065,6 +1070,7 @@ class XMLState(object):
                         fullsize=fullsize,
                         mountpoint=mountpoint,
                         realpath=realpath,
+                        label=label,
                         attributes=attributes
                     )
                 )
@@ -1087,6 +1093,7 @@ class XMLState(object):
                     fullsize=fullsize,
                     mountpoint=None,
                     realpath='/',
+                    label=None,
                     attributes=[]
                 )
             )

--- a/test/data/example_lvm_default_config.xml
+++ b/test/data/example_lvm_default_config.xml
@@ -20,7 +20,7 @@
         <bootloader-theme>openSUSE</bootloader-theme>
         <type image="oem" filesystem="ext3" boot="oemboot/suse-13.2" installiso="true" bootloader="grub2" kernelcmdline="splash" firmware="efi">
             <systemdisk>
-                <volume name="usr/lib" size="1G"/>
+                <volume name="usr/lib" size="1G" label="library"/>
                 <volume name="@root" freespace="500M"/>
                 <volume name="etc_volume" mountpoint="etc" copy_on_write="false"/>
                 <volume name="bin_volume" size="all" mountpoint="/usr/bin"/>

--- a/test/data/example_runtime_checker_config.xml
+++ b/test/data/example_runtime_checker_config.xml
@@ -74,10 +74,10 @@
                 <vmnic driver="e1000" interface="0" mode="bridged"/>
             </machine>
         </type>
-        <type bootloader="grub2" image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="my_edit_boot_install" filesystem="ext4" initrd_system="dracut" installiso="true">
+        <type bootloader="grub2" image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="my_edit_boot_install" filesystem="btrfs" initrd_system="dracut" installiso="true">
             <size unit="G" additive="true">1</size>
             <systemdisk name="mydisk">
-                <volume name="root" size="6G" mountpoint="/"/>
+                <volume name="root" size="6G" mountpoint="/" label="foo"/>
             </systemdisk>
             <machine memory="512" xen_loader="pvgrub">
                 <vmdisk id="0" device="/dev/xvda" controller="ide"/>

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -347,3 +347,7 @@ class TestRuntimeChecker(object):
         )
         runtime_checker = RuntimeChecker(xml_state)
         runtime_checker.check_dracut_module_for_oem_install_in_package_list()
+
+    @raises(KiwiRuntimeError)
+    def test_check_volume_label_used_with_lvm(self):
+        self.runtime_checker.check_volume_label_used_with_lvm()

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -100,6 +100,7 @@ class TestSystemBuildTask(object):
         self.runtime_checker.check_consistent_kernel_in_boot_and_system_image.assert_called_once_with()
         self.runtime_checker.check_docker_tool_chain_installed.assert_called_once_with()
         self.runtime_checker.check_volume_setup_has_no_root_definition.assert_called_once_with()
+        self.runtime_checker.check_volume_label_used_with_lvm.assert_called_once_with()
         self.runtime_checker.check_xen_uniquely_setup_as_server_or_guest.assert_called_once_with()
         self.runtime_checker.check_target_directory_not_in_shared_cache.assert_called_once_with(self.abs_target_dir)
         self.runtime_checker.check_mediacheck_only_for_x86_arch.assert_called_once_with()

--- a/test/unit/tasks_system_prepare_test.py
+++ b/test/unit/tasks_system_prepare_test.py
@@ -90,6 +90,7 @@ class TestSystemPrepareTask(object):
         self.runtime_checker.check_consistent_kernel_in_boot_and_system_image.assert_called_once_with()
         self.runtime_checker.check_docker_tool_chain_installed.assert_called_once_with()
         self.runtime_checker.check_volume_setup_has_no_root_definition.assert_called_once_with()
+        self.runtime_checker.check_volume_label_used_with_lvm.assert_called_once_with()
         self.runtime_checker.check_xen_uniquely_setup_as_server_or_guest.assert_called_once_with()
         self.runtime_checker.check_target_directory_not_in_shared_cache.assert_called_once_with(
             self.abs_root_dir

--- a/test/unit/volume_manager_lvm_test.py
+++ b/test/unit/volume_manager_lvm_test.py
@@ -22,25 +22,26 @@ class TestVolumeManagerLVM(object):
                 'realpath',
                 'mountpoint',
                 'fullsize',
+                'label',
                 'attributes'
             ]
         )
         self.volumes = [
             self.volume_type(
                 name='LVRoot', size='freespace:100', realpath='/',
-                mountpoint=None, fullsize=False, attributes=[]
+                mountpoint=None, fullsize=False, label=None, attributes=[]
             ),
             self.volume_type(
                 name='LVetc', size='freespace:200', realpath='/etc',
-                mountpoint='/etc', fullsize=False, attributes=[]
+                mountpoint='/etc', fullsize=False, label='etc', attributes=[]
             ),
             self.volume_type(
                 name='myvol', size='size:500', realpath='/data',
-                mountpoint='LVdata', fullsize=False, attributes=[]
+                mountpoint='LVdata', fullsize=False, label=None, attributes=[]
             ),
             self.volume_type(
                 name='LVhome', size=None, realpath='/home',
-                mountpoint='/home', fullsize=True, attributes=[]
+                mountpoint='/home', fullsize=True, label=None, attributes=[]
             ),
         ]
         mock_path.return_value = True
@@ -135,6 +136,8 @@ class TestVolumeManagerLVM(object):
         self, mock_attrs, mock_mount, mock_mapped_device, mock_fs,
         mock_command, mock_size, mock_os_exists
     ):
+        filesystem = mock.Mock()
+        mock_fs.return_value = filesystem
         self.volume_manager.mountpoint = 'tmpdir'
         mock_mapped_device.return_value = 'mapped_device'
         size = mock.Mock()
@@ -153,19 +156,22 @@ class TestVolumeManagerLVM(object):
             call(
                 'root_dir', self.volume_type(
                     name='LVRoot', size='freespace:100', realpath='/',
-                    mountpoint=None, fullsize=False, attributes=[]
+                    mountpoint=None, fullsize=False, label=None,
+                    attributes=[]
                 )
             ),
             call(
                 'root_dir', self.volume_type(
                     name='myvol', size='size:500', realpath='/data',
-                    mountpoint='LVdata', fullsize=False, attributes=[]
+                    mountpoint='LVdata', fullsize=False, label=None,
+                    attributes=[]
                 )
             ),
             call(
                 'root_dir', self.volume_type(
                     name='LVetc', size='freespace:200', realpath='/etc',
-                    mountpoint='/etc', fullsize=False, attributes=[]
+                    mountpoint='/etc', fullsize=False, label='etc',
+                    attributes=[]
                 )
             )
         ]
@@ -216,6 +222,12 @@ class TestVolumeManagerLVM(object):
                 device_provider='mapped_device',
                 name='ext3'
             )
+        ]
+        assert filesystem.create_on_device.call_args_list == [
+            call(label='ROOT'),
+            call(label=None),
+            call(label='etc'),
+            call(label=None)
         ]
         self.volume_manager.volume_group = None
 

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -264,6 +264,7 @@ class TestXMLState(object):
                 'realpath',
                 'mountpoint',
                 'fullsize',
+                'label',
                 'attributes'
             ]
         )
@@ -272,24 +273,28 @@ class TestXMLState(object):
                 name='usr_lib', size='size:1024',
                 realpath='usr/lib',
                 mountpoint='usr/lib', fullsize=False,
+                label='library',
                 attributes=[]
             ),
             volume_type(
                 name='LVRoot', size='freespace:500',
                 realpath='/',
                 mountpoint=None, fullsize=False,
+                label=None,
                 attributes=[]
             ),
             volume_type(
                 name='etc_volume', size='freespace:30',
                 realpath='etc',
                 mountpoint='etc', fullsize=False,
+                label=None,
                 attributes=['no-copy-on-write']
             ),
             volume_type(
                 name='bin_volume', size=None,
                 realpath='/usr/bin',
                 mountpoint='/usr/bin', fullsize=True,
+                label=None,
                 attributes=[]
             )
         ]
@@ -305,6 +310,7 @@ class TestXMLState(object):
                 'realpath',
                 'mountpoint',
                 'fullsize',
+                'label',
                 'attributes'
             ]
         )
@@ -312,6 +318,7 @@ class TestXMLState(object):
             volume_type(
                 name='LVRoot', size=None, realpath='/',
                 mountpoint=None, fullsize=True,
+                label=None,
                 attributes=[]
             )
         ]
@@ -329,6 +336,7 @@ class TestXMLState(object):
                 'realpath',
                 'mountpoint',
                 'fullsize',
+                'label',
                 'attributes'
             ]
         )
@@ -336,11 +344,13 @@ class TestXMLState(object):
             volume_type(
                 name='usr', size=None, realpath='usr',
                 mountpoint='usr', fullsize=True,
+                label=None,
                 attributes=[]
             ),
             volume_type(
                 name='LVRoot', size='freespace:30', realpath='/',
                 mountpoint=None, fullsize=False,
+                label=None,
                 attributes=[]
             )
         ]


### PR DESCRIPTION
The optional label attribute in a volume section allows
to specify a filesystem label for the selected volume.
The label setup will have no effect on filesystems
which implements their own volume management like it's
the case for btrfs. This Fixes #738


