### PR TITLE
Fixed URI handling with token query option

### DIFF
--- a/kiwi/system/uri.py
+++ b/kiwi/system/uri.py
@@ -120,7 +120,14 @@ class Uri(object):
         elif uri.scheme == 'iso':
             return self._iso_mount_path(uri.path)
         elif uri.scheme.startswith('http') or uri.scheme == 'ftp':
-            return ''.join([uri.scheme, '://', uri.netloc, uri.path])
+            if self._has_credentials_query() or not uri.query:
+                return ''.join(
+                    [uri.scheme, '://', uri.netloc, uri.path]
+                )
+            else:
+                return ''.join(
+                    [uri.scheme, '://', uri.netloc, uri.path, '?', uri.query]
+                )
         else:
             raise KiwiUriStyleUnknown(
                 'URI schema %s not supported' % self.uri
@@ -134,13 +141,13 @@ class Uri(object):
 
         :rtype: str
         """
-        uri = urlparse(self.uri)
+        uri = self._has_credentials_query()
         # initialize query with default credentials file name.
         # The information will be overwritten if the uri contains
         # a parameter query with a credentials parameter
         query = {'credentials': 'kiwiRepoCredentials'}
 
-        if uri.query:
+        if uri:
             query = dict(params.split('=') for params in uri.query.split('&'))
 
         return query['credentials']
@@ -216,6 +223,11 @@ class Uri(object):
         """
         uri = urlparse(self.uri)
         return uri.fragment
+
+    def _has_credentials_query(self):
+        uri = urlparse(self.uri)
+        if uri.query and uri.query.startswith('credentials='):
+            return uri
 
     def _iso_mount_path(self, path):
         # The prefix name 'kiwi_iso_mount' has a meaning here because the

--- a/kiwi/system/uri.py
+++ b/kiwi/system/uri.py
@@ -120,7 +120,7 @@ class Uri(object):
         elif uri.scheme == 'iso':
             return self._iso_mount_path(uri.path)
         elif uri.scheme.startswith('http') or uri.scheme == 'ftp':
-            if self._has_credentials_query() or not uri.query:
+            if self._get_credentials_uri() or not uri.query:
                 return ''.join(
                     [uri.scheme, '://', uri.netloc, uri.path]
                 )
@@ -141,7 +141,7 @@ class Uri(object):
 
         :rtype: str
         """
-        uri = self._has_credentials_query()
+        uri = self._get_credentials_uri()
         # initialize query with default credentials file name.
         # The information will be overwritten if the uri contains
         # a parameter query with a credentials parameter
@@ -224,7 +224,7 @@ class Uri(object):
         uri = urlparse(self.uri)
         return uri.fragment
 
-    def _has_credentials_query(self):
+    def _get_credentials_uri(self):
         uri = urlparse(self.uri)
         if uri.query and uri.query.startswith('credentials='):
             return uri

--- a/test/unit/system_uri_test.py
+++ b/test/unit/system_uri_test.py
@@ -120,6 +120,13 @@ class TestUri(object):
         )
         assert uri.credentials_file_name() == 'kiwiRepoCredentials'
 
+    def test_translate_http_path_with_token(self):
+        uri = Uri(
+            'http://foo.bar/baz?asdf',
+            'rpm-md'
+        )
+        assert uri.translate() == 'http://foo.bar/baz?asdf'
+
     def test_translate_http_path_with_credentials(self):
         uri = Uri(
             'http://example.com/foo?credentials=kiwiRepoCredentials',


### PR DESCRIPTION
So far only the query format ?credentials=... was supported.
In case of ?random_token_data the returned uri was truncated
and also the format check on the query caused a python trace.
This Fixes #830 and Fixes #828

