### PR TITLE
Make result compression in the bundler optional

### DIFF
--- a/kiwi/runtime_config.py
+++ b/kiwi/runtime_config.py
@@ -90,6 +90,33 @@ class RuntimeConfig(object):
             obs_public = True
         return bool(obs_public)
 
+    def is_bundle_compression_requested(self):
+        """
+        Return boolean value to express if the image bundle should
+        contain XZ compressed image results or not.
+
+        bundle:
+          - compress: true|false
+
+        If compression of image build results is activated the size
+        of the bundle is smaller and the download speed increases.
+        However the image must be uncompressed before use
+
+        By default the bundle won't contain compressed results.
+
+        :return: True or False
+
+        :rtype: bool
+        """
+        bundle_compress = self._get_attribute(
+            element='bundle', attribute='compress'
+        )
+        if bundle_compress is None:
+            # if the bundle compression is not set,
+            # the default is to not compress image results
+            bundle_compress = False
+        return bool(bundle_compress)
+
     def get_xz_options(self):
         """
         Return list of XZ compression options in:

--- a/test/data/.config/kiwi/config.yml
+++ b/test/data/.config/kiwi/config.yml
@@ -1,6 +1,9 @@
 xz:
   - options: -a -b xxx
 
+bundle:
+  - compress: true
+
 obs:
   - download_url: http://example.com
   - public: true

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -38,6 +38,14 @@ class TestRuntimeConfig(object):
     def test_is_obs_public(self):
         assert self.runtime_config.is_obs_public() is True
 
+    def test_is_bundle_compression_requested(self):
+        assert self.runtime_config.is_bundle_compression_requested() is True
+
+    def test_is_bundle_compression_requested_default(self):
+        with patch.dict('os.environ', {'HOME': './'}):
+            runtime_config = RuntimeConfig()
+            assert runtime_config.is_bundle_compression_requested() is False
+
     def test_is_obs_public_default(self):
         with patch.dict('os.environ', {'HOME': './'}):
             runtime_config = RuntimeConfig()

--- a/test/unit/tasks_result_bundle_test.py
+++ b/test/unit/tasks_result_bundle_test.py
@@ -49,6 +49,12 @@ class TestResultBundleTask(object):
         )
         self.task = ResultBundleTask()
 
+        runtime_config = mock.Mock()
+        runtime_config.is_bundle_compression_requested = mock.Mock(
+            return_value=True
+        )
+        self.task.runtime_config = runtime_config
+
     def teardown(self):
         sys.argv = argv_kiwi_tests
 


### PR DESCRIPTION
Calling kiwi result bundle will take the image build results
and bundle the relevant image files according to their image
type. Depending on the result configuration this could instruct
the bundler to compress one or more files from the result.
By default this compression is switched off in the bundler but
can be activated to save storage space and speedup download
of the image with the following runtime configuration:

```yaml
bundle:
  - compress: true|false
```

If compression is activated the result image has to be
uncompressed before it can be used.

This Fixes #901

