### PR TITLE
Fixes LVM based image creation in OBS

### DIFF
--- a/kiwi/volume_manager/lvm.py
+++ b/kiwi/volume_manager/lvm.py
@@ -128,8 +128,20 @@ class VolumeManagerLVM(VolumeManagerBase):
             )
             Command.run(
                 [
-                    'lvcreate', '-L', format(volume_mbsize), '-n',
+                    # if working in a chroot'd environment there will be
+                    # no udev running to automatically create devices nodes
+                    # under /dev, so disable zeroing of newly created LV
+                    # headers to avoid failure due to missing device.
+                    'lvcreate', '-Zn', '-L', format(volume_mbsize), '-n',
                     volume.name, self.volume_group
+                ]
+            )
+            Command.run(
+                [
+                    # if working in a chroot'd environment there will be
+                    # no udev running to automatically create devices so
+                    # use vgscan --mknodes instead.
+                    'vgscan', '--mknodes'
                 ]
             )
             self.apply_attributes_on_volume(
@@ -148,8 +160,20 @@ class VolumeManagerLVM(VolumeManagerBase):
             log.info('--> fullsize volume %s', full_size_volume.name)
             Command.run(
                 [
-                    'lvcreate', '-l', '+100%FREE', '-n', full_size_volume.name,
-                    self.volume_group
+                    # if working in a chroot'd environment there will be
+                    # no udev running to automatically create devices nodes
+                    # under /dev, so disable zeroing of newly created LV
+                    # headers to avoid failure due to missing device.
+                    'lvcreate', '-Zn', '-l', '+100%FREE', '-n',
+                    full_size_volume.name, self.volume_group
+                ]
+            )
+            Command.run(
+                [
+                    # if working in a chroot'd environment there will be
+                    # no udev running to automatically create devices so
+                    # use vgscan --mknodes instead.
+                    'vgscan', '--mknodes'
                 ]
             )
             self._add_to_volume_map(full_size_volume.name)

--- a/kiwi/volume_manager/lvm.py
+++ b/kiwi/volume_manager/lvm.py
@@ -104,6 +104,38 @@ class VolumeManagerLVM(VolumeManagerBase):
         Command.run(['vgcreate', volume_group_name, self.device])
         self.volume_group = volume_group_name
 
+    @staticmethod
+    def _create_volume_no_zero(lvcreate_args):
+        """
+        Create an LV using specified arguments to lvcreate
+
+        The LV will be created with the '-Zn' option prepended
+        to the arguments, which disables the zeroing of the new
+        device's header; this action will fail when running in
+        an environment where udev is not enabled, such as in a
+        chroot'd Open Build Service build. Since the backing
+        device for a kiwi LVM device is a zero filled qemu-img
+        created file, there should be no negative side effects
+        to skipping the zeroing of this header block.
+
+        Then we run 'vgscan --mknodes' to ensure that any /dev
+        nodes have been created for the new LV.
+
+        :param list lvcreate_args: list of lvcreate arguments.
+        """
+        log.debug(
+            '--> running "lvcreate -Zn %s"', " ".join(lvcreate_args)
+        )
+        Command.run(
+            ['lvcreate', '-Zn'] + lvcreate_args
+        )
+        log.debug(
+            '--> running "vgscan --mknodes" to create missing nodes'
+        )
+        Command.run(
+            ['vgscan', '--mknodes']
+        )
+
     def create_volumes(self, filesystem_name):
         """
         Create configured lvm volumes and filesystems
@@ -126,22 +158,10 @@ class VolumeManagerLVM(VolumeManagerBase):
             log.info(
                 '--> volume %s with %s MB', volume.name, volume_mbsize
             )
-            Command.run(
+            self._create_volume_no_zero(
                 [
-                    # if working in a chroot'd environment there will be
-                    # no udev running to automatically create devices nodes
-                    # under /dev, so disable zeroing of newly created LV
-                    # headers to avoid failure due to missing device.
-                    'lvcreate', '-Zn', '-L', format(volume_mbsize), '-n',
+                    '-L', format(volume_mbsize), '-n',
                     volume.name, self.volume_group
-                ]
-            )
-            Command.run(
-                [
-                    # if working in a chroot'd environment there will be
-                    # no udev running to automatically create devices so
-                    # use vgscan --mknodes instead.
-                    'vgscan', '--mknodes'
                 ]
             )
             self.apply_attributes_on_volume(
@@ -158,22 +178,10 @@ class VolumeManagerLVM(VolumeManagerBase):
         if canonical_volume_list.full_size_volume:
             full_size_volume = canonical_volume_list.full_size_volume
             log.info('--> fullsize volume %s', full_size_volume.name)
-            Command.run(
+            self._create_volume_no_zero(
                 [
-                    # if working in a chroot'd environment there will be
-                    # no udev running to automatically create devices nodes
-                    # under /dev, so disable zeroing of newly created LV
-                    # headers to avoid failure due to missing device.
-                    'lvcreate', '-Zn', '-l', '+100%FREE', '-n',
+                    '-l', '+100%FREE', '-n',
                     full_size_volume.name, self.volume_group
-                ]
-            )
-            Command.run(
-                [
-                    # if working in a chroot'd environment there will be
-                    # no udev running to automatically create devices so
-                    # use vgscan --mknodes instead.
-                    'vgscan', '--mknodes'
                 ]
             )
             self._add_to_volume_map(full_size_volume.name)

--- a/test/unit/volume_manager_lvm_test.py
+++ b/test/unit/volume_manager_lvm_test.py
@@ -186,20 +186,24 @@ class TestVolumeManagerLVM(object):
             call(['mkdir', '-p', 'root_dir/data']),
             call(['mkdir', '-p', 'root_dir/home']),
             call([
-                'lvcreate', '-L', format(root_size), '-n', 'LVRoot',
+                'lvcreate', '-Zn', '-L', format(root_size), '-n', 'LVRoot',
                 'volume_group'
             ]),
+            call(['vgscan', '--mknodes']),
             call([
-                'lvcreate', '-L', format(myvol_size), '-n', 'myvol',
+                'lvcreate', '-Zn', '-L', format(myvol_size), '-n', 'myvol',
                 'volume_group'
             ]),
+            call(['vgscan', '--mknodes']),
             call([
-                'lvcreate', '-L', format(etc_size), '-n', 'LVetc',
+                'lvcreate', '-Zn', '-L', format(etc_size), '-n', 'LVetc',
                 'volume_group'
             ]),
+            call(['vgscan', '--mknodes']),
             call([
-                'lvcreate', '-l', '+100%FREE', '-n', 'LVhome', 'volume_group'
-            ])
+                'lvcreate', '-Zn', '-l', '+100%FREE', '-n', 'LVhome', 'volume_group'
+            ]),
+            call(['vgscan', '--mknodes'])
         ]
         assert mock_fs.call_args_list == [
             call(


### PR DESCRIPTION
While attempting to create LVM based images under the Open Build
Service I recently ran into some issues related to the fact that
there is no udev running in the chroot environment used to build
kiwi based images.

Two workarounds have been implemented in this patch:

(1) When calling lvcreate, include the `-Zn` option to disable
    the automatic zeroing of the header of the newly created
    LV device; doing so requires that the LV device's /dev
    entry exists immediately after it has been created, but
    in a chroot'd environment udev isn't going to be running
    to automatically populate /dev/<vg_name>/<lv_name> or
    /dev/mapper/<vg_name>-<lv_name>.
    This should be safe to do since the LV is being created
    within a loopback device based partition, which is backed
    by a zero filled file, created by qemu-img.

(2) After creating an LV we need to run `vgscan --mknodes`
    to create the required device nodes under /dev, which
    won't be automatically created since udev isn't running
    in the chroot'd environment.

Unit tests updated to account for additional `-Zn` arguments that
are being passed to `lvcreate` and for additional call that is
being made to `vgscan --mknodes`.

Fixes #824 .