### PR TITLE
Don't cache packages from local repos for zypper

### DIFF
--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -22,6 +22,7 @@ from tempfile import NamedTemporaryFile
 # project
 from kiwi.command import Command
 from kiwi.repository.base import RepositoryBase
+from kiwi.system.uri import Uri
 from kiwi.path import Path
 
 from kiwi.exceptions import (
@@ -218,7 +219,8 @@ class RepositoryZypper(RepositoryBase):
                 'addrepo',
                 '--refresh',
                 '--type', self._translate_repo_type(repo_type),
-                '--keep-packages',
+                '--keep-packages' if Uri(uri).is_remote() else
+                '--no-keep-packages',
                 '-C',
                 uri,
                 name


### PR DESCRIPTION
Access to packages from local repositories is as fast as reading
them from a cache location. The additional package copy and cache
update is superfluous and should be avoided. This Fixes #847

