### PR TITLE
Fixed deploy target

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -121,6 +121,7 @@ usedevelop = True
 deps = {[testenv:doc]deps}
 changedir=doc
 commands =
+    make man
     travis-sphinx build --nowarn --source ./source
     bash -c 'cp -a ./source/development/schema/images ./doc/build/development || true'
 


### PR DESCRIPTION
As part of the deploy process in travis a bundle to pypi is
uploaded. The bundle is missing the compiled manual pages because
the doc_travis stage did not create them.


