### PR TITLE
Fix use of SysConfig objects

### DIFF
--- a/kiwi/utils/sysconfig.py
+++ b/kiwi/utils/sysconfig.py
@@ -41,6 +41,9 @@ class SysConfig(object):
     def __contains__(self, key):
         return key in self.data_dict
 
+    def get(self, key):
+        return self.data_dict.get(key)
+
     def write(self):
         """
         Write back source file with changed content but in same order

--- a/test/unit/utils_sysconfig_test.py
+++ b/test/unit/utils_sysconfig_test.py
@@ -21,6 +21,7 @@ class TestSysConfig(object):
 
     def test_get_item(self):
         assert self.sysconfig['name'] == ' "Marcus"'
+        assert self.sysconfig.get('name') == ' "Marcus"'
 
     def test_set_item_existing(self):
         self.sysconfig['name'] = 'Bob'


### PR DESCRIPTION
objects of that class does not provide a get method but overload
the bracket [] operator which itself accesses elements of a
standard dictionary using the get() method. Thus it's safe to
use the bracket operator. This patch fixes the one place where
the get() method was used. This Fixes #910

