### PR TITLE
Gh pages deploy setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,24 @@ jobs:
     env: TOXENV=unit_py2_7,check,doc
   - stage: deploy
     python: 3.6
-    env: TOXENV=doc_travis,doc_travis_deploy
+    env: TOXENV=doc_travis
     deploy:
-      skip_cleanup: true
-      provider: pypi
-      user: schaefi
-      password:
-        secure: oGf30REGDDqQIGntwx/sklLp/4mAsLNWM6+cPFOzk5Q3T6f1jzXjhi3jo6vMbeGzHxZ4XOHUn/pzuhNY6d2Qlpjvsvxphdx4c9j/VxKopbLlKqBO9aQtRA+SaHFLgVgPGezuflcbKvIOQsNaejTalIVGsPDao1f30dfSZZL6kFTh++nDLBQih7Blu7lXauNekWn6F3/835x9LQe+EEE3pT9nydbKLkFKoTIzCMSgakBm0vBSDXR9DtBUT78roP1KcubGgoMgsgTJr2SN11J0IdMY1RK2NXdPUfoDNIblh7jcfd7UVslK3BjdZ3fWgLY7WrI3jNvuAf/7bIDXr1TjIvMZUu2p4R5Vfyoia9R/z9SZ+yGaRZiDh39fuWWwU0YeCvAhGdLXJOSqBGGxfQcD47i07Xo5oSd+hmT1c0XMwKe+GphVyl2jX/24GsVRfvZeySqBzcQxVEVClq8aoF7LYkRCAksaJMz/aeVFApHJRBalb70ESp0W7+LbGzUC+fVnQVRZZfbM7DXq4TIuAgl0ReVJcb4D7KN7ZS/VPwPBB4BFenm/p+73X2vr+5f7Swykigmyx8gFGjuOqYBUtR1q27qSCShmxCZvVdAsuexCqq3IQ1/XHAbgYn6fQK+pAycQLyEMwCTy9CmazmPYMLZmW2+bbpUUjjIchI1Kp19V3Wk=
-      distributions: sdist
-      on:
-        tags: true
+      - provider: pypi
+        skip_cleanup: true
+        user: schaefi
+        password:
+          secure: oGf30REGDDqQIGntwx/sklLp/4mAsLNWM6+cPFOzk5Q3T6f1jzXjhi3jo6vMbeGzHxZ4XOHUn/pzuhNY6d2Qlpjvsvxphdx4c9j/VxKopbLlKqBO9aQtRA+SaHFLgVgPGezuflcbKvIOQsNaejTalIVGsPDao1f30dfSZZL6kFTh++nDLBQih7Blu7lXauNekWn6F3/835x9LQe+EEE3pT9nydbKLkFKoTIzCMSgakBm0vBSDXR9DtBUT78roP1KcubGgoMgsgTJr2SN11J0IdMY1RK2NXdPUfoDNIblh7jcfd7UVslK3BjdZ3fWgLY7WrI3jNvuAf/7bIDXr1TjIvMZUu2p4R5Vfyoia9R/z9SZ+yGaRZiDh39fuWWwU0YeCvAhGdLXJOSqBGGxfQcD47i07Xo5oSd+hmT1c0XMwKe+GphVyl2jX/24GsVRfvZeySqBzcQxVEVClq8aoF7LYkRCAksaJMz/aeVFApHJRBalb70ESp0W7+LbGzUC+fVnQVRZZfbM7DXq4TIuAgl0ReVJcb4D7KN7ZS/VPwPBB4BFenm/p+73X2vr+5f7Swykigmyx8gFGjuOqYBUtR1q27qSCShmxCZvVdAsuexCqq3IQ1/XHAbgYn6fQK+pAycQLyEMwCTy9CmazmPYMLZmW2+bbpUUjjIchI1Kp19V3Wk=
+        distributions: sdist
+        on:
+          tags: true
+      - provider: pages
+        skip_cleanup: true
+        local-dir: doc/build/html
+        github-token:
+          secure: H6gF9STlXtiCvmIkBgbuCLY0ovkjvRX69OfaliKdhvmysHfFTiHn6rx2keGmd0kdEhGj12YgNEVwAd9qEEZonFfmqEzNNSW5+nIEvVjGZ9b8FnnwSGX/y2XBldIDNu+imuhkxzzFlylbMABJSvJy8W6dwuic2DBdiVAsb8e9fUHnvbTTice76DyuHCDjM7EGt34K3xP8sjwMm3dPKvO2s+Ij3u+j5TE/aovxoaY5oRO8fp2j7lbTUXIQb4P4mysro22K4rgWng83/IVaIAT0nFlX24WltraUxIzW/MJe8SYXaDSbgyzMpOtUxlKs+5/wAAdEBoE8aMTBwOF0f5eQJHTguL2oCy+7VELtMVq8oUeHzyRh7JcBAE7Hd3WgWrWrZCfIxEZ8pAEwLb3SJUnegb7z0PRBnHDNbwLcsxzKKupMVJ1eCJmlowJUea5ODW3ruizhvg9S3pBQOUwmQqvj2TS2byXa4zToqOzxcrMMWK0v667eO9XKAFkhNdA6Vr7XuwTbIMt/+dSQUH3VwxNK2Hpbe7EEf9Kh8K2L1U2UnrfpHmcm+8Fd1aYA0UsvVNhFF/MvDBBoHguvmAbw/x5rrbbNYW1Q+pUkYj/UTvrI/GU7w1h421R4VMigIkI7u6Yq5cVBYT95SzNPb6Bt2rKTAr6RpcqRwZV5AB7oL2Flgak=
+        keep-history: true
+        on:
+          tags: true
 
 before_install:
 - sudo apt-get update -qq

--- a/.virtualenv.dev-requirements.txt
+++ b/.virtualenv.dev-requirements.txt
@@ -42,7 +42,3 @@ sphinx
 sphinx_rtd_theme
 sphinxcontrib-spelling
 pyenchant
-
-# for travis deployment tasks
-travis-sphinx
-ghp-import

--- a/doc/source/building/working_with_images/vmx_setup_for_azure.rst
+++ b/doc/source/building/working_with_images/vmx_setup_for_azure.rst
@@ -57,5 +57,6 @@ description as follows:
       </type>
 
 An image built with the above setup can be uploaded into the
-Microsoft Azure cloud and registered as image. For further information
-on how to upload to Azure see: `azurectl <https://github.com/SUSE/azurectl>`_
+Microsoft Azure cloud and registered as image. For further
+information on how to upload to Azure see:
+`azurectl <https://github.com/SUSE-Enceladus/azurectl>`_

--- a/tox.ini
+++ b/tox.ini
@@ -30,12 +30,12 @@ whitelist_externals =
     /usr/bin/shellcheck
     /bin/bash
 basepython =
-    {check,packagedoc,doc,doc_travis,doc_travis_deploy}: python3
+    {check,packagedoc,doc,doc_travis}: python3
     unit_py3_6: python3.6
     unit_py3_4: python3.4
     unit_py2_7: python2.7
 envdir =
-    {check,packagedoc,doc,doc_travis,doc_travis_deploy}: {toxworkdir}/3
+    {check,packagedoc,doc,doc_travis}: {toxworkdir}/3
     unit_py3_6: {toxworkdir}/3.6
     unit_py3_4: {toxworkdir}/3.4
     unit_py2_7: {toxworkdir}/2.7
@@ -131,19 +131,9 @@ usedevelop = True
 deps = {[testenv:doc]deps}
 changedir=doc
 commands =
+    {[testenv:doc.html]commands}
     {[testenv:doc.man]commands}
-    travis-sphinx build --nowarn --source ./source
-    bash -c 'cp -a ./source/development/schema/images ./doc/build/development || true'
-
-
-# Documentation deploy from travis env
-[testenv:doc_travis_deploy]
-skip_install = True
-usedevelop = True
-deps = {[testenv:doc]deps}
-changedir=doc
-commands =
-    travis-sphinx deploy
+    bash -c 'cp -a ./source/development/schema/images ./build/html/development'
 
 
 # Documentation build html result


### PR DESCRIPTION
Use the travis pages provider for doc deployment
    
In the past we used the travis-sphinx script to deploy
the documentation to gh-pages via the travis CI. However
with the change to the travis github App we need to
change this deployment into a real deployment stage
of the travis setup