### PR TITLE
Sort filesystem listings

### DIFF
--- a/kiwi/archive/tar.py
+++ b/kiwi/archive/tar.py
@@ -155,7 +155,7 @@ class ArchiveTar(object):
         final_archive_contents = []
         archive_contents = file_list
         if not archive_contents:
-            archive_contents = os.listdir(source_dir)
+            archive_contents = sorted(os.listdir(source_dir))
 
         for item in archive_contents:
             if not exclude_list:

--- a/kiwi/system/kernel.py
+++ b/kiwi/system/kernel.py
@@ -163,7 +163,7 @@ class Kernel(object):
             # lookup for the symlink first
             'vmlinux', 'vmlinuz'
         ]
-        kernel_dirs = os.listdir(''.join([self.root_dir, '/lib/modules']))
+        kernel_dirs = sorted(os.listdir(''.join([self.root_dir, '/lib/modules'])))
         if kernel_dirs:
             # append lookup for the real kernel image names
             # depending on the arch and os they are different

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -169,7 +169,7 @@ class SystemSetup(object):
         :param str target_dir: directory to unpack archive to
         """
         glob_match = self.description_dir + '/config-cdroot.tar*'
-        for cdroot_archive in glob.iglob(glob_match):
+        for cdroot_archive in sorted(glob.iglob(glob_match)):
             log.info(
                 'Extracting ISO user config archive: {0} to: {1}'.format(
                     cdroot_archive, target_dir
@@ -743,7 +743,7 @@ class SystemSetup(object):
 
     def _import_cdroot_archive(self):
         glob_match = self.description_dir + '/config-cdroot.tar*'
-        for cdroot_archive in glob.iglob(glob_match):
+        for cdroot_archive in sorted(glob.iglob(glob_match)):
             log.info(
                 '--> Importing {0} archive as /image/{0}'.format(
                     cdroot_archive

--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -109,7 +109,7 @@ class CliTask(object):
         if not os.path.exists(config_file):
             # glob config file search, first match wins
             glob_match = description_directory + '/*.kiwi'
-            for kiwi_file in glob.iglob(glob_match):
+            for kiwi_file in sorted(glob.iglob(glob_match)):
                 config_file = kiwi_file
                 break
 

--- a/test/unit/archive_tar_test.py
+++ b/test/unit/archive_tar_test.py
@@ -41,7 +41,7 @@ class TestArchiveTar(object):
             [
                 'tar', '-C', 'source-dir',
                 '--xattrs', '--xattrs-include=*',
-                '-c', '-f', 'foo.tar', 'foo', 'bar'
+                '-c', '-f', 'foo.tar', 'bar', 'foo'
             ]
         )
 
@@ -70,7 +70,7 @@ class TestArchiveTar(object):
                 'tar', '-C', 'source-dir',
                 '--fake-option', 'fake_arg',
                 '--xattrs', '--xattrs-include=*',
-                '-c', '-f', 'foo.tar', 'foo', 'bar'
+                '-c', '-f', 'foo.tar', 'bar', 'foo'
             ]
         )
 
@@ -88,7 +88,7 @@ class TestArchiveTar(object):
             call(
                 [
                     'tar', '-C', 'source-dir',
-                    '-c', '-f', 'foo.tar', 'foo', 'bar'
+                    '-c', '-f', 'foo.tar', 'bar', 'foo'
                 ]
             )
         ]
@@ -126,7 +126,7 @@ class TestArchiveTar(object):
                 ' '.join([
                     'tar', '-C', 'source-dir', '--xattrs',
                     '--xattrs-include=*', '-c', '--to-stdout',
-                    'foo', 'bar', '|', 'xz', '-f', '--threads=0',
+                    'bar', 'foo', '|', 'xz', '-f', '--threads=0',
                     '>', 'foo.tar.xz'
                 ])
             ]
@@ -147,7 +147,7 @@ class TestArchiveTar(object):
                 ' '.join([
                     'tar', '-C', 'source-dir', '--xattrs',
                     '--xattrs-include=*', '-c', '--to-stdout',
-                    'foo', 'bar', '|', 'xz', '-f', '-a', '-b',
+                    'bar', 'foo', '|', 'xz', '-f', '-a', '-b',
                     '>', 'foo.tar.xz'
                 ])
             ]
@@ -162,7 +162,7 @@ class TestArchiveTar(object):
         mock_command.assert_called_once_with(
             [
                 'tar', '-C', 'source-dir',
-                '--format=gnu', '-cSz', '-f', 'foo.tar.gz', 'foo', 'bar'
+                '--format=gnu', '-cSz', '-f', 'foo.tar.gz', 'bar', 'foo'
             ]
         )
 

--- a/test/unit/iso_tools_cdrtools_test.py
+++ b/test/unit/iso_tools_cdrtools_test.py
@@ -54,7 +54,7 @@ class TestIsoToolsCdrTools(object):
         )
         mock_walk_results = [
             [('source-dir', ('EFI',), ())],
-            [('source-dir', ('bar', 'baz'), ('efi', 'eggs'))]
+            [('source-dir', ('bar', 'baz'), ('eggs', 'efi'))]
         ]
 
         def side_effect(arg):

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ changedir=test/unit
 commands =
     bash -c 'cd ../../ && ./setup.py develop'
     pytest --no-cov-on-fail --cov=kiwi \
-        --cov-report=term-missing --cov-fail-under=100 --cov-config .coveragerc
+        --cov-report=term-missing --cov-fail-under=100 --cov-config .coveragerc {posargs}
 
 
 # Unit Test run with basepython set to 3.4


### PR DESCRIPTION
Change proposed in this pull request:

Sort filesystem listings
so that kiwi works in a reproducible way
in spite of indeterministic filesystem readdir order
and http://bugs.python.org/issue30461

See https://reproducible-builds.org/ for why this is good.

Notes:

- not all sorts might be needed
- not tested
- listifies some iterators from iglob, which would have a performance impact if there were thousands of matching entries