### PR TITLE
Fixed package specs for dracut modules on debian

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -273,7 +273,7 @@ BuildRequires:  dracut
 %endif
 Requires:       bc
 Requires:       cryptsetup
-%if 0%{?fedora} || 0%{?rhel} || 0%{?debian} || 0%{?ubuntu}
+%if 0%{?fedora} || 0%{?rhel}
 Requires:       btrfs-progs
 Requires:       gdisk
 %else
@@ -294,6 +294,9 @@ Requires:       curl
 %if 0%{?debian} || 0%{?ubuntu}
 Requires:       xz-utils
 Requires:       dmsetup
+Requires:       btrfs-tools
+Requires:       gdisk
+Requires:       dracut-network
 %else
 Requires:       xz
 Requires:       device-mapper
@@ -367,6 +370,7 @@ Requires:       e2fsprogs
 Requires:       util-linux
 %if 0%{?debian} || 0%{?ubuntu}
 Requires:       dmsetup
+Requires:       dracut-network
 %else
 Requires:       device-mapper
 %endif

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -276,6 +276,7 @@ Requires:       cryptsetup
 %if 0%{?fedora} || 0%{?rhel}
 Requires:       btrfs-progs
 Requires:       gdisk
+Requires:       dracut-network
 %else
 Requires:       btrfsprogs
 Requires:       gptfdisk
@@ -371,7 +372,12 @@ Requires:       util-linux
 %if 0%{?debian} || 0%{?ubuntu}
 Requires:       dmsetup
 Requires:       dracut-network
-%else
+%endif
+%if 0%{?fedora} || 0%{?rhel}
+Requires:       device-mapper
+Requires:       dracut-network
+%endif
+%if 0%{?suse_version}
 Requires:       device-mapper
 %endif
 Requires:       dracut


### PR DESCRIPTION
btrfs tools are provided by btrfs-tools package and not by
btrfs-progs. In addition dracut-network is a separate package
on debian/ubuntu based distributions. This Fixes #837

