### PR TITLE
Fixed isolinux fallback path

### DIFF
--- a/kiwi/iso_tools/iso.py
+++ b/kiwi/iso_tools/iso.py
@@ -28,7 +28,6 @@ from builtins import bytes
 from kiwi.iso_tools.cdrtools import IsoToolsCdrTools
 from kiwi.logger import log
 from kiwi.defaults import Defaults
-from kiwi.path import Path
 from kiwi.command import Command
 from kiwi.utils.codec import Codec
 from kiwi.exceptions import (
@@ -332,16 +331,18 @@ class Iso(object):
             # isolinux-config was not able to identify the isolinux
             # signature. As a workaround a compat directory /isolinux
             # is created which hardlinks all loader files
-            compat_base_directory = self.source_dir + '/isolinux'
-            loader_files = '/'.join(
-                [self.source_dir, self.boot_path, 'loader/*']
+            loader_source_directory = os.sep.join(
+                [self.source_dir, loader_base_directory]
             )
-            Path.create(compat_base_directory)
-            bash_command = ' '.join(
-                ['ln', loader_files, compat_base_directory]
+            loader_compat_target_directory = os.sep.join(
+                [self.source_dir, 'isolinux']
             )
             Command.run(
-                ['bash', '-c', bash_command]
+                [
+                    'cp', '-a', '-l',
+                    loader_source_directory + os.sep,
+                    loader_compat_target_directory + os.sep
+                ]
             )
 
     @staticmethod

--- a/test/unit/iso_tools_iso_test.py
+++ b/test/unit/iso_tools_iso_test.py
@@ -56,10 +56,9 @@ class TestIso(object):
         )
 
     @patch('kiwi.iso_tools.iso.Command.run')
-    @patch('kiwi.iso_tools.iso.Path.create')
     @patch('os.path.exists')
     def test_setup_isolinux_boot_path_failed_isolinux_config(
-        self, mock_exists, mock_path, mock_command
+        self, mock_exists, mock_command
     ):
         mock_exists.return_value = True
         command_raises = [False, True]
@@ -70,11 +69,10 @@ class TestIso(object):
 
         mock_command.side_effect = side_effect
         self.iso.setup_isolinux_boot_path()
-        mock_path.assert_called_once_with('source-dir/isolinux')
         assert mock_command.call_args_list[1] == call(
             [
-                'bash', '-c',
-                'ln source-dir/boot/x86_64/loader/* source-dir/isolinux'
+                'cp', '-a', '-l',
+                'source-dir/boot/x86_64/loader/', 'source-dir/isolinux/'
             ]
         )
 


### PR DESCRIPTION
In case isolinux-config failed or does not exist on the
distribution a fallback path is called. That code hardlinks
the files to the isolinux compiled in standard path. However
due to the move of the grub unicode file for iso images
the path contains a directory. Directories can't be hardlinked
thus this patch uses 'cp -l' instead of the 'ln' command to
create the linked target contents.


