### PR TITLE
Change bundling of image formats

### DIFF
--- a/kiwi/storage/subformat/base.py
+++ b/kiwi/storage/subformat/base.py
@@ -174,8 +174,9 @@ class DiskFormatBase(object):
         Store result file of the format conversion into the
         provided result instance.
 
-        By default only the converted image file will be stored.
-        Subformats which creates additional metadata files needs
+        By default only the converted image file will be stored
+        as compressed file. Subformats which creates additional
+        metadata files or want to use other result flags needs
         to overwrite this method
 
         :param object result: Instance of Result
@@ -186,7 +187,7 @@ class DiskFormatBase(object):
                 self.image_format
             ),
             use_for_bundle=True,
-            compress=False,
+            compress=True,
             shasum=True
         )
 

--- a/kiwi/storage/subformat/gce.py
+++ b/kiwi/storage/subformat/gce.py
@@ -93,6 +93,25 @@ class DiskFormatGce(DiskFormatBase):
             self.temp_image_dir
         )
 
+    def store_to_result(self, result):
+        """
+        Store result file of the gce format conversion into the
+        provided result instance. In this case compression is unwanted
+        because the gce tarball is already created as a compressed
+        archive
+
+        :param object result: Instance of Result
+        """
+        result.add(
+            key='disk_format_image',
+            filename=self.get_target_file_path_for_format(
+                self.image_format
+            ),
+            use_for_bundle=True,
+            compress=False,
+            shasum=True
+        )
+
     def get_target_file_path_for_format(self, format_name):
         """
         Google requires the image name to follow their naming

--- a/kiwi/storage/subformat/vagrant_libvirt.py
+++ b/kiwi/storage/subformat/vagrant_libvirt.py
@@ -102,6 +102,24 @@ class DiskFormatVagrantLibVirt(DiskFormatBase):
             ]
         )
 
+    def store_to_result(self, result):
+        """
+        Store result file of the vagrant format conversion into the
+        provided result instance. In this case compression is unwanted
+        because the box is already created as a compressed tarball
+
+        :param object result: Instance of Result
+        """
+        result.add(
+            key='disk_format_image',
+            filename=self.get_target_file_path_for_format(
+                self.image_format
+            ),
+            use_for_bundle=True,
+            compress=False,
+            shasum=True
+        )
+
     def _create_box_metadata(self):
         metadata = {
             'provider': 'libvirt',

--- a/kiwi/storage/subformat/vmdk.py
+++ b/kiwi/storage/subformat/vmdk.py
@@ -81,7 +81,7 @@ class DiskFormatVmdk(DiskFormatBase):
             key='disk_format_image',
             filename=self.get_target_file_path_for_format('vmdk'),
             use_for_bundle=True,
-            compress=False,
+            compress=True,
             shasum=True
         )
         result.add(

--- a/test/unit/storage_subformat_base_test.py
+++ b/test/unit/storage_subformat_base_test.py
@@ -59,7 +59,7 @@ class TestDiskFormatBase(object):
         self.disk_format.image_format = 'qcow2'
         self.disk_format.store_to_result(result)
         result.add.assert_called_once_with(
-            compress=False,
+            compress=True,
             filename='target_dir/some-disk-image.x86_64-1.2.3.qcow2',
             key='disk_format_image',
             shasum=True,

--- a/test/unit/storage_subformat_gce_test.py
+++ b/test/unit/storage_subformat_gce_test.py
@@ -26,6 +26,17 @@ class TestDiskFormatGce(object):
         self.disk_format.post_init({'option': 'value', '--tag': 'tag'})
         assert self.disk_format.tag == 'tag'
 
+    def test_store_to_result(self):
+        result = mock.Mock()
+        self.disk_format.store_to_result(result)
+        result.add.assert_called_once_with(
+            compress=False,
+            filename='target_dir/some-disk-image.x86_64-0.8.15.tar.gz',
+            key='disk_format_image',
+            shasum=True,
+            use_for_bundle=True
+        )
+
     @patch('kiwi.storage.subformat.gce.Command.run')
     @patch('kiwi.storage.subformat.gce.ArchiveTar')
     @patch_open

--- a/test/unit/storage_subformat_vagrant_libvirt_test.py
+++ b/test/unit/storage_subformat_vagrant_libvirt_test.py
@@ -37,6 +37,18 @@ class TestDiskFormatVagrantLibVirt(object):
     def test_post_init_missing_vagrantconfig(self):
         self.disk_format.post_init({'vagrantconfig': None})
 
+    def test_store_to_result(self):
+        result = mock.Mock()
+        self.disk_format.store_to_result(result)
+        result.add.assert_called_once_with(
+            compress=False,
+            filename='target_dir/'
+            'some-disk-image.x86_64-1.2.3.vagrant.libvirt.box',
+            key='disk_format_image',
+            shasum=True,
+            use_for_bundle=True
+        )
+
     @patch('kiwi.storage.subformat.vagrant_libvirt.Command.run')
     @patch('kiwi.storage.subformat.vagrant_libvirt.mkdtemp')
     @patch('kiwi.storage.subformat.vagrant_libvirt.DiskFormatQcow2')

--- a/test/unit/storage_subformat_vmdk_test.py
+++ b/test/unit/storage_subformat_vmdk_test.py
@@ -114,7 +114,7 @@ class TestDiskFormatVmdk(object):
         self.disk_format.store_to_result(result)
         assert result.add.call_args_list == [
             call(
-                compress=False,
+                compress=True,
                 filename='target_dir/some-disk-image.x86_64-1.2.3.vmdk',
                 key='disk_format_image',
                 shasum=True,


### PR DESCRIPTION
By default none of the image formats were stored as compressed
file. The reason behind this was the assumption that some
formats automatically makes use of compression, which is true
but only in their processing and not in their data blocks at
creation time. Storage and handling of the image file itself
becomes cumbersome and therefore we change the default bundle
setup for image formats to be compressed. This means the image
as it gets packed by KIWI needs to be uncompressed before use.
The following image formats are affected by the change in a
call of the result bundler:

```
kiwi result bundle ...
```

* qcow2 (.qcow2.xz)
* vdi   (.vdi.xz)
* vhd   (.vhd.xz)
* vhdx  (.vhdx.xz)
* vmdk  (.vmdk.xz)

All other image formats already defined a custom bundling
setup including compression and are not affected by this change.
This Fixes #650

