### PR TITLE
Fix rsync call for filesystem images

### DIFF
--- a/kiwi/builder/filesystem.py
+++ b/kiwi/builder/filesystem.py
@@ -16,6 +16,7 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import platform
+import os
 
 # project
 from kiwi.filesystem import FileSystem
@@ -158,7 +159,7 @@ class FileSystemBuilder(object):
         loop_provider.create()
         filesystem = FileSystem(
             self.requested_filesystem, loop_provider,
-            self.root_dir, self.filesystem_custom_parameters
+            self.root_dir + os.sep, self.filesystem_custom_parameters
         )
         filesystem.create_on_device(self.label)
         log.info(

--- a/test/unit/builder_filesystem_test.py
+++ b/test/unit/builder_filesystem_test.py
@@ -97,7 +97,7 @@ class TestFileSystemBuilder(object):
         )
         self.loop_provider.create.assert_called_once_with()
         mock_fs.assert_called_once_with(
-            'ext3', self.loop_provider, 'root_dir', {'mount_options': 'async'}
+            'ext3', self.loop_provider, 'root_dir/', {'mount_options': 'async'}
         )
         self.filesystem.create_on_device.assert_called_once_with(None)
         self.filesystem.sync_data.assert_called_once_with(


### PR DESCRIPTION
For filesystem images the rsync call was missing a finale slash for
the source path causing the sync also the containing directory. With
this change the filesystem image does not include the rootfs in any
subdirectory.

Fixes #875
