### PR TITLE
Fixup validation of boottimeout attribute

### DIFF
--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -193,7 +193,7 @@ class BootLoaderConfigBase(object):
         :rtype: int
         """
         timeout_seconds = self.xml_state.build_type.get_boottimeout()
-        if not timeout_seconds:
+        if timeout_seconds is None:
             timeout_seconds = Defaults.get_default_boot_timeout_seconds()
         return timeout_seconds
 

--- a/test/unit/bootloader_config_base_test.py
+++ b/test/unit/bootloader_config_base_test.py
@@ -74,8 +74,13 @@ class TestBootLoaderConfigBase(object):
     def test_get_boot_theme(self):
         assert self.bootloader.get_boot_theme() == 'openSUSE'
 
-    def test_get_boot_timeout_seconds(self):
+    def test_get_boot_timeout_seconds_default_applies(self):
         assert self.bootloader.get_boot_timeout_seconds() == 10
+
+    @patch('kiwi.xml_parse.type_.get_boottimeout')
+    def test_get_boot_timeout_seconds(self, mock_get_boottimeout):
+        mock_get_boottimeout.return_value = 0
+        assert self.bootloader.get_boot_timeout_seconds() == 0
 
     @patch('kiwi.xml_parse.type_.get_installprovidefailsafe')
     def test_failsafe_boot_entry_requested(


### PR DESCRIPTION
If boottimeout is set to zero it is evaluated as "not set"
and the default applies. However it's a fairly well approach
to set a zero second boot timeout. This Fixes #789