### PR TITLE
Support alternative EFI and grub modules paths

### DIFF
--- a/kiwi/bootloader/install/grub2.py
+++ b/kiwi/bootloader/install/grub2.py
@@ -193,17 +193,18 @@ class BootLoaderInstallGrub2(BootLoaderInstallBase):
         self.sysfs_mount.bind_mount()
 
         # check if a grub installation could be found in the image system
-        grub_directory = Defaults.get_grub_path(
-            self.root_mount.mountpoint + '/usr/lib'
+        module_directory = Defaults.get_grub_path(
+            self.root_mount.mountpoint, self.target, raise_on_error=False
         )
-        if not grub_directory:
+        if not module_directory:
             raise KiwiBootLoaderGrubDataError(
-                'No grub2 installation found in %s' % self.root_mount.mountpoint
+                'No grub2 installation found in {0} for target {1}'.format(
+                    self.root_mount.mountpoint, self.target
+                )
             )
-        grub_directory = grub_directory.replace(
+        module_directory = module_directory.replace(
             self.root_mount.mountpoint, ''
         )
-        module_directory = grub_directory + '/' + self.target
         boot_directory = '/boot'
 
         # wipe existing grubenv to allow the grub installer to create a new one

--- a/test/unit/bootloader_install_grub2_test.py
+++ b/test/unit/bootloader_install_grub2_test.py
@@ -152,7 +152,7 @@ class TestBootLoaderInstallGrub2(object):
     ):
         mock_glob.return_value = ['tmp_root/boot/grub2/grubenv']
         mock_grub_path.return_value = \
-            self.root_mount.mountpoint + '/usr/lib/grub2'
+            self.root_mount.mountpoint + '/usr/lib/grub2/i386-pc'
 
         def side_effect(device, mountpoint=None):
             return self.mount_managers.pop()
@@ -196,7 +196,7 @@ class TestBootLoaderInstallGrub2(object):
     ):
         mock_glob.return_value = ['tmp_root/boot/grub2/grubenv']
         mock_grub_path.return_value = \
-            self.root_mount.mountpoint + '/usr/lib/grub2'
+            self.root_mount.mountpoint + '/usr/lib/grub2/powerpc-ieee1275'
         self.bootloader.arch = 'ppc64'
 
         def side_effect(device, mountpoint=None):
@@ -235,7 +235,7 @@ class TestBootLoaderInstallGrub2(object):
     ):
         mock_glob.return_value = ['tmp_root/boot/grub2/grubenv']
         mock_grub_path.return_value = \
-            self.root_mount.mountpoint + '/usr/lib/grub2'
+            self.root_mount.mountpoint + '/usr/lib/grub2/i386-pc'
         self.boot_mount.device = self.root_mount.device
 
         def side_effect(device, mountpoint=None):
@@ -281,7 +281,7 @@ class TestBootLoaderInstallGrub2(object):
         mock_exists.return_value = True
         mock_glob.return_value = ['tmp_root/boot/grub2/grubenv']
         mock_grub_path.return_value = \
-            self.root_mount.mountpoint + '/usr/lib/grub2'
+            self.root_mount.mountpoint + '/usr/lib/grub2/i386-pc'
         self.firmware.efi_mode.return_value = 'uefi'
         self.boot_mount.device = self.root_mount.device
 
@@ -342,7 +342,7 @@ class TestBootLoaderInstallGrub2(object):
         mock_exists.return_value = True
         mock_glob.return_value = ['tmp_root/boot/grub2/grubenv']
         mock_grub_path.return_value = \
-            self.root_mount.mountpoint + '/usr/lib/grub2'
+            self.root_mount.mountpoint + '/usr/lib/grub2/i386-pc'
         self.firmware.efi_mode.return_value = 'uefi'
         self.boot_mount.device = self.root_mount.device
 

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -89,7 +89,7 @@ class TestDefaults(object):
 
     @patch('kiwi.defaults.glob.iglob')
     def test_get_unsigned_grub_loader(self, mock_glob):
-        mock_glob.return_value = ['/usr/lib/grub2/x86_64-efi/grub.efi']
+        mock_glob.return_value = ['/usr/share/grub2/x86_64-efi/grub.efi']
         assert Defaults.get_unsigned_grub_loader('root') == \
             mock_glob.return_value.pop()
-        mock_glob.assert_called_once_with('root/usr/lib/grub*/*-efi/grub.efi')
+        mock_glob.assert_called_once_with('root/usr/share/grub*/*-efi/grub.efi')


### PR DESCRIPTION
In SUSE products EFI binaries are historically located in
/usr/lib*/efi. In a recent move to package grub2 as noarch
fate#326960, a collision between x86_64 and aarch64 has been
identified, as both place platform-specific files in the same
spot. To rectify this, a new location was devised:
/usr/share/efi/$(uname -m). At the same time /usr/lib/grub2 will
move to /usr/share/grub2. This Fixes #924

