### PR TITLE
Make sure manual pages are part of pypi archive

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -131,6 +131,7 @@ usedevelop = True
 deps = {[testenv:doc]deps}
 changedir=doc
 commands =
+    {[testenv:doc.man]commands}
     travis-sphinx --outdir build_travis build --nowarn --source ./source
     bash -c 'touch ./build_travis/.nojekyll'
     bash -c 'cp -a ./source/development/schema/images ./build_travis/development'


### PR DESCRIPTION
As consequence of the change in the travis setup to make
use of the native 'pages' and 'pypi' providers from travis the
environment for the sdist target has changed. Within the
doc_travis tox env no manual pages was build. In combination
with the 'pypi' provider setup in .travis.yml which uses
skip_cleanup: true, this caused the pypi archive to miss
any manual pages which lead to a runtime error on install
via pip.

