### PR TITLE
Unicode decode errors

### DIFF
--- a/kiwi/command.py
+++ b/kiwi/command.py
@@ -26,6 +26,8 @@ from collections import namedtuple
 from builtins import bytes
 
 # project
+from .utils.codec import Codec
+
 from .exceptions import (
     KiwiCommandError,
     KiwiCommandNotFound
@@ -108,17 +110,18 @@ class Command(object):
             output = bytes(b'(no output on stdout)')
         if process.returncode != 0 and raise_on_error:
             log.debug(
-                'EXEC: Failed with stderr: %s, stdout: %s',
-                error.decode(), output.decode()
+                'EXEC: Failed with stderr: {0}, stdout: {1}'.format(
+                    Codec.decode(error), Codec.decode(output)
+                )
             )
             raise KiwiCommandError(
-                '%s: stderr: %s, stdout: %s' % (
-                    command[0], error.decode(), output.decode()
+                '{0}: stderr: {1}, stdout: {2}'.format(
+                    command[0], Codec.decode(error), Codec.decode(output)
                 )
             )
         return command_type(
-            output=output.decode(),
-            error=error.decode(),
+            output=Codec.decode(output),
+            error=Codec.decode(error),
             returncode=process.returncode
         )
 

--- a/kiwi/command_process.py
+++ b/kiwi/command_process.py
@@ -25,6 +25,7 @@ from collections import namedtuple
 
 # project
 from .logger import log
+from .utils.codec import Codec
 
 from .exceptions import (
     KiwiCommandError
@@ -173,7 +174,7 @@ class CommandIterator(six.Iterator):
             if not byte_read:
                 self.output_eof_reached = True
             elif byte_read == bytes(b'\n'):
-                line_read = self.command_output_line.decode()
+                line_read = Codec.decode(self.command_output_line)
                 self.command_output_line = bytes(b'')
             else:
                 self.command_output_line += byte_read
@@ -195,7 +196,7 @@ class CommandIterator(six.Iterator):
 
         :rtype: str
         """
-        return self.command_error_output.decode()
+        return Codec.decode(self.command_error_output)
 
     def get_error_code(self):
         """

--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -779,3 +779,9 @@ class KiwiCommandCapabilitiesError(KiwiError):
     Exception is raised when some the CommandCapabilities methods fails,
     usually meaning there is some issue trying to parse some command output.
     """
+
+
+class KiwiDecodingError(KiwiError):
+    """
+    Exception is raised on decoding literals failure
+    """

--- a/kiwi/iso_tools/iso.py
+++ b/kiwi/iso_tools/iso.py
@@ -30,6 +30,7 @@ from kiwi.logger import log
 from kiwi.defaults import Defaults
 from kiwi.path import Path
 from kiwi.command import Command
+from kiwi.utils.codec import Codec
 from kiwi.exceptions import (
     KiwiIsoLoaderError,
     KiwiIsoMetaDataError,
@@ -405,12 +406,14 @@ class Iso(object):
 
     @staticmethod
     def _validate_iso_metadata(iso_header):
-        if 'CD001' not in iso_header.volume_id.decode():
+        if 'CD001' not in Codec.decode(iso_header.volume_id):
             raise KiwiIsoMetaDataError(
                 '%s: this is not an iso9660 filesystem' %
                 iso_header.isofile
             )
-        if 'EL TORITO SPECIFICATION' not in iso_header.eltorito_id.decode():
+        if 'EL TORITO SPECIFICATION' not in Codec.decode(
+            iso_header.eltorito_id
+        ):
             raise KiwiIsoMetaDataError(
                 '%s: this iso is not bootable' %
                 iso_header.isofile

--- a/kiwi/mount_manager.py
+++ b/kiwi/mount_manager.py
@@ -120,7 +120,7 @@ class MountManager(object):
         :rtype: bool
         """
         mountpoint_call = Command.run(
-            command=['mountpoint', self.mountpoint],
+            command=['mountpoint', '-q', self.mountpoint],
             raise_on_error=False
         )
         if mountpoint_call.returncode == 0:

--- a/kiwi/utils/codec.py
+++ b/kiwi/utils/codec.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2015 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+
+from kiwi.logger import log
+from kiwi.exceptions import KiwiDecodingError
+
+
+class Codec(object):
+    """
+    **Performs conversions of literal byte sequences to strings**
+    """
+    @classmethod
+    def decode(self, literal):
+        """
+        Decodes the given literal with the default charset. In case of
+        failure attemps to decode using utf-8 charset.
+
+        :param bytes literal: literal to decode
+
+        :return: decoded string
+        :rtype: str
+        """
+        try:
+            return Codec._wrapped_decode(literal)
+        except Exception:
+            log.warning("Failed decoding literal. Forcing UTF-8 decoding")
+            try:
+                return Codec._wrapped_decode(literal, 'utf_8')
+            except Exception:
+                raise KiwiDecodingError(
+                    'Locale setup is not utf-8 compatible'
+                )
+
+    @classmethod
+    def _wrapped_decode(self, literal, charset=None):
+        # This decode wrapper is only implemented to facilitate unit testing
+        if charset:
+            return literal.decode(charset)
+        else:
+            return literal.decode()

--- a/test/unit/mount_manager_test.py
+++ b/test/unit/mount_manager_test.py
@@ -76,6 +76,10 @@ class TestMountManager(object):
         command.returncode = 0
         mock_command.return_value = command
         assert self.mount_manager.is_mounted() is True
+        mock_command.assert_called_once_with(
+            command=['mountpoint', '-q', '/some/mountpoint'],
+            raise_on_error=False
+        )
 
     @patch('kiwi.mount_manager.Command.run')
     def test_is_mounted_false(self, mock_command):
@@ -83,6 +87,10 @@ class TestMountManager(object):
         command.returncode = 1
         mock_command.return_value = command
         assert self.mount_manager.is_mounted() is False
+        mock_command.assert_called_once_with(
+            command=['mountpoint', '-q', '/some/mountpoint'],
+            raise_on_error=False
+        )
 
     @patch('kiwi.mount_manager.Path.wipe')
     @patch('kiwi.mount_manager.MountManager.is_mounted')

--- a/test/unit/package_manager_apt_test.py
+++ b/test/unit/package_manager_apt_test.py
@@ -102,7 +102,7 @@ class TestPackageManagerApt(object):
             options=['-a', '-H', '-X', '-A']
         )
         assert mock_run.call_args_list == [
-            call(command=['mountpoint', 'root-dir/dev'], raise_on_error=False),
+            call(command=['mountpoint', '-q', 'root-dir/dev'], raise_on_error=False),
             call([
                 'debootstrap', '--no-check-gpg', '--variant=minbase',
                 'xenial', 'root-dir.debootstrap', 'xenial_path'],

--- a/test/unit/utils_codec_test.py
+++ b/test/unit/utils_codec_test.py
@@ -1,0 +1,64 @@
+from mock import patch
+import sys
+import pytest
+
+from .test_helper import raises
+
+from kiwi.utils.codec import Codec
+from kiwi.exceptions import KiwiDecodingError
+
+
+class TestCodec(object):
+
+    def setup(self):
+        self.literal = bytes(b'\xc3\xbc')
+
+    @patch('kiwi.utils.codec.Codec._wrapped_decode')
+    @patch('kiwi.logger.log.warning')
+    def test_decode_ascii_failure(self, mock_warn, mock_decode):
+        msg = 'utf-8 compatible string'
+
+        def mocked_decode(literal, charset):
+            if charset:
+                return msg
+            else:
+                raise KiwiDecodingError('ascii decoding failure')
+
+        mock_decode.side_effect = mocked_decode
+        assert msg == Codec.decode(self.literal)
+        assert mock_warn.called
+
+    @patch('kiwi.utils.codec.Codec._wrapped_decode')
+    def test_decode(self, mock_decode):
+        msg = 'utf-8 compatible string'
+        mock_decode.return_value = msg
+        assert msg == Codec.decode(self.literal)
+
+    @raises(KiwiDecodingError)
+    @patch('kiwi.utils.codec.Codec._wrapped_decode')
+    @patch('kiwi.logger.log.warning')
+    def test_decode_utf8_failure(self, mock_warn, mock_decode):
+
+        def mocked_decode(literal, charset):
+            if charset:
+                raise KiwiDecodingError('utf-8 decoding failure')
+            else:
+                raise KiwiDecodingError('ascii decoding failure')
+
+        mock_decode.side_effect = mocked_decode
+        Codec.decode(self.literal)
+        assert mock_warn.called
+
+    @pytest.mark.skipif(sys.version_info > (3, 0), reason="requires Python2")
+    @patch('kiwi.logger.log.warning')
+    def test_real_decode_non_ascii(self, mock_warn):
+        reload(sys)  # noqa:F821
+        sys.setdefaultencoding('ASCII')
+        assert unichr(252) == Codec.decode(self.literal)  # noqa:F821
+        assert mock_warn.called
+
+    @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
+    def test_wrapped_decode(self):
+        assert self.literal.decode() == Codec._wrapped_decode(
+            self.literal, 'utf-8'
+        )


### PR DESCRIPTION
In case of a literal decoding failure it tries to decode
the result in utf-8. This is handy in python2 environments where
python and the host might be using different charset configurations.
In python3 this issue seams to be solved.

Fixes #829 and bsc#1110871