### PR TITLE
Added support for %_install_langs rpm macro

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -1253,6 +1253,18 @@ class Defaults(object):
         return 'macros.kiwi-bootstrap-config'
 
     @classmethod
+    def get_custom_rpm_image_macro_name(cls):
+        """
+        Returns the rpm image macro file name created
+        in the custom rpm macros path
+
+        :return: filename
+
+        :rtype: str
+        """
+        return 'macros.kiwi-image-config'
+
+    @classmethod
     def get_default_packager_tool(cls, package_manager):
         """
         Provides the packager tool according to the package manager

--- a/kiwi/repository/dnf.py
+++ b/kiwi/repository/dnf.py
@@ -21,6 +21,7 @@ from six.moves.configparser import ConfigParser
 from tempfile import NamedTemporaryFile
 
 # project
+from kiwi.defaults import Defaults
 from kiwi.repository.base import RepositoryBase
 from kiwi.path import Path
 from kiwi.command import Command
@@ -62,6 +63,12 @@ class RepositoryDnf(RepositoryBase):
         else:
             self.gpg_check = '0'
 
+        self.locale = list(
+            item for item in self.custom_args if '_install_langs' in item
+        )
+        if self.locale:
+            self.custom_args.remove(self.locale[0])
+
         self.repo_names = []
 
         # dnf support is based on creating repo files which contains
@@ -94,11 +101,21 @@ class RepositoryDnf(RepositoryBase):
 
     def setup_package_database_configuration(self):
         """
-        Make sure for bootstrapping the rpm database location
-        matches the host rpm database setup
+        Setup rpm macros for bootstrapping and image building
+
+        1. Create the rpm image macro which persists during the build
+        2. Create the rpm bootstrap macro to make sure for bootstrapping
+           the rpm database location matches the host rpm database setup.
+           This macro only persists during the bootstrap phase
         """
-        rpmdb = RpmDataBase(self.root_dir)
-        rpmdb.set_database_to_host_path()
+        rpmdb = RpmDataBase(
+            self.root_dir, Defaults.get_custom_rpm_image_macro_name()
+        )
+        if self.locale:
+            rpmdb.set_macro_from_string(self.locale[0])
+        rpmdb.write_config()
+
+        RpmDataBase(self.root_dir).set_database_to_host_path()
 
     def use_default_location(self):
         """

--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -20,6 +20,7 @@ from six.moves.configparser import ConfigParser
 from tempfile import NamedTemporaryFile
 
 # project
+from kiwi.defaults import Defaults
 from kiwi.command import Command
 from kiwi.repository.base import RepositoryBase
 from kiwi.system.uri import Uri
@@ -62,6 +63,12 @@ class RepositoryZypper(RepositoryBase):
         if 'check_signatures' in self.custom_args:
             self.custom_args.remove('check_signatures')
             self.gpgcheck = True
+
+        self.locale = list(
+            item for item in self.custom_args if '_install_langs' in item
+        )
+        if self.locale:
+            self.custom_args.remove(self.locale[0])
 
         self.repo_names = []
 
@@ -142,11 +149,21 @@ class RepositoryZypper(RepositoryBase):
 
     def setup_package_database_configuration(self):
         """
-        Make sure for bootstrapping the rpm database location
-        matches the host rpm database setup
+        Setup rpm macros for bootstrapping and image building
+
+        1. Create the rpm image macro which persists during the build
+        2. Create the rpm bootstrap macro to make sure for bootstrapping
+           the rpm database location matches the host rpm database setup.
+           This macro only persists during the bootstrap phase
         """
-        rpmdb = RpmDataBase(self.root_dir)
-        rpmdb.set_database_to_host_path()
+        rpmdb = RpmDataBase(
+            self.root_dir, Defaults.get_custom_rpm_image_macro_name()
+        )
+        if self.locale:
+            rpmdb.set_macro_from_string(self.locale[0])
+        rpmdb.write_config()
+
+        RpmDataBase(self.root_dir).set_database_to_host_path()
 
     def use_default_location(self):
         """

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -364,6 +364,27 @@ div { # locale
         }
 }
 
+
+#==========================================
+# common element <rpm-locale-filtering>
+#
+div {
+    k.rpm-locale-filtering.content = xsd:boolean
+    k.rpm-locale-filtering.attlist = empty
+    k.rpm-locale-filtering =
+        # locale-filtering sets the install_lang macro for rpm based
+        # installations to the configured locale list. This results
+        # in language specific files to become filtered out by rpm
+        # if they don't match the configured list. Please note it
+        # depends on the package design if the install_lang macro
+        # contents apply to the package or not.
+        element rpm-locale-filtering {
+            k.rpm-locale-filtering.attlist,
+            k.rpm-locale-filtering.content
+        }
+}
+
+
 #==========================================
 # common element <namedCollection>
 #
@@ -2638,6 +2659,7 @@ div {
             k.keytable? &
             k.locale? &
             k.packagemanager? &
+            k.rpm-locale-filtering? &
             k.rpm-check-signatures? &
             k.rpm-excludedocs? &
             k.showlicense* &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -611,6 +611,33 @@ specifies the where to find the boot kernel</a:documentation>
   </div>
   <!--
     ==========================================
+    common element <rpm-locale-filtering>
+    
+  -->
+  <div>
+    <define name="k.rpm-locale-filtering.content">
+      <data type="boolean"/>
+    </define>
+    <define name="k.rpm-locale-filtering.attlist">
+      <empty/>
+    </define>
+    <define name="k.rpm-locale-filtering">
+      <!--
+        locale-filtering sets the install_lang macro for rpm based
+        installations to the configured locale list. This results
+        in language specific files to become filtered out by rpm
+        if they don't match the configured list. Please note it
+        depends on the package design if the install_lang macro
+        contents apply to the package or not.
+      -->
+      <element name="rpm-locale-filtering">
+        <ref name="k.rpm-locale-filtering.attlist"/>
+        <ref name="k.rpm-locale-filtering.content"/>
+      </element>
+    </define>
+  </div>
+  <!--
+    ==========================================
     common element <namedCollection>
     
   -->
@@ -4164,6 +4191,9 @@ definition</a:documentation>
           </optional>
           <optional>
             <ref name="k.packagemanager"/>
+          </optional>
+          <optional>
+            <ref name="k.rpm-locale-filtering"/>
           </optional>
           <optional>
             <ref name="k.rpm-check-signatures"/>

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -99,10 +99,15 @@ class SystemPrepare(object):
         repository_sections = \
             self.xml_state.get_repository_sections_used_for_build()
         package_manager = self.xml_state.get_package_manager()
+        locale_list = self.xml_state.get_locale()
         if self.xml_state.get_rpm_check_signatures():
             repository_options.append('check_signatures')
         if self.xml_state.get_rpm_excludedocs():
             repository_options.append('exclude_docs')
+        if locale_list:
+            repository_options.append(
+                '_install_langs%{0}'.format(':'.join(locale_list))
+            )
         repo = Repository(
             self.root_bind, package_manager, repository_options
         )

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -99,14 +99,14 @@ class SystemPrepare(object):
         repository_sections = \
             self.xml_state.get_repository_sections_used_for_build()
         package_manager = self.xml_state.get_package_manager()
-        locale_list = self.xml_state.get_locale()
+        rpm_locale_list = self.xml_state.get_rpm_locale()
         if self.xml_state.get_rpm_check_signatures():
             repository_options.append('check_signatures')
         if self.xml_state.get_rpm_excludedocs():
             repository_options.append('exclude_docs')
-        if locale_list:
+        if rpm_locale_list:
             repository_options.append(
-                '_install_langs%{0}'.format(':'.join(locale_list))
+                '_install_langs%{0}'.format(':'.join(rpm_locale_list))
             )
         repo = Repository(
             self.root_bind, package_manager, repository_options

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -97,6 +97,7 @@ from kiwi.defaults import Defaults
 from kiwi.privileges import Privileges
 from kiwi.path import Path
 from kiwi.logger import log
+from kiwi.utils.rpm import Rpm
 
 
 class SystemBuildTask(CliTask):
@@ -249,6 +250,11 @@ class SystemBuildTask(CliTask):
         # handle delete package requests, forced uninstall without
         # any dependency resolution
         system.pinch_system(force=True)
+
+        # delete any custom rpm macros created
+        Rpm(
+            image_root, Defaults.get_custom_rpm_image_macro_name()
+        ).wipe_config()
 
         # make sure system instance is cleaned up now
         del system

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -93,6 +93,7 @@ from kiwi.system.setup import SystemSetup
 from kiwi.defaults import Defaults
 from kiwi.system.profile import Profile
 from kiwi.logger import log
+from kiwi.utils.rpm import Rpm
 
 
 class SystemPrepareTask(CliTask):
@@ -237,6 +238,11 @@ class SystemPrepareTask(CliTask):
         # handle delete package requests, forced uninstall without
         # any dependency resolution
         system.pinch_system(force=True)
+
+        # delete any custom rpm macros created
+        Rpm(
+            abs_root_path, Defaults.get_custom_rpm_image_macro_name()
+        ).wipe_config()
 
         # make sure system instance is cleaned up now
         del system

--- a/kiwi/utils/rpm.py
+++ b/kiwi/utils/rpm.py
@@ -28,7 +28,7 @@ class Rpm(object):
     """
     **Helper methods to handle the rpm database configuration**
     """
-    def __init__(self, root_dir=None):
+    def __init__(self, root_dir=None, macro_file=None):
         self.root_dir = root_dir
         self.config = []
         self.custom_config = []
@@ -38,7 +38,11 @@ class Rpm(object):
             ]
         )
         self.macro_file = os.sep.join(
-            [self.macro_path, Defaults.get_custom_rpm_bootstrap_macro_name()]
+            [
+                self.macro_path,
+                macro_file if macro_file else
+                Defaults.get_custom_rpm_bootstrap_macro_name()
+            ]
         )
 
     def expand_query(self, key):

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -7239,7 +7239,7 @@ class preferences(GeneratedsSuper):
     sections based on profiles combine to create on vaild definition"""
     subclass = None
     superclass = None
-    def __init__(self, profiles=None, bootsplash_theme=None, bootloader_theme=None, keytable=None, locale=None, packagemanager=None, rpm_check_signatures=None, rpm_excludedocs=None, showlicense=None, timezone=None, type_=None, version=None):
+    def __init__(self, profiles=None, bootsplash_theme=None, bootloader_theme=None, keytable=None, locale=None, packagemanager=None, rpm_locale_filtering=None, rpm_check_signatures=None, rpm_excludedocs=None, showlicense=None, timezone=None, type_=None, version=None):
         self.original_tagname_ = None
         self.profiles = _cast(None, profiles)
         if bootsplash_theme is None:
@@ -7262,6 +7262,10 @@ class preferences(GeneratedsSuper):
             self.packagemanager = []
         else:
             self.packagemanager = packagemanager
+        if rpm_locale_filtering is None:
+            self.rpm_locale_filtering = []
+        else:
+            self.rpm_locale_filtering = rpm_locale_filtering
         if rpm_check_signatures is None:
             self.rpm_check_signatures = []
         else:
@@ -7322,6 +7326,11 @@ class preferences(GeneratedsSuper):
     def add_packagemanager(self, value): self.packagemanager.append(value)
     def insert_packagemanager_at(self, index, value): self.packagemanager.insert(index, value)
     def replace_packagemanager_at(self, index, value): self.packagemanager[index] = value
+    def get_rpm_locale_filtering(self): return self.rpm_locale_filtering
+    def set_rpm_locale_filtering(self, rpm_locale_filtering): self.rpm_locale_filtering = rpm_locale_filtering
+    def add_rpm_locale_filtering(self, value): self.rpm_locale_filtering.append(value)
+    def insert_rpm_locale_filtering_at(self, index, value): self.rpm_locale_filtering.insert(index, value)
+    def replace_rpm_locale_filtering_at(self, index, value): self.rpm_locale_filtering[index] = value
     def get_rpm_check_signatures(self): return self.rpm_check_signatures
     def set_rpm_check_signatures(self, rpm_check_signatures): self.rpm_check_signatures = rpm_check_signatures
     def add_rpm_check_signatures(self, value): self.rpm_check_signatures.append(value)
@@ -7361,6 +7370,7 @@ class preferences(GeneratedsSuper):
             self.keytable or
             self.locale or
             self.packagemanager or
+            self.rpm_locale_filtering or
             self.rpm_check_signatures or
             self.rpm_excludedocs or
             self.showlicense or
@@ -7416,6 +7426,9 @@ class preferences(GeneratedsSuper):
         for packagemanager_ in self.packagemanager:
             showIndent(outfile, level, pretty_print)
             outfile.write('<packagemanager>%s</packagemanager>%s' % (self.gds_encode(self.gds_format_string(quote_xml(packagemanager_), input_name='packagemanager')), eol_))
+        for rpm_locale_filtering_ in self.rpm_locale_filtering:
+            showIndent(outfile, level, pretty_print)
+            outfile.write('<rpm-locale-filtering>%s</rpm-locale-filtering>%s' % (self.gds_format_boolean(rpm_locale_filtering_, input_name='rpm-locale-filtering'), eol_))
         for rpm_check_signatures_ in self.rpm_check_signatures:
             showIndent(outfile, level, pretty_print)
             outfile.write('<rpm-check-signatures>%s</rpm-check-signatures>%s' % (self.gds_format_boolean(rpm_check_signatures_, input_name='rpm-check-signatures'), eol_))
@@ -7474,6 +7487,16 @@ class preferences(GeneratedsSuper):
                 packagemanager_ = ""
             packagemanager_ = self.gds_validate_string(packagemanager_, node, 'packagemanager')
             self.packagemanager.append(packagemanager_)
+        elif nodeName_ == 'rpm-locale-filtering':
+            sval_ = child_.text
+            if sval_ in ('true', '1'):
+                ival_ = True
+            elif sval_ in ('false', '0'):
+                ival_ = False
+            else:
+                raise_parse_error(child_, 'requires boolean')
+            ival_ = self.gds_validate_boolean(ival_, node, 'rpm_locale_filtering')
+            self.rpm_locale_filtering.append(ival_)
         elif nodeName_ == 'rpm-check-signatures':
             sval_ = child_.text
             if sval_ in ('true', '1'):

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -139,6 +139,41 @@ class XMLState(object):
             if locale_section:
                 return locale_section[0].split(',')
 
+    def get_rpm_locale(self):
+        """
+        Gets list of locale names to filter out by rpm
+        if rpm-locale-filtering is switched on the
+        the list always contains: [POSIX, C, C.UTF-8]
+        and is extended by the optionaly configured
+        locale
+
+        :return: List of names or None
+
+        :rtype: list|None
+        """
+        if self.get_rpm_locale_filtering():
+            rpm_locale = ['POSIX', 'C', 'C.UTF-8']
+            configured_locale = self.get_locale()
+            if configured_locale:
+                for locale in configured_locale:
+                    rpm_locale.append(locale)
+            return rpm_locale
+
+    def get_rpm_locale_filtering(self):
+        """
+        Gets the rpm-locale-filtering configuration flag. Returns
+        False if not present.
+
+        :return: True or False
+
+        :rtype: bool
+        """
+        for preferences in self.get_preferences_sections():
+            locale_filtering = preferences.get_rpm_locale_filtering()
+            if locale_filtering:
+                return locale_filtering[0]
+        return False
+
     def get_rpm_excludedocs(self):
         """
         Gets the rpm-excludedocs configuration flag. Returns

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -124,6 +124,21 @@ class XMLState(object):
             initrd_system = self.build_type.get_initrd_system()
         return initrd_system
 
+    def get_locale(self):
+        """
+        Gets list of locale names if configured. Takes
+        the first locale setup from the existing preferences
+        sections into account.
+
+        :return: List of names or None
+
+        :rtype: list|None
+        """
+        for preferences in self.get_preferences_sections():
+            locale_section = preferences.get_locale()
+            if locale_section:
+                return locale_section[0].split(',')
+
     def get_rpm_excludedocs(self):
         """
         Gets the rpm-excludedocs configuration flag. Returns

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -36,7 +36,7 @@
         </profile>
     </profiles>
     <preferences>
-        <locale>de_DE</locale>
+        <locale>en_US,de_DE</locale>
     </preferences>
     <preferences>
         <type bootloader="grub2" image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async" btrfs_root_is_snapshot="true" spare_part="200M" xen_server="true" formatoptions="force_size,super=man" filesystem="ext4">

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -37,6 +37,7 @@
     </profiles>
     <preferences>
         <locale>en_US,de_DE</locale>
+        <rpm-locale-filtering>true</rpm-locale-filtering>
     </preferences>
     <preferences>
         <type bootloader="grub2" image="oem" primary="true" boot="oemboot/example-distribution" firmware="efi" kernelcmdline="splash" vga="0x303" editbootconfig="my_edit_boot_script" editbootinstall="/absolute/path/to/my_edit_boot_install" fsmountoptions="async" btrfs_root_is_snapshot="true" spare_part="200M" xen_server="true" formatoptions="force_size,super=man" filesystem="ext4">

--- a/test/unit/repository_dnf_test.py
+++ b/test/unit/repository_dnf_test.py
@@ -27,7 +27,9 @@ class TestRepositoryDnf(object):
         )
         root_bind.root_dir = '../data'
         root_bind.shared_location = '/shared-dir'
-        self.repo = RepositoryDnf(root_bind, ['exclude_docs'])
+        self.repo = RepositoryDnf(
+            root_bind, ['exclude_docs', '_install_langs%en_US:de_DE']
+        )
 
         assert runtime_dnf_config.set.call_args_list == [
             call('main', 'cachedir', '/shared-dir/dnf/cache'),
@@ -115,6 +117,14 @@ class TestRepositoryDnf(object):
         rpmdb = mock.Mock()
         mock_RpmDataBase.return_value = rpmdb
         self.repo.setup_package_database_configuration()
+        assert mock_RpmDataBase.call_args_list == [
+            call('../data', 'macros.kiwi-image-config'),
+            call('../data')
+        ]
+        rpmdb.set_macro_from_string.assert_called_once_with(
+            '_install_langs%en_US:de_DE'
+        )
+        rpmdb.write_config.assert_called_once_with()
         rpmdb.set_database_to_host_path.assert_called_once_with()
 
     @patch('kiwi.repository.dnf.ConfigParser')

--- a/test/unit/repository_yum_test.py
+++ b/test/unit/repository_yum_test.py
@@ -26,7 +26,9 @@ class TestRepositoryYum(object):
         )
         root_bind.root_dir = '../data'
         root_bind.shared_location = '/shared-dir'
-        self.repo = RepositoryYum(root_bind, ['exclude_docs'])
+        self.repo = RepositoryYum(
+            root_bind, ['exclude_docs', '_install_langs%en_US:de_DE']
+        )
 
         assert runtime_yum_config.set.call_args_list == [
             call('main', 'cachedir', '/shared-dir/yum/cache'),
@@ -99,6 +101,14 @@ class TestRepositoryYum(object):
         rpmdb = mock.Mock()
         mock_RpmDataBase.return_value = rpmdb
         self.repo.setup_package_database_configuration()
+        assert mock_RpmDataBase.call_args_list == [
+            call('../data', 'macros.kiwi-image-config'),
+            call('../data')
+        ]
+        rpmdb.set_macro_from_string.assert_called_once_with(
+            '_install_langs%en_US:de_DE'
+        )
+        rpmdb.write_config.assert_called_once_with()
         rpmdb.set_database_to_host_path.assert_called_once_with()
 
     @patch('kiwi.repository.yum.ConfigParser')

--- a/test/unit/repository_zypper_test.py
+++ b/test/unit/repository_zypper_test.py
@@ -32,7 +32,9 @@ class TestRepositoryZypper(object):
         )
         self.root_bind.root_dir = '../data'
         self.root_bind.shared_location = '/shared-dir'
-        self.repo = RepositoryZypper(self.root_bind, ['exclude_docs'])
+        self.repo = RepositoryZypper(
+            self.root_bind, ['exclude_docs', '_install_langs%en_US:de_DE']
+        )
 
     @patch('kiwi.command.Command.run')
     @patch('kiwi.repository.zypper.NamedTemporaryFile')
@@ -226,6 +228,14 @@ class TestRepositoryZypper(object):
         rpmdb = mock.Mock()
         mock_RpmDataBase.return_value = rpmdb
         self.repo.setup_package_database_configuration()
+        assert mock_RpmDataBase.call_args_list == [
+            call('../data', 'macros.kiwi-image-config'),
+            call('../data')
+        ]
+        rpmdb.set_macro_from_string.assert_called_once_with(
+            '_install_langs%en_US:de_DE'
+        )
+        rpmdb.write_config.assert_called_once_with()
         rpmdb.set_database_to_host_path.assert_called_once_with()
 
     @patch('kiwi.command.Command.run')

--- a/test/unit/system_prepare_test.py
+++ b/test/unit/system_prepare_test.py
@@ -182,8 +182,10 @@ class TestSystemPrepare(object):
         )
 
         mock_repo.assert_called_once_with(
-            self.system.root_bind, 'package-manager-name',
-            ['check_signatures', 'exclude_docs', '_install_langs%en_US:de_DE']
+            self.system.root_bind, 'package-manager-name', [
+                'check_signatures', 'exclude_docs',
+                '_install_langs%POSIX:C:C.UTF-8:en_US:de_DE'
+            ]
         )
         # mock local repos will be translated and bind mounted
         assert uri.translate.call_args_list == [

--- a/test/unit/system_prepare_test.py
+++ b/test/unit/system_prepare_test.py
@@ -183,7 +183,7 @@ class TestSystemPrepare(object):
 
         mock_repo.assert_called_once_with(
             self.system.root_bind, 'package-manager-name',
-            ['check_signatures', 'exclude_docs']
+            ['check_signatures', 'exclude_docs', '_install_langs%en_US:de_DE']
         )
         # mock local repos will be translated and bind mounted
         assert uri.translate.call_args_list == [

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -47,6 +47,11 @@ class TestSystemBuildTask(object):
             return_value=self.system_prepare
         )
 
+        self.rpm = mock.Mock()
+        kiwi.tasks.system_build.Rpm = mock.Mock(
+            return_value=self.rpm
+        )
+
         self.setup = mock.Mock()
         kiwi.tasks.system_build.SystemSetup = mock.Mock(
             return_value=self.setup
@@ -135,6 +140,7 @@ class TestSystemBuildTask(object):
         self.system_prepare.pinch_system.assert_has_calls(
             [call(force=False), call(force=True)]
         )
+        self.rpm.wipe_config.assert_called_once_with()
         self.setup.call_image_script.assert_called_once_with()
         self.builder.create.assert_called_once_with()
         self.result.print_results.assert_called_once_with()

--- a/test/unit/tasks_system_prepare_test.py
+++ b/test/unit/tasks_system_prepare_test.py
@@ -43,6 +43,11 @@ class TestSystemPrepareTask(object):
             return_value=self.manager
         )
 
+        self.rpm = mock.Mock()
+        kiwi.tasks.system_prepare.Rpm = mock.Mock(
+            return_value=self.rpm
+        )
+
         self.setup = mock.Mock()
         kiwi.tasks.system_prepare.SystemSetup = mock.Mock(
             return_value=self.setup
@@ -128,6 +133,7 @@ class TestSystemPrepareTask(object):
         self.system_prepare.pinch_system.assert_has_calls(
             [call(force=False), call(force=True)]
         )
+        self.rpm.wipe_config.assert_called_once_with()
 
     def test_process_system_prepare_add_package(self):
         self._init_command_args()

--- a/test/unit/utils_rpm_database_test.py
+++ b/test/unit/utils_rpm_database_test.py
@@ -51,3 +51,13 @@ class TestRpmDataBase(object):
             ['chroot', 'root_dir', 'rpmdb', '--rebuilddb']
         )
         assert self.rpmdb.rpmdb_image.wipe_config.call_count == 2
+
+    def test_set_macro_from_string(self):
+        self.rpmdb.set_macro_from_string('_install_langs%en_US:de_DE')
+        self.rpmdb.rpmdb_image.set_config_value.assert_called_once_with(
+            '_install_langs', 'en_US:de_DE'
+        )
+
+    def test_write_config(self):
+        self.rpmdb.write_config()
+        self.rpmdb.rpmdb_image.write_config.assert_called_once_with()

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -736,3 +736,6 @@ class TestXMLState(object):
         assert state.get_initrd_system() is None
         state = XMLState(xml_data, [], 'oem')
         assert state.get_initrd_system() == 'kiwi'
+
+    def test_get_locale(self):
+        assert self.state.get_locale() == ['en_US', 'de_DE']

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -737,5 +737,14 @@ class TestXMLState(object):
         state = XMLState(xml_data, [], 'oem')
         assert state.get_initrd_system() == 'kiwi'
 
+    def test_get_rpm_locale_filtering(self):
+        assert self.state.get_rpm_locale_filtering() is True
+        assert self.boot_state.get_rpm_locale_filtering() is False
+
     def test_get_locale(self):
         assert self.state.get_locale() == ['en_US', 'de_DE']
+
+    def test_get_rpm_locale(self):
+        assert self.state.get_rpm_locale() == [
+            'POSIX', 'C', 'C.UTF-8', 'en_US', 'de_DE'
+        ]


### PR DESCRIPTION
During the image build the custom rpm macro %_install_langs
is configured with the <locale> setup from the KIWI XML
description. This allows to filter language specific packages
on the rpm level and Fixes #771

