### PR TITLE
Move dracut modules into its own source archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,14 +25,15 @@ tools:
 	# called
 	${MAKE} -C tools all
 
+install_dracut:
+	install -d -m 755 ${buildroot}usr/lib/dracut/modules.d
+	cp -a dracut/modules.d/* ${buildroot}usr/lib/dracut/modules.d
+
 install:
 	# apart from all python source we also need to install
 	# the C tools, the manual pages and the completion
 	# see setup.py for details when this target is called
 	${MAKE} -C tools buildroot=${buildroot} install
-	# dracut modules
-	install -d -m 755 ${buildroot}usr/lib/dracut/modules.d
-	cp -a dracut/modules.d/* ${buildroot}usr/lib/dracut/modules.d
 	# manual pages
 	install -d -m 755 ${buildroot}usr/share/man/man8
 	for man in doc/build/man/*.8; do \

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -427,6 +427,9 @@ python2 setup.py install --prefix=%{_prefix} --root=%{buildroot} %{?is_deb:--ins
 python3 setup.py install --prefix=%{_prefix} --root=%{buildroot} %{?is_deb:--install-layout=deb}
 %endif
 
+# Install dracut modules
+make buildroot=%{buildroot} install_dracut
+
 %if %{_vendor} != "debbuild"
 # init alternatives setup
 mkdir -p %{buildroot}%{_sysconfdir}/alternatives


### PR DESCRIPTION
The dracut modules like kiwi provides it should not be part
of the default install target. If kiwi gets installed from
source or via pip all dracut code gets installed on that
system which is unwanted and in the worst case leads to
boot trouble next time this system rebuilds its initrd
via dracut. The dracut modules are built into sub-packages
and serves their purpose for the specific build type of
the image. They are not needed at all on the machine
building the images.


