### PR TITLE
Fix Failed to cache rpm database on zypper addrepo

### DIFF
--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -522,13 +522,6 @@ class KiwiRepositorySetupError(KiwiError):
     """
 
 
-class KiwiRepoTypeUnknown(KiwiError):
-    """
-    Exception raised if an unsupported repository type is specified
-    for the corresponding package manager.
-    """
-
-
 class KiwiRequestedTypeError(KiwiError):
     """
     Exception raised if an attempt was made to build an image for


### PR DESCRIPTION
Occasionally zypper fails when adding the repo with the
rpm error message 'Failed to cache rpm database'. I was
not able to find out why this happens and I also could
not find a way to reproduce it safely. However this
commit adds a workaround that seems to fix the issue
when it happens. If the first call of zypper addrepo
fails kiwi now issues the exact same call again and
only if that fails too an exception is thrown

