### PR TITLE
Fixed grub theme lookup

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -724,8 +724,10 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         Path.create(boot_fonts_dir)
         boot_unicode_font = boot_fonts_dir + '/unicode.pf2'
         if not os.path.exists(boot_unicode_font):
-            unicode_font = Defaults.get_grub_path(lookup_path, 'unicode.pf2')
             try:
+                unicode_font = Defaults.get_grub_path(
+                    lookup_path, 'unicode.pf2'
+                )
                 Command.run(
                     ['cp', unicode_font, boot_unicode_font]
                 )
@@ -741,12 +743,12 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
 
         if self.theme:
             theme_dir = Defaults.get_grub_path(
-                lookup_path, 'themes/' + self.theme
+                lookup_path, 'themes/' + self.theme, raise_on_error=False
             )
             boot_theme_background_file = self._find_theme_background_file(
                 lookup_path
             )
-            if os.path.exists(theme_dir):
+            if theme_dir and os.path.exists(theme_dir):
                 if boot_theme_background_file:
                     # A background file was found. Preserve a copy of the
                     # file which was created at install time of the theme

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -1070,7 +1070,9 @@ class TestBootLoaderConfigGrub2(object):
         self.find_grub['themes/some-theme'] = 'some-theme'
         self.find_grub['i386-pc'] = 'i386-pc'
 
-        def find_grub_data_side_effect(root_path, filename):
+        def find_grub_data_side_effect(
+            root_path, filename, raise_on_error=True
+        ):
             return self.find_grub[filename]
 
         def side_effect(arg):


### PR DESCRIPTION
If the theme was not found at the expected place an exception
was thrown. However the alternative lookup code in /boot was
not reached with that exception. This commit fixes this

