### PR TITLE
dracut/kiwi-lib: add a custom "die" function

### DIFF
--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -12,7 +12,7 @@ function initialize {
     local profile=/.profile
 
     test -f ${profile} || \
-        die "No profile setup found"
+        kiwi_die "No profile setup found"
 
     import_file ${profile}
 }
@@ -92,7 +92,7 @@ function get_disk_list {
     if [ -z "${list_items}" ];then
         local no_device_text="No device(s) for installation found"
         run_dialog --msgbox "\"${no_device_text}\"" 5 60
-        die "${no_device_text}"
+        kiwi_die "${no_device_text}"
     fi
     echo "${list_items}"
 }
@@ -138,7 +138,7 @@ function get_selected_disk {
                 --radiolist "\"Select Installation Disk\"" 20 75 15 \
                 "$(get_disk_list)"
             then
-                die "System installation canceled"
+                kiwi_die "System installation canceled"
             fi
             get_dialog_result
         fi
@@ -156,7 +156,7 @@ function export_image_metadata {
     meta_file="$(echo "${image_source_files}" | cut -f2 -d\|)"
     if ! read -r checksum blocks blocksize zblocks zblocksize < "${meta_file}"
     then
-        die "Reading ${meta_file} failed"
+        kiwi_die "Reading ${meta_file} failed"
     fi
     echo "Image checksum: ${checksum}"
     echo "Image blocks: ${blocks} / blocksize: ${blocksize}"
@@ -174,7 +174,7 @@ function check_image_fits_target {
     echo "Have size: ${image_target} -> ${have_mbytes} MB"
     echo "Need size: ${image_source} -> ${need_mbytes} MB"
     if [ ${need_mbytes} -gt ${have_mbytes} ];then
-        die "Not enough space available for this image"
+        kiwi_die "Not enough space available for this image"
     fi
 }
 
@@ -206,7 +206,7 @@ function dump_image {
         if ! run_dialog --yesno "\"${ack_dump_text}\"" 7 80; then
             local install_cancel_text="System installation canceled"
             run_dialog --msgbox "\"${install_cancel_text}\"" 5 60
-            die "${install_cancel_text}"
+            kiwi_die "${install_cancel_text}"
         fi
     fi
 
@@ -219,7 +219,7 @@ function dump_image {
     else
         # dump with silently blocked console
         if ! eval "${dump}" "${image_source}" "${image_target}"; then
-            die "Failed to install image"
+            kiwi_die "Failed to install image"
         fi
     fi
 }
@@ -284,7 +284,7 @@ function check_image_integrity {
     read -r checksum_dumped_image checksum_fileref < ${verify_result}
     echo "Dumped Image checksum: ${checksum_dumped_image}/${checksum_fileref}"
     if [ "${checksum}" != "${checksum_dumped_image}" ];then
-        die "Image checksum test failed"
+        kiwi_die "Image checksum test failed"
     fi
 }
 
@@ -297,11 +297,11 @@ function get_local_image_source_files {
     local image_md5
     mkdir -m 0755 -p "${iso_mount_point}"
     if ! mount -n "${iso_device}" "${iso_mount_point}"; then
-        die "Failed to mount install ISO device"
+        kiwi_die "Failed to mount install ISO device"
     fi
     mkdir -m 0755 -p "${image_mount_point}"
     if ! mount -n "${iso_mount_point}"/*.squashfs ${image_mount_point};then
-        die "Failed to mount install image squashfs filesystem"
+        kiwi_die "Failed to mount install image squashfs filesystem"
     fi
     image_source="$(echo "${image_mount_point}"/*.raw)"
     image_md5="$(echo "${image_mount_point}"/*.md5)"
@@ -328,20 +328,20 @@ function get_remote_image_source_files {
     )
 
     if ! ifup lan0 &>/tmp/net.info;then
-        die "Network setup failed, see /tmp/net.info"
+        kiwi_die "Network setup failed, see /tmp/net.info"
     fi
 
     if ! fetch_file "${image_md5_uri}" > "${image_md5}";then
-        die "Failed to fetch ${image_md5_uri}, see /tmp/fetch.info"
+        kiwi_die "Failed to fetch ${image_md5_uri}, see /tmp/fetch.info"
     fi
 
     if ! fetch_file "${image_kernel_uri}" > "${metadata_dir}/linux";then
-        die "Failed to fetch ${image_kernel_uri}, see /tmp/fetch.info"
+        kiwi_die "Failed to fetch ${image_kernel_uri}, see /tmp/fetch.info"
     fi
 
     if ! fetch_file "${image_initrd_uri}" > "${install_dir}/initrd.system_image"
     then
-        die "Failed to fetch ${image_initrd_uri}, see /tmp/fetch.info"
+        kiwi_die "Failed to fetch ${image_initrd_uri}, see /tmp/fetch.info"
     fi
 
     echo "${image_uri}|${image_md5}"
@@ -357,7 +357,7 @@ function boot_installed_system {
         --initrd /run/install/initrd.system_image \
         --command-line "${boot_options}"
     if ! kexec -e; then
-        die "Failed to boot system"
+        kiwi_die "Failed to boot system"
     fi
 }
 

--- a/dracut/modules.d/90kiwi-live/kiwi-live-lib.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-live-lib.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
+type kiwi_die >/dev/null 2>&1 || ./lib/kiwi-lib.sh
 
 function lookupIsoDiskDevice {
     local root=$1
@@ -53,11 +54,11 @@ function loadKernelModules {
 
 function initGlobalDevices {
     if [ -z "$1" ]; then
-        die "No root device for operation given"
+        kiwi_die "No root device for operation given"
     fi
     if getargbool 0 rd.kiwi.live.pxe; then
         if ! ifup lan0 &>/tmp/net.info;then
-            die "Network setup failed, see /tmp/net.info"
+            kiwi_die "Network setup failed, see /tmp/net.info"
         fi
         modprobe aoe
         isodev="${1#live:aoe:}"
@@ -92,7 +93,7 @@ function mountIso {
     local iso_mount_point=/run/initramfs/live
     mkdir -m 0755 -p "${iso_mount_point}"
     if ! mount -n -t "${isofs_type}" "${isodev}" "${iso_mount_point}"; then
-        die "Failed to mount live ISO device"
+        kiwi_die "Failed to mount live ISO device"
     fi
     echo "${iso_mount_point}"
 }
@@ -103,7 +104,7 @@ function mountCompressedContainerFromIso {
     squashfs_container="${iso_mount_point}/${live_dir}/${squash_image}"
     mkdir -m 0755 -p "${container_mount_point}"
     if ! mount -n "${squashfs_container}" "${container_mount_point}";then
-        die "Failed to mount live ISO squashfs container"
+        kiwi_die "Failed to mount live ISO squashfs container"
     fi
     echo "${container_mount_point}"
 }
@@ -114,7 +115,7 @@ function mountReadOnlyRootImageFromContainer {
     local root_mount_point=/run/rootfsbase
     mkdir -m 0755 -p "${root_mount_point}"
     if ! mount -n "${rootfs_image}" "${root_mount_point}"; then
-        die "Failed to mount live ISO root filesystem"
+        kiwi_die "Failed to mount live ISO root filesystem"
     fi
     echo "${root_mount_point}"
 }
@@ -175,7 +176,7 @@ function runMediaCheck {
     echo "Press key to continue (waiting ${timeout}sec...)" >> ${check_result}
     _run_dialog --timeout ${timeout} --textbox ${check_result} 20 70
     if [ ${check_status} != 0 ];then
-        die "Failed to verify system integrity"
+        kiwi_die "Failed to verify system integrity"
     fi
 }
 

--- a/dracut/modules.d/90kiwi-overlay/kiwi-overlay-root.sh
+++ b/dracut/modules.d/90kiwi-overlay/kiwi-overlay-root.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
+type kiwi_die >/dev/null 2>&1 || . /lib/kiwi-lib.sh
 
 #======================================
 # functions
@@ -20,7 +21,7 @@ function loadKernelModules {
 
 function initGlobalDevices {
     if [ -z "$1" ]; then
-        die "No root device for operation given"
+        kiwi_die "No root device for operation given"
     fi
     write_partition="$1"
     root_disk=$(
@@ -37,7 +38,7 @@ function mountReadOnlyRootImage {
     local root_mount_point=/run/rootfsbase
     mkdir -m 0755 -p ${root_mount_point}
     if ! mount -n "${read_only_partition}" "${root_mount_point}"; then
-        die "Failed to mount overlay(ro) root filesystem"
+        kiwi_die "Failed to mount overlay(ro) root filesystem"
     fi
     echo "${root_mount_point}"
 }
@@ -46,7 +47,7 @@ function preparePersistentOverlay {
     local overlay_mount_point=/run/overlayfs
     mkdir -m 0755 -p ${overlay_mount_point}
     if ! mount "${write_partition}" "${overlay_mount_point}"; then
-        die "Failed to mount overlay(rw) filesystem"
+        kiwi_die "Failed to mount overlay(rw) filesystem"
     fi
     mkdir -m 0755 -p ${overlay_mount_point}/rw
     mkdir -m 0755 -p ${overlay_mount_point}/work

--- a/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
+++ b/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
@@ -16,9 +16,9 @@ function initialize {
     local partition_ids=/config.partids
 
     test -f ${profile} || \
-        die "No profile setup found"
+        kiwi_die "No profile setup found"
     test -f ${partition_ids} || \
-        die "No partition id setup found"
+        kiwi_die "No partition id setup found"
 
     import_file ${profile}
     import_file ${partition_ids}

--- a/dracut/modules.d/99kiwi-lib/kiwi-filesystem-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-filesystem-lib.sh
@@ -1,4 +1,5 @@
 type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
+type kiwi_die >/dev/null 2>&1 || . /lib/kiwi-lib.sh
 
 function resize_filesystem {
     local device=$1
@@ -32,7 +33,7 @@ function resize_filesystem {
     fi
     info "Resizing ${fstype} filesystem on ${device}..."
     if ! eval "${resize_fs}"; then
-        die "Failed to resize filesystem"
+        kiwi_die "Failed to resize filesystem"
     fi
 }
 
@@ -60,7 +61,7 @@ function check_filesystem {
     esac
     info "Checking ${fstype} filesystem on ${device}..."
     if ! eval "${check_fs}"; then
-        die "Failed to check filesystem"
+        kiwi_die "Failed to check filesystem"
     fi
 }
 
@@ -88,7 +89,7 @@ function create_swap {
     local swap_label="SWAP"
     test -n "${device}" || return
     if ! mkswap "${device}" --label "${swap_label}" 1>&2;then
-        die "Failed to create swap signature"
+        kiwi_die "Failed to create swap signature"
     fi
     echo "LABEL=${swap_label} swap swap defaults 0 0" > /fstab.swap
 }

--- a/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
@@ -10,6 +10,11 @@ function setup_debug {
     fi
 }
 
+function kiwi_die {
+    echo 7 > /proc/sys/kernel/printk
+    die $@
+}
+
 function set_root_map {
     root_map=$1
     export root_map
@@ -32,7 +37,7 @@ function lookup_disk_device_from_root {
     declare root=${root}
     local root_device=${root#block:}
     if [ -z "${root_device}" ];then
-        die "No root device found"
+        kiwi_die "No root device found"
     fi
     if [ -L "${root_device}" ];then
         root_device=/dev/$(basename "$(readlink "${root_device}")")

--- a/dracut/modules.d/99kiwi-lib/kiwi-lvm-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-lvm-lib.sh
@@ -30,7 +30,7 @@ function activate_volume_group {
             fi
         done
         if [ ${vg_count} -gt 1 ];then
-            die "Duplicate VolumeGroup name ${kiwi_lvmgroup} found !"
+            kiwi_die "Duplicate VolumeGroup name ${kiwi_lvmgroup} found !"
         fi
         vgchange -a y "${kiwi_lvmgroup}"
         udev_pending

--- a/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
@@ -182,7 +182,7 @@ function create_fdasd_partitions {
     echo "w" >> ${partition_setup_file}
     echo "q" >> ${partition_setup_file}
     if ! fdasd "${disk_device}" < ${partition_setup_file} 1>&2;then
-        die "Failed to create partition table"
+        kiwi_die "Failed to create partition table"
     fi
     partprobe "${disk_device}"
 }
@@ -230,7 +230,7 @@ function wait_for_storage_device {
             sleep 1; return 0
         fi
         if [ "${check}" -eq "${limit}" ]; then
-            die "Storage device ${device} did not appear"
+            kiwi_die "Storage device ${device} did not appear"
         fi
         info "Waiting for storage device ${device} to settle..."
         check=$((check + 1))
@@ -308,7 +308,7 @@ function relocate_gpt_at_end_of_disk {
         echo $cmd >> ${cmd_file}
     done
     if ! gdisk "$1" < ${cmd_file} &>/dev/null; then
-        die "Failed to write backup GPT at end of disk"
+        kiwi_die "Failed to write backup GPT at end of disk"
     fi
 }
 
@@ -333,7 +333,7 @@ function create_hybrid_gpt {
         partition_count=3
     fi
     if ! sgdisk -h $(seq -s : 1 "${partition_count}") "${disk_device}";then
-        die "Failed to create hybrid GPT/MBR !"
+        kiwi_die "Failed to create hybrid GPT/MBR !"
     fi
 }
 
@@ -479,7 +479,7 @@ function _parted_write {
     local disk_device=$1
     local commands=$2
     if ! parted -a cyl -m -s "${disk_device}" unit cyl "${commands}";then
-        die "Failed to create partition table"
+        kiwi_die "Failed to create partition table"
     fi
     _parted_init "${disk_device}"
 }


### PR DESCRIPTION
The message passed to "die" is never seen by most, because of
"loglevel=0" usually passed to e.g. oem iso installs.
Create a custom wrapper function, that increases kernel loglevel before
actually calling dracut's die, so users can see what's going on.

How to test: abort an interactive OEM ISO installation at the disk selection without this patch, and with it.
Without, you only see "Started dracut interactive", before the machine being silently halted (not powered off), with this version you can actually guess what is going on by the on-screen messages.