### PR TITLE
Add Ubuntu Bionic build tests

### DIFF
--- a/build-tests/x86/test-image-ubuntu/appliance.kiwi
+++ b/build-tests/x86/test-image-ubuntu/appliance.kiwi
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- The line below is required in order to use the multibuild OBS features -->
+<!-- OBS-Profiles: @BUILD_FLAVOR@ -->
+
+<image schemaversion="6.9" name="LimeJeOS-Ubuntu-18.04">
+    <description type="system">
+        <author>Marcus Schaefer</author>
+        <contact>ms@suse.com</contact>
+        <specification>vmx disk test build for Ubuntu</specification>
+    </description>
+    <profiles>
+        <profile name="Live" description="Live image of Ubuntu 18.04"/>
+        <profile name="Virtual" description="Virtual image of Ubuntu 18.04"/>
+        <profile name="Disk" description="OEM image of Ubuntu 18.04"/>
+    </profiles>
+    <preferences>
+        <version>1.16.4</version>
+        <packagemanager>apt-get</packagemanager>
+        <bootsplash-theme>sabily</bootsplash-theme>
+        <bootloader-theme>ubuntu-mate</bootloader-theme>
+        <locale>en_US</locale>
+        <keytable>us</keytable>
+        <timezone>UTC</timezone>
+        <rpm-check-signatures>false</rpm-check-signatures>
+    </preferences>
+    <preferences profiles="Live">
+        <type image="iso" flags="overlay" hybridpersistent_filesystem="ext4" hybridpersistent="true"/>
+    </preferences>
+    <preferences profiles="Virtual">
+        <type image="vmx" filesystem="ext4" bootloader="grub2" kernelcmdline="console=ttyS0 splash"/>
+    </preferences>
+    <preferences profiles="Disk">
+        <type image="oem" initrd_system="dracut" filesystem="ext4" installiso="true" bootloader="grub2">
+            <oemconfig>
+                <oem-systemsize>2048</oem-systemsize>
+                <oem-swap>true</oem-swap>
+                <oem-swapsize>200</oem-swapsize>
+                <oem-multipath-scan>false</oem-multipath-scan>
+            </oemconfig>
+        </type>
+    </preferences>
+    <users>
+        <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
+    </users>
+    <repository type="apt-deb" alias="kiwi-next-generation" priority="1" repository_gpgcheck="false">
+        <source path="obs://Virtualization:Appliances:Staging/xUbuntu_18.04"/>
+    </repository>
+    <repository type="apt-deb" alias="Ubuntu-Bionic-Universe" distribution="bionic" components="main multiverse restricted universe" repository_gpgcheck="false">
+        <source path="obs://Ubuntu:18.04/universe"/>
+     </repository>
+    <repository type="apt-deb" alias="Ubuntu-Bionic" distribution="bionic" components="main multiverse restricted universe" repository_gpgcheck="false">
+        <source path="obs://Ubuntu:18.04/standard"/>
+    </repository>
+    <packages type="image">
+        <package name="grub2-themes-ubuntu-mate"/>
+        <package name="plymouth-theme-sabily"/>
+        <package name="plymouth"/>
+        <package name="linux-generic"/>
+        <package name="isolinux"/>
+        <package name="syslinux"/>
+        <package name="syslinux-common"/>
+        <package name="dracut"/>
+        <package name="grub2"/>
+        <package name="init"/>
+        <package name="gnupg"/>
+        <package name="iproute2"/>
+        <package name="iptables"/>
+        <package name="iputils-ping"/>
+        <package name="ifupdown"/>
+        <package name="isc-dhcp-client"/>
+        <package name="netbase"/>
+        <package name="dbus"/>
+    </packages>
+    <packages type="image" profiles="Live">
+        <package name="dracut-kiwi-live"/>
+    </packages>
+    <packages type="image" profiles="Disk">
+        <package name="dracut-kiwi-oem-repart"/>
+        <package name="dracut-kiwi-oem-dump"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="mawk"/>
+    </packages>
+</image>

--- a/build-tests/x86/test-image-ubuntu/config.sh
+++ b/build-tests/x86/test-image-ubuntu/config.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#================
+# FILE          : config.sh
+#----------------
+# PROJECT       : OpenSuSE KIWI Image System
+# COPYRIGHT     : (c) 2006 SUSE LINUX Products GmbH. All rights reserved
+#               :
+# AUTHOR        : Marcus Schaefer <ms@suse.de>
+#               :
+# BELONGS TO    : Operating System images
+#               :
+# DESCRIPTION   : configuration script for Ubuntu based
+#               : operating systems
+#               :
+#               :
+# STATUS        : BETA
+#----------------
+#======================================
+# Functions...
+#--------------------------------------
+test -f /.kconfig && . /.kconfig
+test -f /.profile && . /.profile
+
+#======================================
+# Greeting...
+#--------------------------------------
+echo "Configure image: [$kiwi_iname]..."
+
+#======================================
+# Setup default target, multi-user
+#--------------------------------------
+baseSetRunlevel 3
+
+#======================================
+# Enable firstboot resolv.conf setting
+#--------------------------------------
+baseInsertService symlink-resolvconf
+
+#======================================
+# Clear apt-get data
+#--------------------------------------
+apt-get clean
+rm -r /var/lib/apt/*
+rm -r /var/cache/apt/*
+
+exit 0

--- a/build-tests/x86/test-image-ubuntu/root/etc/network/interfaces.d/lan0
+++ b/build-tests/x86/test-image-ubuntu/root/etc/network/interfaces.d/lan0
@@ -1,0 +1,3 @@
+auto lan0
+allow-hotplug lan0
+iface lan0 inet dhcp

--- a/build-tests/x86/test-image-ubuntu/root/etc/systemd/system/symlink-resolvconf.service
+++ b/build-tests/x86/test-image-ubuntu/root/etc/systemd/system/symlink-resolvconf.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Make the resolv.conf symlink during first boot
+ConditionPathExists=!/etc/resolv.conf
+ConditionPathExists=/etc/firstboot
+
+[Service]
+Type=oneshot
+ExecStart=/bin/ln -s /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
+ExecStartPost=/bin/rm /etc/firstboot
+
+[Install]
+WantedBy=multi-user.target

--- a/build-tests/x86/test-image-ubuntu/root/etc/udev/rules.d/70-persistent-net.rules
+++ b/build-tests/x86/test-image-ubuntu/root/etc/udev/rules.d/70-persistent-net.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="?*", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="?*", NAME="lan0"


### PR DESCRIPTION
Adding ubuntu tests for iso and vmx image types. The test for oem is there, but it does not resolves due to the already known issue of `sg3-utils` conflicting with `dracut`, there is already a track for this issue in Debian universe [here](https://salsa.debian.org/linux-blocks-team/sg3-utils/merge_requests).