### PR TITLE
Add API for package manager returncode validation

### DIFF
--- a/kiwi/command_process.py
+++ b/kiwi/command_process.py
@@ -119,6 +119,9 @@ class CommandProcess(object):
             return method(item_to_match, data)
         return create_method
 
+    def returncode(self):
+        return self.command.get_error_code()
+
     def _init_progress(self):
         log.progress(
             0, 100, '[ INFO    ]: Processing'

--- a/kiwi/package_manager/base.py
+++ b/kiwi/package_manager/base.py
@@ -192,6 +192,21 @@ class PackageManagerBase(object):
         """
         pass
 
+    def has_failed(self, returncode):
+        """
+        Evaluate given result return code
+
+        Any returncode != 0 is considered an error unless
+        overwritten in specialized package manager class
+
+        :param int returncode: return code number
+
+        :return: True|False
+
+        :rtype: boolean
+        """
+        return True if returncode != 0 else False
+
     def cleanup_requests(self):
         """
         Cleanup request queues

--- a/kiwi/package_manager/zypper.py
+++ b/kiwi/package_manager/zypper.py
@@ -254,6 +254,24 @@ class PackageManagerZypper(PackageManagerBase):
         rpmdb = RpmDataBase(self.root_dir)
         rpmdb.set_database_to_image_path()
 
+    def has_failed(self, returncode):
+        """
+        Evaluate given result return code
+
+        In zypper any return code == 0 or >= 100 is considered success.
+        Any return code different from 0 and < 100 is treated as an
+        error we care for. Return codes >= 100 indicates an issue
+        like 'new kernel needs reboot of the system' or similar which
+        we don't care in the scope of image building
+
+        :param int returncode: return code number
+
+        :return: True|False
+
+        :rtype: boolean
+        """
+        return False if returncode == 0 or returncode >= 100 else True
+
     def _install_items(self):
         items = self.package_requests + self.collection_requests \
             + self.product_requests

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -202,10 +202,11 @@ class SystemPrepare(object):
                     manager.match_package_installed
                 )
             )
-        except Exception as e:
-            raise KiwiBootStrapPhaseFailed(
-                'Bootstrap package installation failed: %s' % format(e)
-            )
+        except Exception as issue:
+            if manager.has_failed(process.returncode()):
+                raise KiwiBootStrapPhaseFailed(
+                    'Bootstrap package installation failed: {0}'.format(issue)
+                )
         manager.post_process_install_requests_bootstrap()
         # process archive installations
         if bootstrap_archives:
@@ -262,10 +263,11 @@ class SystemPrepare(object):
                         manager.match_package_installed
                     )
                 )
-            except Exception as e:
-                raise KiwiInstallPhaseFailed(
-                    'System package installation failed: %s' % format(e)
-                )
+            except Exception as issue:
+                if manager.has_failed(process.returncode()):
+                    raise KiwiInstallPhaseFailed(
+                        'System package installation failed: {0}'.format(issue)
+                    )
         # process archive installations
         if system_archives:
             try:

--- a/test/unit/command_process_test.py
+++ b/test/unit/command_process_test.py
@@ -37,13 +37,26 @@ class TestCommandProcess(object):
 
     def setup(self):
         self.data_flow = [True, None, None, None, None, None, None]
-        self.data_out = [bytes(b''), bytes(b'\n'), bytes(b'a'), bytes(b't'), bytes(b'a'), bytes(b'd')]
-        self.data_err = [bytes(b''), bytes(b'r'), bytes(b'o'), bytes(b'r'), bytes(b'r'), bytes(b'e')]
+        self.data_out = [
+            bytes(b''), bytes(b'\n'), bytes(b'a'),
+            bytes(b't'), bytes(b'a'), bytes(b'd')
+        ]
+        self.data_err = [
+            bytes(b''), bytes(b'r'), bytes(b'o'),
+            bytes(b'r'), bytes(b'r'), bytes(b'e')
+        ]
         self.flow = self.create_flow_method(self.poll)
         self.flow_out_available = self.create_flow_method(self.outavailable)
         self.flow_err_available = self.create_flow_method(self.erravailable)
         self.flow_out = self.create_flow_method(self.outdata)
         self.flow_err = self.create_flow_method(self.errdata)
+
+    @patch('kiwi.command.Command')
+    def test_returncode(self, mock_command):
+        command = mock.Mock()
+        mock_command.return_value = command
+        process = CommandProcess(command)
+        assert process.returncode() == command.process.returncode
 
     @patch('kiwi.command.Command')
     @patch('kiwi.logger.log.debug')

--- a/test/unit/package_manager_base_test.py
+++ b/test/unit/package_manager_base_test.py
@@ -74,6 +74,10 @@ class TestPackageManagerBase(object):
     def test_dump_reload_package_database(self):
         self.manager.dump_reload_package_database()
 
+    def test_has_failed(self):
+        assert self.manager.has_failed(0) is False
+        assert self.manager.has_failed(1) is True
+
     def test_cleanup_requests(self):
         self.manager.cleanup_requests()
         assert self.manager.package_requests == []

--- a/test/unit/package_manager_zypper_test.py
+++ b/test/unit/package_manager_zypper_test.py
@@ -153,3 +153,11 @@ class TestPackageManagerZypper(object):
         mock_RpmDataBase.return_value = rpmdb
         self.manager.post_process_install_requests_bootstrap()
         rpmdb.set_database_to_image_path.assert_called_once_with()
+
+    def test_has_failed(self):
+        assert self.manager.has_failed(0) is False
+        assert self.manager.has_failed(102) is False
+        assert self.manager.has_failed(100) is False
+        assert self.manager.has_failed(1) is True
+        assert self.manager.has_failed(4) is True
+        assert self.manager.has_failed(-42) is True


### PR DESCRIPTION
Allow to validate the return code from a package manager
operation. In case of zypper the standard UNIX return
code validation does not apply. Return codes from zypper
which are >= 100 are not treated as an error anymore


