### PR TITLE
Handle location of the rpm DB on the macro level

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1230,6 +1230,29 @@ class Defaults(object):
             sys.setdefaultencoding('utf-8')
 
     @classmethod
+    def get_custom_rpm_macros_path(cls):
+        """
+        Returns the custom macros directory for the rpm database.
+
+        :return: path name
+
+        :rtype: str
+        """
+        return 'usr/lib/rpm/macros.d'
+
+    @classmethod
+    def get_custom_rpm_bootstrap_macro_name(cls):
+        """
+        Returns the rpm bootstrap macro file name created
+        in the custom rpm macros path
+
+        :return: filename
+
+        :rtype: str
+        """
+        return 'macros.kiwi-bootstrap-config'
+
+    @classmethod
     def get_default_packager_tool(cls, package_manager):
         """
         Provides the packager tool according to the package manager
@@ -1246,17 +1269,6 @@ class Defaults(object):
             return 'rpm'
         elif package_manager in deb_based:
             return 'dpkg'
-
-    @classmethod
-    def get_default_rpmdb_path(cls):
-        """
-        Returns the default path of the rpm database.
-
-        :return: rpmdb default path
-
-        :rtype: str
-        """
-        return '/var/lib/rpm'
 
     def get(self, key):
         """

--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -579,12 +579,6 @@ class KiwiRootInitCreationError(KiwiError):
     """
 
 
-class KiwiRpmDatabaseReloadError(KiwiError):
-    """
-    Exception raised on error of an rpm DB dump -> reload process.
-    """
-
-
 class KiwiRpmDirNotRemoteError(KiwiError):
     """
     Exception raised if the provided rpm-dir repository is not local

--- a/kiwi/package_manager/apt.py
+++ b/kiwi/package_manager/apt.py
@@ -306,24 +306,6 @@ class PackageManagerApt(PackageManagerBase):
             '.*Removing ' + re.escape(package_name) + '.*', apt_get_output
         )
 
-    def database_consistent(self):
-        """
-        Check if package database is consistent
-
-        There is no database consistency/rebuild for apt-get
-        """
-        pass
-
-    def dump_reload_package_database(self, version=45):
-        """
-        Dump and reload the package database to match the desired db version
-
-        There is no such reload cycle for apt-get
-
-        :param str version: unused
-        """
-        pass
-
     def _package_requests(self):
         items = self.package_requests[:]
         self.cleanup_requests()

--- a/kiwi/package_manager/base.py
+++ b/kiwi/package_manager/base.py
@@ -84,8 +84,9 @@ class PackageManagerBase(object):
         """
         Queue a package exclusion(skip) request
 
-        Obsolete method, only kept for API compatbility
-        Method calls: request_package_exclusion
+        OBSOLETE: Will be removed 2019-06-05
+
+        Kept for API compatbility Method calls: request_package_exclusion
         """
         return self.request_package_exclusion(name)
 
@@ -173,22 +174,23 @@ class PackageManagerBase(object):
 
     def database_consistent(self):
         """
-        Check if package database is consistent
-
-        Implementation in specialized package manager class
+        OBSOLETE: Will be removed 2019-06-05
         """
-        raise NotImplementedError
+        pass
 
     def dump_reload_package_database(self, version=45):
         """
-        For rpm based package managers, dump and reload the database
-        to match the desired rpm db version
+        OBSOLETE: Will be removed 2019-06-05
+        """
+        pass
+
+    def post_process_install_requests_bootstrap(self):
+        """
+        Process extra code required after bootstrapping
 
         Implementation in specialized package manager class
-
-        :param str version: unused
         """
-        raise NotImplementedError
+        pass
 
     def cleanup_requests(self):
         """

--- a/kiwi/package_manager/yum.py
+++ b/kiwi/package_manager/yum.py
@@ -20,6 +20,7 @@ import re
 
 # project
 from kiwi.command import Command
+from kiwi.utils.rpm_database import RpmDataBase
 from kiwi.package_manager.base import PackageManagerBase
 from kiwi.path import Path
 from kiwi.exceptions import (
@@ -289,26 +290,10 @@ class PackageManagerYum(PackageManagerBase):
             '.*Removing: ' + re.escape(package_name) + '.*', yum_output
         )
 
-    def database_consistent(self):
+    def post_process_install_requests_bootstrap(self):
         """
-        Check if rpm package database is consistent
-
-        :return: True or False
-
-        :rtype: bool
+        Move the rpm database to the place as it is expected by the
+        rpm package installed during bootstrap phase
         """
-        try:
-            Command.run(['chroot', self.root_dir, 'rpmdb', '--initdb'])
-            return True
-        except Exception:
-            return False
-
-    def dump_reload_package_database(self, version=45):
-        """
-        Dump and reload the rpm database to match the desired rpm db version
-
-        For the supported RHEL versions there is no dump/reload cycle required
-
-        :param str version: unused
-        """
-        pass
+        rpmdb = RpmDataBase(self.root_dir)
+        rpmdb.set_database_to_image_path()

--- a/kiwi/repository/apt.py
+++ b/kiwi/repository/apt.py
@@ -29,7 +29,8 @@ class RepositoryApt(RepositoryBase):
     """
     **Implements repository handling for apt-get package manager**
 
-    :param str shared_apt_get_dir: shared directory between image root and build system root
+    :param str shared_apt_get_dir:
+        shared directory between image root and build system root
     :param str runtime_apt_get_config_file: apt-get runtime config file name
     :param list apt_get_args: apt-get caller arguments
     :param dict command_env: customized os.environ for apt-get
@@ -91,6 +92,14 @@ class RepositoryApt(RepositoryBase):
         # config file for apt-get tool
         self.apt_conf = PackageManagerTemplateAptGet()
         self._write_runtime_config()
+
+    def setup_package_database_configuration(self):
+        """
+        Setup package database configuration
+
+        No special database configuration required for apt
+        """
+        pass
 
     def use_default_location(self):
         """

--- a/kiwi/repository/base.py
+++ b/kiwi/repository/base.py
@@ -84,6 +84,14 @@ class RepositoryBase(object):
         """
         raise NotImplementedError
 
+    def setup_package_database_configuration(self):
+        """
+        Setup package database configuration
+
+        Implementation in specialized repository class
+        """
+        raise NotImplementedError
+
     def import_trusted_keys(self, signing_keys):
         """
         Imports trusted keys into the image

--- a/kiwi/repository/dnf.py
+++ b/kiwi/repository/dnf.py
@@ -24,6 +24,7 @@ from tempfile import NamedTemporaryFile
 from kiwi.repository.base import RepositoryBase
 from kiwi.path import Path
 from kiwi.command import Command
+from kiwi.utils.rpm_database import RpmDataBase
 
 
 class RepositoryDnf(RepositoryBase):
@@ -90,6 +91,14 @@ class RepositoryDnf(RepositoryBase):
         self._create_runtime_config_parser()
         self._create_runtime_plugin_config_parser()
         self._write_runtime_config()
+
+    def setup_package_database_configuration(self):
+        """
+        Make sure for bootstrapping the rpm database location
+        matches the host rpm database setup
+        """
+        rpmdb = RpmDataBase(self.root_dir)
+        rpmdb.set_database_to_host_path()
 
     def use_default_location(self):
         """

--- a/kiwi/repository/yum.py
+++ b/kiwi/repository/yum.py
@@ -23,6 +23,7 @@ from tempfile import NamedTemporaryFile
 from kiwi.logger import log
 from kiwi.command import Command
 from kiwi.repository.base import RepositoryBase
+from kiwi.utils.rpm_database import RpmDataBase
 from kiwi.path import Path
 
 
@@ -89,6 +90,14 @@ class RepositoryYum(RepositoryBase):
         self._create_runtime_config_parser()
         self._create_runtime_plugin_config_parser()
         self._write_runtime_config()
+
+    def setup_package_database_configuration(self):
+        """
+        Make sure for bootstrapping the rpm database location
+        matches the host rpm database setup
+        """
+        rpmdb = RpmDataBase(self.root_dir)
+        rpmdb.set_database_to_host_path()
 
     def use_default_location(self):
         """

--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -24,7 +24,7 @@ from kiwi.command import Command
 from kiwi.repository.base import RepositoryBase
 from kiwi.system.uri import Uri
 from kiwi.path import Path
-from kiwi.defaults import Defaults
+from kiwi.utils.rpm_database import RpmDataBase
 
 from kiwi.exceptions import (
     KiwiRepoTypeUnknown
@@ -144,6 +144,14 @@ class RepositoryZypper(RepositoryBase):
 
         self._write_runtime_config()
 
+    def setup_package_database_configuration(self):
+        """
+        Make sure for bootstrapping the rpm database location
+        matches the host rpm database setup
+        """
+        rpmdb = RpmDataBase(self.root_dir)
+        rpmdb.set_database_to_host_path()
+
     def use_default_location(self):
         """
         Setup zypper repository operations to store all data
@@ -254,10 +262,8 @@ class RepositoryZypper(RepositoryBase):
         :param list signing_keys: list of the key files to import
         """
         for key in signing_keys:
-            # Including --dbpath flag is a workaround for bsc#1112357
             Command.run([
-                'rpm', '--root', self.root_dir, '--import',
-                key, '--dbpath', Defaults.get_default_rpmdb_path()
+                'rpm', '--root', self.root_dir, '--import', key
             ])
 
     def delete_repo(self, name):

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -106,6 +106,7 @@ class SystemPrepare(object):
         repo = Repository(
             self.root_bind, package_manager, repository_options
         )
+        repo.setup_package_database_configuration()
         if signing_keys:
             repo.import_trusted_keys(signing_keys)
         for xml_repo in repository_sections:
@@ -205,7 +206,7 @@ class SystemPrepare(object):
             raise KiwiBootStrapPhaseFailed(
                 'Bootstrap package installation failed: %s' % format(e)
             )
-        manager.dump_reload_package_database()
+        manager.post_process_install_requests_bootstrap()
         # process archive installations
         if bootstrap_archives:
             try:

--- a/kiwi/utils/rpm.py
+++ b/kiwi/utils/rpm.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2019 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+import os
+import re
+
+# project
+from kiwi.command import Command
+from kiwi.defaults import Defaults
+from kiwi.path import Path
+
+
+class Rpm(object):
+    """
+    **Helper methods to handle the rpm database configuration**
+    """
+    def __init__(self, root_dir=None):
+        self.root_dir = root_dir
+        self.config = []
+        self.custom_config = []
+        self.macro_path = os.sep.join(
+            [
+                self.root_dir or '', Defaults.get_custom_rpm_macros_path()
+            ]
+        )
+        self.macro_file = os.sep.join(
+            [self.macro_path, Defaults.get_custom_rpm_bootstrap_macro_name()]
+        )
+
+    def expand_query(self, key):
+        """
+        Query database configuration and expand it
+        """
+        if self.root_dir:
+            rpmdb_call = Command.run(
+                ['chroot', self.root_dir, 'rpm', '-E', key]
+            )
+        else:
+            rpmdb_call = Command.run(
+                ['rpm', '-E', key]
+            )
+        return rpmdb_call.output.strip()
+
+    def get_query(self, key):
+        """
+        Query database configuration
+
+        Extract the first match for the given key. The method
+        expects the format of entries to match the regular
+        expression: '.*key[\t ]+value'
+
+        :param string key: query key name
+
+        :returns: match or None if there isn't any match
+
+        :rtype: string | None
+        """
+        if not self.config:
+            self.config = self._read_macro_configuration()
+        item_list = list(
+            filter(lambda item: key in item, self.config)
+        )
+        for item in item_list:
+            match = re.match('.*{0}[\t ]+(.*)'.format(key), item)
+            if match:
+                return match.group(1)
+
+    def set_config_value(self, key, value):
+        """
+        Set custom database configuration key/value pair
+
+        :param string key: key name
+        :param string value: key value name
+        """
+        self.custom_config.append('%{0}\t{1}'.format(key, value))
+
+    def write_config(self):
+        """
+        Write custom database configuration
+
+        Write bootstrap macro file to the custom rpm macros path
+        """
+        Path.create(self.macro_path)
+        with open(self.macro_file, 'w') as macro:
+            for entry in self.custom_config:
+                macro.write('{0}{1}'.format(entry, os.linesep))
+
+    def wipe_config(self):
+        """
+        Delete custom database configuration
+        """
+        Path.wipe(self.macro_file)
+
+    def _read_macro_configuration(self):
+        """
+        Read rpm database macro and configuration setup
+
+        Please note we intentionally don't use 'rpm -E' here because
+        it tries to expand the complete macro and if that is not
+        possible it returns with the given unexpanded macro. There
+        is no way to detect if the macro really existed or not.
+        In addition for the use case of this class the macro should
+        be read as it was configured and not its expanded form.
+        """
+        if self.root_dir:
+            rpmdb_call = Command.run(
+                ['chroot', self.root_dir, 'rpmdb', '--showrc']
+            )
+        else:
+            rpmdb_call = Command.run(
+                ['rpmdb', '--showrc']
+            )
+        return rpmdb_call.output.split(os.linesep)

--- a/kiwi/utils/rpm_database.py
+++ b/kiwi/utils/rpm_database.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2019 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+import os
+
+# project
+from kiwi.command import Command
+from kiwi.path import Path
+from kiwi.utils.rpm import Rpm
+
+
+class RpmDataBase(object):
+    """
+    **Setup RPM database configuration**
+    """
+    def __init__(self, root_dir):
+        self.rpmdb_host = Rpm()
+        self.rpmdb_image = Rpm(root_dir)
+        self.root_dir = root_dir
+
+    def has_rpm(self):
+        """
+        Check if rpm binary was found in root_dir
+        """
+        rpm_search_env = {
+            'PATH': os.sep.join([self.root_dir, 'usr', 'bin'])
+        }
+        rpm_bin = Path.which(
+            'rpm', custom_env=rpm_search_env, access_mode=os.X_OK
+        )
+        if not rpm_bin:
+            return False
+        return True
+
+    def rebuild_database(self):
+        """
+        Rebuild image rpm database taking current macro setup into account
+        """
+        Command.run([
+            'chroot', self.root_dir, 'rpmdb', '--rebuilddb'
+        ])
+
+    def set_database_to_host_path(self):
+        """
+        Setup dbpath to point to the host rpm dbpath configuration
+        """
+        self.rpmdb_image.set_config_value(
+            '_dbpath', self.rpmdb_host.get_query('_dbpath')
+        )
+        self.rpmdb_image.write_config()
+
+    def set_database_to_image_path(self):
+        """
+        Setup dbpath to point to the image rpm dbpath configuration
+        """
+        self.rpmdb_image.wipe_config()
+        rpm_image_dbpath = self.rpmdb_image.expand_query('%_dbpath')
+        if rpm_image_dbpath != self.rpmdb_host.expand_query('%_dbpath'):
+            self.rpmdb_image.set_config_value(
+                '_dbpath_rebuild', self.rpmdb_image.get_query('_dbpath')
+            )
+            Path.wipe(
+                os.sep.join([self.root_dir, rpm_image_dbpath])
+            )
+            self.rpmdb_image.write_config()
+            self.rebuild_database()
+            self.rpmdb_image.wipe_config()

--- a/test/unit/package_manager_apt_test.py
+++ b/test/unit/package_manager_apt_test.py
@@ -193,9 +193,3 @@ class TestPackageManagerApt(object):
 
     def test_match_package_deleted(self):
         assert self.manager.match_package_deleted('foo', 'Removing foo')
-
-    def test_database_consistent(self):
-        self.manager.database_consistent()
-
-    def test_dump_reload_package_database(self):
-        self.manager.dump_reload_package_database()

--- a/test/unit/package_manager_base_test.py
+++ b/test/unit/package_manager_base_test.py
@@ -37,6 +37,9 @@ class TestPackageManagerBase(object):
     def test_process_install_requests_bootstrap(self):
         self.manager.process_install_requests_bootstrap()
 
+    def test_post_process_install_requests_bootstrap(self):
+        self.manager.post_process_install_requests_bootstrap()
+
     @raises(NotImplementedError)
     def test_process_install_requests(self):
         self.manager.process_install_requests()
@@ -65,11 +68,9 @@ class TestPackageManagerBase(object):
     def test_match_package_deleted(self):
         self.manager.match_package_deleted('package_name', 'log')
 
-    @raises(NotImplementedError)
     def test_database_consistent(self):
         self.manager.database_consistent()
 
-    @raises(NotImplementedError)
     def test_dump_reload_package_database(self):
         self.manager.dump_reload_package_database()
 

--- a/test/unit/package_manager_dnf_test.py
+++ b/test/unit/package_manager_dnf_test.py
@@ -1,5 +1,4 @@
 from mock import patch
-
 import mock
 
 from .test_helper import raises
@@ -62,17 +61,13 @@ class TestPackageManagerDnf(object):
         )
 
     @patch('kiwi.command.Command.call')
-    @patch('kiwi.command.Command.run')
-    def test_process_install_requests(self, mock_run, mock_call):
+    def test_process_install_requests(self, mock_call):
         self.manager.request_package('vim')
         self.manager.request_collection('collection')
         self.manager.request_package_exclusion('skipme')
         self.manager.process_install_requests()
         self.manager.root_bind.move_to_root(
             self.manager.dnf_args
-        )
-        mock_run.assert_called_once_with(
-            ['chroot', 'root-dir', 'rpm', '--rebuilddb']
         )
         mock_call.assert_called_once_with(
             [
@@ -147,7 +142,8 @@ class TestPackageManagerDnf(object):
         self.manager.process_only_required()
         assert self.manager.custom_args == ['--setopt=install_weak_deps=False']
         self.manager.process_plus_recommended()
-        assert '--setopt=install_weak_deps=False' not in self.manager.custom_args
+        assert \
+            '--setopt=install_weak_deps=False' not in self.manager.custom_args
 
     def test_match_package_installed(self):
         assert self.manager.match_package_installed('foo', 'Installing  : foo')
@@ -155,17 +151,9 @@ class TestPackageManagerDnf(object):
     def test_match_package_deleted(self):
         assert self.manager.match_package_deleted('foo', 'Removing: foo')
 
-    @patch('kiwi.command.Command.run')
-    def test_database_consistent(self, mock_command):
-        assert self.manager.database_consistent() is True
-        mock_command.assert_called_once_with(
-            ['chroot', 'root-dir', 'rpmdb', '--initdb']
-        )
-
-    @patch('kiwi.command.Command.run')
-    def test_database_not_consistent(self, mock_command):
-        mock_command.side_effect = Exception
-        assert self.manager.database_consistent() is False
-
-    def test_dump_reload_package_database(self):
-        self.manager.dump_reload_package_database()
+    @patch('kiwi.package_manager.dnf.RpmDataBase')
+    def test_post_process_install_requests_bootstrap(self, mock_RpmDataBase):
+        rpmdb = mock.Mock()
+        mock_RpmDataBase.return_value = rpmdb
+        self.manager.post_process_install_requests_bootstrap()
+        rpmdb.set_database_to_image_path.assert_called_once_with()

--- a/test/unit/package_manager_yum_test.py
+++ b/test/unit/package_manager_yum_test.py
@@ -177,17 +177,9 @@ class TestPackageManagerYum(object):
     def test_match_package_deleted(self):
         assert self.manager.match_package_deleted('foo', 'Removing: foo')
 
-    @patch('kiwi.command.Command.run')
-    def test_database_consistent(self, mock_command):
-        assert self.manager.database_consistent() is True
-        mock_command.assert_called_once_with(
-            ['chroot', 'root-dir', 'rpmdb', '--initdb']
-        )
-
-    @patch('kiwi.command.Command.run')
-    def test_database_not_consistent(self, mock_command):
-        mock_command.side_effect = Exception
-        assert self.manager.database_consistent() is False
-
-    def test_dump_reload_package_database(self):
-        self.manager.dump_reload_package_database()
+    @patch('kiwi.package_manager.yum.RpmDataBase')
+    def test_post_process_install_requests_bootstrap(self, mock_RpmDataBase):
+        rpmdb = mock.Mock()
+        mock_RpmDataBase.return_value = rpmdb
+        self.manager.post_process_install_requests_bootstrap()
+        rpmdb.set_database_to_image_path.assert_called_once_with()

--- a/test/unit/repository_apt_test.py
+++ b/test/unit/repository_apt_test.py
@@ -83,6 +83,10 @@ class TestRepositoryApt(object):
         assert self.repo.runtime_config()['command_env'] == \
             self.repo.command_env
 
+    def test_setup_package_database_configuration(self):
+        # just pass
+        self.repo.setup_package_database_configuration()
+
     @patch('os.path.exists')
     @patch_open
     def test_add_repo_with_priority(self, mock_open, mock_exists):

--- a/test/unit/repository_base_test.py
+++ b/test/unit/repository_base_test.py
@@ -28,6 +28,10 @@ class TestRepositoryBase(object):
         )
 
     @raises(NotImplementedError)
+    def test_setup_package_database_configuration(self):
+        self.repo.setup_package_database_configuration()
+
+    @raises(NotImplementedError)
     def test_import_trusted_keys(self):
         self.repo.import_trusted_keys(['key-file.asc'])
 

--- a/test/unit/repository_dnf_test.py
+++ b/test/unit/repository_dnf_test.py
@@ -110,6 +110,13 @@ class TestRepositoryDnf(object):
             '/shared-dir/dnf/repos/foo.repo', 'w'
         )
 
+    @patch('kiwi.repository.dnf.RpmDataBase')
+    def test_setup_package_database_configuration(self, mock_RpmDataBase):
+        rpmdb = mock.Mock()
+        mock_RpmDataBase.return_value = rpmdb
+        self.repo.setup_package_database_configuration()
+        rpmdb.set_database_to_host_path.assert_called_once_with()
+
     @patch('kiwi.repository.dnf.ConfigParser')
     @patch('os.path.exists')
     @patch_open

--- a/test/unit/repository_yum_test.py
+++ b/test/unit/repository_yum_test.py
@@ -94,6 +94,13 @@ class TestRepositoryYum(object):
         assert self.repo.runtime_config()['command_env'] == \
             self.repo.command_env
 
+    @patch('kiwi.repository.yum.RpmDataBase')
+    def test_setup_package_database_configuration(self, mock_RpmDataBase):
+        rpmdb = mock.Mock()
+        mock_RpmDataBase.return_value = rpmdb
+        self.repo.setup_package_database_configuration()
+        rpmdb.set_database_to_host_path.assert_called_once_with()
+
     @patch('kiwi.repository.yum.ConfigParser')
     @patch('os.path.exists')
     @patch_open

--- a/test/unit/repository_zypper_test.py
+++ b/test/unit/repository_zypper_test.py
@@ -217,17 +217,22 @@ class TestRepositoryZypper(object):
             '../data/shared-dir/zypper/repos/foo.repo', 'w'
         )
 
+    @patch('kiwi.repository.zypper.RpmDataBase')
+    def test_setup_package_database_configuration(self, mock_RpmDataBase):
+        rpmdb = mock.Mock()
+        mock_RpmDataBase.return_value = rpmdb
+        self.repo.setup_package_database_configuration()
+        rpmdb.set_database_to_host_path.assert_called_once_with()
+
     @patch('kiwi.command.Command.run')
     def test_import_trusted_keys(self, mock_run):
         self.repo.import_trusted_keys(['key-file-a.asc', 'key-file-b.asc'])
         assert mock_run.call_args_list == [
             call([
-                'rpm', '--root', '../data', '--import',
-                'key-file-a.asc', '--dbpath', '/var/lib/rpm'
+                'rpm', '--root', '../data', '--import', 'key-file-a.asc',
             ]),
             call([
-                'rpm', '--root', '../data', '--import',
-                'key-file-b.asc', '--dbpath', '/var/lib/rpm'
+                'rpm', '--root', '../data', '--import', 'key-file-b.asc'
             ])
         ]
 

--- a/test/unit/system_prepare_test.py
+++ b/test/unit/system_prepare_test.py
@@ -209,6 +209,7 @@ class TestSystemPrepare(object):
             call('uri-alias'),
             call('uri-alias')
         ]
+        repo.setup_package_database_configuration.assert_called_once_with()
         repo.import_trusted_keys.assert_called_once_with(
             ['key-file-a.asc', 'key-file-b.asc']
         )
@@ -272,6 +273,7 @@ class TestSystemPrepare(object):
         )
         mock_tar.assert_called_once_with('../data/bootstrap.tgz')
         tar.extract.assert_called_once_with('root_dir')
+        self.manager.post_process_install_requests_bootstrap.assert_called_once_with()
 
     @patch('kiwi.logger.log.warning')
     @patch('kiwi.xml_state.XMLState.get_bootstrap_packages_sections')

--- a/test/unit/utils_rpm_database_test.py
+++ b/test/unit/utils_rpm_database_test.py
@@ -1,0 +1,53 @@
+from mock import (
+    patch, Mock
+)
+
+from kiwi.utils.rpm_database import RpmDataBase
+
+
+class TestRpmDataBase(object):
+    def setup(self):
+        self.rpmdb = RpmDataBase('root_dir')
+        self.rpmdb.rpmdb_host = Mock()
+        self.rpmdb.rpmdb_image = Mock()
+
+    @patch('kiwi.utils.rpm_database.Path.which')
+    def test_has_rpm(self, mock_Path_which):
+        mock_Path_which.return_value = None
+        assert self.rpmdb.has_rpm() is False
+        mock_Path_which.assert_called_once_with(
+            'rpm', access_mode=1, custom_env={'PATH': 'root_dir/usr/bin'}
+        )
+        mock_Path_which.return_value = 'rpm'
+        assert self.rpmdb.has_rpm() is True
+
+    @patch('kiwi.command.Command.run')
+    def test_rebuild_database(self, mock_Command_run):
+        self.rpmdb.rebuild_database()
+        mock_Command_run.assert_called_once_with(
+            ['chroot', 'root_dir', 'rpmdb', '--rebuilddb']
+        )
+
+    def test_set_database_to_host_path(self):
+        self.rpmdb.set_database_to_host_path()
+        self.rpmdb.rpmdb_image.set_config_value.assert_called_once_with(
+            '_dbpath', self.rpmdb.rpmdb_host.get_query.return_value
+        )
+        self.rpmdb.rpmdb_image.write_config.assert_called_once_with()
+        self.rpmdb.rpmdb_host.get_query.assert_called_once_with('_dbpath')
+
+    @patch('kiwi.utils.rpm_database.Path.wipe')
+    @patch('kiwi.command.Command.run')
+    def test_set_database_to_image_path(self, mock_Command_run, mock_Path_wipe):
+        self.rpmdb.rpmdb_image.expand_query.return_value = '/var/lib/rpm'
+        self.rpmdb.set_database_to_image_path()
+        self.rpmdb.rpmdb_image.expand_query.assert_called_once_with('%_dbpath')
+        self.rpmdb.rpmdb_image.set_config_value.assert_called_once_with(
+            '_dbpath_rebuild', self.rpmdb.rpmdb_image.get_query.return_value
+        )
+        mock_Path_wipe.assert_called_once_with('root_dir//var/lib/rpm')
+        self.rpmdb.rpmdb_image.write_config.assert_called_once_with()
+        mock_Command_run.assert_called_once_with(
+            ['chroot', 'root_dir', 'rpmdb', '--rebuilddb']
+        )
+        assert self.rpmdb.rpmdb_image.wipe_config.call_count == 2

--- a/test/unit/utils_rpm_test.py
+++ b/test/unit/utils_rpm_test.py
@@ -1,0 +1,90 @@
+import io
+import os
+from .test_helper import patch_open
+from mock import (
+    patch, Mock, MagicMock, call
+)
+
+from kiwi.utils.rpm import Rpm
+from kiwi.defaults import Defaults
+
+
+class TestRpm(object):
+    def setup(self):
+        self.rpm_host = Rpm()
+        self.rpm_image = Rpm('root_dir')
+        self.macro_file = os.sep.join(
+            [
+                Defaults.get_custom_rpm_macros_path(),
+                Defaults.get_custom_rpm_bootstrap_macro_name()
+            ]
+        )
+
+    @patch('kiwi.utils.rpm.Command.run')
+    def test_expand_query(self, mock_Command_run):
+        self.rpm_host.expand_query('foo')
+        mock_Command_run.assert_called_once_with(
+            ['rpm', '-E', 'foo']
+        )
+        mock_Command_run.reset_mock()
+        self.rpm_image.expand_query('foo')
+        mock_Command_run.assert_called_once_with(
+            ['chroot', 'root_dir', 'rpm', '-E', 'foo']
+        )
+
+    @patch('kiwi.utils.rpm.Command.run')
+    def test_get_query(self, mock_Command_run):
+        rpmdb_call = Mock()
+        rpmdb_call.output = '%_dbpath  %{_usr}/lib/sysimage/rpm'
+        mock_Command_run.return_value = rpmdb_call
+        assert self.rpm_host.get_query('_dbpath') == \
+            '%{_usr}/lib/sysimage/rpm'
+        mock_Command_run.assert_called_once_with(
+            ['rpmdb', '--showrc']
+        )
+        mock_Command_run.reset_mock()
+        assert self.rpm_image.get_query('_dbpath') == \
+            '%{_usr}/lib/sysimage/rpm'
+        mock_Command_run.assert_called_once_with(
+            ['chroot', 'root_dir', 'rpmdb', '--showrc']
+        )
+
+    def test_set_config_value(self):
+        self.rpm_host.set_config_value('key', 'value')
+        assert self.rpm_host.custom_config[0] == '%key\tvalue'
+
+    @patch('kiwi.utils.rpm.Path.wipe')
+    def test_wipe_config(self, mock_Path_wipe):
+        self.rpm_host.wipe_config()
+        mock_Path_wipe.assert_called_once_with(
+            os.sep + self.macro_file
+        )
+        mock_Path_wipe.reset_mock()
+        self.rpm_image.wipe_config()
+        mock_Path_wipe.assert_called_once_with(
+            os.sep.join(['root_dir', self.macro_file])
+        )
+
+    @patch_open
+    @patch('kiwi.utils.rpm.Path.create')
+    def test_write_config(self, mock_Path_create, mock_open):
+        mock_open.return_value = MagicMock(spec=io.IOBase)
+        file_handle = mock_open.return_value.__enter__.return_value
+        self.rpm_host.set_config_value('key', 'value')
+        self.rpm_host.write_config()
+        mock_open.assert_called_once_with(
+            os.sep + self.macro_file, 'w'
+        )
+        assert file_handle.write.call_args_list == [
+            call('%key\tvalue\n')
+        ]
+        mock_open.reset_mock()
+        file_handle.write.reset_mock()
+        self.rpm_image.set_config_value('foo', 'bar')
+        self.rpm_image.write_config()
+        mock_open.assert_called_once_with(
+            os.sep.join(['root_dir', self.macro_file]), 'w'
+        )
+        assert file_handle.write.call_args_list == [
+            call('%foo\tbar\n')
+        ]


### PR DESCRIPTION
The location of the rpm database is no longer a standard
path one can trust. Some distributions put it to /var/lib
others to /usr/lib. This introduces the problem of dealing
with different locations between the bootstrapping (host rpm)
phase and the image installation (image rpm) phase.

This commit implements a solution based on an intermediate
rpm database configuration. KIWI creates the macros.kiwi file
inside of the image root which is read by any call of rpm
in the inner and outer system. During bootstrap phase the
rpm dbpath from the host system is used and later in the
install phase the dbpath from the rpm package as it was
installed by the target image distribution is used. In case
of a dbpath difference the database is automatically moved
to the new location by setting the _dbpath_rebuild macro
to the correct location. At the end the custom KIWI macro
is deleted.

As this process allows custom macro defintions during the
KIWI run it also serves as the base for a solution to
Issue #771 which will be done in a follow up request to
this commit.

Also the workaround for bsc#1112357 which uses a static
dbpath to store an optionally given signing key will be
addressed with this commit. The macro setup happens before
the import_trusted_keys method which makes any specification
for a strict dbpath obsolete.