### PR TITLE
Added gfxboot to required packages in spec

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -106,6 +106,7 @@ Requires:       grub2-x86_64-efi
 Requires:       qemu-tools
 Requires:       squashfs
 Requires:       gptfdisk
+Requires:       gfxboot
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 Requires:         chkconfig
@@ -114,6 +115,7 @@ Requires(postun): chkconfig
 Requires:       qemu-img
 Requires:       squashfs-tools
 Requires:       gdisk
+Requires:       gfxboot
 Requires:       yum
 Provides:       kiwi-packagemanager:yum
 %if 0%{?fedora} || 0%{?rhel} >= 8
@@ -130,6 +132,7 @@ Requires:       debootstrap
 Requires:       qemu-utils
 Requires:       squashfs-tools
 Requires:       gdisk
+Requires:       gfxboot
 %endif
 Requires:       dosfstools
 Requires:       e2fsprogs
@@ -183,6 +186,7 @@ Requires:       grub2-x86_64-efi
 Requires:       qemu-tools
 Requires:       squashfs
 Requires:       gptfdisk
+Requires:       gfxboot
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 Requires:         chkconfig
@@ -191,6 +195,7 @@ Requires(postun): chkconfig
 Requires:       qemu-img
 Requires:       squashfs-tools
 Requires:       gdisk
+Requires:       gfxboot
 %endif
 %if 0%{?rhel} && 0%{?rhel} < 8
 Requires:       yum

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -115,7 +115,6 @@ Requires(postun): chkconfig
 Requires:       qemu-img
 Requires:       squashfs-tools
 Requires:       gdisk
-Requires:       gfxboot
 Requires:       yum
 Provides:       kiwi-packagemanager:yum
 %if 0%{?fedora} || 0%{?rhel} >= 8
@@ -195,7 +194,6 @@ Requires(postun): chkconfig
 Requires:       qemu-img
 Requires:       squashfs-tools
 Requires:       gdisk
-Requires:       gfxboot
 %endif
 %if 0%{?rhel} && 0%{?rhel} < 8
 Requires:       yum


### PR DESCRIPTION
kiwi calls gfxboot as tool when building live iso images.
Thus this tool provided by the gfxboot package should be
a requirement for kiwi

