### PR TITLE
Added support for pxe live boot via AOE

### DIFF
--- a/doc/source/building/working_with_images.rst
+++ b/doc/source/building/working_with_images.rst
@@ -17,3 +17,4 @@ different image types.
    working_with_images/pxe_client_configuration
    working_with_images/uninstall_package_requests 
    working_with_images/vagrant_setup
+   working_with_images/pxe_live_iso_boot

--- a/doc/source/building/working_with_images/pxe_live_iso_boot.rst
+++ b/doc/source/building/working_with_images/pxe_live_iso_boot.rst
@@ -1,0 +1,112 @@
+.. _pxe_live_boot:
+
+Booting a Live ISO Image from Network
+=====================================
+
+.. sidebar:: Abstract
+
+   This page provides further information for handling
+   ISO images built with KIWI and references the following
+   articles:
+
+   * :ref:`hybrid_iso`
+
+In KIWI, live ISO images can be configured to boot via PXE.
+This functionality requires a network boot server setup on the
+system. Details how to setup such a server can be found in
+:ref:`pxe-boot-server`.
+
+After the live ISO was built as shown in :ref:`hybrid_iso`,
+the following configuration steps are required to boot from
+the network:
+
+1. Extract initrd/kernel From Live ISO
+
+   The PXE boot process loads the configured kernel and initrd from
+   the PXE server. For this reason, those two files must be extracted
+   from the live ISO image and copied to the PXE server as follows:
+   
+   .. code:: bash
+
+       $ mount LimeJeOS-Leap-42.3.x86_64-1.42.3.iso /mnt
+       $ cp /mnt/boot/x86_64/loader/initrd /srv/tftpboot/boot/initrd
+       $ cp /mnt/boot/x86_64/loader/linux /srv/tftpboot/boot/linux
+       $ umount /mnt
+
+   .. note::
+
+       This step must be repeated with any new build of the live ISO image
+
+2. Export Live ISO To The Network
+
+   Access to the live ISO file is implemented using the AoE protocol
+   in KIWI. This requires the export of the live ISO file as remote
+   block device which is typically done with the :command:`vblade`
+   toolkit. Install the following package on the system which is
+   expected to export the live ISO image:
+
+   .. code:: bash
+
+       $ zypper in vblade
+
+   .. note::
+
+       Not all versions of AoE are compatible with any kernel. This
+       means the kernel on the system exporting the live ISO image
+       must provide a compatible aoe kernel module compared to the
+       kernel used in the live ISO image.
+   
+   Once done, export the live ISO image as follows:
+
+   .. code:: bash
+
+       $ vbladed 0 1 INTERFACE LimeJeOS-Leap-42.3.x86_64-1.42.3.iso
+
+   The above command exports the given ISO file as a block storage
+   device to the network of the given INTERFACE. On any machine
+   except the one exporting the file, it will appear as
+   :file:`/dev/etherd/e0.1` once the :command:`aoe` kernel module
+   was loaded. The two numbers, 0 and 1 in the above example, classifies
+   a major and minor number which is used in the device node name
+   on the reading side, in this case :file:`e0.1`. The numbers given
+   at export time must match the AOEINTERFACE name as described in
+   the next step.
+
+   .. note::
+
+       Only machines in the same network of the given INTERFACE
+       can see the exported live ISO image. If virtual machines
+       are the target to boot the live ISO image they could all
+       be connected through a bridge. In this case INTERFACE
+       is the bridge device. The availability scope of the live
+       ISO image on the network is in general not influenced
+       by KIWI and is a task for the network administrators.
+
+3. Setup live ISO boot entry in PXE configuration
+
+   Edit the file :file:`/srv/tftpboot/pxelinux.cfg/default` and create
+   a boot entry of the form:
+
+   .. code:: bash
+
+      LABEL Live-Boot
+          kernel boot/linux
+          append initrd=boot/initrd rd.kiwi.live.pxe root=live:AOEINTERFACE=e0.1
+
+   * The boot parameter `rd.kiwi.live.pxe` tells the KIWI boot process to
+     setup the network and to load the required :mod:`aoe` kernel module.
+
+   * The boot parameter `root=live:AOEINTERFACE=e0.1` specifies the
+     interface name as it was exported by the :command:`vbladed` command
+     from the last step. Currently only AoE (Ata Over Ethernet)
+     is supported.
+
+4. Boot from the Network
+
+   Within the network which has access to the PXE server and the
+   exported live ISO image, any network client can now boot the
+   live system. A test based on QEMU is done as follows:
+
+   .. code:: bash
+
+      $ qemu -boot n

--- a/dracut/modules.d/90kiwi-live/kiwi-generator.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-generator.sh
@@ -16,6 +16,11 @@ case "${liveroot}" in
         root="$(echo "${root}" | sed 's,/,\\x2f,g')"
         root="live:/dev/disk/by-label/${root#CDLABEL=}"
         rootok=1 ;;
+    live:AOEINTERFACE=*|AOEINTERFACE=*) \
+        root="${root#live:}"
+        root="$(echo "${root}" | sed 's,/,\\x2f,g')"
+        root="live:aoe:/dev/etherd/${root#AOEINTERFACE=}"
+        rootok=1 ;;
 esac
 
 [ "${rootok}" != "1" ] && exit 0

--- a/dracut/modules.d/90kiwi-live/kiwi-live-genrules.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-live-genrules.sh
@@ -4,12 +4,18 @@ declare root=${root}
 
 case "${root}" in
     live:/dev/*)
-    {
-        printf 'KERNEL=="%s", RUN+="/sbin/initqueue --settled --onetime --unique /sbin/kiwi-live-root %s"\n' \
-            "${root#live:/dev/}" "${root#live:}"
-        printf 'SYMLINK=="%s", RUN+="/sbin/initqueue --settled --onetime --unique /sbin/kiwi-live-root %s"\n' \
-            "${root#live:/dev/}" "${root#live:}"
-    } >> /etc/udev/rules.d/99-live-kiwi.rules
-    wait_for_dev -n "${root#live:}"
-    ;;
+        {
+        printf 'KERNEL=="%s", RUN+="/sbin/initqueue %s %s %s"\n' \
+            "${root#live:/dev/}" "--settled --onetime --unique" \
+            "/sbin/kiwi-live-root" "${root#live:}"
+        printf 'SYMLINK=="%s", RUN+="/sbin/initqueue %s %s %s"\n' \
+            "${root#live:/dev/}" "--settled --onetime --unique" \
+            "/sbin/kiwi-live-root" "${root#live:}"
+        } >> /etc/udev/rules.d/99-live-kiwi.rules
+        wait_for_dev -n "${root#live:}"
+        ;;
+    live:aoe:/dev/*)
+        /sbin/initqueue \
+            --settled --onetime --unique /sbin/kiwi-live-root "${root}"
+        ;;
 esac

--- a/dracut/modules.d/90kiwi-live/kiwi-live-lib.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-live-lib.sh
@@ -41,7 +41,15 @@ function initGlobalDevices {
     if [ -z "$1" ]; then
         die "No root device for operation given"
     fi
-    isodev="$1"
+    if getargbool 0 rd.kiwi.live.pxe; then
+        if ! ifup lan0 &>/tmp/net.info;then
+            die "Network setup failed, see /tmp/net.info"
+        fi
+        modprobe aoe
+        isodev="${1#live:aoe:}"
+    else
+        isodev="$1"
+    fi
     isodiskdev=$(lookupIsoDiskDevice "${isodev}")
     isofs_type=$(blkid -s TYPE -o value "${isodev}")
     media_check_device=${isodev}

--- a/dracut/modules.d/90kiwi-live/kiwi-live-net-genrules.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-live-net-genrules.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
+
+if getargbool 0 rd.kiwi.live.pxe; then
+    {
+        echo -n "SUBSYSTEM==\"net\", ACTION==\"add\", "
+        echo -n "DRIVERS==\"?*\", ATTR{address}==\"?*\", "
+        echo -n "ATTR{dev_id}==\"0x0\", ATTR{type}==\"1\", "
+        echo -n "KERNEL==\"?*\", NAME=\"lan0\""
+        echo
+    } > /etc/udev/rules.d/90-net.rules
+fi

--- a/dracut/modules.d/90kiwi-live/module-setup.sh
+++ b/dracut/modules.d/90kiwi-live/module-setup.sh
@@ -10,13 +10,13 @@ check() {
 
 # called by dracut
 depends() {
-    echo rootfs-block dm
+    echo network rootfs-block dm
     return 0
 }
 
 # called by dracut
 installkernel() {
-    instmods squashfs loop iso9660 overlay
+    instmods squashfs loop aoe iso9660 overlay
 }
 
 # called by dracut
@@ -40,6 +40,7 @@ install() {
 
     inst_hook cmdline 30 "${moddir}/parse-kiwi-live.sh"
     inst_hook pre-udev 30 "${moddir}/kiwi-live-genrules.sh"
+    inst_hook pre-udev 60 "${moddir}/kiwi-live-net-genrules.sh"
     inst_hook pre-mount 30 "${moddir}/kiwi-live-checkmedia.sh"
     inst_script "${moddir}/kiwi-live-root.sh" "/sbin/kiwi-live-root"
     inst_script "${moddir}/kiwi-generator.sh" \

--- a/dracut/modules.d/90kiwi-live/parse-kiwi-live.sh
+++ b/dracut/modules.d/90kiwi-live/parse-kiwi-live.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # live images are specified with
 # root=live:CDLABEL=label
+# root=live:AOEINTERFACE=name
 
 [ -z "${root}" ] && root=$(getarg root=)
 
@@ -17,6 +18,11 @@ case "${liveroot}" in
         root="${root#live:}"
         root="$(echo "${root}" | sed 's,/,\\x2f,g')"
         root="live:/dev/disk/by-label/${root#CDLABEL=}"
+        rootok=1 ;;
+    live:AOEINTERFACE=*|AOEINTERFACE=*) \
+        root="${root#live:}"
+        root="$(echo "${root}" | sed 's,/,\\x2f,g')"
+        root="live:aoe:/dev/etherd/${root#AOEINTERFACE=}"
         rootok=1 ;;
 esac
 


### PR DESCRIPTION
The live ISO should support a network reference. We are using the Ata Over Ethernet protocol to achieve this. In combination with pxe boot of the kernel/initrd a live iso can boot from the network using the following parameter example:
    
        root=live:AOEINTERFACE:e0.1 rd.kiwi.live.pxe
    
Export of the live iso file via AOE can be achieved using the vblade toolkit which needs to be available on the exporting system and compatible with the live operating system.

This Fixes #796