### PR TITLE
Another round of OCI tools refactoring

### DIFF
--- a/test/unit/container_image_oci_test.py
+++ b/test/unit/container_image_oci_test.py
@@ -92,27 +92,13 @@ class TestContainerImageOCI(object):
         assert 'labels' not in container.oci_config
         assert mock_warn.called
 
-    @patch('kiwi.container.oci.Path.wipe')
-    def test_del(self, mock_wipe):
-        self.oci.oci_root_dir = 'kiwi_oci_root_dir'
-        self.oci.__del__()
-        mock_wipe.assert_called_once_with('kiwi_oci_root_dir')
-
     @patch('kiwi.container.oci.ArchiveTar')
-    @patch('kiwi.container.oci.DataSync')
-    @patch('kiwi.container.oci.mkdtemp')
     @patch('kiwi.container.oci.Defaults.get_shared_cache_location')
-    def test_create(
-        self, mock_cache, mock_mkdtemp, mock_sync, mock_tar
-    ):
+    def test_create(self, mock_cache, mock_tar):
         oci_tarfile = mock.Mock()
         mock_tar.return_value = oci_tarfile
 
         mock_cache.return_value = 'var/cache/kiwi'
-        oci_root = mock.Mock()
-        mock_sync.return_value = oci_root
-
-        mock_mkdtemp.return_value = 'kiwi_oci_root_dir'
 
         self.oci.runtime_config.get_container_compression = mock.Mock(
             return_value='xz'
@@ -121,8 +107,14 @@ class TestContainerImageOCI(object):
         self.oci.create('result.tar', None)
 
         self.oci.oci.init_layout.assert_called_once_with(False)
-        self.oci.oci.unpack.assert_called_once_with('kiwi_oci_root_dir')
-        self.oci.oci.repack.assert_called_once_with('kiwi_oci_root_dir')
+        self.oci.oci.unpack.assert_called_once_with()
+        self.oci.oci.sync_rootfs.assert_called_once_with(
+            'root_dir/', [
+                'image', '.profile', '.kconfig', '.buildenv',
+                'var/cache/kiwi', 'boot', 'dev', 'sys', 'proc'
+            ]
+        )
+        self.oci.oci.repack.assert_called_once_with()
         self.oci.oci.set_config.assert_called_once_with({
             'container_name': 'foo/bar',
             'additional_tags': ['current', 'foobar'],
@@ -134,17 +126,6 @@ class TestContainerImageOCI(object):
             call('current'), call('foobar')
         ]
         self.oci.oci.garbage_collect.assert_called_once_with()
-
-        mock_sync.assert_called_once_with(
-            'root_dir/', 'kiwi_oci_root_dir/rootfs'
-        )
-        oci_root.sync_data.assert_called_once_with(
-            exclude=[
-                'image', '.profile', '.kconfig', '.buildenv',
-                'var/cache/kiwi', 'boot', 'dev', 'sys', 'proc',
-            ],
-            options=['-a', '-H', '-X', '-A', '--delete']
-        )
         mock_tar.assert_called_once_with('result.tar')
         oci_tarfile.create_xz_compressed.assert_called_once_with(
             'kiwi_oci_dir.XXXX/oci_layout',
@@ -162,26 +143,25 @@ class TestContainerImageOCI(object):
         )
 
     @patch('kiwi.container.oci.ArchiveTar')
-    @patch('kiwi.container.oci.DataSync')
-    @patch('kiwi.container.oci.mkdtemp')
     @patch('kiwi.container.oci.Path.create')
     @patch('kiwi.container.oci.Defaults.get_shared_cache_location')
     def test_create_derived(
-        self, mock_cache, mock_create, mock_mkdtemp, mock_sync, mock_tar
+        self, mock_cache, mock_create, mock_tar
     ):
         mock_cache.return_value = 'var/cache/kiwi'
-        oci_root = mock.Mock()
-        mock_sync.return_value = oci_root
-
-        mock_mkdtemp.return_value = 'kiwi_oci_root_dir'
 
         self.oci.create('result.tar', 'root_dir/image/image_file')
-
         mock_create.assert_called_once_with('kiwi_oci_dir.XXXX/oci_layout')
 
         self.oci.oci.init_layout.assert_called_once_with(True)
-        self.oci.oci.unpack.assert_called_once_with('kiwi_oci_root_dir')
-        self.oci.oci.repack.assert_called_once_with('kiwi_oci_root_dir')
+        self.oci.oci.unpack.assert_called_once_with()
+        self.oci.oci.sync_rootfs.assert_called_once_with(
+            'root_dir/', [
+                'image', '.profile', '.kconfig', '.buildenv',
+                'var/cache/kiwi', 'boot', 'dev', 'sys', 'proc'
+            ]
+        )
+        self.oci.oci.repack.assert_called_once_with()
         self.oci.oci.set_config.assert_called_once_with({
             'container_name': 'foo/bar',
             'additional_tags': ['current', 'foobar'],
@@ -194,16 +174,6 @@ class TestContainerImageOCI(object):
         ]
         self.oci.oci.garbage_collect.assert_called_once_with()
 
-        mock_sync.assert_called_once_with(
-            'root_dir/', 'kiwi_oci_root_dir/rootfs'
-        )
-        oci_root.sync_data.assert_called_once_with(
-            exclude=[
-                'image', '.profile', '.kconfig', '.buildenv',
-                'var/cache/kiwi', 'boot', 'dev', 'sys', 'proc'
-            ],
-            options=['-a', '-H', '-X', '-A', '--delete']
-        )
         assert mock_tar.call_args_list == [
             call('root_dir/image/image_file'), call('result.tar')
         ]

--- a/test/unit/oci_tools_base_test.py
+++ b/test/unit/oci_tools_base_test.py
@@ -10,11 +10,11 @@ class TestOCIBase(object):
         mock_mkdtemp.return_value = 'kiwi_oci_dir.XXXX'
         self.oci = OCIBase('tag')
         mock_mkdtemp.assert_called_once_with(prefix='kiwi_oci_dir.')
-        assert self.oci.container_name == 'kiwi_oci_dir.XXXX/oci_layout:tag'
+        assert self.oci.container_tag == 'tag'
 
     def test_setup_existing_container_dir(self):
         oci = OCIBase('tag', 'layout_dir')
-        assert oci.container_name == 'layout_dir:tag'
+        assert oci.container_dir == 'layout_dir'
 
     def test_init_layout(self):
         with raises(NotImplementedError):
@@ -22,11 +22,19 @@ class TestOCIBase(object):
 
     def test_unpack(self):
         with raises(NotImplementedError):
-            self.oci.unpack('dir')
+            self.oci.unpack()
+
+    def test_sync_rootfs(self):
+        with raises(NotImplementedError):
+            self.oci.sync_rootfs('root_dir')
+
+    def test_import_rootfs(self):
+        with raises(NotImplementedError):
+            self.oci.import_rootfs('root_dir')
 
     def test_repack(self):
         with raises(NotImplementedError):
-            self.oci.repack('dir')
+            self.oci.repack()
 
     def test_add_tag(self):
         with raises(NotImplementedError):


### PR DESCRIPTION
In order to provide buildah support some of the logic about
temporary directories for OCI images creation needs to be moved
to the dedicated OCI tool class.

While umoci can operate in any directory and this is passed as an
argument, this is not the case for buildah. In buildah workflow
the storage path of work-in-progress images/containers is not
customizable neither the mountpoint of the container rootfs.

Related with #764
