### PR TITLE
Fix update-alternatives path for ubuntu

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -20,10 +20,15 @@
 # If they aren't provided by a system installed macro, define them
 %{!?_defaultdocdir: %global _defaultdocdir %{_datadir}/doc}
 %{!?__python2: %global __python2 /usr/bin/python2}
+%{!?__python3: %global __python3 /usr/bin/python3}
 
 # Expanded form required for debbuild's simpler engine
 %if %{undefined python2_sitelib}
 %global python2_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
+%endif
+
+%if %{undefined python3_sitelib}
+%global python3_sitelib %(%{__python3} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
 %endif
 
 %if 0%{?debian} || 0%{?ubuntu}
@@ -31,10 +36,12 @@
 %global pygroup python
 %global sysgroup admin
 %global develsuffix dev
+%global update_alternatives %{_bindir}/update-alternatives
 %else
 %global pygroup Development/Languages/Python
 %global sysgroup System/Management
 %global develsuffix devel
+%global update_alternatives %{_sbindir}/update-alternatives
 %endif
 
 Name:           python-kiwi
@@ -54,6 +61,8 @@ Source1:        %{name}-rpmlintrc
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 %if 0%{?fedora} || 0%{?suse_version}
 BuildRequires:  python3-devel
+%endif
+%if 0%{?fedora} || 0%{?suse_version} || 0%{?ubuntu} >= 1804 || 0%{?debian} >= 9
 BuildRequires:  python3-setuptools
 BuildRequires:  fdupes
 %endif
@@ -161,13 +170,17 @@ Python 2 library of the KIWI Image System. Provides an operating system
 image builder for Linux supported hardware platforms as well as for
 virtualization and cloud systems like Xen, KVM, VMware, EC2 and more.
 
-%if 0%{?fedora} || 0%{?suse_version}
+%if 0%{?fedora} || 0%{?suse_version} || 0%{?ubuntu} >= 1804 || 0%{?debian} >= 9
 # python3-kiwi
 %package -n python3-kiwi
 Summary:        KIWI - Appliance Builder Next Generation
 Group:          Development/Languages/Python
 Recommends:     jing
+%if 0%{?ubuntu} || 0%{?debian}
+Requires:       python3-yaml
+%else
 Requires:       python3-PyYAML
+%endif
 Requires:       python3-docopt
 Requires:       python3-future
 Requires:       python3-lxml
@@ -209,6 +222,12 @@ Provides:       kiwi-packagemanager:dnf
 %if 0%{?fedora} >= 26 || 0%{?suse_version}
 Requires:       zypper
 Provides:       kiwi-packagemanager:zypper
+%endif
+%if 0%{?debian} || 0%{?ubuntu}
+Requires:       debootstrap
+Requires:       qemu-utils
+Requires:       squashfs-tools
+Requires:       gdisk
 %endif
 Requires:       dosfstools
 Requires:       e2fsprogs
@@ -276,13 +295,18 @@ BuildRequires:  dracut
 %endif
 Requires:       bc
 Requires:       cryptsetup
-%if 0%{?fedora} || 0%{?rhel}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?ubuntu} >= 1804 || 0%{?debian} >= 9
 Requires:       btrfs-progs
 Requires:       gdisk
 Requires:       dracut-network
 %else
+%if 0%{?debian} || 0%{?ubuntu}
+Requires:       btrfs-tools
+Requires:       gdisk
+%else
 Requires:       btrfsprogs
 Requires:       gptfdisk
+%endif
 %endif
 Requires:       coreutils
 Requires:       e2fsprogs
@@ -298,9 +322,6 @@ Requires:       curl
 %if 0%{?debian} || 0%{?ubuntu}
 Requires:       xz-utils
 Requires:       dmsetup
-Requires:       btrfs-tools
-Requires:       gdisk
-Requires:       dracut-network
 %else
 Requires:       xz
 Requires:       device-mapper
@@ -429,7 +450,7 @@ sed -e "s|#!/usr/bin/env python||" -i kiwi/xml_parse.py
 # Build Python 2 version
 python2 setup.py build --cflags="${RPM_OPT_FLAGS}"
 
-%if 0%{?fedora} || 0%{?suse_version}
+%if 0%{?fedora} || 0%{?suse_version} || 0%{?ubuntu} >= 1804 || 0%{?debian} >= 9
 # Build Python 3 version
 python3 setup.py build --cflags="${RPM_OPT_FLAGS}"
 %endif
@@ -438,7 +459,7 @@ python3 setup.py build --cflags="${RPM_OPT_FLAGS}"
 # Install Python 2 version
 python2 setup.py install --prefix=%{_prefix} --root=%{buildroot} %{?is_deb:--install-layout=deb}
 
-%if 0%{?fedora} || 0%{?suse_version}
+%if 0%{?fedora} || 0%{?suse_version} || 0%{?ubuntu} >= 1804 || 0%{?debian} >= 9
 # Install Python 3 version
 python3 setup.py install --prefix=%{_prefix} --root=%{buildroot} %{?is_deb:--install-layout=deb}
 %endif
@@ -481,38 +502,38 @@ done
 %endif
 
 %post -n python2-kiwi
-%{_sbindir}/update-alternatives \
+%{update_alternatives} \
     --install %_bindir/kiwi kiwi %_bindir/kiwi-ng-2 10
-%{_sbindir}/update-alternatives \
+%{update_alternatives} \
     --install %_bindir/kiwi-ng kiwi-ng %_bindir/kiwi-ng-2 10
-%{_sbindir}/update-alternatives \
+%{update_alternatives} \
     --install %_bindir/kiwicompat kiwicompat %_bindir/kiwicompat-2 10
 
-%if 0%{?fedora} || 0%{?suse_version}
+%if 0%{?fedora} || 0%{?suse_version} || 0%{?ubuntu} >= 1804 || 0%{?debian} >= 9
 %post -n python3-kiwi
-%{_sbindir}/update-alternatives \
+%{update_alternatives} \
     --install %_bindir/kiwi kiwi %_bindir/kiwi-ng-3 10
-%{_sbindir}/update-alternatives \
+%{update_alternatives} \
     --install %_bindir/kiwi-ng kiwi-ng %_bindir/kiwi-ng-3 10
-%{_sbindir}/update-alternatives \
+%{update_alternatives} \
     --install %_bindir/kiwicompat kiwicompat %_bindir/kiwicompat-3 10
 %endif
 
 %preun -n python2-kiwi
-%{_sbindir}/update-alternatives \
+%{update_alternatives} \
     --remove kiwi %_bindir/kiwi
-%{_sbindir}/update-alternatives \
+%{update_alternatives} \
     --remove kiwi %_bindir/kiwi-ng
-%{_sbindir}/update-alternatives \
+%{update_alternatives} \
     --remove kiwicompat %_bindir/kiwicompat
 
-%if 0%{?fedora} || 0%{?suse_version}
+%if 0%{?fedora} || 0%{?suse_version} || 0%{?ubuntu} >= 1804 || 0%{?debian} >= 9
 %preun -n python3-kiwi
-%{_sbindir}/update-alternatives \
+%{update_alternatives} \
     --remove kiwi %_bindir/kiwi
-%{_sbindir}/update-alternatives \
+%{update_alternatives} \
     --remove kiwi %_bindir/kiwi-ng
-%{_sbindir}/update-alternatives \
+%{update_alternatives} \
     --remove kiwicompat %_bindir/kiwicompat
 %endif
 
@@ -544,7 +565,7 @@ fi
 %{python2_sitelib}/*
 %config %_sysconfdir/bash_completion.d/kiwi-ng-2*.sh
 
-%if 0%{?fedora} || 0%{?suse_version}
+%if 0%{?fedora} || 0%{?suse_version} || 0%{?ubuntu} >= 1804 || 0%{?debian} >= 9
 %files -n python3-kiwi
 %defattr(-,root,root,-)
 %{_bindir}/kiwi-ng-3*


### PR DESCRIPTION
This commit fixes the path for the update-alternatives for the
ubuntu builds. In addition it also sets the python3-kiwi builds
for ubuntu.
