### PR TITLE
Allow setting the protocol for exposed ports

### DIFF
--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -34,6 +34,7 @@ partition-size-type = xsd:token {pattern = "\d+|\d+M|\d+G"}
 vhd-tag-type = xsd:token {pattern = "[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}"}
 groups-list = xsd:token {pattern = "[a-zA-Z0-9_\-\.]+(,[a-zA-Z0-9_\-\.]+)*"}
 arch-name = xsd:token {pattern = "(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x)(,(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x))*"}
+portnum-type = xsd:token {pattern = "(\d+|\d+/(udp|tcp))"}
 
 #==========================================
 # start with image description
@@ -2297,8 +2298,9 @@ div {
 #
 div {
     k.port.number.attribute =
-        ## Specifies the port number to expose
-        attribute number { xsd:nonNegativeInteger }
+        ## Specifies the port number and transport protocol to expose.
+        ## If no protocol is defined OCI defaults are applied.
+        attribute number { portnum-type }
 
     k.port.attlist =
         k.port.number.attribute

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -71,6 +71,11 @@
       <param name="pattern">(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x)(,(x86_64|i586|i686|ix86|aarch64|arm64|armv5el|armv5tel|armv6hl|armv6l|armv7hl|armv7l|ppc|ppc64|ppc64le|s390|s390x))*</param>
     </data>
   </define>
+  <define name="portnum-type">
+    <data type="token">
+      <param name="pattern">(\d+|\d+/(udp|tcp))</param>
+    </data>
+  </define>
   <!--
     ==========================================
     start with image description
@@ -3555,8 +3560,9 @@ be configured</a:documentation>
   <div>
     <define name="k.port.number.attribute">
       <attribute name="number">
-        <a:documentation>Specifies the port number to expose</a:documentation>
-        <data type="nonNegativeInteger"/>
+        <a:documentation>Specifies the port number and transport protocol to expose.
+If no protocol is defined OCI defaults are applied.</a:documentation>
+        <ref name="portnum-type"/>
       </attribute>
     </define>
     <define name="k.port.attlist">

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -5475,7 +5475,7 @@ class port(GeneratedsSuper):
     superclass = None
     def __init__(self, number=None):
         self.original_tagname_ = None
-        self.number = _cast(int, number)
+        self.number = _cast(None, number)
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -5489,6 +5489,13 @@ class port(GeneratedsSuper):
     factory = staticmethod(factory)
     def get_number(self): return self.number
     def set_number(self, number): self.number = number
+    def validate_portnum_type(self, value):
+        # Validate type portnum-type, a restriction on xs:token.
+        if value is not None and Validate_simpletypes_:
+            if not self.gds_validate_simple_patterns(
+                    self.validate_portnum_type_patterns_, value):
+                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_portnum_type_patterns_, ))
+    validate_portnum_type_patterns_ = [['^(\\d+$|^\\d+/(udp$|^tcp))$']]
     def hasContent_(self):
         if (
 
@@ -5519,7 +5526,7 @@ class port(GeneratedsSuper):
     def exportAttributes(self, outfile, level, already_processed, namespace_='', name_='port'):
         if self.number is not None and 'number' not in already_processed:
             already_processed.add('number')
-            outfile.write(' number="%s"' % self.gds_format_integer(self.number, input_name='number'))
+            outfile.write(' number=%s' % (quote_attrib(self.number), ))
     def exportChildren(self, outfile, level, namespace_='', name_='port', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node):
@@ -5533,12 +5540,9 @@ class port(GeneratedsSuper):
         value = find_attr_value_('number', node)
         if value is not None and 'number' not in already_processed:
             already_processed.add('number')
-            try:
-                self.number = int(value)
-            except ValueError as exp:
-                raise_parse_error(node, 'Bad integer attribute: %s' % exp)
-            if self.number < 0:
-                raise_parse_error(node, 'Invalid NonNegativeInteger')
+            self.number = value
+            self.number = ' '.join(self.number.split())
+            self.validate_portnum_type(self.number)    # validate type portnum-type
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         pass
 # end class port


### PR DESCRIPTION
With this commit it is possible to set tcp or upd (e.g. "80/tcp") for
exposed container ports. If no protocol is provided OCI defaults are
applied.

Fixes #906
