### PR TITLE
Use cls in @classmethods instead of self

### DIFF
--- a/kiwi/command.py
+++ b/kiwi/command.py
@@ -43,7 +43,7 @@ class Command(object):
     stdout and stderr is given to the caller
     """
     @classmethod
-    def run(self, command, custom_env=None, raise_on_error=True):
+    def run(cls, command, custom_env=None, raise_on_error=True):
         """
         Execute a program and block the caller. The return value
         is a hash containing the stdout, stderr and return code
@@ -126,7 +126,7 @@ class Command(object):
         )
 
     @classmethod
-    def call(self, command, custom_env=None):
+    def call(cls, command, custom_env=None):
         """
         Execute a program and return an io file handle pair back.
         stdout and stderr are both on different channels. The caller

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -62,7 +62,7 @@ class Defaults(object):
         ]
 
     @classmethod
-    def get_xz_compression_options(self):
+    def get_xz_compression_options(cls):
         """
         Provides compression options for the xz compressor
 
@@ -80,7 +80,7 @@ class Defaults(object):
         ]
 
     @classmethod
-    def is_buildservice_worker(self):
+    def is_buildservice_worker(cls):
         """
         Checks if build host is an open buildservice machine
 
@@ -96,7 +96,7 @@ class Defaults(object):
         )
 
     @classmethod
-    def get_buildservice_env_name(self):
+    def get_buildservice_env_name(cls):
         """
         Provides the base name of the environment file in a
         buildservice worker
@@ -108,7 +108,7 @@ class Defaults(object):
         return '.buildenv'
 
     @classmethod
-    def get_obs_download_server_url(self):
+    def get_obs_download_server_url(cls):
         """
         Provides the default download server url hosting the public open
         buildservice repositories
@@ -120,7 +120,7 @@ class Defaults(object):
         return 'http://download.opensuse.org/repositories'
 
     @classmethod
-    def get_s390_disk_block_size(self):
+    def get_s390_disk_block_size(cls):
         """
         Provides the default block size for s390 storage disks
 
@@ -131,7 +131,7 @@ class Defaults(object):
         return '4096'
 
     @classmethod
-    def get_s390_disk_type(self):
+    def get_s390_disk_type(cls):
         """
         Provides the default disk type for s390 storage disks
 
@@ -142,7 +142,7 @@ class Defaults(object):
         return 'CDL'
 
     @classmethod
-    def get_solvable_location(self):
+    def get_solvable_location(cls):
         """
         Provides the directory to store SAT solvables for repositories.
         The solvable files are used to perform package
@@ -155,7 +155,7 @@ class Defaults(object):
         return '/var/tmp/kiwi/satsolver'
 
     @classmethod
-    def get_shared_cache_location(self):
+    def get_shared_cache_location(cls):
         """
         Provides the shared cache location
 
@@ -175,7 +175,7 @@ class Defaults(object):
         )).lstrip(os.sep)
 
     @classmethod
-    def get_exclude_list_for_root_data_sync(self):
+    def get_exclude_list_for_root_data_sync(cls):
         """
         Provides the list of files or folders that are created
         by KIWI for its own purposes. Those files should be not
@@ -193,7 +193,7 @@ class Defaults(object):
         return exclude_list
 
     @classmethod
-    def get_failsafe_kernel_options(self):
+    def get_failsafe_kernel_options(cls):
         """
         Provides failsafe boot kernel options
 
@@ -218,7 +218,7 @@ class Defaults(object):
         )
 
     @classmethod
-    def get_video_mode_map(self):
+    def get_video_mode_map(cls):
         """
         Provides video mode map
 
@@ -257,7 +257,7 @@ class Defaults(object):
         }
 
     @classmethod
-    def get_volume_id(self):
+    def get_volume_id(cls):
         """
         Provides default value for ISO volume ID
 
@@ -268,7 +268,7 @@ class Defaults(object):
         return 'CDROM'
 
     @classmethod
-    def get_install_volume_id(self):
+    def get_install_volume_id(cls):
         """
         Provides default value for ISO volume ID for install media
 
@@ -279,7 +279,7 @@ class Defaults(object):
         return 'INSTALL'
 
     @classmethod
-    def get_snapper_config_template_file(self):
+    def get_snapper_config_template_file(cls):
         """
         Provides the default configuration template file for snapper
 
@@ -290,7 +290,7 @@ class Defaults(object):
         return '/etc/snapper/config-templates/default'
 
     @classmethod
-    def get_default_video_mode(self):
+    def get_default_video_mode(cls):
         """
         Provides 800x600 default video mode as hex value for the kernel
 
@@ -301,7 +301,7 @@ class Defaults(object):
         return '0x303'
 
     @classmethod
-    def get_grub_boot_directory_name(self, lookup_path):
+    def get_grub_boot_directory_name(cls, lookup_path):
         """
         Provides grub2 data directory name in boot/ directory
 
@@ -327,7 +327,7 @@ class Defaults(object):
             return 'grub'
 
     @classmethod
-    def get_grub_basic_modules(self, multiboot):
+    def get_grub_basic_modules(cls, multiboot):
         """
         Provides list of basic grub modules
 
@@ -369,7 +369,7 @@ class Defaults(object):
         return modules
 
     @classmethod
-    def get_grub_efi_modules(self, multiboot=False):
+    def get_grub_efi_modules(cls, multiboot=False):
         """
         Provides list of grub efi modules
 
@@ -393,7 +393,7 @@ class Defaults(object):
         return modules
 
     @classmethod
-    def get_grub_bios_modules(self, multiboot=False):
+    def get_grub_bios_modules(cls, multiboot=False):
         """
         Provides list of grub bios modules
 
@@ -415,7 +415,7 @@ class Defaults(object):
         return modules
 
     @classmethod
-    def get_grub_ofw_modules(self):
+    def get_grub_ofw_modules(cls):
         """
         Provides list of grub ofw modules (ppc)
 
@@ -431,7 +431,7 @@ class Defaults(object):
         return modules
 
     @classmethod
-    def get_grub_path(self, lookup_path):
+    def get_grub_path(cls, lookup_path):
         """
         Provides grub install path
 
@@ -451,7 +451,7 @@ class Defaults(object):
                 return grub_path
 
     @classmethod
-    def get_preparer(self):
+    def get_preparer(cls):
         """
         Provides ISO preparer name
 
@@ -462,7 +462,7 @@ class Defaults(object):
         return 'KIWI - http://suse.github.com/kiwi'
 
     @classmethod
-    def get_publisher(self):
+    def get_publisher(cls):
         """
         Provides ISO publisher name
 
@@ -473,7 +473,7 @@ class Defaults(object):
         return 'SUSE LINUX GmbH'
 
     @classmethod
-    def get_shim_loader(self, root_path):
+    def get_shim_loader(cls, root_path):
         """
         Provides shim loader file path
 
@@ -495,7 +495,7 @@ class Defaults(object):
                 return shim_file
 
     @classmethod
-    def get_unsigned_grub_loader(self, root_path):
+    def get_unsigned_grub_loader(cls, root_path):
         """
         Provides unsigned grub efi loader file path
 
@@ -518,7 +518,7 @@ class Defaults(object):
                 return unsigned_grub_file
 
     @classmethod
-    def get_signed_grub_loader(self, root_path):
+    def get_signed_grub_loader(cls, root_path):
         """
         Provides shim signed grub loader file path
 
@@ -540,7 +540,7 @@ class Defaults(object):
                 return signed_grub
 
     @classmethod
-    def get_shim_vendor_directory(self, root_path):
+    def get_shim_vendor_directory(cls, root_path):
         """
         Provides shim vendor directory
 
@@ -563,7 +563,7 @@ class Defaults(object):
                 return os.path.dirname(shim_file)
 
     @classmethod
-    def get_default_volume_group_name(self):
+    def get_default_volume_group_name(cls):
         """
         Provides default LVM volume group name
 
@@ -574,7 +574,7 @@ class Defaults(object):
         return 'systemVG'
 
     @classmethod
-    def get_min_volume_mbytes(self):
+    def get_min_volume_mbytes(cls):
         """
         Provides default minimum LVM volume size in mbytes
 
@@ -585,7 +585,7 @@ class Defaults(object):
         return 30
 
     @classmethod
-    def get_lvm_overhead_mbytes(self):
+    def get_lvm_overhead_mbytes(cls):
         """
         Provides empiric LVM overhead size in mbytes
 
@@ -596,7 +596,7 @@ class Defaults(object):
         return 80
 
     @classmethod
-    def get_default_boot_mbytes(self):
+    def get_default_boot_mbytes(cls):
         """
         Provides default boot partition size in mbytes
 
@@ -607,7 +607,7 @@ class Defaults(object):
         return 300
 
     @classmethod
-    def get_default_efi_boot_mbytes(self):
+    def get_default_efi_boot_mbytes(cls):
         """
         Provides default EFI partition size in mbytes
 
@@ -618,7 +618,7 @@ class Defaults(object):
         return 20
 
     @classmethod
-    def get_recovery_spare_mbytes(self):
+    def get_recovery_spare_mbytes(cls):
         """
         Provides spare size of recovery partition in mbytes
 
@@ -629,7 +629,7 @@ class Defaults(object):
         return 300
 
     @classmethod
-    def get_default_legacy_bios_mbytes(self):
+    def get_default_legacy_bios_mbytes(cls):
         """
         Provides default size of bios_grub partition in mbytes
 
@@ -640,7 +640,7 @@ class Defaults(object):
         return 2
 
     @classmethod
-    def get_default_prep_mbytes(self):
+    def get_default_prep_mbytes(cls):
         """
         Provides default size of prep partition in mbytes
 
@@ -651,7 +651,7 @@ class Defaults(object):
         return 8
 
     @classmethod
-    def get_disk_format_types(self):
+    def get_disk_format_types(cls):
         """
         Provides supported disk format types
 
@@ -665,7 +665,7 @@ class Defaults(object):
         ]
 
     @classmethod
-    def get_firmware_types(self):
+    def get_firmware_types(cls):
         """
         Provides supported architecture specific firmware types
 
@@ -693,7 +693,7 @@ class Defaults(object):
         }
 
     @classmethod
-    def get_default_firmware(self, arch):
+    def get_default_firmware(cls, arch):
         """
         Provides default firmware for specified architecture
 
@@ -722,7 +722,7 @@ class Defaults(object):
             return default_firmware[arch]
 
     @classmethod
-    def get_efi_capable_firmware_names(self):
+    def get_efi_capable_firmware_names(cls):
         """
         Provides list of EFI capable firmware names. These are
         those for which kiwi supports the creation of an EFI
@@ -735,7 +735,7 @@ class Defaults(object):
         return ['efi', 'uefi']
 
     @classmethod
-    def get_ec2_capable_firmware_names(self):
+    def get_ec2_capable_firmware_names(cls):
         """
         Provides list of EC2 capable firmware names. These are
         those for which kiwi supports the creation of disk images
@@ -748,7 +748,7 @@ class Defaults(object):
         return ['ec2']
 
     @classmethod
-    def get_efi_module_directory_name(self, arch):
+    def get_efi_module_directory_name(cls, arch):
         """
         Provides architecture specific EFI directory name which
         stores the EFI binaries for the desired architecture.
@@ -778,7 +778,7 @@ class Defaults(object):
             return default_module_directory_names[arch]
 
     @classmethod
-    def get_efi_image_name(self, arch):
+    def get_efi_image_name(cls, arch):
         """
         Provides architecture specific EFI boot binary name
 
@@ -801,7 +801,7 @@ class Defaults(object):
             return default_efi_image_names[arch]
 
     @classmethod
-    def get_default_boot_timeout_seconds(self):
+    def get_default_boot_timeout_seconds(cls):
         """
         Provides default boot timeout in seconds
 
@@ -812,7 +812,7 @@ class Defaults(object):
         return 10
 
     @classmethod
-    def get_default_disk_start_sector(self):
+    def get_default_disk_start_sector(cls):
         """
         Provides the default initial disk sector for the first disk
         partition.
@@ -824,7 +824,7 @@ class Defaults(object):
         return Defaults().defaults['kiwi_startsector']
 
     @classmethod
-    def get_default_efi_partition_table_type(self):
+    def get_default_efi_partition_table_type(cls):
         """
         Provides the default partition table type for efi firmwares.
 
@@ -835,7 +835,7 @@ class Defaults(object):
         return 'gpt'
 
     @classmethod
-    def get_default_inode_size(self):
+    def get_default_inode_size(cls):
         """
         Provides default size of inodes in bytes. This is only
         relevant for inode based filesystems
@@ -847,7 +847,7 @@ class Defaults(object):
         return Defaults().defaults['kiwi_inode_size']
 
     @classmethod
-    def get_archive_image_types(self):
+    def get_archive_image_types(cls):
         """
         Provides list of supported archive image types
 
@@ -858,7 +858,7 @@ class Defaults(object):
         return ['tbz']
 
     @classmethod
-    def get_container_image_types(self):
+    def get_container_image_types(cls):
         """
         Provides list of supported container image types
 
@@ -869,7 +869,7 @@ class Defaults(object):
         return ['docker', 'oci']
 
     @classmethod
-    def get_filesystem_image_types(self):
+    def get_filesystem_image_types(cls):
         """
         Provides list of supported filesystem image types
 
@@ -883,7 +883,7 @@ class Defaults(object):
         ]
 
     @classmethod
-    def get_default_live_iso_type(self):
+    def get_default_live_iso_type(cls):
         """
         Provides default live iso union type
 
@@ -894,7 +894,7 @@ class Defaults(object):
         return 'overlay'
 
     @classmethod
-    def get_default_uri_type(self):
+    def get_default_uri_type(cls):
         """
         Provides default URI type
 
@@ -908,7 +908,7 @@ class Defaults(object):
         return 'dir:/'
 
     @classmethod
-    def get_dracut_conf_name(self):
+    def get_dracut_conf_name(cls):
         """
         Provides file path of dracut config file to be used with KIWI
 
@@ -919,7 +919,7 @@ class Defaults(object):
         return '/etc/dracut.conf.d/02-kiwi.conf'
 
     @classmethod
-    def get_live_dracut_module_from_flag(self, flag_name):
+    def get_live_dracut_module_from_flag(cls, flag_name):
         """
         Provides flag_name to dracut module name map
 
@@ -940,7 +940,7 @@ class Defaults(object):
             return 'kiwi-live'
 
     @classmethod
-    def get_default_live_iso_root_filesystem(self):
+    def get_default_live_iso_root_filesystem(cls):
         """
         Provides default live iso root filesystem type
 
@@ -951,7 +951,7 @@ class Defaults(object):
         return 'ext4'
 
     @classmethod
-    def get_live_iso_persistent_boot_options(self, persistent_filesystem=None):
+    def get_live_iso_persistent_boot_options(cls, persistent_filesystem=None):
         """
         Provides list of boot options passed to the dracut
         kiwi-live module to setup persistent writing
@@ -970,7 +970,7 @@ class Defaults(object):
         return live_iso_persistent_boot_options
 
     @classmethod
-    def get_disk_image_types(self):
+    def get_disk_image_types(cls):
         """
         Provides supported disk image types
 
@@ -981,7 +981,7 @@ class Defaults(object):
         return ['oem', 'vmx']
 
     @classmethod
-    def get_live_image_types(self):
+    def get_live_image_types(cls):
         """
         Provides supported live image types
 
@@ -992,7 +992,7 @@ class Defaults(object):
         return ['iso']
 
     @classmethod
-    def get_network_image_types(self):
+    def get_network_image_types(cls):
         """
         Provides supported pxe image types
 
@@ -1003,7 +1003,7 @@ class Defaults(object):
         return ['pxe']
 
     @classmethod
-    def get_boot_image_description_path(self):
+    def get_boot_image_description_path(cls):
         """
         Provides the path to find custom kiwi boot descriptions
 
@@ -1014,7 +1014,7 @@ class Defaults(object):
         return '/usr/share/kiwi/custom_boot'
 
     @classmethod
-    def get_boot_image_strip_file(self):
+    def get_boot_image_strip_file(cls):
         """
         Provides the file path to bootloader strip metadata.
         This file contains information about the files and directories
@@ -1027,7 +1027,7 @@ class Defaults(object):
         return Defaults.project_file('config/strip.xml')
 
     @classmethod
-    def get_schema_file(self):
+    def get_schema_file(cls):
         """
         Provides file path to kiwi RelaxNG schema
 
@@ -1038,7 +1038,7 @@ class Defaults(object):
         return Defaults.project_file('schema/kiwi.rng')
 
     @classmethod
-    def get_common_functions_file(self):
+    def get_common_functions_file(cls):
         """
         Provides the file path to config functions metadata.
 
@@ -1052,7 +1052,7 @@ class Defaults(object):
         return Defaults.project_file('config/functions.sh')
 
     @classmethod
-    def get_xsl_stylesheet_file(self):
+    def get_xsl_stylesheet_file(cls):
         """
         Provides the file path to the KIWI XSLT style sheets
 
@@ -1063,7 +1063,7 @@ class Defaults(object):
         return Defaults.project_file('xsl/master.xsl')
 
     @classmethod
-    def project_file(self, filename):
+    def project_file(cls, filename):
         """
         Provides the python module base directory search path
 
@@ -1079,7 +1079,7 @@ class Defaults(object):
         return resource_filename('kiwi', filename)
 
     @classmethod
-    def get_imported_root_image(self, root_dir):
+    def get_imported_root_image(cls, root_dir):
         """
         Provides the path to an imported root system image
 
@@ -1096,7 +1096,7 @@ class Defaults(object):
         return os.sep.join([root_dir, 'image', 'imported_root'])
 
     @classmethod
-    def get_iso_boot_path(self):
+    def get_iso_boot_path(cls):
         """
         Provides arch specific relative path to boot files
         on kiwi iso filesystems
@@ -1111,7 +1111,7 @@ class Defaults(object):
         return os.sep.join(['boot', arch])
 
     @classmethod
-    def get_iso_tool_category(self):
+    def get_iso_tool_category(cls):
         """
         Provides default iso tool category
 
@@ -1122,7 +1122,7 @@ class Defaults(object):
         return 'xorriso'
 
     @classmethod
-    def get_container_compression(self):
+    def get_container_compression(cls):
         """
         Provides default container compression algorithm
 
@@ -1133,7 +1133,7 @@ class Defaults(object):
         return 'xz'
 
     @classmethod
-    def get_default_container_name(self):
+    def get_default_container_name(cls):
         """
         Provides the default container name.
 
@@ -1144,7 +1144,7 @@ class Defaults(object):
         return 'kiwi-container'
 
     @classmethod
-    def get_oci_archive_tool(self):
+    def get_oci_archive_tool(cls):
         """
         Provides the default OCI archive tool name.
 
@@ -1155,7 +1155,7 @@ class Defaults(object):
         return 'umoci'
 
     @classmethod
-    def get_default_container_tag(self):
+    def get_default_container_tag(cls):
         """
         Provides the default container tag.
 
@@ -1166,7 +1166,7 @@ class Defaults(object):
         return 'latest'
 
     @classmethod
-    def get_default_container_subcommand(self):
+    def get_default_container_subcommand(cls):
         """
         Provides the default container subcommand.
 
@@ -1177,7 +1177,7 @@ class Defaults(object):
         return ['/bin/bash']
 
     @classmethod
-    def get_default_container_created_by(self):
+    def get_default_container_created_by(cls):
         """
         Provides the default 'created by' history entry for containers.
 
@@ -1188,7 +1188,7 @@ class Defaults(object):
         return 'KIWI {0}'.format(__version__)
 
     @classmethod
-    def set_python_default_encoding_to_utf8(self):
+    def set_python_default_encoding_to_utf8(cls):
         """
         Set python default encoding to utf-8 if not already done
 
@@ -1204,7 +1204,7 @@ class Defaults(object):
             sys.setdefaultencoding('utf-8')
 
     @classmethod
-    def get_default_packager_tool(self, package_manager):
+    def get_default_packager_tool(cls, package_manager):
         """
         Provides the packager tool according to the package manager
 
@@ -1222,7 +1222,7 @@ class Defaults(object):
             return 'dpkg'
 
     @classmethod
-    def get_default_rpmdb_path(self):
+    def get_default_rpmdb_path(cls):
         """
         Returns the default path of the rpm database.
 

--- a/kiwi/iso_tools/iso.py
+++ b/kiwi/iso_tools/iso.py
@@ -55,7 +55,7 @@ class Iso(object):
         self.boot_path = Defaults.get_iso_boot_path()
 
     @classmethod
-    def create_hybrid(self, offset, mbrid, isofile, efi_mode=False):
+    def create_hybrid(cls, offset, mbrid, isofile, efi_mode=False):
         """
         Create hybrid ISO
 
@@ -109,7 +109,7 @@ class Iso(object):
                 )
 
     @classmethod
-    def set_media_tag(self, isofile):
+    def set_media_tag(cls, isofile):
         """
         Include checksum tag in the ISO so it can be verified with
         the mediacheck program.
@@ -127,7 +127,7 @@ class Iso(object):
         )
 
     @classmethod
-    def relocate_boot_catalog(self, isofile):
+    def relocate_boot_catalog(cls, isofile):
         """
         Move ISO boot catalog to the standardized place
 
@@ -187,7 +187,7 @@ class Iso(object):
                     )
 
     @classmethod
-    def fix_boot_catalog(self, isofile):
+    def fix_boot_catalog(cls, isofile):
         """
         Fixup inconsistencies in boot catalog
 

--- a/kiwi/kiwi_compat.py
+++ b/kiwi/kiwi_compat.py
@@ -212,11 +212,11 @@ class Translate(object):
 
 class Command(object):
     @classmethod
-    def execute(self, arguments):
+    def execute(cls, arguments):
         os.execvp(Command.lookup_kiwi(), ['kiwi'] + arguments)
 
     @classmethod
-    def lookup_kiwi(self):
+    def lookup_kiwi(cls):
         for kiwi_name in ['kiwi-ng-3', 'kiwi-ng-2']:
             kiwi = Path.which(kiwi_name, access_mode=os.X_OK)
             if kiwi:

--- a/kiwi/oci_tools/base.py
+++ b/kiwi/oci_tools/base.py
@@ -147,7 +147,7 @@ class OCIBase(object):
         raise NotImplementedError
 
     @classmethod
-    def _sync_data(self, origin, destination, exclude_list=None, options=None):
+    def _sync_data(cls, origin, destination, exclude_list=None, options=None):
         """
         Synchronizes the origin and destination paths to be equivalent
 

--- a/kiwi/oci_tools/umoci.py
+++ b/kiwi/oci_tools/umoci.py
@@ -150,7 +150,7 @@ class OCIUmoci(OCIBase):
             )
 
     @classmethod                                                # noqa:C091
-    def _process_oci_config_to_arguments(self, oci_config):
+    def _process_oci_config_to_arguments(cls, oci_config):
         """
         Process the oci configuration dictionary into a list of arguments
         for the 'umoci config' command
@@ -211,11 +211,11 @@ class OCIUmoci(OCIBase):
                     name, oci_config['labels'][name]
                 ))
 
-        arguments.extend(self._process_oci_history_to_arguments(oci_config))
+        arguments.extend(cls._process_oci_history_to_arguments(oci_config))
         return arguments
 
     @classmethod
-    def _process_oci_history_to_arguments(self, oci_config):
+    def _process_oci_history_to_arguments(cls, oci_config):
         history_args = []
         if 'history' in oci_config:
             if 'comment' in oci_config['history']:

--- a/kiwi/path.py
+++ b/kiwi/path.py
@@ -28,7 +28,7 @@ class Path(object):
     **Directory path helpers**
     """
     @classmethod
-    def sort_by_hierarchy(self, path_list):
+    def sort_by_hierarchy(cls, path_list):
         """
         Sort given list of path names by their hierachy in the tree
 
@@ -61,7 +61,7 @@ class Path(object):
         return ordered_paths
 
     @classmethod
-    def create(self, path):
+    def create(cls, path):
         """
         Create path and all sub directories to target
 
@@ -72,7 +72,7 @@ class Path(object):
         )
 
     @classmethod
-    def wipe(self, path):
+    def wipe(cls, path):
         """
         Delete path and all contents
 
@@ -83,7 +83,7 @@ class Path(object):
         )
 
     @classmethod
-    def remove(self, path):
+    def remove(cls, path):
         """
         Delete empty path, causes an error if target is not empty
 
@@ -94,7 +94,7 @@ class Path(object):
         )
 
     @classmethod
-    def remove_hierarchy(self, path):
+    def remove_hierarchy(cls, path):
         """
         Recursively remove an empty path and its sub directories
         ignore non empty or protected paths and leave them untouched
@@ -124,7 +124,7 @@ class Path(object):
 
     @classmethod
     def which(
-        self, filename, alternative_lookup_paths=None,
+        cls, filename, alternative_lookup_paths=None,
         custom_env=None, access_mode=None
     ):
         """

--- a/kiwi/privileges.py
+++ b/kiwi/privileges.py
@@ -28,7 +28,7 @@ class Privileges(object):
     **Implements check for root privileges**
     """
     @classmethod
-    def check_for_root_permissions(self):
+    def check_for_root_permissions(cls):
         """
         Check if we are effectively root on the system. If not
         an exception is thrown

--- a/kiwi/system/result.py
+++ b/kiwi/system/result.py
@@ -103,7 +103,7 @@ class Result(object):
             )
 
     @classmethod
-    def load(self, filename):
+    def load(cls, filename):
         """
         Load pickle dumped filename into a Result instance
 

--- a/kiwi/system/shell.py
+++ b/kiwi/system/shell.py
@@ -27,7 +27,7 @@ class Shell(object):
     **Special character handling for shell evaluated code**
     """
     @classmethod
-    def quote(self, message):
+    def quote(cls, message):
         """
         Quote characters which have a special meaning for bash
         but should be used as normal characters. actually I had
@@ -48,7 +48,7 @@ class Shell(object):
         return message
 
     @classmethod
-    def quote_key_value_file(self, filename):
+    def quote_key_value_file(cls, filename):
         """
         Quote given input file which has to be of the form
         key=value to be able to become sourced by the shell
@@ -66,7 +66,7 @@ class Shell(object):
             return quoted.read().splitlines()
 
     @classmethod
-    def run_common_function(self, name, parameters):
+    def run_common_function(cls, name, parameters):
         """
         Run a function implemented in config/functions.sh
 

--- a/kiwi/utils/codec.py
+++ b/kiwi/utils/codec.py
@@ -25,7 +25,7 @@ class Codec(object):
     **Performs conversions of literal byte sequences to strings**
     """
     @classmethod
-    def decode(self, literal):
+    def decode(cls, literal):
         """
         Decodes the given literal with the default charset. In case of
         failure attemps to decode using utf-8 charset.
@@ -47,7 +47,7 @@ class Codec(object):
                 )
 
     @classmethod
-    def _wrapped_decode(self, literal, charset=None):
+    def _wrapped_decode(cls, literal, charset=None):
         # This decode wrapper is only implemented to facilitate unit testing
         if charset:
             return literal.decode(charset)

--- a/kiwi/utils/command_capabilities.py
+++ b/kiwi/utils/command_capabilities.py
@@ -33,7 +33,7 @@ class CommandCapabilities(object):
     """
     @classmethod
     def has_option_in_help(
-        self, call, flag, help_flags=None,
+        cls, call, flag, help_flags=None,
         root=None, raise_on_error=True
     ):
         """
@@ -72,7 +72,7 @@ class CommandCapabilities(object):
 
     @classmethod
     def check_version(
-        self, call, version_waterline, version_flags=None,
+        cls, call, version_waterline, version_flags=None,
         root=None, raise_on_error=True
     ):
         """

--- a/kiwi/utils/size.py
+++ b/kiwi/utils/size.py
@@ -26,7 +26,7 @@ class StringToSize(object):
     **Performs size convertions from strings to numbers**
     """
     @classmethod
-    def to_bytes(self, size_value):
+    def to_bytes(cls, size_value):
         """
         Convert the given string representig a size into the appropriate
         number of bytes.

--- a/kiwi/volume_manager/btrfs.py
+++ b/kiwi/volume_manager/btrfs.py
@@ -377,7 +377,7 @@ class VolumeManagerBtrfs(VolumeManagerBase):
             ])
 
     @classmethod
-    def _set_snapper_sysconfig_file(self, root_path):
+    def _set_snapper_sysconfig_file(cls, root_path):
         sysconf_file = SysConfig(
             os.sep.join([root_path, 'etc/sysconfig/snapper'])
         )

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -100,7 +100,7 @@ except ImportError:
 try:
     from generatedssuper import GeneratedsSuper
 except ImportError as exp:
-    
+
     class GeneratedsSuper(object):
         tzoff_pattern = re_.compile(r'(\+|-)((0\d|1[0-3]):[0-5]\d|14:00)$')
         class _FixedOffsetTZ(datetime_.tzinfo):


### PR DESCRIPTION
No related issue, just to improve consistency.

Changes proposed in this pull request:
* whenever there is a `@classmethod` decorator, use `cls` instead of `self`. This change makes it more consistent with the Python convention; see https://docs.python.org/3/library/functions.html#classmethod
* No other code changes
