### PR TITLE
Added machine id setup in dracut preparation

### DIFF
--- a/kiwi/boot/image/dracut.py
+++ b/kiwi/boot/image/dracut.py
@@ -55,7 +55,10 @@ class BootImageDracut(BootImageBase):
 
     def prepare(self):
         """
-        Prepare kiwi profile environment to be included in dracut initrd
+        Prepare dracut caller environment
+
+        * Create kiwi .profile environment to be included in dracut initrd
+        * Setup machine_id(s) to be generic and rebuild by dracut on boot
         """
         profile = Profile(self.xml_state)
         defaults = Defaults()
@@ -64,6 +67,7 @@ class BootImageDracut(BootImageBase):
             self.xml_state, self.boot_root_directory
         )
         setup.import_shell_environment(profile)
+        setup.setup_machine_id()
         self.dracut_options.append('--install')
         self.dracut_options.append('/.profile')
 

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -216,6 +216,29 @@ class SystemSetup(object):
             archive = ArchiveTar(overlay_archive)
             archive.extract(self.root_dir)
 
+    def setup_machine_id(self):
+        """
+        Setup systemd machine id
+
+        Empty out the machine id which was provided by the package
+        installation process. This will instruct the dracut initrd
+        code to create a new machine id. This way a golden image
+        produces unique machine id's on first deployment and boot
+        of the image.
+
+        Note: Requires dracut connected image type
+
+        This method must only be called if the image is of
+        a type which gets booted via a dracut created initrd.
+        Deleting the machine-id without the dracut initrd
+        creating a new one produces an inconsistent system
+        """
+        machine_id = os.sep.join(
+            [self.root_dir, 'etc', 'machine-id']
+        )
+        with open(machine_id, 'w'):
+            pass
+
     def setup_keyboard_map(self):
         """
         Setup console keyboard

--- a/test/unit/boot_image_dracut_test.py
+++ b/test/unit/boot_image_dracut_test.py
@@ -45,6 +45,7 @@ class TestBootImageKiwi(object):
         mock_setup.return_value = setup
         self.boot_image.prepare()
         setup.import_shell_environment.assert_called_once_with(profile)
+        setup.setup_machine_id.assert_called_once_with()
         assert self.boot_image.dracut_options == [
             '--install', '/.profile'
         ]

--- a/test/unit/system_setup_test.py
+++ b/test/unit/system_setup_test.py
@@ -795,6 +795,13 @@ class TestSystemSetup(object):
             'target_dir/some-image.x86_64-1.2.3.packages', 'w'
         )
 
+    @patch_open
+    def test_setup_machine_id(self, mock_open):
+        self.setup.setup_machine_id()
+        mock_open.assert_called_once_with(
+            'root_dir/etc/machine-id', 'w'
+        )
+
     @patch('kiwi.system.setup.Command.run')
     @patch_open
     def test_export_package_list_rpm_no_dbpath(


### PR DESCRIPTION
In case of a dracut booted image we empty out the systemd
machine-id configuration file to trigger the rebuild of that
information by the dracut boot code at boot time. This allows
for unique systemd identifiers if the same image gets deployed
on different machines. This also makes the script implementations
people put in in config.sh or images.sh to solve this problem
obsolete.

This Fixes #843

