### PR TITLE
Fixed make obs_test_status

### DIFF
--- a/.obs_test_status
+++ b/.obs_test_status
@@ -5,7 +5,7 @@ function kiwi_version {
 }
 
 function kiwi_build_version {
-    echo -n "$1" | grep python3-kiwi- | head -n 1 | cut -f 3 -d -
+    echo -n "$1" | grep python[32]-kiwi- | head -n 1 | cut -f 3 -d -
 }
 
 kiwi_local_version=$(kiwi_version)
@@ -14,8 +14,16 @@ while read -r project arch; do
     echo $project
     while read -r result; do
         test -z "${result}" && continue
+        opts=""
         package=$(echo "${result}" | cut -f2 -d \")
-        build_log=$(osc rbuildlog --last ${project} ${package} images ${arch})
+        multibuild=$(echo "${package}" | cut -f2 -d:)
+        if [ ! "${package}" = "${multibuild}" ];then
+            package=$(echo "${package}" | cut -f1 -d:)
+            opts="-M ${multibuild}"
+        fi
+        build_log=$(
+            osc rbuildlog --last ${opts} ${project} ${package} images ${arch}
+        )
         kiwi_obs_version=$(kiwi_build_version "${build_log}")
         if [ "$kiwi_obs_version" = "$kiwi_local_version" ];then
             result="${result} kiwi=\"${kiwi_obs_version}\""
@@ -25,7 +33,7 @@ while read -r project arch; do
         fi
         echo "  ${result}"
     done < <(
-        osc results "${project}" --xml |\
+        osc results "${project}" --xml | grep -v excluded |\
             grep status | cut -f2 -d \< | cut -f1 -d \/
     )
 done < .obs_test

--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -18,7 +18,7 @@ lxml
 PyYAML
 
 # Python wrapper for extended filesystem attributes
-xattr
+xattr==0.9.3
 
 # Python 2 compatibility
 future


### PR DESCRIPTION
The helper script .obs_test_status looks up the build
results from the integration tests. With the introduction
of multibuild integration tests the script has to apply
some modifications to get the correct results
This is related to Issue #791

