### PR TITLE
Include livenet module with dmsquash-live support

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -915,7 +915,7 @@ class Defaults(object):
         """
         live_modules = {
             'overlay': 'kiwi-live',
-            'dmsquash': 'dmsquash-live'
+            'dmsquash': 'dmsquash-live livenet'
         }
         if flag_name in live_modules:
             return live_modules[flag_name]

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -78,7 +78,7 @@ class TestDefaults(object):
         assert Defaults.get_live_dracut_module_from_flag('overlay') == \
             'kiwi-live'
         assert Defaults.get_live_dracut_module_from_flag('dmsquash') == \
-            'dmsquash-live'
+            'dmsquash-live livenet'
 
     @patch('platform.machine')
     def test_get_iso_boot_path(self, mock_machine):


### PR DESCRIPTION
The upstream dracut dmsquash-live module supports network
mode with the livenet module. But that module must be
explicitly included and is not fetched automatically.
This Fixes #827

