### PR TITLE
Fixed building VMware images with pvscsi adapter

### DIFF
--- a/kiwi/storage/subformat/base.py
+++ b/kiwi/storage/subformat/base.py
@@ -128,6 +128,15 @@ class DiskFormatBase(object):
         if custom_args:
             ordered_args = OrderedDict(sorted(custom_args.items()))
             for key, value in list(ordered_args.items()):
+                if key == 'adapter_type=pvscsi':
+                    # qemu does not support the pvscsi type:
+                    # To build a vmdk image with ddb.adapterType set to
+                    # pvscsi we need to manually change the header but
+                    # have to create a vmdk with lsilogic as scsi adapter
+                    # first. I don't really like this hack but it seems
+                    # there is no way around. For details see
+                    # bsc#1099569
+                    key = 'adapter_type=lsilogic'
                 options.append('-o')
                 if value:
                     options.append('{0}={1}'.format(key, value))

--- a/kiwi/storage/subformat/ova.py
+++ b/kiwi/storage/subformat/ova.py
@@ -21,6 +21,7 @@ from textwrap import dedent
 
 # project
 from kiwi.storage.subformat.vmdk import DiskFormatVmdk
+from kiwi.storage.subformat.base import DiskFormatBase
 from kiwi.command import Command
 from kiwi.utils.command_capabilities import CommandCapabilities
 from kiwi.path import Path
@@ -31,7 +32,7 @@ from kiwi.exceptions import (
 )
 
 
-class DiskFormatOva(DiskFormatVmdk):
+class DiskFormatOva(DiskFormatBase):
     """
     **Create ova disk format, based on vmdk**
     """
@@ -48,6 +49,9 @@ class DiskFormatOva(DiskFormatVmdk):
             raise KiwiFormatSetupError('Unsupported ovftype %s' % ovftype)
         self.image_format = 'ova'
         self.options = self.get_qemu_option_list(custom_args)
+        self.vmdk = DiskFormatVmdk(
+            self.xml_state, self.root_dir, self.target_dir, custom_args
+        )
 
     def create_image_format(self):
         """
@@ -70,7 +74,7 @@ class DiskFormatOva(DiskFormatVmdk):
             )
 
         # Create the vmdk disk image and vmx config
-        super(DiskFormatOva, self).create_image_format()
+        self.vmdk.create_image_format()
 
         # Convert to ova using ovftool
         vmx = self.get_target_file_path_for_format('vmx')


### PR DESCRIPTION
Qemu does not natively support the pvscsi adapter type.
However there is a VMware suggested procedure which allows
to change the lsilogic setup to pvscsi inside of the DDB
of a formerly created lsilogic configured image format.
This patch implementes that procedure and
Fixes bsc#1099569


