### PR TITLE
Fixup zypper calls in documentation

### DIFF
--- a/doc/source/building/build_docker_container.rst
+++ b/doc/source/building/build_docker_container.rst
@@ -60,11 +60,11 @@ openSUSE Leap:
 1. Make sure you have checked out the example image descriptions,
    see :ref:`example-descriptions`.
 
-#. Include the ``Virtualization`` repository to your list:
+#. Include the ``Virtualization/containers`` repository to your list:
 
    .. code:: bash
 
-      $ zypper ar -f http://download.opensuse.org/repositories/Virtualization:/containers/<DIST>
+      $ zypper addrepo http://download.opensuse.org/repositories/Virtualization:/containers/<DIST> container-tools
 
    where the placeholder `<DIST>` is the preferred distribution. 
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -24,12 +24,12 @@ To install KIWI, do:
    copy the URL. In Firefox it is the menu :menuselection:`Copy link address`.
 
 3. Insert the copied URL from the last step in your shell. The ``DIST``
-   placeholder contains the respective distribution. Use :command:`zypper ar`
-   to add it to your list of repositories:
+   placeholder contains the respective distribution.
+   Use :command:`zypper addrepo` to add it to your list of repositories:
 
    .. code-block:: shell-session
 
-       $ sudo zypper ar -f http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/<DIST>
+       $ sudo zypper addrepo http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/<DIST> appliance-builder
 
 4. Install KIWI:
 


### PR DESCRIPTION
The way the documentation describes the zypper call to add
a repository was wrong in several places.

