### PR TITLE
Make gfxboot a recommended package

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -104,7 +104,7 @@ Requires(postun): update-alternatives
 Requires:       grub2-x86_64-efi
 %endif
 %ifarch %{ix86} x86_64
-Requires:       gfxboot
+Recommends:     gfxboot
 %endif
 Requires:       qemu-tools
 Requires:       squashfs
@@ -133,9 +133,6 @@ Requires:       debootstrap
 Requires:       qemu-utils
 Requires:       squashfs-tools
 Requires:       gdisk
-%ifarch %{ix86} x86_64
-Requires:       gfxboot
-%endif
 %endif
 Requires:       dosfstools
 Requires:       e2fsprogs
@@ -187,7 +184,7 @@ Requires(postun): update-alternatives
 Requires:       grub2-x86_64-efi
 %endif
 %ifarch %{ix86} x86_64
-Requires:       gfxboot
+Recommends:     gfxboot
 %endif
 Requires:       qemu-tools
 Requires:       squashfs


### PR DESCRIPTION
gfxboot is needed on the host for certain boot graphics
operations. It's used if the boot theme provides a gfxboot.cfg
In this case the tool is also required. The setup of the
boot themes is differently implemented in each of the
distributions we support. In addition on suse distributions
gfxboot is no longer in the core system. Given that we are
not able to find a common base on requirement of the package
we changed gfxboot from a required to a recommended package
and deleted the requirement on debian based distros

