### PR TITLE
Fix disk size calculation for VMX

### DIFF
--- a/kiwi/storage/setup.py
+++ b/kiwi/storage/setup.py
@@ -340,7 +340,7 @@ class DiskSetup(object):
     def _calculate_volume_mbytes(self):
         """
         Calculate the number of mbytes each volume path currently
-        consumes and also provide a total number of these values
+        consumes and also provide a total number of these values.
         """
         volume_mbytes_type = namedtuple(
             'volume_mbytes_type', ['volume', 'total']
@@ -356,7 +356,9 @@ class DiskSetup(object):
                         volume_size.accumulate_mbyte_file_sizes(),
                         self.filesystem
                     )
-                    volume_total += volume_mbytes[volume.realpath]
+                else:
+                    volume_mbytes[volume.realpath] = 0
+                volume_total += volume_mbytes[volume.realpath]
 
         return volume_mbytes_type(
             volume=volume_mbytes,

--- a/test/data/example_disk_size_volume_config.xml
+++ b/test/data/example_disk_size_volume_config.xml
@@ -25,6 +25,7 @@
                 <volume name="@root" freespace="500M"/>
                 <volume name="etc_volume" mountpoint="etc"/>
                 <volume name="bin_volume" size="all" mountpoint="/usr/bin"/>
+                <volume name="new_volume" mountpoint="newfolder"/>
             </systemdisk>
         </type>
     </preferences>

--- a/test/unit/storage_setup_test.py
+++ b/test/unit/storage_setup_test.py
@@ -180,7 +180,7 @@ class TestDiskSetup(object):
     @patch('os.path.exists')
     @patch('kiwi.logger.log.warning')
     def test_get_disksize_mbytes_volumes(self, mock_log_warn, mock_exists):
-        mock_exists.return_value = True
+        mock_exists.side_effect = lambda path: path != 'root_dir/newfolder'
         root_size = self.size.accumulate_mbyte_file_sizes.return_value
         assert self.setup_volumes.get_disksize_mbytes() == \
             Defaults.get_lvm_overhead_mbytes() + \
@@ -191,6 +191,8 @@ class TestDiskSetup(object):
             1024 - root_size + \
             500 + Defaults.get_min_volume_mbytes() + \
             30 + Defaults.get_min_volume_mbytes() + \
+            Defaults.get_min_volume_mbytes() + \
+            Defaults.get_min_volume_mbytes() + \
             Defaults.get_min_volume_mbytes()
         assert mock_log_warn.called
 


### PR DESCRIPTION
Disk size calculation must take into account the empty volumes that
are to be mounted in a directory that does not exist in the root tree
otherwise there is KeyError. The result of
storate/setup._calculate_volume_mbytes must be a dict including all
defined volumes.

Fixes #904
