### PR TITLE
More clarity on kernel version lookup

### DIFF
--- a/kiwi/system/kernel.py
+++ b/kiwi/system/kernel.py
@@ -16,6 +16,7 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
+import platform
 from collections import namedtuple
 
 # project
@@ -51,6 +52,7 @@ class Kernel(object):
 
         :rtype: namedtuple
         """
+        arch = platform.machine()
         for kernel_name in self.kernel_names:
             kernel_file = self.root_dir + '/boot/' + kernel_name
             if os.path.exists(kernel_file):
@@ -66,12 +68,17 @@ class Kernel(object):
                     kernel_file_to_check = kernel_file_to_check.replace(
                         'zImage', 'vmlinux'
                     ) + '.gz'
-                if 'vmlinuz' in kernel_file_to_check:
-                    new_file_to_check = kernel_file_to_check.replace(
+                if 'vmlinuz' in kernel_file_to_check and 's390' in arch:
+                    # On s390 it seems the vmlinuz kernel file cannot be used
+                    # to read the kernel version from via the kversion tool.
+                    # Therefore we try to apply the same fallback as in the
+                    # zImage case.
+                    #
+                    # FIXME: The explanation here should be much better
+                    #
+                    kernel_file_to_check = kernel_file_to_check.replace(
                         'vmlinuz', 'vmlinux'
                     ) + '.gz'
-                    if os.path.exists(new_file_to_check):
-                        kernel_file_to_check = new_file_to_check
                 version = Command.run(
                     command=['kversion', kernel_file_to_check],
                     raise_on_error=False

--- a/kiwi/system/kernel.py
+++ b/kiwi/system/kernel.py
@@ -56,10 +56,9 @@ class Kernel(object):
                 [self.root_dir, 'boot', kernel_name]
             )
             if os.path.exists(kernel_file):
-                kernel_file_for_version_check = os.sep.join(
-                    [self.root_dir, 'boot', 'vmlinux.gz']
-                )
-                if not os.path.exists(kernel_file_for_version_check):
+                kernel_file_for_version_check = \
+                    self._get_kernel_name_for_version_lookup()
+                if not kernel_file_for_version_check:
                     # The system does not provide a gzip compressed binary
                     # of the kernel. Thus we try to fetch the version from
                     # the arbitrary kernel image format. Please Note:
@@ -181,3 +180,14 @@ class Kernel(object):
                         )
                     )
         return kernel_names
+
+    def _get_kernel_name_for_version_lookup(self):
+        vmlinux_kernel_files = list(
+            filter(lambda kernel: 'vmlinux-' in kernel, self.kernel_names)
+        )
+        if vmlinux_kernel_files:
+            kernel_file_for_version_check = os.sep.join(
+                [self.root_dir, 'boot', vmlinux_kernel_files[0] + '.gz']
+            )
+            if os.path.exists(kernel_file_for_version_check):
+                return kernel_file_for_version_check

--- a/test/unit/system_kernel_test.py
+++ b/test/unit/system_kernel_test.py
@@ -76,7 +76,9 @@ class TestKernel(object):
     @patch('os.path.exists')
     @patch('os.path.realpath')
     @patch('kiwi.command.Command.run')
-    def test_get_kernel_from_zImage_vmlinux(self, mock_run, mock_realpath, mock_os):
+    def test_get_kernel_from_zImage_vmlinux(
+        self, mock_run, mock_realpath, mock_os
+    ):
         self.kernel.kernel_names = ['zImage']
         run = namedtuple(
             'run', ['output']
@@ -94,10 +96,14 @@ class TestKernel(object):
         assert data.version == '42'
         assert data.name == 'vmlinux.gz'
 
+    @patch('platform.machine')
     @patch('os.path.exists')
     @patch('os.path.realpath')
     @patch('kiwi.command.Command.run')
-    def test_get_kernel_from_vmlinuz_vmlinux(self, mock_run, mock_realpath, mock_os):
+    def test_get_kernel_from_vmlinuz_on_s390(
+        self, mock_run, mock_realpath, mock_os, mock_platform_machine
+    ):
+        mock_platform_machine.return_value = 's390'
         self.kernel.kernel_names = ['vmlinuz']
         run = namedtuple(
             'run', ['output']

--- a/test/unit/system_kernel_test.py
+++ b/test/unit/system_kernel_test.py
@@ -45,7 +45,7 @@ class TestKernel(object):
         mock_realpath.return_value = 'vmlinux-realpath'
         data = self.kernel.get_kernel()
         mock_run.assert_called_once_with(
-            command=['kversion', 'root-dir/boot/vmlinux.gz'],
+            command=['kversion', 'root-dir/boot/vmlinux-1.2.3-default.gz'],
             raise_on_error=False
         )
         assert data.filename == 'root-dir/boot/vmlinux'
@@ -89,7 +89,7 @@ class TestKernel(object):
         mock_run.return_value = result
         data = self.kernel.get_kernel()
         mock_run.assert_called_once_with(
-            command=['kversion', 'root-dir/boot/vmlinux.gz'],
+            command=['kversion', 'root-dir/boot/vmlinux-1.2.3-default.gz'],
             raise_on_error=False
         )
         assert data.filename == 'root-dir/boot/vmlinux'

--- a/test/unit/system_kernel_test.py
+++ b/test/unit/system_kernel_test.py
@@ -45,7 +45,7 @@ class TestKernel(object):
         mock_realpath.return_value = 'vmlinux-realpath'
         data = self.kernel.get_kernel()
         mock_run.assert_called_once_with(
-            command=['kversion', 'root-dir/boot/vmlinux'],
+            command=['kversion', 'root-dir/boot/vmlinux.gz'],
             raise_on_error=False
         )
         assert data.filename == 'root-dir/boot/vmlinux'
@@ -55,71 +55,28 @@ class TestKernel(object):
     @patch('os.path.exists')
     @patch('os.path.realpath')
     @patch('kiwi.command.Command.run')
-    def test_get_kernel_from_zImage(self, mock_run, mock_realpath, mock_os):
-        self.kernel.kernel_names = ['zImage-1.2.3-default']
-        run = namedtuple(
-            'run', ['output']
-        )
-        result = run(output='42')
-        mock_os.return_value = True
-        mock_run.return_value = result
-        mock_realpath.return_value = 'zImage-realpath'
-        data = self.kernel.get_kernel()
-        mock_run.assert_called_once_with(
-            command=['kversion', 'root-dir/boot/vmlinux-1.2.3-default.gz'],
-            raise_on_error=False
-        )
-        assert data.filename == 'root-dir/boot/zImage-1.2.3-default'
-        assert data.version == '42'
-        assert data.name == 'zImage-realpath'
-
-    @patch('os.path.exists')
-    @patch('os.path.realpath')
-    @patch('kiwi.command.Command.run')
-    def test_get_kernel_from_zImage_vmlinux(
+    def test_get_kernel_from_arbitrary_kernel_image(
         self, mock_run, mock_realpath, mock_os
     ):
+        def path_exists(path):
+            return False if 'vmlinux.gz' in path else True
+
         self.kernel.kernel_names = ['zImage']
         run = namedtuple(
             'run', ['output']
         )
         result = run(output='42')
-        mock_os.return_value = True
+        mock_os.side_effect = path_exists
         mock_run.return_value = result
         mock_realpath.return_value = 'vmlinux.gz'
         data = self.kernel.get_kernel()
         mock_run.assert_called_once_with(
-            command=['kversion', 'root-dir/boot/vmlinux.gz'],
+            command=['kversion', 'root-dir/boot/zImage'],
             raise_on_error=False
         )
         assert data.filename == 'root-dir/boot/zImage'
         assert data.version == '42'
-        assert data.name == 'vmlinux.gz'
-
-    @patch('platform.machine')
-    @patch('os.path.exists')
-    @patch('os.path.realpath')
-    @patch('kiwi.command.Command.run')
-    def test_get_kernel_from_vmlinuz_on_s390(
-        self, mock_run, mock_realpath, mock_os, mock_platform_machine
-    ):
-        mock_platform_machine.return_value = 's390'
-        self.kernel.kernel_names = ['vmlinuz']
-        run = namedtuple(
-            'run', ['output']
-        )
-        result = run(output='42')
-        mock_os.return_value = True
-        mock_run.return_value = result
-        mock_realpath.return_value = 'vmlinux.gz'
-        data = self.kernel.get_kernel()
-        mock_run.assert_called_once_with(
-            command=['kversion', 'root-dir/boot/vmlinux.gz'],
-            raise_on_error=False
-        )
-        assert data.filename == 'root-dir/boot/vmlinuz'
-        assert data.version == '42'
-        assert data.name == 'vmlinux.gz'
+        assert data.name == mock_realpath.return_value
 
     @patch('os.path.exists')
     @patch('kiwi.command.Command.run')
@@ -132,7 +89,7 @@ class TestKernel(object):
         mock_run.return_value = result
         data = self.kernel.get_kernel()
         mock_run.assert_called_once_with(
-            command=['kversion', 'root-dir/boot/vmlinux'],
+            command=['kversion', 'root-dir/boot/vmlinux.gz'],
             raise_on_error=False
         )
         assert data.filename == 'root-dir/boot/vmlinux'


### PR DESCRIPTION
Lookup of the kernel version is done by directly reading the
kernel image via a small tool named kversion. The scope of the
tool is limited and does not work for e.g kernel images which
contains its own decompressor code. For the special cases we
defined exceptions, one was zImage. The recently added exception
for vmlinuz seemed too intrusive to me and was also not well
documented. This patch tries to clarify and get us back to
explicit and easy to read coding. Fixes #899

