### PR TITLE
Add container history metadata on umoci repack call

### DIFF
--- a/kiwi/container/oci.py
+++ b/kiwi/container/oci.py
@@ -128,7 +128,7 @@ class ContainerImageOCI(object):
 
         self.oci.unpack()
         self.oci.sync_rootfs(''.join([self.root_dir, os.sep]), exclude_list)
-        self.oci.repack()
+        self.oci.repack(self.oci_config)
 
         if 'additional_tags' in self.oci_config:
             for tag in self.oci_config['additional_tags']:

--- a/kiwi/oci_tools/base.py
+++ b/kiwi/oci_tools/base.py
@@ -106,11 +106,13 @@ class OCIBase(object):
         """
         raise NotImplementedError
 
-    def repack(self):
+    def repack(self, oci_config):
         """
         Pack root data directory into container image
 
         Implementation in specialized tool class
+
+        :param list oci_config: meta data list
         """
         raise NotImplementedError
 

--- a/kiwi/oci_tools/umoci.py
+++ b/kiwi/oci_tools/umoci.py
@@ -37,7 +37,7 @@ class OCIUmoci(OCIBase):
             [self.container_dir, self.container_tag]
         )
         if CommandCapabilities.has_option_in_help(
-            'umoci', '--no-history', ['repack', '--help']
+            'umoci', '--no-history', ['config', '--help']
         ):
             self.no_history_flag = ['--no-history']
         else:
@@ -102,12 +102,16 @@ class OCIUmoci(OCIBase):
             options=['-a', '-H', '-X', '-A']
         )
 
-    def repack(self):
+    def repack(self, oci_config):
         """
         Pack root data directory into container image
+
+        :param list oci_config: meta data list
         """
+        history_flags = self._process_oci_history_to_arguments(oci_config)
+        history_flags.extend(['--history.created', self.creation_date])
         Command.run(
-            ['umoci', 'repack'] + self.no_history_flag + [
+            ['umoci', 'repack'] + history_flags + [
                 '--image', self.container_name, self.oci_root_dir
             ]
         )
@@ -136,8 +140,7 @@ class OCIUmoci(OCIBase):
         Command.run(
             [
                 'umoci', 'config'
-            ] + config_args + [
-                '--history.created', self.creation_date,
+            ] + config_args + self.no_history_flag + [
                 '--image', self.container_name,
                 '--tag', self.container_tag,
                 '--created', self.creation_date
@@ -211,7 +214,6 @@ class OCIUmoci(OCIBase):
                     name, oci_config['labels'][name]
                 ))
 
-        arguments.extend(cls._process_oci_history_to_arguments(oci_config))
         return arguments
 
     @classmethod

--- a/test/unit/container_image_oci_test.py
+++ b/test/unit/container_image_oci_test.py
@@ -114,7 +114,13 @@ class TestContainerImageOCI(object):
                 'var/cache/kiwi', 'boot', 'dev', 'sys', 'proc'
             ]
         )
-        self.oci.oci.repack.assert_called_once_with()
+        self.oci.oci.repack.assert_called_once_with({
+            'container_name': 'foo/bar',
+            'additional_tags': ['current', 'foobar'],
+            'container_tag': 'latest',
+            'entry_subcommand': ['/bin/bash'],
+            'history': {'created_by': 'KIWI {0}'.format(__version__)}
+        })
         self.oci.oci.set_config.assert_called_once_with({
             'container_name': 'foo/bar',
             'additional_tags': ['current', 'foobar'],
@@ -161,7 +167,13 @@ class TestContainerImageOCI(object):
                 'var/cache/kiwi', 'boot', 'dev', 'sys', 'proc'
             ]
         )
-        self.oci.oci.repack.assert_called_once_with()
+        self.oci.oci.repack.assert_called_once_with({
+            'container_name': 'foo/bar',
+            'additional_tags': ['current', 'foobar'],
+            'container_tag': 'latest',
+            'entry_subcommand': ['/bin/bash'],
+            'history': {'created_by': 'KIWI {0}'.format(__version__)}
+        })
         self.oci.oci.set_config.assert_called_once_with({
             'container_name': 'foo/bar',
             'additional_tags': ['current', 'foobar'],

--- a/test/unit/oci_tools_base_test.py
+++ b/test/unit/oci_tools_base_test.py
@@ -34,7 +34,7 @@ class TestOCIBase(object):
 
     def test_repack(self):
         with raises(NotImplementedError):
-            self.oci.repack()
+            self.oci.repack({})
 
     def test_add_tag(self):
         with raises(NotImplementedError):
@@ -42,7 +42,7 @@ class TestOCIBase(object):
 
     def test_set_config(self):
         with raises(NotImplementedError):
-            self.oci.set_config(['data'])
+            self.oci.set_config({})
 
     def test_garbage_collect(self):
         with raises(NotImplementedError):


### PR DESCRIPTION
This commit makes sure that `umoci repack` call includes history
metadata and skips that in `umoci config` call.

Fixes #918
