### PR TITLE
Fix baseStripUnusedLibs config method

### DIFF
--- a/kiwi/config/functions.sh
+++ b/kiwi/config/functions.sh
@@ -552,18 +552,17 @@ function baseStripUnusedLibs {
     # /.../
     # add exceptions
     # ----
-    while [ ! -z "$1" ];do
+    for j in $1; do
         for i in \
-            /lib*/$1* /usr/lib*/$1* \
-            /lib/x86_64-linux-gnu/$1* /usr/lib/x86_64-linux-gnu/$1* \
-            /usr/X11R6/lib*/$1*
+            /lib*/$j* /usr/lib*/$j* \
+            /lib/x86_64-linux-gnu/$j* /usr/lib/x86_64-linux-gnu/$j* \
+            /usr/X11R6/lib*/$j*
         do
             if [ -e "$i" ];then
                 needlibs[$count]=$i
                 count=$((count + 1))
             fi
         done
-        shift
     done
     # /.../
     # find unused libs and remove it, dl loaded libs

--- a/kiwi/config/functions.sh
+++ b/kiwi/config/functions.sh
@@ -552,14 +552,14 @@ function baseStripUnusedLibs {
     # /.../
     # add exceptions
     # ----
-    for j in $1; do
-        for i in \
-            /lib*/$j* /usr/lib*/$j* \
-            /lib/x86_64-linux-gnu/$j* /usr/lib/x86_64-linux-gnu/$j* \
-            /usr/X11R6/lib*/$j*
+    for libname in $1; do
+        for libfile in \
+            /lib*/$libname* /usr/lib*/$libname* \
+            /lib/x86_64-linux-gnu/$libname* /usr/lib/x86_64-linux-gnu/$libname* \
+            /usr/X11R6/lib*/$libname*
         do
-            if [ -e "$i" ];then
-                needlibs[$count]=$i
+            if [ -e "$libfile" ];then
+                needlibs[$count]=$libfile
                 count=$((count + 1))
             fi
         done


### PR DESCRIPTION
This commit arguments handling of the baseStripUnusedLibs
that was not prepared to handle quoted variable containing a list.

Fixes #798

