### PR TITLE
Fixed overlay of intermediate config files

### DIFF
--- a/kiwi/system/root_bind.py
+++ b/kiwi/system/root_bind.py
@@ -217,7 +217,10 @@ class RootBind(object):
         """
         for config in self.config_files:
             config_rpm_new = self.root_dir + config + '.rpmnew'
-            if os.path.exists(config_rpm_new):
+            if (
+                os.path.exists(config_rpm_new) and
+                not os.path.exists(self.root_dir + config)
+            ):
                 shutil.move(config_rpm_new, self.root_dir + config)
 
     def _cleanup_mount_stack(self):

--- a/test/unit/system_root_bind_test.py
+++ b/test/unit/system_root_bind_test.py
@@ -121,8 +121,13 @@ class TestRootBind(object):
         self, mock_move, mock_exists, mock_islink, mock_remove_hierarchy,
         mock_command, mock_is_mounted
     ):
+        os_exists_return_values = [False, True]
+
+        def exists_side_effect(*args):
+            return os_exists_return_values.pop()
+
         mock_is_mounted.return_value = False
-        mock_exists.return_value = True
+        mock_exists.side_effect = exists_side_effect
         mock_islink.return_value = True
         self.bind_root.cleanup()
         self.mount_manager.umount_lazy.assert_called_once_with()


### PR DESCRIPTION
Some config files e.g etc/hosts needs to be temporary copied from the buildsystem host to the image root system. This is done by a custom copy with the .kiwi extension and a symlink to that file.

During the installation process the package manager either overwrites the file or creates a .rpmnew variant. In case a .rpmnew variant exists there is code in kiwi which restores that .rpmnew variant to become the real file.

However that _restore_intermediate_config_rpmnew_variants() method runs after overlay files has been applied to the system because it's part of the final cleanup step. In order to preserve an eventual overlay version of the file the .rpmnew variant gets only restored if the real file does not exist.

This Fixes #807

