### PR TITLE
Allow to switch off install image boot timeout

### DIFF
--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -197,6 +197,20 @@ class BootLoaderConfigBase(object):
             timeout_seconds = Defaults.get_default_boot_timeout_seconds()
         return timeout_seconds
 
+    def get_continue_on_timeout(self):
+        """
+        Check if the boot should continue after boot timeout or not
+
+        :return: True or False
+
+        :rtype: bool
+        """
+        continue_on_timeout = \
+            self.xml_state.build_type.get_install_continue_on_timeout()
+        if continue_on_timeout is None:
+            continue_on_timeout = True
+        return continue_on_timeout
+
     def failsafe_boot_entry_requested(self):
         """
         Check if a failsafe boot entry is requested

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -86,6 +86,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         self.bootpath = self.get_boot_path()
         self.theme = self.get_boot_theme()
         self.timeout = self.get_boot_timeout_seconds()
+        self.continue_on_timeout = self.get_continue_on_timeout()
         self.failsafe_boot = self.failsafe_boot_entry_requested()
         self.mediacheck_boot = self.xml_state.build_type.get_mediacheck()
         self.xen_guest = self.xml_state.is_xen_guest()
@@ -313,13 +314,15 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             log.info('--> Using multiboot install template')
             parameters['hypervisor'] = hypervisor
             template = self.grub2.get_multiboot_install_template(
-                self.failsafe_boot, self.terminal
+                self.failsafe_boot, self.terminal,
+                self.continue_on_timeout
             )
         else:
             log.info('--> Using standard boot install template')
             hybrid_boot = True
             template = self.grub2.get_install_template(
-                self.failsafe_boot, hybrid_boot, self.terminal
+                self.failsafe_boot, hybrid_boot, self.terminal,
+                self.continue_on_timeout
             )
         try:
             self.config = template.substitute(parameters)

--- a/kiwi/bootloader/config/isolinux.py
+++ b/kiwi/bootloader/config/isolinux.py
@@ -86,6 +86,7 @@ class BootLoaderConfigIsoLinux(BootLoaderConfigBase):
         self.gfxmode = self.get_gfxmode('isolinux')
         # isolinux counts the timeout in units of 1/10 sec
         self.timeout = self.get_boot_timeout_seconds() * 10
+        self.continue_on_timeout = self.get_continue_on_timeout()
         self.cmdline = self.get_boot_cmdline()
         self.cmdline_failsafe = ' '.join(
             [self.cmdline, Defaults.get_failsafe_kernel_options()]
@@ -152,12 +153,14 @@ class BootLoaderConfigIsoLinux(BootLoaderConfigBase):
             log.info('--> Using multiboot install template')
             parameters['hypervisor'] = hypervisor
             template = self.isolinux.get_multiboot_install_template(
-                self.failsafe_boot, self._have_theme(), self.terminal
+                self.failsafe_boot, self._have_theme(), self.terminal,
+                self.continue_on_timeout
             )
         else:
             log.info('--> Using install template')
             template = self.isolinux.get_install_template(
-                self.failsafe_boot, self._have_theme(), self.terminal
+                self.failsafe_boot, self._have_theme(), self.terminal,
+                self.continue_on_timeout
             )
         try:
             self.config = template.substitute(parameters)

--- a/kiwi/bootloader/template/grub2.py
+++ b/kiwi/bootloader/template/grub2.py
@@ -31,12 +31,15 @@ class BootLoaderTemplateGrub2(object):
             export btrfs_relative_path
             search ${search_params}
             set default=${default_boot}
-            set timeout=${boot_timeout}
             if [ -n "$$extra_cmdline" ]; then
               submenu "Bootable snapshot $$snapshot_num" {
                 menuentry "If OK, run snapper rollback and reboot." { true; }
               }
             fi
+        ''').strip() + os.linesep
+
+        self.timeout = dedent('''
+            set timeout=${boot_timeout}
         ''').strip() + os.linesep
 
         self.header_hybrid = dedent('''
@@ -317,6 +320,7 @@ class BootLoaderTemplateGrub2(object):
         :rtype: Template
         """
         template_data = self.header
+        template_data += self.timeout
         if hybrid:
             template_data += '\n' + self.header_hybrid
         if terminal == 'gfxterm':
@@ -354,6 +358,7 @@ class BootLoaderTemplateGrub2(object):
         :rtype: Template
         """
         template_data = self.header
+        template_data += self.timeout
         if terminal == 'gfxterm':
             template_data += self.header_gfxterm
             template_data += self.header_theme
@@ -384,6 +389,7 @@ class BootLoaderTemplateGrub2(object):
         :rtype: Template
         """
         template_data = self.header
+        template_data += self.timeout
         if hybrid:
             template_data += self.header_hybrid
         if terminal == 'gfxterm':
@@ -426,6 +432,7 @@ class BootLoaderTemplateGrub2(object):
         :rtype: Template
         """
         template_data = self.header
+        template_data += self.timeout
         if terminal == 'gfxterm':
             template_data += self.header_gfxterm
             template_data += self.header_theme_iso
@@ -445,7 +452,7 @@ class BootLoaderTemplateGrub2(object):
         return Template(template_data)
 
     def get_install_template(
-        self, failsafe=True, hybrid=True, terminal='gfxterm'
+        self, failsafe=True, hybrid=True, terminal='gfxterm', with_timeout=True
     ):
         """
         Bootloader configuration template for install media
@@ -459,6 +466,8 @@ class BootLoaderTemplateGrub2(object):
         :rtype: Template
         """
         template_data = self.header
+        if with_timeout:
+            template_data += self.timeout
         if hybrid:
             template_data += self.header_hybrid
         if terminal == 'gfxterm':
@@ -483,7 +492,7 @@ class BootLoaderTemplateGrub2(object):
         return Template(template_data)
 
     def get_multiboot_install_template(
-        self, failsafe=True, terminal='gfxterm'
+        self, failsafe=True, terminal='gfxterm', with_timeout=True
     ):
         """
         Bootloader configuration template for install media with
@@ -497,6 +506,8 @@ class BootLoaderTemplateGrub2(object):
         :rtype: Template
         """
         template_data = self.header
+        if with_timeout:
+            template_data += self.timeout
         if terminal == 'gfxterm':
             template_data += self.header_gfxterm
             template_data += self.header_theme_iso

--- a/kiwi/bootloader/template/isolinux.py
+++ b/kiwi/bootloader/template/isolinux.py
@@ -55,9 +55,12 @@ class BootLoaderTemplateIsoLinux(object):
             # kiwi generated isolinux config file
             implicit 1
             prompt   1
-            timeout  ${boot_timeout}
             display isolinux.msg
             default ${default_boot}
+        ''').strip() + self.cr
+
+        self.timeout = dedent('''
+            timeout  ${boot_timeout}
         ''').strip() + self.cr
 
         self.ui_theme = dedent('''
@@ -171,6 +174,7 @@ class BootLoaderTemplateIsoLinux(object):
         :rtype: Template
         """
         template_data = self.header
+        template_data += self.timeout
         if terminal == 'serial':
             template_data += self.serial
             with_theme = False
@@ -201,6 +205,7 @@ class BootLoaderTemplateIsoLinux(object):
         :rtype: Template
         """
         template_data = self.header
+        template_data += self.timeout
         if terminal == 'serial':
             template_data += self.serial
             with_theme = False
@@ -217,7 +222,7 @@ class BootLoaderTemplateIsoLinux(object):
         return Template(template_data)
 
     def get_install_template(
-        self, failsafe=True, with_theme=True, terminal=None
+        self, failsafe=True, with_theme=True, terminal=None, with_timeout=True
     ):
         """
         Bootloader configuration template for install media
@@ -230,6 +235,8 @@ class BootLoaderTemplateIsoLinux(object):
         :rtype: Template
         """
         template_data = self.header
+        if with_timeout:
+            template_data += self.timeout
         if terminal == 'serial':
             template_data += self.serial
             with_theme = False
@@ -244,7 +251,7 @@ class BootLoaderTemplateIsoLinux(object):
         return Template(template_data)
 
     def get_multiboot_install_template(
-        self, failsafe=True, with_theme=True, terminal=None
+        self, failsafe=True, with_theme=True, terminal=None, with_timeout=True
     ):
         """
         Bootloader configuration template for install media with
@@ -258,6 +265,8 @@ class BootLoaderTemplateIsoLinux(object):
         :rtype: Template
         """
         template_data = self.header
+        if with_timeout:
+            template_data += self.timeout
         if terminal == 'serial':
             template_data += self.serial
             with_theme = False

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1346,9 +1346,8 @@ div {
         ]
     k.type.boottimeout.attribute =
         ## Specifies the boot timeout in seconds prior to launching
-        ## the default boot option. the unit for the timeout value
-        ## is seconds if GRUB is used as the boot loader and 1/10
-        ## seconds if syslinux is used
+        ## the default boot option. By default the timeout is set
+        ## to 10sec
         attribute boottimeout { xsd:nonNegativeInteger }
         >> sch:pattern [ id = "boottimeout" is-a = "image_type"
             sch:param [ name = "attr" value = "boottimeout" ]
@@ -1546,9 +1545,9 @@ div {
             "vmx" | "xfs" | "oci"
         }
     k.type.installboot.attribute =
-        ## Specifies the bootloader default boot entry for the"
-        ## initial boot of a kiwi install image. This value is"
-        ## only evaluated for grub and ext|syslinux"
+        ## Specifies the bootloader default boot entry for the
+        ## initial boot of a kiwi install image. This value is
+        ## only evaluated for grub and ext|syslinux
         attribute installboot {
             "failsafe-install" | "harddisk" | "install"
         }
@@ -1556,9 +1555,19 @@ div {
             sch:param [ name = "attr" value = "installboot" ]
             sch:param [ name = "types" value = "oem" ]
         ]
+    k.type.install_continue_on_timeout.attribute =
+        ## Specifies the boot timeout handling for the KIWI
+        ## install image. If set to "true" the configured boottimeout
+        ## or its default value applies. If set to "false" no
+        ## timeout applies in the boot menu of the install image.
+        attribute install_continue_on_timeout { xsd:boolean }
+        >> sch:pattern [ id = "install_continue_on_timeout" is-a = "image_type"
+            sch:param [ name = "attr" value = "install_continue_on_timeout" ]
+            sch:param [ name = "types" value = "oem vmx iso pxe" ]
+        ]
     k.type.installprovidefailsafe.attribute =
-        ## Specifies if the bootloader menu should provide an"
-        ## failsafe entry with special kernel parameters or not"
+        ## Specifies if the bootloader menu should provide an
+        ## failsafe entry with special kernel parameters or not
         attribute installprovidefailsafe { xsd:boolean }
         >> sch:pattern [ id = "installprovidefailsafe" is-a = "image_type"
             sch:param [ name = "attr" value = "installprovidefailsafe" ]
@@ -1587,9 +1596,9 @@ div {
             sch:param [ name = "types" value = "oem" ]
         ]
     k.type.mediacheck.attribute =
-        ## Specifies if the bootloader menu should provide an"
+        ## Specifies if the bootloader menu should provide an
         ## mediacheck entry to verify ISO integrity or not.
-        ## Disabled by default and only available for x86 arch family."
+        ## Disabled by default and only available for x86 arch family.
         attribute mediacheck { xsd:boolean }
         >> sch:pattern [ id = "mediacheck" is-a = "image_type"
             sch:param [ name = "attr" value = "mediacheck" ]
@@ -1754,6 +1763,7 @@ div {
         k.type.initrd_system.attribute? &
         k.type.image.attribute &
         k.type.installboot.attribute? &
+        k.type.install_continue_on_timeout.attribute? &
         k.type.installprovidefailsafe.attribute? &
         k.type.installiso.attribute? &
         k.type.installstick.attribute? &

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1563,7 +1563,7 @@ div {
         attribute install_continue_on_timeout { xsd:boolean }
         >> sch:pattern [ id = "install_continue_on_timeout" is-a = "image_type"
             sch:param [ name = "attr" value = "install_continue_on_timeout" ]
-            sch:param [ name = "types" value = "oem vmx iso pxe" ]
+            sch:param [ name = "types" value = "oem" ]
         ]
     k.type.installprovidefailsafe.attribute =
         ## Specifies if the bootloader menu should provide an

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2016,9 +2016,8 @@ information is passed as add-profile option</a:documentation>
     <define name="k.type.boottimeout.attribute">
       <attribute name="boottimeout">
         <a:documentation>Specifies the boot timeout in seconds prior to launching
-the default boot option. the unit for the timeout value
-is seconds if GRUB is used as the boot loader and 1/10
-seconds if syslinux is used</a:documentation>
+the default boot option. By default the timeout is set
+to 10sec</a:documentation>
         <data type="nonNegativeInteger"/>
       </attribute>
       <sch:pattern id="boottimeout" is-a="image_type">
@@ -2311,9 +2310,9 @@ system does not support all features of the kiwi initrd</a:documentation>
     </define>
     <define name="k.type.installboot.attribute">
       <attribute name="installboot">
-        <a:documentation>Specifies the bootloader default boot entry for the"
-initial boot of a kiwi install image. This value is"
-only evaluated for grub and ext|syslinux"</a:documentation>
+        <a:documentation>Specifies the bootloader default boot entry for the
+initial boot of a kiwi install image. This value is
+only evaluated for grub and ext|syslinux</a:documentation>
         <choice>
           <value>failsafe-install</value>
           <value>harddisk</value>
@@ -2325,10 +2324,23 @@ only evaluated for grub and ext|syslinux"</a:documentation>
         <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
+    <define name="k.type.install_continue_on_timeout.attribute">
+      <attribute name="install_continue_on_timeout">
+        <a:documentation>Specifies the boot timeout handling for the KIWI
+install image. If set to "true" the configured boottimeout
+or its default value applies. If set to "false" no
+timeout applies in the boot menu of the install image.</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+      <sch:pattern id="install_continue_on_timeout" is-a="image_type">
+        <sch:param name="attr" value="install_continue_on_timeout"/>
+        <sch:param name="types" value="oem vmx iso pxe"/>
+      </sch:pattern>
+    </define>
     <define name="k.type.installprovidefailsafe.attribute">
       <attribute name="installprovidefailsafe">
-        <a:documentation>Specifies if the bootloader menu should provide an"
-failsafe entry with special kernel parameters or not"</a:documentation>
+        <a:documentation>Specifies if the bootloader menu should provide an
+failsafe entry with special kernel parameters or not</a:documentation>
         <data type="boolean"/>
       </attribute>
       <sch:pattern id="installprovidefailsafe" is-a="image_type">
@@ -2369,9 +2381,9 @@ be created (oem only)</a:documentation>
     </define>
     <define name="k.type.mediacheck.attribute">
       <attribute name="mediacheck">
-        <a:documentation>Specifies if the bootloader menu should provide an"
+        <a:documentation>Specifies if the bootloader menu should provide an
 mediacheck entry to verify ISO integrity or not.
-Disabled by default and only available for x86 arch family."</a:documentation>
+Disabled by default and only available for x86 arch family.</a:documentation>
         <data type="boolean"/>
       </attribute>
       <sch:pattern id="mediacheck" is-a="image_type">
@@ -2642,6 +2654,9 @@ default.</a:documentation>
         <ref name="k.type.image.attribute"/>
         <optional>
           <ref name="k.type.installboot.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.install_continue_on_timeout.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.installprovidefailsafe.attribute"/>

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2334,7 +2334,7 @@ timeout applies in the boot menu of the install image.</a:documentation>
       </attribute>
       <sch:pattern id="install_continue_on_timeout" is-a="image_type">
         <sch:param name="attr" value="install_continue_on_timeout"/>
-        <sch:param name="types" value="oem vmx iso pxe"/>
+        <sch:param name="types" value="oem"/>
       </sch:pattern>
     </define>
     <define name="k.type.installprovidefailsafe.attribute">

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -16,7 +16,7 @@
 #   kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Command line:
-#   /home/david/work/kiwi/.env3/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
+#   /home/ms/Project/kiwi/.tox/3.6/bin/generateDS.py -f --external-encoding="utf-8" --no-dates --no-warnings -o "kiwi/xml_parse.py" kiwi/schema/kiwi_for_generateDS.xsd
 #
 # Current working directory (os.getcwd()):
 #   kiwi
@@ -100,7 +100,7 @@ except ImportError:
 try:
     from generatedssuper import GeneratedsSuper
 except ImportError as exp:
-
+    
     class GeneratedsSuper(object):
         tzoff_pattern = re_.compile(r'(\+|-)((0\d|1[0-3]):[0-5]\d|14:00)$')
         class _FixedOffsetTZ(datetime_.tzinfo):
@@ -2732,7 +2732,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, boottimeout=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, installboot=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, containerconfig=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, boottimeout=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, containerconfig=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2767,6 +2767,7 @@ class type_(GeneratedsSuper):
         self.initrd_system = _cast(None, initrd_system)
         self.image = _cast(None, image)
         self.installboot = _cast(None, installboot)
+        self.install_continue_on_timeout = _cast(bool, install_continue_on_timeout)
         self.installprovidefailsafe = _cast(bool, installprovidefailsafe)
         self.installiso = _cast(bool, installiso)
         self.installstick = _cast(bool, installstick)
@@ -2931,6 +2932,8 @@ class type_(GeneratedsSuper):
     def set_image(self, image): self.image = image
     def get_installboot(self): return self.installboot
     def set_installboot(self, installboot): self.installboot = installboot
+    def get_install_continue_on_timeout(self): return self.install_continue_on_timeout
+    def set_install_continue_on_timeout(self, install_continue_on_timeout): self.install_continue_on_timeout = install_continue_on_timeout
     def get_installprovidefailsafe(self): return self.installprovidefailsafe
     def set_installprovidefailsafe(self, installprovidefailsafe): self.installprovidefailsafe = installprovidefailsafe
     def get_installiso(self): return self.installiso
@@ -3134,6 +3137,9 @@ class type_(GeneratedsSuper):
         if self.installboot is not None and 'installboot' not in already_processed:
             already_processed.add('installboot')
             outfile.write(' installboot=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.installboot), input_name='installboot')), ))
+        if self.install_continue_on_timeout is not None and 'install_continue_on_timeout' not in already_processed:
+            already_processed.add('install_continue_on_timeout')
+            outfile.write(' install_continue_on_timeout="%s"' % self.gds_format_boolean(self.install_continue_on_timeout, input_name='install_continue_on_timeout'))
         if self.installprovidefailsafe is not None and 'installprovidefailsafe' not in already_processed:
             already_processed.add('installprovidefailsafe')
             outfile.write(' installprovidefailsafe="%s"' % self.gds_format_boolean(self.installprovidefailsafe, input_name='installprovidefailsafe'))
@@ -3434,6 +3440,15 @@ class type_(GeneratedsSuper):
             already_processed.add('installboot')
             self.installboot = value
             self.installboot = ' '.join(self.installboot.split())
+        value = find_attr_value_('install_continue_on_timeout', node)
+        if value is not None and 'install_continue_on_timeout' not in already_processed:
+            already_processed.add('install_continue_on_timeout')
+            if value in ('true', '1'):
+                self.install_continue_on_timeout = True
+            elif value in ('false', '0'):
+                self.install_continue_on_timeout = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
         value = find_attr_value_('installprovidefailsafe', node)
         if value is not None and 'installprovidefailsafe' not in already_processed:
             already_processed.add('installprovidefailsafe')

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -320,9 +320,15 @@ class TestBootLoaderConfigGrub2(object):
         mock_sysconfig.assert_called_once_with('root_dir/etc/default/grub')
         grub_default.write.assert_called_once_with()
         assert grub_default.__setitem__.call_args_list == [
-            call('GRUB_BACKGROUND', '/boot/grub2/themes/openSUSE/background.png'),
+            call(
+                'GRUB_BACKGROUND',
+                '/boot/grub2/themes/openSUSE/background.png'
+            ),
             call('GRUB_CMDLINE_LINUX_DEFAULT', '"some-cmdline"'),
-            call('GRUB_SERIAL_COMMAND', '"serial --speed=38400 --unit=0 --word=8 --parity=no --stop=1"'),
+            call(
+                'GRUB_SERIAL_COMMAND',
+                '"serial --speed=38400 --unit=0 --word=8 --parity=no --stop=1"'
+            ),
             call('GRUB_THEME', '/boot/grub2/themes/openSUSE/theme.txt'),
             call('GRUB_TIMEOUT', 10),
             call('GRUB_USE_INITRDEFI', 'true'),
@@ -386,7 +392,7 @@ class TestBootLoaderConfigGrub2(object):
         self.bootloader.multiboot = True
         self.bootloader.setup_install_image_config(self.mbrid)
         self.grub2.get_multiboot_install_template.assert_called_once_with(
-            True, 'gfxterm'
+            True, 'gfxterm', True
         )
 
     def test_setup_disk_image_config_standard(self):
@@ -428,7 +434,7 @@ class TestBootLoaderConfigGrub2(object):
         self.bootloader.multiboot = False
         self.bootloader.setup_install_image_config(self.mbrid)
         self.grub2.get_install_template.assert_called_once_with(
-            True, True, 'gfxterm'
+            True, True, 'gfxterm', True
         )
 
     @raises(KiwiTemplateError)

--- a/test/unit/bootloader_config_isolinux_test.py
+++ b/test/unit/bootloader_config_isolinux_test.py
@@ -44,6 +44,9 @@ class TestBootLoaderConfigIsoLinux(object):
         self.state.build_type.get_boottimeout = mock.Mock(
             return_value=None
         )
+        self.state.build_type.get_install_continue_on_timeout = mock.Mock(
+            return_value=None
+        )
         self.state.get_initrd_system = mock.Mock(
             return_value='dracut'
         )
@@ -150,7 +153,7 @@ class TestBootLoaderConfigIsoLinux(object):
 
         self.bootloader.setup_install_image_config(mbrid=None)
         self.isolinux.get_install_template.assert_called_once_with(
-            True, False, None
+            True, False, None, True
         )
         self.isolinux.get_install_message_template.assert_called_once_with()
         assert template_cfg.substitute.called
@@ -161,7 +164,7 @@ class TestBootLoaderConfigIsoLinux(object):
 
         self.bootloader.setup_install_image_config(mbrid=None)
         self.isolinux.get_multiboot_install_template.assert_called_once_with(
-            True, False, None
+            True, False, None, True
         )
 
     @patch('os.path.exists')
@@ -170,7 +173,7 @@ class TestBootLoaderConfigIsoLinux(object):
 
         self.bootloader.setup_install_image_config(mbrid=None)
         self.isolinux.get_install_template.assert_called_once_with(
-            True, True, None
+            True, True, None, True
         )
 
     @raises(KiwiTemplateError)


### PR DESCRIPTION
This commit adds a new attribute called:

    <type ... install_continue_on_timeout="true|false"/>

It allows to setup the boot timeout for install images
build with KIWI. If not set or set to 'true' the configured
boottimeout or its default applies to the install image
as it was before. If set to 'false' there will be no
timeout in the install image bootloader setup and the boot
only continues on manual intervention.

