### PR TITLE
Add a runtime check for preferences metadata

### DIFF
--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -587,3 +587,34 @@ class RuntimeChecker(object):
                 raise KiwiRuntimeError(
                     message_tool_not_found.format(name=tool)
                 )
+
+    def check_minimal_required_preferences(self):
+        """
+        Kiwi requires some of the elements of the `preferences` element
+        to be present at least in one of the preferences section. This
+        runtime check validates <version> and <packagemanager> are
+        provided.
+        """
+        message_missing_package_manager = dedent('''\n
+            No package manager is defined in any of the <preferences>
+            sections. Please add
+
+                <packagemanager>desired_package_manager<packagemanager/>
+
+            inside the <preferences> section.
+        ''')
+
+        message_missing_version = dedent('''\n
+            No version is defined in any of the <preferences>
+            sections. Please add
+
+                <version>image_version<version/>
+
+            inside the <preferences> section.
+        ''')
+
+        if not self.xml_state.get_package_manager():
+            raise KiwiRuntimeError(message_missing_package_manager)
+
+        if not self.xml_state.get_image_version():
+            raise KiwiRuntimeError(message_missing_version)

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -134,6 +134,7 @@ class SystemBuildTask(CliTask):
         self.load_xml_description(
             self.command_args['--description']
         )
+        self.runtime_checker.check_minimal_required_preferences()
         self.runtime_checker.check_efi_mode_for_disk_overlay_correctly_setup()
         self.runtime_checker.check_boot_description_exists()
         self.runtime_checker.check_consistent_kernel_in_boot_and_system_image()

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -120,6 +120,7 @@ class SystemPrepareTask(CliTask):
 
         abs_root_path = os.path.abspath(self.command_args['--root'])
 
+        self.runtime_checker.check_minimal_required_preferences()
         self.runtime_checker.check_efi_mode_for_disk_overlay_correctly_setup()
         self.runtime_checker.check_grub_efi_installed_for_efi_firmware()
         self.runtime_checker.check_boot_description_exists()

--- a/test/data/example_runtime_checker_config.xml
+++ b/test/data/example_runtime_checker_config.xml
@@ -26,15 +26,22 @@
         </specification>
     </description>
     <profiles>
+        <profile name="metadata" description="Inlude some preferences metadata"/>
+        <profile name="noVersion" description="Does not include version element"/>
         <profile name="xenFlavour" description="VMX with Xen kernel"/>
         <profile name="ec2Flavour" description="VMX with EC2/Xen kernel"/>
-        <profile name="docker" description="docker image"/>
-        <profile name="vmxFlavour" description="VMX with default kernel" import="true"/>
+        <profile name="docker" description="docker image">
+            <requires profile="noVersion"/>
+        </profile>
+        <profile name="vmxFlavour" description="VMX with default kernel" import="true">
+            <requires profile="metadata"/>
+        </profile>
     </profiles>
-    <preferences>
+    <preferences profiles="noVersion">
         <locale>de_DE</locale>
+        <packagemanager>zypper</packagemanager>
     </preferences>
-    <preferences>
+    <preferences profiles="metadata">
         <version>1.13.2</version>
         <packagemanager>zypper</packagemanager>
         <locale>en_US</locale>

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -351,3 +351,19 @@ class TestRuntimeChecker(object):
     @raises(KiwiRuntimeError)
     def test_check_volume_label_used_with_lvm(self):
         self.runtime_checker.check_volume_label_used_with_lvm()
+
+    @raises(KiwiRuntimeError)
+    def test_check_preferences_data_no_version(self):
+        xml_state = XMLState(
+            self.description.load(), ['docker'], 'docker'
+        )
+        runtime_checker = RuntimeChecker(xml_state)
+        runtime_checker.check_minimal_required_preferences()
+
+    @raises(KiwiRuntimeError)
+    def test_check_preferences_data_no_packagemanager(self):
+        xml_state = XMLState(
+            self.description.load(), ['xenFlavour'], 'vmx'
+        )
+        runtime_checker = RuntimeChecker(xml_state)
+        runtime_checker.check_minimal_required_preferences()


### PR DESCRIPTION
This commit adds a runtime check for preferences metadata. More
specfic verifies there is a packagemanager defined and an image version
defined.

Fixes #925
