### PR TITLE
Distinguish install and image dracut config

### DIFF
--- a/kiwi/boot/image/base.py
+++ b/kiwi/boot/image/base.py
@@ -78,7 +78,7 @@ class BootImageBase(object):
         """
         pass
 
-    def include_file(self, filename):
+    def include_file(self, filename, install_media=False):
         """
         Include file to boot image
 
@@ -87,6 +87,8 @@ class BootImageBase(object):
         for kiwi boot images the method is a noop
 
         :param string filename: file path name
+
+        :param bool install_media: include also for installation media initrd
         """
         pass
 
@@ -136,12 +138,13 @@ class BootImageBase(object):
         """
         raise NotImplementedError
 
-    def create_initrd(self, mbrid=None, basename=None):
+    def create_initrd(self, mbrid=None, basename=None, install_initrd=False):
         """
         Implements creation of the initrd
 
         :param object mbrid: instance of ImageIdentifier
         :param string basename: base initrd file name
+        :param bool install_initrd: installation media initrd
 
         Implementation in specialized boot image class
         """

--- a/kiwi/boot/image/builtin_kiwi.py
+++ b/kiwi/boot/image/builtin_kiwi.py
@@ -102,12 +102,14 @@ class BootImageKiwi(BootImageBase):
         self.setup.call_image_script()
         self.setup.create_init_link_from_linuxrc()
 
-    def create_initrd(self, mbrid=None, basename=None):
+    def create_initrd(self, mbrid=None, basename=None, install_initrd=False):
         """
         Create initrd from prepared boot system tree and compress the result
 
         :param object mbrid: instance of ImageIdentifier
         :param string basename: base initrd file name
+        :param bool install_initrd: installation media initrd
+
         """
         if self.is_prepared():
             log.info('Creating initrd cpio archive')

--- a/kiwi/boot/image/dracut.py
+++ b/kiwi/boot/image/dracut.py
@@ -43,15 +43,20 @@ class BootImageDracut(BootImageBase):
         Initialize empty list of dracut caller options
         """
         self.dracut_options = []
+        self.included_files = []
+        self.included_files_install = []
 
-    def include_file(self, filename):
+    def include_file(self, filename, install_media=False):
         """
         Include file to dracut boot image
 
         :param string filename: file path name
         """
-        self.dracut_options.append('--install')
-        self.dracut_options.append(filename)
+        self.included_files.append('--install')
+        self.included_files.append(filename)
+        if install_media:
+            self.included_files_install.append('--install')
+            self.included_files_install.append(filename)
 
     def prepare(self):
         """
@@ -71,13 +76,14 @@ class BootImageDracut(BootImageBase):
         self.dracut_options.append('--install')
         self.dracut_options.append('/.profile')
 
-    def create_initrd(self, mbrid=None, basename=None):
+    def create_initrd(self, mbrid=None, basename=None, install_initrd=False):
         """
         Call dracut as chroot operation to create the initrd and move
         the result into the image build target directory
 
         :param object mbrid: unused
         :param string basename: base initrd file name
+        :param bool install_initrd: installation media initrd
         """
         if self.is_prepared():
             log.info('Creating generic dracut initrd archive')
@@ -87,6 +93,10 @@ class BootImageDracut(BootImageBase):
                 dracut_initrd_basename = basename
             else:
                 dracut_initrd_basename = self.initrd_base_name
+            if install_initrd:
+                included_files = self.included_files_install
+            else:
+                included_files = self.included_files
             dracut_initrd_basename += '.xz'
             Command.run(
                 [
@@ -95,7 +105,7 @@ class BootImageDracut(BootImageBase):
                     '--no-hostonly',
                     '--no-hostonly-cmdline',
                     '--xz'
-                ] + self.dracut_options + [
+                ] + self.dracut_options + included_files + [
                     dracut_initrd_basename,
                     kernel_details.version
                 ]

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -352,7 +352,10 @@ class InstallImageBuilder(object):
         if self.initrd_system == 'dracut':
             self._create_dracut_install_config()
             self._add_system_image_boot_options_to_boot_image()
-        self.boot_image_task.create_initrd(self.mbrid, 'initrd_kiwi_install')
+        self.boot_image_task.create_initrd(
+            self.mbrid, 'initrd_kiwi_install',
+            install_initrd=True
+        )
         Command.run(
             [
                 'mv', self.boot_image_task.initrd_filename,
@@ -383,7 +386,10 @@ class InstallImageBuilder(object):
         if self.initrd_system == 'dracut':
             self._create_dracut_install_config()
             self._add_system_image_boot_options_to_boot_image()
-        self.boot_image_task.create_initrd(self.mbrid, 'initrd_kiwi_install')
+        self.boot_image_task.create_initrd(
+            self.mbrid, 'initrd_kiwi_install',
+            install_initrd=True
+        )
         Command.run(
             [
                 'mv', self.boot_image_task.initrd_filename,
@@ -396,7 +402,7 @@ class InstallImageBuilder(object):
             [self.boot_image_task.boot_root_directory, '/config.bootoptions']
         )
         self.boot_image_task.include_file(
-            os.sep + os.path.basename(filename)
+            os.sep + os.path.basename(filename), install_media=True
         )
 
     def _copy_system_image_initrd_to_iso_image(self):

--- a/test/unit/boot_image_dracut_test.py
+++ b/test/unit/boot_image_dracut_test.py
@@ -52,7 +52,17 @@ class TestBootImageKiwi(object):
 
     def test_include_file(self):
         self.boot_image.include_file('foo')
-        assert self.boot_image.dracut_options == [
+        assert self.boot_image.included_files == [
+            '--install', 'foo'
+        ]
+        assert self.boot_image.included_files_install == []
+
+    def test_include_file_install(self):
+        self.boot_image.include_file('foo', install_media=True)
+        assert self.boot_image.included_files == [
+            '--install', 'foo'
+        ]
+        assert self.boot_image.included_files_install == [
             '--install', 'foo'
         ]
 
@@ -68,7 +78,9 @@ class TestBootImageKiwi(object):
         kernel.get_kernel = mock.Mock(return_value=kernel_details)
         mock_kernel.return_value = kernel
         self.boot_image.include_file('system-directory/etc/foo')
-        self.boot_image.include_file('/system-directory/var/lib/bar')
+        self.boot_image.include_file(
+            '/system-directory/var/lib/bar', install_media=True
+        )
         self.boot_image.create_initrd()
         assert mock_command.call_args_list == [
             call([
@@ -86,13 +98,12 @@ class TestBootImageKiwi(object):
             ])
         ]
         mock_command.reset_mock()
-        self.boot_image.create_initrd(basename='foo')
+        self.boot_image.create_initrd(basename='foo', install_initrd=True)
         assert mock_command.call_args_list == [
             call([
                 'chroot', 'system-directory',
                 'dracut', '--force', '--no-hostonly',
                 '--no-hostonly-cmdline', '--xz',
-                '--install', 'system-directory/etc/foo',
                 '--install', '/system-directory/var/lib/bar',
                 'foo.xz', '1.2.3'
             ]),

--- a/test/unit/builder_install_test.py
+++ b/test/unit/builder_install_test.py
@@ -173,7 +173,7 @@ class TestInstallImageBuilder(object):
             call(), call()
         ]
         self.boot_image_task.create_initrd.assert_called_once_with(
-            self.mbrid, 'initrd_kiwi_install'
+            self.mbrid, 'initrd_kiwi_install', install_initrd=True
         )
         self.kernel.copy_kernel.assert_called_once_with(
             'temp_media_dir/boot/x86_64/loader', '/linux'
@@ -206,7 +206,7 @@ class TestInstallImageBuilder(object):
         self.install_image.create_install_iso()
 
         self.boot_image_task.include_file.assert_called_once_with(
-            '/config.bootoptions'
+            '/config.bootoptions', install_media=True
         )
         assert mock_open.call_args_list == [
             call('temp_media_dir/config.isoclient', 'w'),
@@ -336,7 +336,7 @@ class TestInstallImageBuilder(object):
             'tmpdir', '/pxeboot.xen.gz'
         )
         self.boot_image_task.create_initrd.assert_called_once_with(
-            self.mbrid, 'initrd_kiwi_install'
+            self.mbrid, 'initrd_kiwi_install', install_initrd=True
         )
         assert mock_command.call_args_list[1] == call(
             ['mv', 'initrd', 'tmpdir/pxeboot.initrd.xz']
@@ -359,7 +359,7 @@ class TestInstallImageBuilder(object):
         self.install_image.create_install_pxe_archive()
 
         self.boot_image_task.include_file.assert_called_once_with(
-            '/config.bootoptions'
+            '/config.bootoptions', install_media=True
         )
         mock_copy.assert_called_once_with(
             'root_dir/boot/initrd-kernel_version', 'tmpdir/result-image.initrd'


### PR DESCRIPTION
This commit distinguishes the files that should be installed inside
the image dracut only than the ones installed in both, in install initrd
and image initrd.

Fixes #858
