### PR TITLE
Add a hardcoded rpm database path to import trusted keys

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1171,6 +1171,17 @@ class Defaults(object):
         elif package_manager in deb_based:
             return 'dpkg'
 
+    @classmethod
+    def get_default_rpmdb_path(self):
+        """
+        Returns the default path of the rpm database.
+
+        :return: rpmdb default path
+
+        :rtype: str
+        """
+        return '/var/lib/rpm'
+
     def get(self, key):
         """
         Implements get method for profile elements

--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -24,6 +24,7 @@ from kiwi.command import Command
 from kiwi.repository.base import RepositoryBase
 from kiwi.system.uri import Uri
 from kiwi.path import Path
+from kiwi.defaults import Defaults
 
 from kiwi.exceptions import (
     KiwiRepoTypeUnknown
@@ -256,7 +257,7 @@ class RepositoryZypper(RepositoryBase):
             # Including --dbpath flag is a workaround for bsc#1112357
             Command.run([
                 'rpm', '--root', self.root_dir, '--import',
-                key, '--dbpath', '/var/lib/rpm'
+                key, '--dbpath', Defaults.get_default_rpmdb_path()
             ])
 
     def delete_repo(self, name):

--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -253,7 +253,11 @@ class RepositoryZypper(RepositoryBase):
         :param list signing_keys: list of the key files to import
         """
         for key in signing_keys:
-            Command.run(['rpm', '--root', self.root_dir, '--import', key])
+            # Including --dbpath flag is a workaround for bsc#1112357
+            Command.run([
+                'rpm', '--root', self.root_dir, '--import',
+                key, '--dbpath', '/var/lib/rpm'
+            ])
 
     def delete_repo(self, name):
         """

--- a/test/unit/repository_zypper_test.py
+++ b/test/unit/repository_zypper_test.py
@@ -221,8 +221,14 @@ class TestRepositoryZypper(object):
     def test_import_trusted_keys(self, mock_run):
         self.repo.import_trusted_keys(['key-file-a.asc', 'key-file-b.asc'])
         assert mock_run.call_args_list == [
-            call(['rpm', '--root', '../data', '--import', 'key-file-a.asc']),
-            call(['rpm', '--root', '../data', '--import', 'key-file-b.asc'])
+            call([
+                'rpm', '--root', '../data', '--import',
+                'key-file-a.asc', '--dbpath', '/var/lib/rpm'
+            ]),
+            call([
+                'rpm', '--root', '../data', '--import',
+                'key-file-b.asc', '--dbpath', '/var/lib/rpm'
+            ])
         ]
 
     @patch('kiwi.command.Command.run')


### PR DESCRIPTION
This commits adds a hardcoded rpm database location to make
sure the imported keys are in the expected location for zypper.

Fixes #855