### PR TITLE
LVM: fix build on OBS with no running udev

### DIFF
--- a/kiwi/volume_manager/lvm.py
+++ b/kiwi/volume_manager/lvm.py
@@ -27,6 +27,7 @@ from kiwi.logger import log
 from kiwi.exceptions import (
     KiwiVolumeGroupConflict
 )
+import os
 
 
 class VolumeManagerLVM(VolumeManagerBase):
@@ -87,6 +88,7 @@ class VolumeManagerLVM(VolumeManagerBase):
         :param str name: volume group name
         """
         self.setup_mountpoint()
+        os.putenv('DM_DISABLE_UDEV', '1')
 
         if self._volume_group_in_use_on_host_system(volume_group_name):
             raise KiwiVolumeGroupConflict(
@@ -126,6 +128,7 @@ class VolumeManagerLVM(VolumeManagerBase):
         log.debug(
             '--> running "lvcreate -Zn %s"', " ".join(lvcreate_args)
         )
+        os.putenv('DM_DISABLE_UDEV', '1')
         Command.run(
             ['lvcreate', '-Zn'] + lvcreate_args
         )


### PR DESCRIPTION
tell LVM tools that no udev is running by exporting DM_DISABLE_UDEV=1

Fixes #825 (amended)

See
https://build.opensuse.org/package/show/home:seife:kiwitest/firstimage-iso
https://build.opensuse.org/package/show/home:seife:kiwitest/python-kiwi

Also needs "Requires: syslinux" in spec file for oem-iso build to finish.