### PR TITLE
Fixed filesystem builder use of exclude list

### DIFF
--- a/kiwi/builder/filesystem.py
+++ b/kiwi/builder/filesystem.py
@@ -164,11 +164,9 @@ class FileSystemBuilder(object):
         log.info(
             '--> Syncing data to filesystem on %s', loop_provider.get_device()
         )
-        exclude_list = [
-            'image', '.profile', '.kconfig',
-            Defaults.get_shared_cache_location()
-        ]
-        filesystem.sync_data(exclude_list)
+        filesystem.sync_data(
+            Defaults.get_exclude_list_for_root_data_sync()
+        )
 
     def _operate_on_file(self):
         default_provider = DeviceProvider()
@@ -177,5 +175,6 @@ class FileSystemBuilder(object):
             self.root_dir, self.filesystem_custom_parameters
         )
         filesystem.create_on_file(
-            self.filename, self.label
+            self.filename, self.label,
+            Defaults.get_exclude_list_for_root_data_sync()
         )

--- a/test/unit/builder_filesystem_test.py
+++ b/test/unit/builder_filesystem_test.py
@@ -101,7 +101,7 @@ class TestFileSystemBuilder(object):
         )
         self.filesystem.create_on_device.assert_called_once_with(None)
         self.filesystem.sync_data.assert_called_once_with(
-            ['image', '.profile', '.kconfig', 'var/cache/kiwi']
+            ['image', '.profile', '.kconfig', '.buildenv', 'var/cache/kiwi']
         )
         self.setup.export_package_verification.assert_called_once_with(
             'target_dir'
@@ -131,7 +131,8 @@ class TestFileSystemBuilder(object):
             'squashfs', provider, 'root_dir', {'mount_options': 'async'}
         )
         self.filesystem.create_on_file.assert_called_once_with(
-            'target_dir/myimage.x86_64-1.2.3.squashfs', None
+            'target_dir/myimage.x86_64-1.2.3.squashfs', None,
+            ['image', '.profile', '.kconfig', '.buildenv', 'var/cache/kiwi']
         )
         self.setup.export_package_verification.assert_called_once_with(
             'target_dir'


### PR DESCRIPTION
kiwi defines a global Defaults.get_exclude_list_for_root_data_sync
method but it was not used in the scope of the filesystem builder.
Thus this builder was missing the exclusion of the .buildenv
file. This references Issue #422 and Fixes #814


