### PR TITLE
Extend the .packages file by the license field

### DIFF
--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -955,7 +955,7 @@ class SystemSetup(object):
                 '|'.join(
                     [
                         '%{NAME}', '%{EPOCH}', '%{VERSION}',
-                        '%{RELEASE}', '%{ARCH}', '%{DISTURL}'
+                        '%{RELEASE}', '%{ARCH}', '%{DISTURL}', '%{LICENSE}'
                     ]
                 ) + '\\n'
             ] + dbpath_option
@@ -973,7 +973,7 @@ class SystemSetup(object):
                 '|'.join(
                     [
                         '${Package}', 'None', '${Version}',
-                        'None', '${Architecture}', 'None'
+                        'None', '${Architecture}', 'None', 'None'
                     ]
                 ) + '\\n'
             ]

--- a/test/unit/system_setup_test.py
+++ b/test/unit/system_setup_test.py
@@ -787,7 +787,7 @@ class TestSystemSetup(object):
             call(['chroot', 'root_dir', 'rpm', '-E', '%_dbpath']),
             call([
                 'rpm', '--root', 'root_dir', '-qa', '--qf',
-                '%{NAME}|%{EPOCH}|%{VERSION}|%{RELEASE}|%{ARCH}|%{DISTURL}\\n',
+                '%{NAME}|%{EPOCH}|%{VERSION}|%{RELEASE}|%{ARCH}|%{DISTURL}|%{LICENSE}\\n',
                 '--dbpath', 'packages_data'
             ])
         ])
@@ -838,7 +838,7 @@ class TestSystemSetup(object):
             call(['chroot', 'root_dir', 'rpm', '-E', '%_dbpath']),
             call([
                 'rpm', '--root', 'root_dir', '-qa', '--qf',
-                '%{NAME}|%{EPOCH}|%{VERSION}|%{RELEASE}|%{ARCH}|%{DISTURL}\\n'
+                '%{NAME}|%{EPOCH}|%{VERSION}|%{RELEASE}|%{ARCH}|%{DISTURL}|%{LICENSE}\\n'
             ])
         ])
         mock_open.assert_called_once_with(
@@ -860,7 +860,7 @@ class TestSystemSetup(object):
         assert result == 'target_dir/some-image.x86_64-1.2.3.packages'
         mock_command.assert_called_once_with([
             'dpkg-query', '--admindir', 'root_dir/var/lib/dpkg', '-W',
-            '-f', '${Package}|None|${Version}|None|${Architecture}|None\\n'
+            '-f', '${Package}|None|${Version}|None|${Architecture}|None|None\\n'
         ])
         mock_open.assert_called_once_with(
             'target_dir/some-image.x86_64-1.2.3.packages', 'w'


### PR DESCRIPTION
For rpm based builds the License field from the rpm metadata
is extracted into the .packages file. For Debian based build
the license information is in an extra file and not taken
into account for the moment.

