### PR TITLE
Delete dmraid aka: softraid soft/fakeraid support

### DIFF
--- a/.virtualenv.dev-requirements.txt
+++ b/.virtualenv.dev-requirements.txt
@@ -34,7 +34,7 @@ flake8
 
 # Generate Data Structures from XML Schema
 # http://pythonhosted.org/generateDS
-generateDS
+generateDS==2.29.14
 
 # for building documentation
 sphinx

--- a/build-tests/x86/test-image-centos/appliance.kiwi
+++ b/build-tests/x86/test-image-centos/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="6.8" name="LimeJeOS-CentOS-07.0">
+<image schemaversion="6.9" name="LimeJeOS-CentOS-07.0">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>
@@ -12,7 +12,7 @@
     <profiles>
         <profile name="Live" description="Live image of CentOS 7"/>
         <profile name="Virtual" description="Virtual image of CentOS 7"/>
-        <profile name="Disk" description="OEM image of CentOS 7"/>   
+        <profile name="Disk" description="OEM image of CentOS 7"/>
     </profiles>
     <preferences>
         <version>1.3.0</version>
@@ -24,7 +24,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
     </preferences>
     <preferences profiles="Live">
-        <type image="iso" flags="overlay" hybrid="true" firmware="uefi" hybridpersistent_filesystem="ext4" hybridpersistent="true"/>
+        <type image="iso" flags="overlay" firmware="uefi" hybridpersistent_filesystem="ext4" hybridpersistent="true"/>
     </preferences>
     <preferences profiles="Virtual">
         <type image="vmx" primary="true" filesystem="ext4" kernelcmdline="rhgb" bootloader="grub2" firmware="uefi" format="qcow2"/>
@@ -62,7 +62,6 @@
         <package name="grub2"/>
         <package name="kernel"/>
         <package name="plymouth-theme-charge"/>
-        <!-- from core and console-internet collections-->
         <package name="audit"/>
         <package name="btrfs-progs"/>
         <package name="dhclient"/>
@@ -86,7 +85,6 @@
         <package name="tuned"/>
         <package name="xfsprogs"/>
         <package name="NetworkManager"/>
-        <!-- Not resolved by OBS -->
         <package name="iputils"/>
         <package name="fipscheck"/>
     </packages>
@@ -104,7 +102,6 @@
         <package name="grub2-efi-modules"/>
         <package name="grub2-efi"/>
         <package name="shim" arch="x86_64"/>
-        <!-- Not resolved by OBS -->
         <package name="libdb-utils"/>
     </packages>
 </image>

--- a/doc/source/building/working_with_images/vagrant_setup.rst
+++ b/doc/source/building/working_with_images/vagrant_setup.rst
@@ -11,7 +11,7 @@ KIWI Image Description for Vagrant
 
    * :ref:`vmx`
 
-`Vagrant <http://vagrantup.com>`_ is a framework to
+`Vagrant <https://www.vagrantup.com>`_ is a framework to
 implement consistent processing/testing work environments based on
 Virtualization technologies. To run a system, Vagrant needs so-called
 **boxes**. A box is a TAR archive containing a virtual disk image and
@@ -19,7 +19,7 @@ some metadata.
 
 To build Vagrant boxes, use
 `veewee <https://github.com/jedi4ever/veewee>`_ which builds boxes
-based on AutoYaST. As an alternative, use `Packer <http://packer.io>`_,
+based on AutoYaST. As an alternative, use `Packer <https://www.packer.io>`_,
 which is providedby Vagrant itself.
 
 Both tools are based on the official installation media (DVDs) as shipped
@@ -30,12 +30,12 @@ not exist. For example, if the distribution is still under development or
 you want to use a collection of your own repositories.
 
 In addition, you can use the KIWI image description as source for the
-`Open Build Service <http://openbuildservice.org>`_ which allows
+`Open Build Service <https://openbuildservice.org>`_ which allows
 building and maintaining boxes.
 
 A Vagrant box which is able to work with Vagrant has to comply with the
 constraints documented in
-`Vagrant Box Constraints <http://docs.vagrantup.com/v2/boxes/base.html>`_.
+`Vagrant Box Constraints <https://www.vagrantup.com/docs/boxes/base.html>`_.
 Applied to the referenced KIWI image description from :ref:`vmx`,
 the following changes are required:
 
@@ -75,7 +75,7 @@ the following changes are required:
 4. Integrate public SSH key
 
    Reach out to
-   `Insecure Keys <https://github.com/mitchellh/vagrant/tree/master/keys>`_
+   `Insecure Keys <https://github.com/hashicorp/vagrant/tree/master/keys>`_
    for details on this keys. Add the public key to the
    box as overlay file in your image description at
    :file:`home/vagrant/.ssh/authorized_keys`

--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -17,13 +17,6 @@ function initialize {
     import_file ${profile}
 }
 
-function scan_softraid_devices {
-    # """
-    # calls dmraid_scan from dmraid module
-    # """
-    dmraid_scan
-}
-
 function scan_multipath_devices {
     # """
     # starts multipath daemon from multipath module
@@ -33,7 +26,6 @@ function scan_multipath_devices {
 
 function get_disk_list {
     declare kiwi_oemdevicefilter=${kiwi_oemdevicefilter}
-    declare kiwi_oemataraid_scan=${kiwi_oemataraid_scan}
     declare kiwi_oemmultipath_scan=${kiwi_oemmultipath_scan}
     declare kiwi_devicepersistency=${kiwi_devicepersistency}
     local disk_id="by-id"
@@ -45,9 +37,6 @@ function get_disk_list {
     local list_items
     if [ ! -z "${kiwi_devicepersistency}" ];then
         disk_id=${kiwi_devicepersistency}
-    fi
-    if [ ! -z "${kiwi_oemataraid_scan}" ];then
-        scan_softraid_devices
     fi
     if [ ! -z "${kiwi_oemmultipath_scan}" ];then
         scan_multipath_devices

--- a/dracut/modules.d/90kiwi-dump/module-setup.sh
+++ b/dracut/modules.d/90kiwi-dump/module-setup.sh
@@ -2,7 +2,7 @@
 
 # called by dracut
 depends() {
-    echo dmraid network rootfs-block dm kiwi-lib
+    echo network rootfs-block dm kiwi-lib
     return 0
 }
 

--- a/kiwi/config/strip.xml
+++ b/kiwi/config/strip.xml
@@ -114,7 +114,6 @@
         <file name="dirname"/>
         <file name="dmesg"/>
         <file name="dmevent_tool"/>
-        <file name="dmraid"/>
         <file name="dmsetup"/>
         <file name="dropbear"/>
         <file name="dropbearkey"/>
@@ -322,7 +321,6 @@
     no reference except for the ones listed here
     -->
     <strip type="libs">
-        <file name="libdmraid-events-isw"/>
         <file name="libfontenc"/>
         <file name="libfreetype"/>
         <file name="libgcc_s"/>

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -639,22 +639,6 @@ div {
 }
 
 #==========================================
-# common element <oem-ataraid-scan>
-#
-div {
-    k.oem-ataraid-scan.content = xsd:boolean
-    k.oem-ataraid-scan.attlist = empty
-    k.oem-ataraid-scan =
-        ## For oemboot driven images: turn on or off the search
-        ## for ata raid devices (aka fake raid controllers)
-        ## true/false (default is true)
-        element oem-ataraid-scan {
-            k.oem-ataraid-scan.attlist,
-            k.oem-ataraid-scan.content
-        }
-}
-
-#==========================================
 # common element <oem-vmcp-parmfile>
 #
 div {
@@ -2426,7 +2410,6 @@ div {
         ## and setup the system disk.
         element oemconfig {
             k.oemconfig.attlist &
-            k.oem-ataraid-scan? &
             k.oem-boot-title? &
             k.oem-bootwait? &
             k.oem-device-filter? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -984,28 +984,6 @@ verification process, true/false</a:documentation>
   </div>
   <!--
     ==========================================
-    common element <oem-ataraid-scan>
-    
-  -->
-  <div>
-    <define name="k.oem-ataraid-scan.content">
-      <data type="boolean"/>
-    </define>
-    <define name="k.oem-ataraid-scan.attlist">
-      <empty/>
-    </define>
-    <define name="k.oem-ataraid-scan">
-      <element name="oem-ataraid-scan">
-        <a:documentation>For oemboot driven images: turn on or off the search
-for ata raid devices (aka fake raid controllers)
-true/false (default is true)</a:documentation>
-        <ref name="k.oem-ataraid-scan.attlist"/>
-        <ref name="k.oem-ataraid-scan.content"/>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
     common element <oem-vmcp-parmfile>
     
   -->
@@ -3732,9 +3710,6 @@ configuration options which are used to repartition
 and setup the system disk.</a:documentation>
         <interleave>
           <ref name="k.oemconfig.attlist"/>
-          <optional>
-            <ref name="k.oem-ataraid-scan"/>
-          </optional>
           <optional>
             <ref name="k.oem-boot-title"/>
           </optional>

--- a/kiwi/system/profile.py
+++ b/kiwi/system/profile.py
@@ -84,7 +84,6 @@ class Profile(object):
         return Shell.quote_key_value_file(temp_profile.name)
 
     def _oemconfig_to_profile(self):
-        # kiwi_oemataraid_scan
         # kiwi_oemvmcp_parmfile
         # kiwi_oemmultipath_scan
         # kiwi_oemswapMB
@@ -112,8 +111,6 @@ class Profile(object):
         # kiwi_oemrecoveryInPlace
         oemconfig = self.xml_state.get_build_type_oemconfig_section()
         if oemconfig:
-            self.dot_profile['kiwi_oemataraid_scan'] = \
-                self._text(oemconfig.get_oem_ataraid_scan())
             self.dot_profile['kiwi_oemvmcp_parmfile'] = \
                 self._text(oemconfig.get_oem_vmcp_parmfile())
             self.dot_profile['kiwi_oemmultipath_scan'] = \

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -5938,12 +5938,8 @@ class oemconfig(GeneratedsSuper):
     which are used to repartition and setup the system disk."""
     subclass = None
     superclass = None
-    def __init__(self, oem_ataraid_scan=None, oem_boot_title=None, oem_bootwait=None, oem_device_filter=None, oem_nic_filter=None, oem_inplace_recovery=None, oem_kiwi_initrd=None, oem_multipath_scan=None, oem_vmcp_parmfile=None, oem_partition_install=None, oem_reboot=None, oem_reboot_interactive=None, oem_recovery=None, oem_recoveryID=None, oem_recovery_part_size=None, oem_shutdown=None, oem_shutdown_interactive=None, oem_silent_boot=None, oem_silent_install=None, oem_silent_verify=None, oem_skip_verify=None, oem_swap=None, oem_swapsize=None, oem_systemsize=None, oem_unattended=None, oem_unattended_id=None):
+    def __init__(self, oem_boot_title=None, oem_bootwait=None, oem_device_filter=None, oem_nic_filter=None, oem_inplace_recovery=None, oem_kiwi_initrd=None, oem_multipath_scan=None, oem_vmcp_parmfile=None, oem_partition_install=None, oem_reboot=None, oem_reboot_interactive=None, oem_recovery=None, oem_recoveryID=None, oem_recovery_part_size=None, oem_shutdown=None, oem_shutdown_interactive=None, oem_silent_boot=None, oem_silent_install=None, oem_silent_verify=None, oem_skip_verify=None, oem_swap=None, oem_swapsize=None, oem_systemsize=None, oem_unattended=None, oem_unattended_id=None):
         self.original_tagname_ = None
-        if oem_ataraid_scan is None:
-            self.oem_ataraid_scan = []
-        else:
-            self.oem_ataraid_scan = oem_ataraid_scan
         if oem_boot_title is None:
             self.oem_boot_title = []
         else:
@@ -6055,11 +6051,6 @@ class oemconfig(GeneratedsSuper):
         else:
             return oemconfig(*args_, **kwargs_)
     factory = staticmethod(factory)
-    def get_oem_ataraid_scan(self): return self.oem_ataraid_scan
-    def set_oem_ataraid_scan(self, oem_ataraid_scan): self.oem_ataraid_scan = oem_ataraid_scan
-    def add_oem_ataraid_scan(self, value): self.oem_ataraid_scan.append(value)
-    def insert_oem_ataraid_scan_at(self, index, value): self.oem_ataraid_scan.insert(index, value)
-    def replace_oem_ataraid_scan_at(self, index, value): self.oem_ataraid_scan[index] = value
     def get_oem_boot_title(self): return self.oem_boot_title
     def set_oem_boot_title(self, oem_boot_title): self.oem_boot_title = oem_boot_title
     def add_oem_boot_title(self, value): self.oem_boot_title.append(value)
@@ -6187,7 +6178,6 @@ class oemconfig(GeneratedsSuper):
     def replace_oem_unattended_id_at(self, index, value): self.oem_unattended_id[index] = value
     def hasContent_(self):
         if (
-            self.oem_ataraid_scan or
             self.oem_boot_title or
             self.oem_bootwait or
             self.oem_device_filter or
@@ -6245,9 +6235,6 @@ class oemconfig(GeneratedsSuper):
             eol_ = '\n'
         else:
             eol_ = ''
-        for oem_ataraid_scan_ in self.oem_ataraid_scan:
-            showIndent(outfile, level, pretty_print)
-            outfile.write('<oem-ataraid-scan>%s</oem-ataraid-scan>%s' % (self.gds_format_boolean(oem_ataraid_scan_, input_name='oem-ataraid-scan'), eol_))
         for oem_boot_title_ in self.oem_boot_title:
             showIndent(outfile, level, pretty_print)
             outfile.write('<oem-boot-title>%s</oem-boot-title>%s' % (self.gds_encode(self.gds_format_string(quote_xml(oem_boot_title_), input_name='oem-boot-title')), eol_))
@@ -6333,17 +6320,7 @@ class oemconfig(GeneratedsSuper):
     def buildAttributes(self, node, attrs, already_processed):
         pass
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
-        if nodeName_ == 'oem-ataraid-scan':
-            sval_ = child_.text
-            if sval_ in ('true', '1'):
-                ival_ = True
-            elif sval_ in ('false', '0'):
-                ival_ = False
-            else:
-                raise_parse_error(child_, 'requires boolean')
-            ival_ = self.gds_validate_boolean(ival_, node, 'oem_ataraid_scan')
-            self.oem_ataraid_scan.append(ival_)
-        elif nodeName_ == 'oem-boot-title':
+        if nodeName_ == 'oem-boot-title':
             oem_boot_title_ = child_.text
             oem_boot_title_ = self.gds_validate_string(oem_boot_title_, node, 'oem_boot_title')
             self.oem_boot_title.append(oem_boot_title_)

--- a/kiwi/xsl/convert68to69.xsl
+++ b/kiwi/xsl/convert68to69.xsl
@@ -45,4 +45,8 @@
     </type>
 </xsl:template>
 
+<!-- delete oem-ataraid-scan element from oemconfig -->
+<xsl:template match="oemconfig/oem-ataraid-scan" mode="conv68to69">
+</xsl:template>
+
 </xsl:stylesheet>

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -332,7 +332,6 @@ BuildRequires:  dracut
 %endif
 Requires:       dracut-kiwi-lib
 Requires:       kexec-tools
-Requires:       dmraid
 %if 0%{?suse_version} || 0%{?debian} || 0%{?ubuntu}
 Requires:       multipath-tools
 %endif

--- a/test/data/oemboot/example-distribution/config.xml
+++ b/test/data/oemboot/example-distribution/config.xml
@@ -125,7 +125,6 @@
         <package name="cryptsetup"/>
         <package name="curl"/>
         <package name="dialog"/>
-        <package name="dmraid"/>
         <package name="dosfstools"/>
         <package name="e2fsprogs"/>
         <package name="fbiterm"/>

--- a/test/unit/system_profile_test.py
+++ b/test/unit/system_profile_test.py
@@ -55,7 +55,6 @@ class TestProfile(object):
             'kiwi_loader_theme': 'openSUSE',
             'kiwi_lvm': 'true',
             'kiwi_lvmgroup': 'systemVG',
-            'kiwi_oemataraid_scan': None,
             'kiwi_oembootwait': None,
             'kiwi_oemdevicefilter': None,
             'kiwi_oemnicfilter': None,


### PR DESCRIPTION
In fate#323743 the decision was made to drop dmraid from the distribution. Along with the low business case for those controllers and the support for linux softraid via mdadm we also drop the support in kiwi for oem-ataraid-scan

* https://fate.suse.com/323743