### PR TITLE
Include PDF build of documentation to the package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,5 @@
 # Manifest describing source package contents
 
-graft doc/build/man
 graft tools
 graft dracut
 graft helper
@@ -31,7 +30,9 @@ include README.rst
 include LICENSE
 include tox.ini
 
-recursive-include doc *.py *.rst Makefile
+recursive-include doc Makefile
+recursive-include doc/build/man *
+recursive-include doc/source *.py *.rst
 recursive-include test *.gz *.iso *.kiwi *.pf2 *.py *.txt *.xml *.xz
 
 include .bumpversion.cfg

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,11 @@ install_dracut:
 	install -d -m 755 ${buildroot}usr/lib/dracut/modules.d
 	cp -a dracut/modules.d/* ${buildroot}usr/lib/dracut/modules.d
 
+install_pdf_docs:
+	install -d -m 755 ${buildroot}/usr/share/doc/packages/python-kiwi
+	install -m 644 doc/build/latex/kiwi.pdf \
+		${buildroot}/usr/share/doc/packages/python-kiwi/kiwi.pdf
+
 install:
 	# apart from all python source we also need to install
 	# the C tools, the manual pages and the completion
@@ -112,6 +117,13 @@ build: clean tox
 	mv setup.pye setup.py
 	# provide rpm source tarball
 	mv dist/kiwi-${version}.tar.gz dist/python-kiwi.tar.gz
+	# append PDF documentation to tarball
+	gzip -d dist/python-kiwi.tar.gz
+	mkdir -p kiwi-${version}/doc/build/latex
+	mv doc/build/latex/kiwi.pdf kiwi-${version}/doc/build/latex
+	tar -uf dist/python-kiwi.tar kiwi-${version}/doc/build/latex/kiwi.pdf
+	gzip dist/python-kiwi.tar
+	rm -rf kiwi-${version}
 	# provide rpm changelog from git changelog
 	git log | helper/changelog_generator |\
 		helper/changelog_descending > dist/python-kiwi.changes
@@ -126,5 +138,6 @@ pypi: clean tox
 
 clean: clean_git_attributes
 	rm -rf dist
-	rm -rf build
+	rm -rf doc/build
+	rm -rf doc/dist
 	${MAKE} -C tools clean

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -56,6 +56,14 @@ def setup(app):
     app.connect("autodoc-process-docstring", remove_module_docstring)
     app.add_stylesheet('css/custom.css')
 
+
+latex_documents = [
+    ('index', 'kiwi.tex', u'KIWI Documentation', u'Marcus Schäfer', 'manual')
+]
+latex_elements = {
+    'papersize': 'a4paper'
+}
+
 spelling_lang = 'en_US'
 spelling_show_suggestions = True
 spelling_ignore_acronyms = True

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -61,7 +61,23 @@ latex_documents = [
     ('index', 'kiwi.tex', u'KIWI Documentation', u'Marcus Schäfer', 'manual')
 ]
 latex_elements = {
-    'papersize': 'a4paper'
+    'papersize': 'a4paper',
+    'pointsize':'12pt',
+    'classoptions': ',openany',
+    'babel': '\\usepackage[english]{babel}',
+    'preamble': ur'''
+      \makeatletter
+      \fancypagestyle{normal}{
+        \fancyhf{}
+        \fancyfoot[LE,RO]{{\py@HeaderFamily\thepage}}
+        \fancyfoot[LO]{{\py@HeaderFamily\nouppercase{\rightmark}}}
+        \fancyfoot[RE]{{\py@HeaderFamily\nouppercase{\leftmark}}}
+        \fancyhead[LE,RO]{{\py@HeaderFamily \@title, \py@release}}
+        \renewcommand{\headrulewidth}{0.4pt}
+        \renewcommand{\footrulewidth}{0.4pt}
+      }
+      \makeatother
+    '''
 }
 
 spelling_lang = 'en_US'

--- a/doc/source/development.rst
+++ b/doc/source/development.rst
@@ -45,7 +45,7 @@ for details). For Python 2.7 use :command:`virtualenv`, which is provided
 via pip or as an extra package in your favourite Linux distribution.
 
 However, for setting up a Python virtual development environment the
-following additional latex, include, header files and compilers are required
+following additional LaTeX, include, header files and compilers are required
 in order to allow for compiling the C parts of the runtime required
 Python modules:
 
@@ -63,8 +63,10 @@ Python modules:
 
 .. code:: bash
 
-    $ zypper in python3-devel libxml2-devel libxslt-devel libffi48-devel glibc-devel gcc
-    $ zypper in texlive-fncychap texlive-wrapfig texlive-capt-of trang
+    $ zypper install \
+        python3-devel libxml2-devel libxslt-devel libffi48-devel \
+        glibc-devel gcc texlive-fncychap texlive-wrapfig \
+        texlive-capt-of trang
 
 Once the basic python module requirements are installed on your system,
 the next step is to create the virtual development environment.
@@ -89,7 +91,7 @@ development environment:
 
     $ pip install -r .virtualenv.dev-requirements.txt
 
-4. Install KIWI in "development mode":
+4. Install KIWI in Development Mode:
 
    .. code:: bash
 
@@ -313,7 +315,7 @@ order to build the documentation just call:
 
     tox -e doc
 
-Whenever a change in the documentation is pushed to the git, it will be
+Whenever a change in the documentation is pushed to GitHub, it will be
 automatically updated via :command:`travis-sphinx` and is available at:
 
 https://opensource.suse.com/kiwi

--- a/doc/source/development.rst
+++ b/doc/source/development.rst
@@ -85,7 +85,7 @@ development environment:
 
    .. code:: bash
 
-    $ pip3.4 install -r .virtualenv.dev-requirements.txt
+    $ pip install -r .virtualenv.dev-requirements.txt
 
 4. Install KIWI in "development mode":
 
@@ -151,11 +151,11 @@ If you want to see the target, use the option `-l` to print a list:
     $ tox -l
 
 To only run a special target, use the `-e` option. The following
-example runs the test cases for the 3.4 interpreter only:
+example runs the test cases for the 3.6 interpreter only:
 
 .. code:: bash
 
-    $ tox -e 3.4
+    $ tox -e 3.6
 
 Create a branch for each feature or bugfix
 ------------------------------------------

--- a/doc/source/development.rst
+++ b/doc/source/development.rst
@@ -45,7 +45,7 @@ for details). For Python 2.7 use :command:`virtualenv`, which is provided
 via pip or as an extra package in your favourite Linux distribution.
 
 However, for setting up a Python virtual development environment the
-following additional include, header files and compilers are required
+following additional latex, include, header files and compilers are required
 in order to allow for compiling the C parts of the runtime required
 Python modules:
 
@@ -53,6 +53,7 @@ Python modules:
 * Foreign function interface library (libffi48)
 * Python header files (for :mod:`xattr`)
 * GCC compiler and glibc-devel header files
+* LaTeX packages for building PDF documentation
 
 .. note::
 
@@ -63,6 +64,7 @@ Python modules:
 .. code:: bash
 
     $ zypper in python3-devel libxml2-devel libxslt-devel libffi48-devel glibc-devel gcc
+    $ zypper in texlive-fncychap texlive-wrapfig texlive-capt-of trang
 
 Once the basic python module requirements are installed on your system,
 the next step is to create the virtual development environment.
@@ -314,4 +316,4 @@ order to build the documentation just call:
 Whenever a change in the documentation is pushed to the git, it will be
 automatically updated via :command:`travis-sphinx` and is available at:
 
-http://suse.github.io/kiwi
+https://opensource.suse.com/kiwi

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -430,6 +430,9 @@ python3 setup.py install --prefix=%{_prefix} --root=%{buildroot} %{?is_deb:--ins
 # Install dracut modules
 make buildroot=%{buildroot}/ install_dracut
 
+# Install documentation in PDF format
+make buildroot=%{buildroot}/ install_pdf_docs
+
 %if %{_vendor} != "debbuild"
 # init alternatives setup
 mkdir -p %{buildroot}%{_sysconfdir}/alternatives
@@ -549,6 +552,7 @@ fi
 %files -n kiwi-man-pages
 %defattr(-, root, root)
 %dir %{_defaultdocdir}/python-kiwi
+%{_defaultdocdir}/python-kiwi/kiwi.pdf
 %{_defaultdocdir}/python-kiwi/LICENSE
 %{_defaultdocdir}/python-kiwi/README
 %doc %{_mandir}/man8/*

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ envlist =
     unit_py3_6,
     unit_py3_4,
     unit_py2_7,
+    pdfdoc,
     doc
 
 
@@ -30,12 +31,12 @@ whitelist_externals =
     /usr/bin/shellcheck
     /bin/bash
 basepython =
-    {check,doc,doc_travis,doc_travis_deploy}: python3
+    {check,pdfdoc,doc,doc_travis,doc_travis_deploy}: python3
     unit_py3_6: python3.6
     unit_py3_4: python3.4
     unit_py2_7: python2.7
 envdir =
-    {check,doc,doc_travis,doc_travis_deploy}: {toxworkdir}/3
+    {check,pdfdoc,doc,doc_travis,doc_travis_deploy}: {toxworkdir}/3
     unit_py3_6: {toxworkdir}/3.6
     unit_py3_4: {toxworkdir}/3.4
     unit_py2_7: {toxworkdir}/2.7
@@ -100,6 +101,16 @@ commands =
         --cov-report=term-missing --cov-fail-under=100 --cov-config .coveragerc
 
 
+# Documentation build run, PDF target
+[testenv:pdfdoc]
+skip_install = True
+usedevelop = True
+deps = {[testenv]deps}
+changedir=doc
+commands =
+    {[testenv:doc.latexpdf]commands}
+
+
 # Documentation build run, collection of doc.X targets
 [testenv:doc]
 skip_install = True
@@ -107,7 +118,6 @@ usedevelop = True
 deps = {[testenv]deps}
 changedir=doc
 commands =
-    make clean
     {[testenv:doc.linkcheck]commands}
     {[testenv:doc.html]commands}
     {[testenv:doc.man]commands}
@@ -143,6 +153,15 @@ deps = {[testenv:doc]deps}
 changedir=doc
 commands =
     make html
+
+
+# Documentation build PDF result
+[testenv:doc.latexpdf]
+skip_install = True
+deps = {[testenv:doc]deps}
+changedir=doc
+commands =
+    make latexpdf
 
 
 # Documentation build man pages


### PR DESCRIPTION
Bundle a PDF version of the online documentation with the rpm package
build. Due to the complexity of getting a latex build environment into
the travis CI which does not take forever to install, the bundling of
a built PDF into the pypi archive has been skipped. Users installing
from pypi would need to install a latex env on their machine and
run make latexpdf from the installed bundle.

This Fixes #819