### PR TITLE
Include the isolinux ubuntu paths

### DIFF
--- a/kiwi/iso_tools/xorriso.py
+++ b/kiwi/iso_tools/xorriso.py
@@ -88,7 +88,8 @@ class IsoToolsXorrIso(IsoToolsBase):
         loader_file = self.boot_path + '/loader/isolinux.bin'
 
         syslinux_lookup_paths = [
-            '/usr/share/syslinux', '/usr/lib/syslinux/modules/bios'
+            '/usr/share/syslinux', '/usr/lib/syslinux/modules/bios',
+            '/usr/lib/ISOLINUX'
         ]
         mbr_file = Path.which('isohdpfx.bin', syslinux_lookup_paths)
         if not mbr_file:

--- a/test/unit/iso_tools_xorriso_test.py
+++ b/test/unit/iso_tools_xorriso_test.py
@@ -39,6 +39,13 @@ class TestIsoToolsXorrIso(object):
                 'volume_id': 'vol_id'
             }
         )
+        mock_which.assert_called_once_with(
+            'isohdpfx.bin', [
+                '/usr/share/syslinux',
+                '/usr/lib/syslinux/modules/bios',
+                '/usr/lib/ISOLINUX'
+            ]
+        )
         assert self.iso_tool.iso_parameters == [
             '-application_id', 'app_id',
             '-publisher', 'org',


### PR DESCRIPTION
This commit adds the ubuntu installation paths the places to look
for isolinux binaries.
