### PR TITLE
Add parted dependency for dracut-kiwi-live package

### DIFF
--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -406,6 +406,7 @@ Requires:       device-mapper
 %endif
 Requires:       dracut
 Requires:       xorriso
+Requires:       parted
 License:        GPL-3.0-or-later
 Group:          %{sysgroup}
 


### PR DESCRIPTION
dracut-kiwi-live requires `partprobe` tool and this is provided by
parted package. Persistent overlay setup fails if parted is not
installed in the image.
