### PR TITLE
Update /etc/machine-id management docs

### DIFF
--- a/doc/source/overview/workflow.rst
+++ b/doc/source/overview/workflow.rst
@@ -518,27 +518,19 @@ fine tune the resulting unpacked image are quickly described:
 
 #. **Stateless systemd UUIDs:**
 
-  Usually during the image packages installation when *dbus* and/or
-  *systemd* are installed machine ID files are created and set
+  During the image packages installation when *systemd* and/or
+  *dbus* are installed machine ID files are created and set
   (:file:`/etc/machine-id`, :file:`/var/lib/dbus/machine-id`). Those
-  UUIDs are meant to be unique and set only once in each deployment. In
-  order to ensure that every single box running out from the same image
-  has its own specific systemd UUID, the original image must not include
-  any systemd or dbus ID, this way it is assigned during the first boot.
-  The following bash snippet allows this behavior in :file:`config.sh`:
-
-  .. code:: bash
-
-     #======================================
-     # Make machine-id stateless
-     #--------------------------------------
-     if [ -e /etc/machine-id ]; then
-         > /etc/machine-id
-         if [ -e /var/lib/dbus/machine-id ]; then
-             rm /var/lib/dbus/machine-id
-         fi
-         ln -s /etc/machine-id /var/lib/dbus/machine-id
-     fi
+  UUIDs are meant to be unique and set only once in each deployment.
+  KIWI follows the `systemd recommandations
+  <https://www.freedesktop.org/software/systemd/man/machine-id.html>`_ and
+  whipes any :file:`/etc/machine-id` content, leaving it as an empty file.
+  Note this is only applied for images based on dracut initrd, on container
+  images, for instance, this setting is not applied.
+  
+  In case this setting is required also for a non dracut based image
+  this could be also achieved by clearing :file:`/etc/machine-id`
+  in :file:`config.sh`.
 
   .. note:: Avoid interactive boot
 
@@ -547,6 +539,26 @@ fine tune the resulting unpacked image are quickly described:
      :command:`systemd-firstboot` service if this file is not present,
      which leads to an interactive firstboot where the user is
      asked to provide some data.
+
+  .. note:: Avoid inconsistent :file:`var/lib/dbus/machine-id`
+
+     It is important to remark that :file:`/etc/machine-id` and
+     :file:`/var/lib/dbus/machine-id` should contain the same unique ID. In
+     modern systems :file:`/var/lib/dbus/machine-id` is already a symlink
+     to :file:`/etc/machine-id`. However in older systems those might be two
+     different files. This is the case for SLE-12 based images, so
+     in those cases it is recommended to add into the :file:`config.sh`
+     the symlink creation:
+  
+     .. code:: bash
+
+        #======================================
+        # Make machine-id consistent with dbus
+        #--------------------------------------
+        if [ -e /var/lib/dbus/machine-id ]; then
+            rm /var/lib/dbus/machine-id
+        fi
+        ln -s /etc/machine-id /var/lib/dbus/machine-id
 
 Image Customization with ``images.sh`` Shell Script
 ...................................................


### PR DESCRIPTION
Updates the information about how `/etc/machine-id` is treated in KIWI and provides some hints for old systems where `/var/lib/dbus/machine-id` is not a symlink to `/etc/machine-id`.

Related to #843