### PR TITLE
Fixed name of checksum file for pxe type

### DIFF
--- a/kiwi/builder/pxe.py
+++ b/kiwi/builder/pxe.py
@@ -77,6 +77,7 @@ class PxeBuilder(object):
             ]
         )
         self.archive_name = ''.join([self.image_name, '.tar.xz'])
+        self.checksum_name = ''.join([self.image_name, '.md5'])
         self.kernel_filename = None
         self.hypervisor_filename = None
         self.result = Result(xml_state)
@@ -112,9 +113,8 @@ class PxeBuilder(object):
             self.image = compress.compressed_filename
 
         log.info('Creating PXE root filesystem MD5 checksum')
-        self.filesystem_checksum = ''.join([self.image, '.md5'])
         checksum = Checksum(self.image)
-        checksum.md5(self.filesystem_checksum)
+        checksum.md5(self.checksum_name)
 
         # prepare boot(initrd) root system
         log.info('Creating PXE boot image')
@@ -179,7 +179,7 @@ class PxeBuilder(object):
             self.kernel_filename,
             os.path.basename(self.boot_image_task.initrd_filename),
             os.path.basename(self.image),
-            os.path.basename(self.filesystem_checksum)
+            os.path.basename(self.checksum_name)
         ] + [
             '|', 'xz', '-f'
         ] + self.xz_options + [

--- a/test/unit/builder_pxe_test.py
+++ b/test/unit/builder_pxe_test.py
@@ -79,7 +79,9 @@ class TestPxeBuilder(object):
             'myimage.fs', 'myimage'
         )
         compress.xz.assert_called_once_with(None)
-        checksum.md5.assert_called_once_with('compressed-file-name.md5')
+        checksum.md5.assert_called_once_with(
+            'target_dir/some-image.x86_64-1.2.3.md5'
+        )
         self.boot_image_task.prepare.assert_called_once_with()
         self.setup.export_modprobe_setup.assert_called_once_with(
             'initrd_dir'
@@ -98,7 +100,7 @@ class TestPxeBuilder(object):
                 'myimage-42.kernel ' +
                 'initrd_file_name ' +
                 'compressed-file-name ' +
-                'compressed-file-name.md5 ' +
+                'some-image.x86_64-1.2.3.md5 ' +
                 '| xz -f --threads=0 > ' +
                 'target_dir/some-image.x86_64-1.2.3.tar.xz'
             ]


### PR DESCRIPTION
The pxe image build generates among others a checksum
file with the suffix '.md5' This file is read by the
legacy netboot code and is expected to have the same
basename as the image file itself. However if the
compressed attribute is set the image file name is
set to 'image.xz' and the checksum is named 'image.xz.md5'
which is wrong because 'image.md5' is expected. This
patch makes sure the checksum file is always set
to 'image.md5' no matter if the compressed flag is
configured or not

