### PR TITLE
Fixed Xen guest detection

### DIFF
--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -541,8 +541,10 @@ class XMLState(object):
     def is_xen_guest(self):
         """
         Check if build type setup specifies a Xen Guest (domX)
-        The check is based on the firmware and xen_loader configuration
-        values:
+        The check is based on the architecture, the firmware and
+        xen_loader configuration values:
+
+        * We only support Xen setup on the x86_64 architecture
 
         * Firmware pointing to ec2 means the image is targeted to run
           in Amazon EC2 which is a Xen guest
@@ -554,6 +556,9 @@ class XMLState(object):
 
         :rtype: bool
         """
+        if self.host_architecture != 'x86_64':
+            # We only support Xen stuff on x86_64
+            return False
         firmware = self.build_type.get_firmware()
         machine_section = self.get_build_type_machine_section()
         if firmware and firmware in Defaults.get_ec2_capable_firmware_names():
@@ -562,6 +567,7 @@ class XMLState(object):
         elif machine_section and machine_section.get_xen_loader():
             # the image provides a machine section with a guest loader setup
             return True
+        return False
 
     def get_build_type_system_disk_section(self):
         """

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -709,10 +709,22 @@ class TestXMLState(object):
     def test_is_xen_guest_by_machine_setup(self):
         assert self.state.is_xen_guest() is True
 
-    def test_is_xen_guest_by_firmware_setup(self):
+    def test_is_xen_guest_no_xen_guest_setup(self):
+        assert self.boot_state.is_xen_guest() is False
+
+    @patch('platform.machine')
+    def test_is_xen_guest_by_firmware_setup(self, mock_platform_machine):
+        mock_platform_machine.return_value = 'x86_64'
         xml_data = self.description.load()
         state = XMLState(xml_data, ['ec2Flavour'], 'vmx')
         assert state.is_xen_guest() is True
+
+    @patch('platform.machine')
+    def test_is_xen_guest_by_architecture(self, mock_platform_machine):
+        mock_platform_machine.return_value = 'unsupported'
+        xml_data = self.description.load()
+        state = XMLState(xml_data, ['ec2Flavour'], 'vmx')
+        assert state.is_xen_guest() is False
 
     def test_get_initrd_system(self):
         xml_data = self.description.load()


### PR DESCRIPTION
We only support Xen setup e.g in the Amazon Cloud for the
x86_64 architecture. On other archs e.g aarch64 Xen does not
exist. The method in kiwi which checks for the guest setup
should take the architecture into account


