### PR TITLE
Use chkstat to verify and fix file permissions

### DIFF
--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -239,6 +239,38 @@ class SystemSetup(object):
         with open(machine_id, 'w'):
             pass
 
+    def setup_permissions(self):
+        """
+        Check and Fix permissions using chkstat
+
+        Call chkstat in system mode which reads /etc/sysconfig/security
+        to determine the configured security level and applies the
+        appropriate permission definitions from the /etc/permissions*
+        files. It's possible to provide those files as overlay files
+        in the image description to apply a certain permission setup
+        when needed. Otherwise the default setup as provided on the
+        package level applies.
+
+        It's required that the image root system has chkstat installed.
+        If not present KIWI skips this step and continuous with a
+        warning.
+        """
+        chkstat_search_env = {
+            'PATH': os.sep.join([self.root_dir, 'usr', 'bin'])
+        }
+        chkstat = Path.which(
+            'chkstat', custom_env=chkstat_search_env, access_mode=os.X_OK
+        )
+        if chkstat:
+            log.info('Check/Fix File Permissions')
+            Command.run(
+                ['chroot', self.root_dir, 'chkstat', '--system', '--set']
+            )
+        else:
+            log.warning(
+                'chkstat not found in image. File Permissions Check skipped'
+            )
+
     def setup_keyboard_map(self):
         """
         Setup console keyboard

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -232,6 +232,7 @@ class SystemBuildTask(CliTask):
         setup.setup_locale()
         setup.setup_plymouth_splash()
         setup.setup_timezone()
+        setup.setup_permissions()
 
         # make sure manager instance is cleaned up now
         del manager

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -220,6 +220,7 @@ class SystemPrepareTask(CliTask):
         setup.setup_locale()
         setup.setup_plymouth_splash()
         setup.setup_timezone()
+        setup.setup_permissions()
 
         # make sure manager instance is cleaned up now
         del manager

--- a/test/unit/system_setup_test.py
+++ b/test/unit/system_setup_test.py
@@ -803,6 +803,21 @@ class TestSystemSetup(object):
         )
 
     @patch('kiwi.system.setup.Command.run')
+    @patch('kiwi.system.setup.Path.which')
+    @patch('kiwi.logger.log.warning')
+    def test_setup_permissions(
+        self, mock_log_warn, mock_path_which, mock_command
+    ):
+        mock_path_which.return_value = 'chkstat'
+        self.setup.setup_permissions()
+        mock_command.assert_called_once_with(
+            ['chroot', 'root_dir', 'chkstat', '--system', '--set']
+        )
+        mock_path_which.return_value = None
+        self.setup.setup_permissions()
+        mock_log_warn.assert_called_once()
+
+    @patch('kiwi.system.setup.Command.run')
     @patch_open
     def test_export_package_list_rpm_no_dbpath(
         self, mock_open, mock_command

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -131,6 +131,7 @@ class TestSystemBuildTask(object):
         self.setup.setup_locale.assert_called_once_with()
         self.setup.setup_plymouth_splash.assert_called_once_with()
         self.setup.setup_timezone.assert_called_once_with()
+        self.setup.setup_permissions.assert_called_once_with()
         self.system_prepare.pinch_system.assert_has_calls(
             [call(force=False), call(force=True)]
         )

--- a/test/unit/tasks_system_prepare_test.py
+++ b/test/unit/tasks_system_prepare_test.py
@@ -123,6 +123,7 @@ class TestSystemPrepareTask(object):
         self.setup.setup_locale.assert_called_once_with()
         self.setup.setup_plymouth_splash.assert_called_once_with()
         self.setup.setup_timezone.assert_called_once_with()
+        self.setup.setup_permissions.assert_called_once_with()
 
         self.system_prepare.pinch_system.assert_has_calls(
             [call(force=False), call(force=True)]


### PR DESCRIPTION
Call chkstat in system mode which reads /etc/sysconfig/security
to determine the configured security level and applies the
appropriate permission definitions from the /etc/permissions*
files. It's possible to provide those files as overlay files
in the image description to apply a certain permission setup
when needed. Otherwise the default setup as provided on the
package level applies. It's required that the image root system
has chkstat installed. If not present KIWI skips this step
and continuous with a warning. This Fixes #895

