### PR TITLE
Fixed GCE image file name

### DIFF
--- a/kiwi/storage/subformat/gce.py
+++ b/kiwi/storage/subformat/gce.py
@@ -111,8 +111,8 @@ class DiskFormatGce(DiskFormatBase):
             [
                 self.target_dir, '/',
                 self.xml_state.xml_data.get_name(),
-                '-guest-gce-',
-                self.xml_state.get_image_version(),
+                '.' + self.arch,
+                '-' + self.xml_state.get_image_version(),
                 '.' + format_name
             ]
         )

--- a/test/unit/storage_subformat_gce_test.py
+++ b/test/unit/storage_subformat_gce_test.py
@@ -61,11 +61,11 @@ class TestDiskFormatGce(object):
             call('{"licenses": ["gce-license"]}')
         ]
         mock_archive.assert_called_once_with(
-            filename='target_dir/some-disk-image-guest-gce-0.8.15.tar',
+            filename='target_dir/some-disk-image.x86_64-0.8.15.tar',
             file_list=['manifest.json', 'disk.raw']
         )
         archive.create_gnu_gzip_compressed.assert_called_once_with(
             'tmpdir'
         )
         assert self.disk_format.get_target_file_path_for_format('gce') == \
-            'target_dir/some-disk-image-guest-gce-0.8.15.tar.gz'
+            'target_dir/some-disk-image.x86_64-0.8.15.tar.gz'


### PR DESCRIPTION
In former times Google requires the image name to follow
their naming conventions. However that seems to have changed
and it is no longer required to match a certain pattern.
Thus this patch changes the output name of the GCE tar file
to use the same naming schema as KIWI applies to its output
files

