### PR TITLE
Fixed file name of completion file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ install:
 	# completion
 	install -d -m 755 ${buildroot}etc/bash_completion.d
 	$(python) helper/completion_generator \
-		> ${buildroot}etc/bash_completion.d/kiwi-ng-${python_version}.sh
+		> ${buildroot}etc/bash_completion.d/kiwi-ng.sh
 
 tox:
 	tox

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -564,7 +564,7 @@ fi
 %ghost %_sysconfdir/alternatives/kiwi-ng
 %ghost %_sysconfdir/alternatives/kiwicompat
 %{python2_sitelib}/*
-%config %_sysconfdir/bash_completion.d/kiwi-ng-2*.sh
+%config %_sysconfdir/bash_completion.d/kiwi-ng.sh
 
 %if 0%{?fedora} || 0%{?suse_version} || 0%{?ubuntu} >= 1804 || 0%{?debian} >= 9
 %files -n python3-kiwi
@@ -578,7 +578,7 @@ fi
 %ghost %_sysconfdir/alternatives/kiwi-ng
 %ghost %_sysconfdir/alternatives/kiwicompat
 %{python3_sitelib}/*
-%config %_sysconfdir/bash_completion.d/kiwi-ng-3*.sh
+%config %_sysconfdir/bash_completion.d/kiwi-ng.sh
 %endif
 
 %files -n kiwi-man-pages


### PR DESCRIPTION
The bash completion file must match one of the alternatives links.
Otherwise the bash completion mechanism will not match. kiwi-ng is
the unique alternative link name compared to the still present
legacy kiwi version and should be used preferably

