### PR TITLE
Allow simple path source in Uri class

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -891,6 +891,20 @@ class Defaults(object):
         return 'overlay'
 
     @classmethod
+    def get_default_uri_type(self):
+        """
+        Provides default URI type
+
+        Absolute path specifications used in the context of an URI
+        will apply the specified default mime type
+
+        :return: URI mime type
+
+        :rtype: str
+        """
+        return 'dir:/'
+
+    @classmethod
     def get_dracut_conf_name(self):
         """
         Provides file path of dracut config file to be used with KIWI

--- a/kiwi/system/uri.py
+++ b/kiwi/system/uri.py
@@ -51,7 +51,9 @@ class Uri(object):
     def __init__(self, uri, repo_type=None):
         self.runtime_config = RuntimeConfig()
         self.repo_type = repo_type
-        self.uri = uri if not uri.startswith(os.sep) else 'file:/' + uri
+        self.uri = uri if not uri.startswith(os.sep) else ''.join(
+            [Defaults.get_default_uri_type(), uri]
+        )
         self.mount_stack = []
 
         self.remote_uri_types = {

--- a/kiwi/system/uri.py
+++ b/kiwi/system/uri.py
@@ -51,7 +51,7 @@ class Uri(object):
     def __init__(self, uri, repo_type=None):
         self.runtime_config = RuntimeConfig()
         self.repo_type = repo_type
-        self.uri = uri
+        self.uri = uri if not uri.startswith(os.sep) else 'file:/' + uri
         self.mount_stack = []
 
         self.remote_uri_types = {

--- a/test/unit/system_uri_test.py
+++ b/test/unit/system_uri_test.py
@@ -78,6 +78,8 @@ class TestUri(object):
         assert uri.is_remote() is True
         uri = Uri('dir:///path/to/repo', 'rpm-md')
         assert uri.is_remote() is False
+        uri = Uri('/path/to/repo')
+        assert uri.is_remote() is False
 
     @patch('kiwi.system.uri.Defaults.is_buildservice_worker')
     def test_is_remote_in_buildservice(


### PR DESCRIPTION
This patch is needed as follow up fix for the setup of the
package cache in local repositories. The is_remote method
from the Uri class is used to identify if a repostory source
is remote or local. At that point the initial repository
source was already translated into its components. In case
of a local repository the Uri instance now receives a simple
path and the is_remote method raised with a style error.
This patch allows the Uri class to be more friendly and
initializes a local path as file:/ typed source.
Related to Issue #847

