### PR TITLE
Fix use of uri type in debootstrap call

### DIFF
--- a/kiwi/repository/apt.py
+++ b/kiwi/repository/apt.py
@@ -146,6 +146,7 @@ class RepositoryApt(RepositoryBase):
         if os.path.exists(uri):
             # apt-get requires local paths to take the file: type
             uri = 'file:/' + uri
+            uri = uri.replace('file://', 'file:/')
         if not components:
             components = 'main'
         with open(list_file, 'w') as repo:

--- a/test/unit/repository_apt_test.py
+++ b/test/unit/repository_apt_test.py
@@ -97,7 +97,7 @@ class TestRepositoryApt(object):
         ]
         print(self.file_mock.write.call_args_list)
         assert self.file_mock.write.call_args_list == [
-            call('deb file://srv/my-repo xenial a b\n'),
+            call('deb file:/srv/my-repo xenial a b\n'),
             call('Package: *\n'),
             call('Pin: origin ""\n'),
             call('Pin-Priority: 42\n')
@@ -160,7 +160,7 @@ class TestRepositoryApt(object):
         mock_open.return_value = self.context_manager_mock
         mock_exists.return_value = True
         self.repo.add_repo(
-            'foo', 'kiwi_iso_mount/uri', 'deb', None, 'xenial'
+            'foo', '/kiwi_iso_mount/uri', 'deb', None, 'xenial'
         )
         self.file_mock.write.assert_called_once_with(
             'deb file:/kiwi_iso_mount/uri xenial main\n'


### PR DESCRIPTION
Referencing a file in a debootstrap call is done using
the file:/ source type. However when using file:// debootstrap
does something different and failed to find the file. The
additional / had a bad impact to the call.


