### PR TITLE
Fix location of grub unicode font

### DIFF
--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+import platform
 from collections import namedtuple
 
 # project
@@ -39,6 +40,7 @@ class BootLoaderConfigBase(object):
     def __init__(self, xml_state, root_dir, custom_args=None):
         self.root_dir = root_dir
         self.xml_state = xml_state
+        self.arch = platform.machine()
 
         self.post_init(custom_args)
 
@@ -344,6 +346,9 @@ class BootLoaderConfigBase(object):
                                     volume.name
                                 )
                             )
+
+        if target == 'iso':
+            bootpath = '/boot/' + self.arch + '/loader'
 
         return bootpath
 

--- a/test/unit/bootloader_config_base_test.py
+++ b/test/unit/bootloader_config_base_test.py
@@ -11,7 +11,9 @@ from kiwi.bootloader.config.base import BootLoaderConfigBase
 
 
 class TestBootLoaderConfigBase(object):
-    def setup(self):
+    @patch('platform.machine')
+    def setup(self, mock_machine):
+        mock_machine.return_value = 'x86_64'
         description = XMLDescription(
             '../data/example_config.xml'
         )
@@ -223,6 +225,10 @@ class TestBootLoaderConfigBase(object):
         mock_disk_setup.return_value = disk_setup
         assert self.bootloader.get_boot_path() == \
             '/boot'
+
+    def test_get_boot_path_iso(self):
+        assert self.bootloader.get_boot_path(target='iso') == \
+            '/boot/x86_64/loader'
 
     def test_quote_title(self):
         assert self.bootloader.quote_title('aaa bbb [foo]') == 'aaa_bbb_(foo)'


### PR DESCRIPTION
This is a follow up patch for #f5bac4495d34. The change of the
location of the font file was not applied if an iso target, live
or install image is being built. This patch completes the change
and Fixes bsc#1124885


