### PR TITLE
Container oci interface

### DIFF
--- a/kiwi/container/docker.py
+++ b/kiwi/container/docker.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
-import os
-
 # project
 from kiwi.container.oci import ContainerImageOCI
 from kiwi.path import Path
@@ -34,10 +32,6 @@ class ContainerImageDocker(ContainerImageOCI):
 
         :param string filename: file name of the resulting packed image
         """
-        oci_image = os.sep.join([
-            self.oci_dir, ':'.join(['umoci_layout', self.container_tag])
-        ])
-
         additional_tags = []
         for tag in self.additional_tags:
             additional_tags.extend([
@@ -50,7 +44,7 @@ class ContainerImageDocker(ContainerImageOCI):
         Command.run(
             [
                 'skopeo', 'copy', 'oci:{0}'.format(
-                    oci_image
+                    self.oci.container_name
                 ),
                 'docker-archive:{0}:{1}:{2}'.format(
                     filename, self.container_name, self.container_tag

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1141,6 +1141,17 @@ class Defaults(object):
         return 'kiwi-container'
 
     @classmethod
+    def get_oci_archive_tool(self):
+        """
+        Provides the default OCI archive tool name.
+
+        :return: name
+
+        :rtype: str
+        """
+        return 'umoci'
+
+    @classmethod
     def get_default_container_tag(self):
         """
         Provides the default container tag.

--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -454,6 +454,12 @@ class KiwiNotImplementedError(KiwiError):
     """
 
 
+class KiwiOCIArchiveToolError(KiwiError):
+    """
+    Exception raised if the requested OCI archive tool is not supported
+    """
+
+
 class KiwiPackageManagerSetupError(KiwiError):
     """
     Exception raised if an attempt was made to create a package

--- a/kiwi/oci_tools/__init__.py
+++ b/kiwi/oci_tools/__init__.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2018 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+# project
+from kiwi.oci_tools.umoci import OCIUmoci
+from kiwi.runtime_config import RuntimeConfig
+
+from kiwi.exceptions import (
+    KiwiOCIArchiveToolError
+)
+
+
+class OCI(object):
+    """
+    **OCI Factory**
+    """
+    def __new__(self, container_tag, container_dir=None):
+        runtime_config = RuntimeConfig()
+        tool_name = runtime_config.get_oci_archive_tool()
+        if tool_name == 'umoci':
+            return OCIUmoci(container_tag, container_dir)
+        else:
+            raise KiwiOCIArchiveToolError(
+                'No support for {0} tool available'.format(tool_name)
+            )

--- a/kiwi/oci_tools/base.py
+++ b/kiwi/oci_tools/base.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2018 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+import os
+from tempfile import mkdtemp
+
+# project
+from kiwi.path import Path
+
+
+class OCIBase(object):
+    """
+    **Base Class for Open Container Interface operations**
+
+    An initiative to formulate industry standards around container
+    formats and runtime is available at https://www.opencontainers.org
+    Different tools to implement the specifications had been
+    created. The purpose of this class and its sub-classes is
+    to provide a common interface in kiwi to allow using all
+    tools such that the container support in kiwi covers every
+    linux distribution no matter what tooling was preferred
+
+    :param string container_tag: primary tag name
+    """
+    def __init__(self, container_tag, container_dir=None):
+        self.container_tag = container_tag
+
+        if container_dir:
+            self.oci_dir = None
+            self.container_dir = container_dir
+        else:
+            self.oci_dir = mkdtemp(prefix='kiwi_oci_dir.')
+            self.container_dir = os.sep.join(
+                [self.oci_dir, 'oci_layout']
+            )
+
+        self.container_name = ':'.join(
+            [self.container_dir, self.container_tag]
+        )
+
+    def init_layout(self, base_image=False):
+        """
+        Initialize a new container layout
+
+        A new container layout can start with a non empty base root image.
+
+        Implementation in specialized tool class
+
+        :param string base_image: True|False
+        """
+        raise NotImplementedError
+
+    def unpack(self, oci_root_dir):
+        """
+        Unpack current container root data to given directory
+
+        Implementation in specialized tool class
+
+        :param string oci_root_dir: root data directory
+        """
+        raise NotImplementedError
+
+    def repack(self, oci_root_dir):
+        """
+        Pack given root data directory into container image
+
+        Implementation in specialized tool class
+
+        :param string oci_root_dir: root data directory
+        :param string container_name: custom container_dir:tag specifier
+        """
+        raise NotImplementedError
+
+    def add_tag(self, tag_name):
+        """
+        Add additional tag name to the container
+
+        Implementation in specialized tool class
+
+        :param string tag_name: A name
+        :param string container_name: custom container_dir:tag specifier
+        """
+        raise NotImplementedError
+
+    def set_config(self, oci_config):
+        """
+        Set list of meta data information such as entry_point,
+        maintainer, etc... to the container. The validation of
+        the list content is handled by the underlaying toolkit
+
+        Implementation in specialized tool class
+
+        :param list oci_config: meta data list
+        :param string container_name: custom container_dir:tag specifier
+        """
+        raise NotImplementedError
+
+    def garbage_collect(self):
+        """
+        Cleanup unused data from operations
+
+        Implementation in specialized tool class
+        """
+        raise NotImplementedError
+
+    def __del__(self):
+        if self.oci_dir:
+            Path.wipe(self.oci_dir)

--- a/kiwi/oci_tools/umoci.py
+++ b/kiwi/oci_tools/umoci.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2018 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+from datetime import datetime
+
+# project
+from kiwi.oci_tools.base import OCIBase
+from kiwi.command import Command
+
+
+class OCIUmoci(OCIBase):
+    """
+    **Open Container Operations using umoci**
+    """
+    def init_layout(self, base_image=False):
+        """
+        Initialize a new container layout
+
+        A new container layout can start with a non empty base
+        root image. If provided that base layout will be used with
+        the given primary tag provided at instance creation time.
+        The import and unpack of the base image is not a
+        responsibility of this class and done beforehead
+
+        :param string base_image: True|False
+        """
+        if base_image:
+            Command.run(
+                [
+                    'umoci', 'config', '--image',
+                    '{0}:base_layer'.format(self.container_dir),
+                    '--tag', self.container_tag
+                ]
+            )
+        else:
+            Command.run(
+                ['umoci', 'init', '--layout', self.container_dir]
+            )
+            Command.run(
+                ['umoci', 'new', '--image', self.container_name]
+            )
+
+    def unpack(self, oci_root_dir):
+        """
+        Unpack current container root data to given directory
+
+        :param string oci_root_dir: root data directory
+        """
+        Command.run(
+            ['umoci', 'unpack', '--image', self.container_name, oci_root_dir]
+        )
+
+    def repack(self, oci_root_dir):
+        """
+        Pack given root data directory into container image
+
+        :param string oci_root_dir: root data directory
+        """
+        Command.run(
+            ['umoci', 'repack', '--image', self.container_name, oci_root_dir]
+        )
+
+    def add_tag(self, tag_name):
+        """
+        Add additional tag name to the container
+
+        :param string tag_name: A name
+        """
+        Command.run(
+            [
+                'umoci', 'config', '--image', self.container_name,
+                '--tag', tag_name
+            ]
+        )
+
+    def set_config(self, oci_config):
+        """
+        Set list of meta data information such as entry_point,
+        maintainer, etc... to the container.
+
+        :param list oci_config: meta data list
+        """
+        Command.run(
+            [
+                'umoci', 'config'
+            ] + oci_config + [
+                '--image', self.container_name,
+                '--created', datetime.utcnow().strftime(
+                    '%Y-%m-%dT%H:%M:%S+00:00'
+                )
+            ]
+        )
+
+    def garbage_collect(self):
+        """
+        Cleanup unused data from operations
+        """
+        Command.run(
+            ['umoci', 'gc', '--layout', self.container_dir]
+        )

--- a/kiwi/runtime_config.py
+++ b/kiwi/runtime_config.py
@@ -171,6 +171,26 @@ class RuntimeConfig(object):
             )
             return Defaults.get_iso_tool_category()
 
+    def get_oci_archive_tool(self):
+        """
+        Return OCI archive tool which should be used on creation of
+        container archives for OCI compliant images, e.g docker
+
+        oci:
+          - archive_tool: umoci
+
+        if no configuration exists the default tool from the
+        Defaults class is returned
+
+        :return: A name
+
+        :rtype: str
+        """
+        oci_archive_tool = self._get_attribute(
+            element='oci', attribute='archive_tool'
+        )
+        return oci_archive_tool or Defaults.get_oci_archive_tool()
+
     def get_max_size_constraint(self):
         """
         Returns the maximum allowed size of the built image. The value is

--- a/kiwi/system/root_import/oci.py
+++ b/kiwi/system/root_import/oci.py
@@ -26,6 +26,7 @@ from kiwi.utils.sync import DataSync
 from kiwi.command import Command
 from kiwi.archive.tar import ArchiveTar
 from kiwi.defaults import Defaults
+from kiwi.oci_tools import OCI
 
 
 class RootImportOCI(RootImportBase):
@@ -50,10 +51,9 @@ class RootImportOCI(RootImportBase):
         directory.
         """
         self.extract_oci_image()
-        Command.run([
-            'umoci', 'unpack', '--image',
-            '{0}:base_layer'.format(self.oci_layout_dir), self.oci_unpack_dir
-        ])
+
+        oci = OCI('base_layer', self.oci_layout_dir)
+        oci.unpack(self.oci_unpack_dir)
 
         synchronizer = DataSync(
             os.sep.join([self.oci_unpack_dir, 'rootfs', '']),

--- a/test/data/.config/kiwi/config.yml
+++ b/test/data/.config/kiwi/config.yml
@@ -8,5 +8,8 @@ obs:
 iso:
   - tool_category: cdrtools
 
+oci:
+  - archive_tool: umoci
+
 container:
   - compress: none

--- a/test/unit/container_image_docker_test.py
+++ b/test/unit/container_image_docker_test.py
@@ -7,11 +7,15 @@ from kiwi.container.docker import ContainerImageDocker
 
 class TestContainerImageDocker(object):
     @patch('kiwi.container.docker.Compress')
-    @patch('kiwi.container.oci.Command.run')
+    @patch('kiwi.container.docker.Command.run')
     @patch('kiwi.container.oci.RuntimeConfig')
+    @patch('kiwi.container.oci.OCI')
     def test_pack_image_to_file(
-        self, mock_RuntimeConfig, mock_command, mock_compress
+        self, mock_OCI, mock_RuntimeConfig, mock_command, mock_compress
     ):
+        oci = Mock()
+        oci.container_name = 'kiwi_oci_dir.XXXX/oci_layout:latest'
+        mock_OCI.return_value = oci
         compressor = Mock()
         compressor.xz = Mock(
             return_value='result.tar.xz'
@@ -23,7 +27,6 @@ class TestContainerImageDocker(object):
                 'additional_tags': ['current', 'foobar']
             }
         )
-        docker.oci_dir = 'kiwi_oci_dir'
         docker.runtime_config.get_container_compression = Mock(
             return_value='xz'
         )
@@ -33,7 +36,7 @@ class TestContainerImageDocker(object):
         assert mock_command.call_args_list == [
             call(['rm', '-r', '-f', 'result.tar']),
             call([
-                'skopeo', 'copy', 'oci:kiwi_oci_dir/umoci_layout:latest',
+                'skopeo', 'copy', 'oci:kiwi_oci_dir.XXXX/oci_layout:latest',
                 'docker-archive:result.tar:foo/bar:latest',
                 '--additional-tag', 'foo/bar:current',
                 '--additional-tag', 'foo/bar:foobar'

--- a/test/unit/oci_tools_base_test.py
+++ b/test/unit/oci_tools_base_test.py
@@ -1,0 +1,46 @@
+from mock import patch
+from pytest import raises
+
+from kiwi.oci_tools.base import OCIBase
+
+
+class TestOCIBase(object):
+    @patch('kiwi.oci_tools.base.mkdtemp')
+    def setup(self, mock_mkdtemp):
+        mock_mkdtemp.return_value = 'kiwi_oci_dir.XXXX'
+        self.oci = OCIBase('tag')
+        mock_mkdtemp.assert_called_once_with(prefix='kiwi_oci_dir.')
+        assert self.oci.container_name == 'kiwi_oci_dir.XXXX/oci_layout:tag'
+
+    def test_setup_existing_container_dir(self):
+        oci = OCIBase('tag', 'layout_dir')
+        assert oci.container_name == 'layout_dir:tag'
+
+    def test_init_layout(self):
+        with raises(NotImplementedError):
+            self.oci.init_layout()
+
+    def test_unpack(self):
+        with raises(NotImplementedError):
+            self.oci.unpack('dir')
+
+    def test_repack(self):
+        with raises(NotImplementedError):
+            self.oci.repack('dir')
+
+    def test_add_tag(self):
+        with raises(NotImplementedError):
+            self.oci.add_tag('tag')
+
+    def test_set_config(self):
+        with raises(NotImplementedError):
+            self.oci.set_config(['data'])
+
+    def test_garbage_collect(self):
+        with raises(NotImplementedError):
+            self.oci.garbage_collect()
+
+    @patch('kiwi.oci_tools.base.Path')
+    def test_destructor(self, mock_Path):
+        self.oci.__del__()
+        mock_Path.wipe.assert_called_once_with('kiwi_oci_dir.XXXX')

--- a/test/unit/oci_tools_test.py
+++ b/test/unit/oci_tools_test.py
@@ -1,0 +1,33 @@
+from pytest import raises
+from mock import (
+    patch, Mock
+)
+
+from kiwi.oci_tools import OCI
+
+from kiwi.exceptions import (
+    KiwiOCIArchiveToolError
+)
+
+
+class TestOCI(object):
+    def setup(self):
+        self.runtime_config = Mock()
+        self.runtime_config.get_oci_archive_tool = Mock()
+
+    @patch('kiwi.oci_tools.OCIUmoci')
+    @patch('kiwi.oci_tools.RuntimeConfig')
+    def test_oci_tool_umoci(
+        self, mock_RuntimeConfig, mock_OCIUmoci
+    ):
+        self.runtime_config.get_oci_archive_tool.return_value = 'umoci'
+        mock_RuntimeConfig.return_value = self.runtime_config
+        OCI('tag_name')
+        mock_OCIUmoci.assert_called_once_with('tag_name', None)
+
+    @patch('kiwi.oci_tools.RuntimeConfig')
+    def test_oci_tool_not_supported(self, mock_RuntimeConfig):
+        self.runtime_config.get_oci_archive_tool.return_value = 'foo'
+        mock_RuntimeConfig.return_value = self.runtime_config
+        with raises(KiwiOCIArchiveToolError):
+            OCI('tag_name')

--- a/test/unit/oci_tools_umoci_test.py
+++ b/test/unit/oci_tools_umoci_test.py
@@ -1,0 +1,77 @@
+from mock import (
+    Mock, patch, call
+)
+
+from kiwi.oci_tools.umoci import OCIUmoci
+
+
+class TestOCIBase(object):
+    @patch('kiwi.oci_tools.base.mkdtemp')
+    def setup(self, mock_mkdtemp):
+        mock_mkdtemp.return_value = 'tmpdir'
+        self.oci = OCIUmoci('tag')
+
+    @patch('kiwi.oci_tools.umoci.Command.run')
+    def test_init_layout(self, mock_Command_run):
+        self.oci.init_layout()
+        assert mock_Command_run.call_args_list == [
+            call(['umoci', 'init', '--layout', 'tmpdir/oci_layout']),
+            call(['umoci', 'new', '--image', 'tmpdir/oci_layout:tag'])
+        ]
+
+    @patch('kiwi.oci_tools.umoci.Command.run')
+    def test_init_layout_base_image(self, mock_Command_run):
+        self.oci.init_layout(True)
+        mock_Command_run.assert_called_once_with(
+            [
+                'umoci', 'config', '--image',
+                'tmpdir/oci_layout:base_layer', '--tag', 'tag'
+            ]
+        )
+
+    @patch('kiwi.oci_tools.umoci.Command.run')
+    def test_unpack(self, mock_Command_run):
+        self.oci.unpack('dir')
+        mock_Command_run.assert_called_once_with(
+            ['umoci', 'unpack', '--image', 'tmpdir/oci_layout:tag', 'dir']
+        )
+
+    @patch('kiwi.oci_tools.umoci.Command.run')
+    def test_repack(self, mock_Command_run):
+        self.oci.repack('dir')
+        mock_Command_run.assert_called_once_with(
+            ['umoci', 'repack', '--image', 'tmpdir/oci_layout:tag', 'dir']
+        )
+
+    @patch('kiwi.oci_tools.umoci.Command.run')
+    def test_add_tag(self, mock_Command_run):
+        self.oci.add_tag('other_tag')
+        mock_Command_run.assert_called_once_with(
+            [
+                'umoci', 'config', '--image', 'tmpdir/oci_layout:tag',
+                '--tag', 'other_tag'
+            ]
+        )
+
+    @patch('kiwi.oci_tools.umoci.Command.run')
+    @patch('kiwi.oci_tools.umoci.datetime')
+    def test_set_config(self, mock_datetime, mock_Command_run):
+        strftime = Mock()
+        strftime.strftime = Mock(return_value='current_date')
+        mock_datetime.utcnow = Mock(
+            return_value=strftime
+        )
+        self.oci.set_config(['data'])
+        mock_Command_run.assert_called_once_with(
+            [
+                'umoci', 'config', 'data', '--image', 'tmpdir/oci_layout:tag',
+                '--created', 'current_date'
+            ]
+        )
+
+    @patch('kiwi.oci_tools.umoci.Command.run')
+    def test_garbage_collect(self, mock_Command_run):
+        self.oci.garbage_collect()
+        mock_Command_run.assert_called_once_with(
+            ['umoci', 'gc', '--layout', 'tmpdir/oci_layout']
+        )

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -95,3 +95,11 @@ class TestRuntimeConfig(object):
         mock_warning.assert_called_once_with(
             'Skipping invalid iso tool category: foo'
         )
+
+    def test_get_oci_archive_tool(self):
+        assert self.runtime_config.get_oci_archive_tool() == 'umoci'
+
+    def test_get_oci_archive_tool_default(self):
+        with patch.dict('os.environ', {'HOME': './'}):
+            runtime_config = RuntimeConfig()
+            assert runtime_config.get_oci_archive_tool() == 'umoci'


### PR DESCRIPTION
Added OCI tooling interface class
    
An initiative to formulate industry standards around container
formats and runtime is available at https://www.opencontainers.org
Different tools to implement the specifications had been
created. The purpose of this class and its sub-classes is
to provide a common interface in kiwi to allow using all
tools such that the container support in kiwi covers every
linux distribution no matter what tooling was preferred.

This Fixes #859