### PR TITLE
Create a custom `setup.py clean` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ pypi: clean tox
 	$(python) setup.py sdist upload
 
 clean: clean_git_attributes
-	rm -rf dist
+	$(python) setup.py clean
 	rm -rf doc/build
 	rm -rf doc/dist
 	${MAKE} -C tools clean


### PR DESCRIPTION
The default `setup.py clean` command does not clean `dist` and
`*.egg-info` folders. This commit makes sure those are cleaned and
also ands a `setup.py clean` command in the `clean` Makefile target
