### PR TITLE
Add support for virtualbox vagrant boxes

### DIFF
--- a/doc/source/development/api/kiwi.storage.subformat.rst
+++ b/doc/source/development/api/kiwi.storage.subformat.rst
@@ -51,11 +51,18 @@ Submodules
     :undoc-members:
     :show-inheritance:
 
-
 `kiwi.storage.subformat.vagrant_libvirt` Module
 -----------------------------------------------
 
 .. automodule:: kiwi.storage.subformat.vagrant_libvirt
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+`kiwi.storage.subformat.vagrant_virtualbox` Module
+-----------------------------------------------
+
+.. automodule:: kiwi.storage.subformat.vagrant_virtualbox
     :members:
     :undoc-members:
     :show-inheritance:

--- a/doc/source/development/api/kiwi.storage.subformat.template.rst
+++ b/doc/source/development/api/kiwi.storage.subformat.template.rst
@@ -20,6 +20,14 @@ Submodules
     :undoc-members:
     :show-inheritance:
 
+`kiwi.storage.subformat.template.virtualbox_ovf` Module
+--------------------------------------------------------
+
+.. automodule:: kiwi.storage.subformat.template.virtualbox_ovf
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 Module contents
 ---------------
 

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -687,8 +687,21 @@ class Defaults(object):
         """
         return [
             'gce', 'qcow2', 'vmdk', 'ova', 'vmx', 'vhd', 'vhdx',
-            'vhdfixed', 'vdi', 'vagrant.libvirt.box'
+            'vhdfixed', 'vdi', 'vagrant.libvirt.box', 'vagrant.virtualbox.box'
         ]
+
+    @classmethod
+    def get_vagrant_config_virtualbox_guest_additions(cls):
+        """
+        Provides the default value for
+        ``vagrantconfig.virtualbox_guest_additions_present``
+
+        :return: whether guest additions are expected to be present in the
+            vagrant box
+
+        :rtype: bool
+        """
+        return False
 
     @classmethod
     def get_firmware_types(cls):

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -2505,7 +2505,10 @@ div {
 div {
     k.vagrantconfig.provider.attribute =
         ## The vagrant provider for this box
-        attribute provider { "libvirt" }
+        attribute provider { "libvirt" | "virtualbox" }
+    k.vagrantconfig.virtualbox_guest_additions_present.attribute =
+        ## Guest additions are present in this box
+        attribute virtualbox_guest_additions_present { xsd:boolean }
     k.vagrantconfig.virtualsize.attribute =
         ## virtualsize provides the value of the virtual_size key which
         ## is embedded in the metadata.json hash inside the box file, as
@@ -2520,7 +2523,8 @@ div {
     k.vagrantconfig.attlist =
         k.vagrantconfig.provider.attribute &
         k.vagrantconfig.virtualsize.attribute &
-        k.vagrantconfig.boxname.attribute?
+        k.vagrantconfig.boxname.attribute? &
+        k.vagrantconfig.virtualbox_guest_additions_present.attribute?
     k.vagrantconfig =
         ## The vagrantconfig element specifies the Vagrant meta
         ## configuration options which are used inside a vagrant box

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -3890,7 +3890,16 @@ and setup the system disk.</a:documentation>
     <define name="k.vagrantconfig.provider.attribute">
       <attribute name="provider">
         <a:documentation>The vagrant provider for this box</a:documentation>
-        <value>libvirt</value>
+        <choice>
+          <value>libvirt</value>
+          <value>virtualbox</value>
+        </choice>
+      </attribute>
+    </define>
+    <define name="k.vagrantconfig.virtualbox_guest_additions_present.attribute">
+      <attribute name="virtualbox_guest_additions_present">
+        <a:documentation>Guest additions are present in this box</a:documentation>
+        <data type="boolean"/>
       </attribute>
     </define>
     <define name="k.vagrantconfig.virtualsize.attribute">
@@ -3915,6 +3924,9 @@ If not specified the image name is used</a:documentation>
         <ref name="k.vagrantconfig.virtualsize.attribute"/>
         <optional>
           <ref name="k.vagrantconfig.boxname.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.vagrantconfig.virtualbox_guest_additions_present.attribute"/>
         </optional>
       </interleave>
     </define>

--- a/kiwi/storage/subformat/__init__.py
+++ b/kiwi/storage/subformat/__init__.py
@@ -26,6 +26,7 @@ from kiwi.storage.subformat.gce import DiskFormatGce
 from kiwi.storage.subformat.vdi import DiskFormatVdi
 from kiwi.storage.subformat.base import DiskFormatBase
 from kiwi.storage.subformat.vagrant_libvirt import DiskFormatVagrantLibVirt
+from kiwi.storage.subformat.vagrant_virtualbox import DiskFormatVagrantVirtualBox
 
 from kiwi.exceptions import (
     KiwiDiskFormatSetupError
@@ -109,6 +110,10 @@ class DiskFormat(object):
                 provider = 'undefined'
             if provider == 'libvirt':
                 return DiskFormatVagrantLibVirt(
+                    xml_state, root_dir, target_dir, custom_args
+                )
+            elif provider == 'virtualbox':
+                return DiskFormatVagrantVirtualBox(
                     xml_state, root_dir, target_dir, custom_args
                 )
             else:

--- a/kiwi/storage/subformat/template/virtualbox_ovf.py
+++ b/kiwi/storage/subformat/template/virtualbox_ovf.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2019 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+
+from string import Template
+
+
+class VirtualboxOvfTemplate(object):
+    """
+    **Generate a OVF file template for a vagrant virtualbox box**
+
+    This class provides a template for virtualbox' ovf configuration file that
+    is embedded inside the vagrant box. The template itself was extracted from
+    a vagrant box that was build via packer and from a script provided by Neal
+    Gompa.
+    """
+
+    def __init__(self):
+        # note: the OS ID is set to Other Linux 64
+        self.OVF_TEMPLATE = """<?xml version="1.0"?>
+<Envelope ovf:version="1.0" xml:lang="en-US" xmlns="http://schemas.dmtf.org/ovf/envelope/1" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:vbox="http://www.virtualbox.org/ovf/machine">
+  <References>
+    <File ovf:id="file1" ovf:href="box.vmdk"/>
+  </References>
+  <DiskSection>
+    <Info>List of the virtual disks used in the package</Info>
+    <Disk ovf:capacity="${disk_image_capacity}" ovf:diskId="vmdisk1" ovf:fileRef="file1" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized"/>
+  </DiskSection>
+  <NetworkSection>
+    <Info>Logical networks used in the package</Info>
+    <Network ovf:name="NAT">
+      <Description>Logical network used by this appliance.</Description>
+    </Network>
+  </NetworkSection>
+  <VirtualSystem ovf:id="${vm_name}">
+    <Info>A virtual machine</Info>
+    <OperatingSystemSection ovf:id="101">
+      <Info>The kind of installed guest operating system</Info>
+      <Description>${vm_description}</Description>
+      <vbox:OSType ovf:required="false">Linux_64</vbox:OSType>
+    </OperatingSystemSection>
+    <VirtualHardwareSection>
+      <Info>Virtual hardware requirements for a virtual machine</Info>
+      <System>
+        <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+        <vssd:InstanceID>0</vssd:InstanceID>
+        <vssd:VirtualSystemIdentifier>${vm_name}</vssd:VirtualSystemIdentifier>
+        <vssd:VirtualSystemType>virtualbox-2.2</vssd:VirtualSystemType>
+      </System>
+      <Item>
+        <rasd:Caption>1 virtual CPU</rasd:Caption>
+        <rasd:Description>Number of virtual CPUs</rasd:Description>
+        <rasd:ElementName>1 virtual CPU(s)</rasd:ElementName>
+        <rasd:InstanceID>1</rasd:InstanceID>
+        <rasd:ResourceType>3</rasd:ResourceType>
+        <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:AllocationUnits>MegaBytes</rasd:AllocationUnits>
+        <rasd:Caption>1024 MB of memory</rasd:Caption>
+        <rasd:Description>Memory Size</rasd:Description>
+        <rasd:ElementName>1024 MB of memory</rasd:ElementName>
+        <rasd:InstanceID>2</rasd:InstanceID>
+        <rasd:ResourceType>4</rasd:ResourceType>
+        <rasd:VirtualQuantity>1024</rasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:Address>0</rasd:Address>
+        <rasd:Caption>ideController0</rasd:Caption>
+        <rasd:Description>IDE Controller</rasd:Description>
+        <rasd:ElementName>ideController0</rasd:ElementName>
+        <rasd:InstanceID>3</rasd:InstanceID>
+        <rasd:ResourceSubType>PIIX4</rasd:ResourceSubType>
+        <rasd:ResourceType>5</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:Address>1</rasd:Address>
+        <rasd:Caption>ideController1</rasd:Caption>
+        <rasd:Description>IDE Controller</rasd:Description>
+        <rasd:ElementName>ideController1</rasd:ElementName>
+        <rasd:InstanceID>4</rasd:InstanceID>
+        <rasd:ResourceSubType>PIIX4</rasd:ResourceSubType>
+        <rasd:ResourceType>5</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:Address>0</rasd:Address>
+        <rasd:Caption>sataController0</rasd:Caption>
+        <rasd:Description>SATA Controller</rasd:Description>
+        <rasd:ElementName>sataController0</rasd:ElementName>
+        <rasd:InstanceID>5</rasd:InstanceID>
+        <rasd:ResourceSubType>AHCI</rasd:ResourceSubType>
+        <rasd:ResourceType>20</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>3</rasd:AddressOnParent>
+        <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+        <rasd:Caption>sound</rasd:Caption>
+        <rasd:Description>Sound Card</rasd:Description>
+        <rasd:ElementName>sound</rasd:ElementName>
+        <rasd:InstanceID>6</rasd:InstanceID>
+        <rasd:ResourceSubType>ensoniq1371</rasd:ResourceSubType>
+        <rasd:ResourceType>35</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>0</rasd:AddressOnParent>
+        <rasd:Caption>disk1</rasd:Caption>
+        <rasd:Description>Disk Image</rasd:Description>
+        <rasd:ElementName>disk1</rasd:ElementName>
+        <rasd:HostResource>/disk/vmdisk1</rasd:HostResource>
+        <rasd:InstanceID>7</rasd:InstanceID>
+        <rasd:Parent>5</rasd:Parent>
+        <rasd:ResourceType>17</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
+        <rasd:Caption>Ethernet adapter on 'NAT'</rasd:Caption>
+        <rasd:Connection>NAT</rasd:Connection>
+        <rasd:ElementName>Ethernet adapter on 'NAT'</rasd:ElementName>
+        <rasd:InstanceID>8</rasd:InstanceID>
+        <rasd:ResourceSubType>E1000</rasd:ResourceSubType>
+        <rasd:ResourceType>10</rasd:ResourceType>
+      </Item>
+    </VirtualHardwareSection>
+  </VirtualSystem>
+</Envelope>
+"""
+
+    def get_template(self):
+        """
+        Return the actual ovf template. The following values must be
+        substituted:
+        - ``vm_name``: the name of this VM
+        - ``disk_image_capacity``: Size of the virtual disk image in GB
+        - ``vm_description``: a description of this VM
+        """
+        return Template(self.OVF_TEMPLATE)

--- a/kiwi/storage/subformat/vagrant_virtualbox.py
+++ b/kiwi/storage/subformat/vagrant_virtualbox.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2019 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import os
+
+# project
+from kiwi.storage.subformat.template.virtualbox_ovf import (
+    VirtualboxOvfTemplate
+)
+from kiwi.storage.subformat.vagrant_base import DiskFormatVagrantBase
+from kiwi.storage.subformat.vmdk import DiskFormatVmdk
+from kiwi.command import Command
+
+
+class DiskFormatVagrantVirtualBox(DiskFormatVagrantBase):
+    """
+    **Create a vagrant box for the virtualbox provider**
+    """
+
+    def vagrant_post_init(self):
+        self.provider = 'virtualbox'
+        self.image_format = 'vagrant.virtualbox.box'
+
+    def get_additional_vagrant_config_settings(self):
+        """
+        Configure the default shared folder to use rsync when guest additions
+        are not present inside the box.
+        """
+        if not self.xml_state.get_vagrant_config_virtualbox_guest_additions():
+            return 'config.vm.synced_folder ".", "/vagrant", type: "rsync"'
+
+    def create_box_img(self, temp_image_dir):
+        """
+        Create the virtual machine image for the Virtualbox vagrant provider.
+
+        This function creates the vmdk disk image and the ovf file. The latter
+        is created via the class
+        :class:`kiwi.storage.subformat.template.virtualbox_ovf.VirtualboxOvfTemplate`.
+        """
+        vmdk = DiskFormatVmdk(self.xml_state, self.root_dir, self.target_dir)
+        vmdk.create_image_format()
+        box_img = os.sep.join([temp_image_dir, 'box.vmdk'])
+        Command.run(
+            [
+                'mv', self.get_target_file_path_for_format(vmdk.image_format),
+                box_img
+            ]
+        )
+        box_ovf = os.sep.join([temp_image_dir, 'box.ovf'])
+        ovf_template = VirtualboxOvfTemplate()
+        disk_image_capacity = self.vagrantconfig.get_virtualsize() or 42
+        xml_description_specification = self.xml_state \
+            .get_description_section().specification
+        with open(box_ovf, "w") as ovf_file:
+            ovf_file.write(
+                ovf_template.get_template().substitute({
+                    'vm_name': self.xml_state.xml_data.name,
+                    'disk_image_capacity': disk_image_capacity,
+                    'vm_description': xml_description_specification
+                })
+            )
+        return [box_img, box_ovf]

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -6685,11 +6685,12 @@ class vagrantconfig(GeneratedsSuper):
     options which are used inside a vagrant box"""
     subclass = None
     superclass = None
-    def __init__(self, provider=None, virtualsize=None, boxname=None):
+    def __init__(self, provider=None, virtualsize=None, boxname=None, virtualbox_guest_additions_present=None):
         self.original_tagname_ = None
         self.provider = _cast(None, provider)
         self.virtualsize = _cast(int, virtualsize)
         self.boxname = _cast(None, boxname)
+        self.virtualbox_guest_additions_present = _cast(bool, virtualbox_guest_additions_present)
     def factory(*args_, **kwargs_):
         if CurrentSubclassModule_ is not None:
             subclass = getSubclassFromModule_(
@@ -6707,6 +6708,8 @@ class vagrantconfig(GeneratedsSuper):
     def set_virtualsize(self, virtualsize): self.virtualsize = virtualsize
     def get_boxname(self): return self.boxname
     def set_boxname(self, boxname): self.boxname = boxname
+    def get_virtualbox_guest_additions_present(self): return self.virtualbox_guest_additions_present
+    def set_virtualbox_guest_additions_present(self, virtualbox_guest_additions_present): self.virtualbox_guest_additions_present = virtualbox_guest_additions_present
     def hasContent_(self):
         if (
 
@@ -6744,6 +6747,9 @@ class vagrantconfig(GeneratedsSuper):
         if self.boxname is not None and 'boxname' not in already_processed:
             already_processed.add('boxname')
             outfile.write(' boxname=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.boxname), input_name='boxname')), ))
+        if self.virtualbox_guest_additions_present is not None and 'virtualbox_guest_additions_present' not in already_processed:
+            already_processed.add('virtualbox_guest_additions_present')
+            outfile.write(' virtualbox_guest_additions_present="%s"' % self.gds_format_boolean(self.virtualbox_guest_additions_present, input_name='virtualbox_guest_additions_present'))
     def exportChildren(self, outfile, level, namespace_='', name_='vagrantconfig', fromsubclass_=False, pretty_print=True):
         pass
     def build(self, node):
@@ -6772,6 +6778,15 @@ class vagrantconfig(GeneratedsSuper):
         if value is not None and 'boxname' not in already_processed:
             already_processed.add('boxname')
             self.boxname = value
+        value = find_attr_value_('virtualbox_guest_additions_present', node)
+        if value is not None and 'virtualbox_guest_additions_present' not in already_processed:
+            already_processed.add('virtualbox_guest_additions_present')
+            if value in ('true', '1'):
+                self.virtualbox_guest_additions_present = True
+            elif value in ('false', '0'):
+                self.virtualbox_guest_additions_present = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         pass
 # end class vagrantconfig

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -686,6 +686,21 @@ class XMLState(object):
         if vagrant_config_sections:
             return vagrant_config_sections[0]
 
+    def get_vagrant_config_virtualbox_guest_additions(self):
+        """
+        Attribute virtualbox_guest_additions_present from the first
+        vagrantconfig section.
+
+        :return: ``<vagrantconfig virtualbox_guest_additions_present=>`` value
+
+        :rtype: bool
+        """
+        vagrant_config_sections = self.get_build_type_vagrant_config_section()
+        if not vagrant_config_sections.virtualbox_guest_additions_present:
+            return Defaults.get_vagrant_config_virtualbox_guest_additions()
+        else:
+            return vagrant_config_sections.virtualbox_guest_additions_present
+
     def get_build_type_vmdisk_section(self):
         """
         First vmdisk section from the first machine section in the

--- a/test/data/vagrant_virtualbox.ovf
+++ b/test/data/vagrant_virtualbox.ovf
@@ -1,0 +1,106 @@
+<?xml version="1.0"?>
+<Envelope ovf:version="1.0" xml:lang="en-US" xmlns="http://schemas.dmtf.org/ovf/envelope/1" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:vbox="http://www.virtualbox.org/ovf/machine">
+  <References>
+    <File ovf:id="file1" ovf:href="box.vmdk"/>
+  </References>
+  <DiskSection>
+    <Info>List of the virtual disks used in the package</Info>
+    <Disk ovf:capacity="42" ovf:diskId="vmdisk1" ovf:fileRef="file1" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized"/>
+  </DiskSection>
+  <NetworkSection>
+    <Info>Logical networks used in the package</Info>
+    <Network ovf:name="NAT">
+      <Description>Logical network used by this appliance.</Description>
+    </Network>
+  </NetworkSection>
+  <VirtualSystem ovf:id="OpenSUSE-Leap-15.0">
+    <Info>A virtual machine</Info>
+    <OperatingSystemSection ovf:id="101">
+      <Info>The kind of installed guest operating system</Info>
+      <Description>OpenSUSE Leap 15.0</Description>
+      <vbox:OSType ovf:required="false">Linux_64</vbox:OSType>
+    </OperatingSystemSection>
+    <VirtualHardwareSection>
+      <Info>Virtual hardware requirements for a virtual machine</Info>
+      <System>
+        <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+        <vssd:InstanceID>0</vssd:InstanceID>
+        <vssd:VirtualSystemIdentifier>OpenSUSE-Leap-15.0</vssd:VirtualSystemIdentifier>
+        <vssd:VirtualSystemType>virtualbox-2.2</vssd:VirtualSystemType>
+      </System>
+      <Item>
+        <rasd:Caption>1 virtual CPU</rasd:Caption>
+        <rasd:Description>Number of virtual CPUs</rasd:Description>
+        <rasd:ElementName>1 virtual CPU(s)</rasd:ElementName>
+        <rasd:InstanceID>1</rasd:InstanceID>
+        <rasd:ResourceType>3</rasd:ResourceType>
+        <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:AllocationUnits>MegaBytes</rasd:AllocationUnits>
+        <rasd:Caption>1024 MB of memory</rasd:Caption>
+        <rasd:Description>Memory Size</rasd:Description>
+        <rasd:ElementName>1024 MB of memory</rasd:ElementName>
+        <rasd:InstanceID>2</rasd:InstanceID>
+        <rasd:ResourceType>4</rasd:ResourceType>
+        <rasd:VirtualQuantity>1024</rasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:Address>0</rasd:Address>
+        <rasd:Caption>ideController0</rasd:Caption>
+        <rasd:Description>IDE Controller</rasd:Description>
+        <rasd:ElementName>ideController0</rasd:ElementName>
+        <rasd:InstanceID>3</rasd:InstanceID>
+        <rasd:ResourceSubType>PIIX4</rasd:ResourceSubType>
+        <rasd:ResourceType>5</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:Address>1</rasd:Address>
+        <rasd:Caption>ideController1</rasd:Caption>
+        <rasd:Description>IDE Controller</rasd:Description>
+        <rasd:ElementName>ideController1</rasd:ElementName>
+        <rasd:InstanceID>4</rasd:InstanceID>
+        <rasd:ResourceSubType>PIIX4</rasd:ResourceSubType>
+        <rasd:ResourceType>5</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:Address>0</rasd:Address>
+        <rasd:Caption>sataController0</rasd:Caption>
+        <rasd:Description>SATA Controller</rasd:Description>
+        <rasd:ElementName>sataController0</rasd:ElementName>
+        <rasd:InstanceID>5</rasd:InstanceID>
+        <rasd:ResourceSubType>AHCI</rasd:ResourceSubType>
+        <rasd:ResourceType>20</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>3</rasd:AddressOnParent>
+        <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+        <rasd:Caption>sound</rasd:Caption>
+        <rasd:Description>Sound Card</rasd:Description>
+        <rasd:ElementName>sound</rasd:ElementName>
+        <rasd:InstanceID>6</rasd:InstanceID>
+        <rasd:ResourceSubType>ensoniq1371</rasd:ResourceSubType>
+        <rasd:ResourceType>35</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>0</rasd:AddressOnParent>
+        <rasd:Caption>disk1</rasd:Caption>
+        <rasd:Description>Disk Image</rasd:Description>
+        <rasd:ElementName>disk1</rasd:ElementName>
+        <rasd:HostResource>/disk/vmdisk1</rasd:HostResource>
+        <rasd:InstanceID>7</rasd:InstanceID>
+        <rasd:Parent>5</rasd:Parent>
+        <rasd:ResourceType>17</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
+        <rasd:Caption>Ethernet adapter on 'NAT'</rasd:Caption>
+        <rasd:Connection>NAT</rasd:Connection>
+        <rasd:ElementName>Ethernet adapter on 'NAT'</rasd:ElementName>
+        <rasd:InstanceID>8</rasd:InstanceID>
+        <rasd:ResourceSubType>E1000</rasd:ResourceSubType>
+        <rasd:ResourceType>10</rasd:ResourceType>
+      </Item>
+    </VirtualHardwareSection>
+  </VirtualSystem>
+</Envelope>

--- a/test/unit/storage_subformat_template_virtualbox_ovf_test.py
+++ b/test/unit/storage_subformat_template_virtualbox_ovf_test.py
@@ -1,0 +1,34 @@
+from lxml import objectify
+
+from kiwi.storage.subformat.template.virtualbox_ovf import (
+    VirtualboxOvfTemplate
+)
+
+
+class TestVirtualboxOvfTemplate(object):
+
+    def setup(self):
+        self.ovf_template = VirtualboxOvfTemplate()
+
+    def test_ovf_parameters(self):
+        args = {
+            'vm_name': 'jumper',
+            'vm_description': 'Leap 15 image',
+            'disk_image_capacity': 21,
+        }
+        ovf_file = self.ovf_template.get_template().substitute(args)
+        ovf = objectify.fromstring(ovf_file)
+
+        for (attr, value) in ovf.DiskSection.Disk.items():
+            if 'capacity' in attr:
+                assert value == str(args['disk_image_capacity'])
+
+        vm_name_attr, vm_name_value = ovf.VirtualSystem.items()[0]
+        assert 'id' in vm_name_attr and vm_name_value == args['vm_name']
+
+        cimos_id_attr, cimos_id_value = \
+            ovf.VirtualSystem.OperatingSystemSection.items()[0]
+        assert 'id' in cimos_id_attr and int(cimos_id_value) == 101
+
+        assert ovf.VirtualSystem.OperatingSystemSection.Description \
+            == args['vm_description']

--- a/test/unit/storage_subformat_vagrant_virtualbox_test.py
+++ b/test/unit/storage_subformat_vagrant_virtualbox_test.py
@@ -1,0 +1,121 @@
+import io
+from mock import (
+    call, patch, Mock, MagicMock
+)
+
+from textwrap import dedent
+from collections import namedtuple
+
+from .test_helper import patch_open
+
+from kiwi.storage.subformat.vagrant_virtualbox import (
+    DiskFormatVagrantVirtualBox
+)
+from kiwi.defaults import Defaults
+
+
+class TestDiskFormatVagrantVirtualBox(object):
+    def setup(self):
+        with open("../data/vagrant_virtualbox.ovf", "r") as ovf_file:
+            self.Leap_15_ovf = ovf_file.read(-1)
+
+        xml_data = Mock()
+        xml_data.get_name = Mock(
+            return_value='some-disk-image'
+        )
+        self.xml_state = Mock()
+        self.xml_state.xml_data = xml_data
+        self.xml_state.get_image_version = Mock(
+            return_value='1.2.3'
+        )
+        self.vagrantconfig = Mock()
+        self.vagrantconfig.get_virtualsize = Mock(
+            return_value=42
+        )
+        self.disk_format = DiskFormatVagrantVirtualBox(
+            self.xml_state, 'root_dir', 'target_dir',
+            {'vagrantconfig': self.vagrantconfig}
+        )
+
+    @patch('kiwi.storage.subformat.vagrant_virtualbox.Command.run')
+    @patch('kiwi.storage.subformat.vagrant_virtualbox.DiskFormatVmdk')
+    @patch_open
+    def test_create_box_img(
+        self, mock_open, mock_vmdk, mock_command
+    ):
+        mock_open.return_value = MagicMock(spec=io.IOBase)
+        file_handle = mock_open.return_value.__enter__.return_value
+        vmdk = Mock()
+        vmdk.image_format = 'vmdk'
+        mock_vmdk.return_value = vmdk
+
+        # override the box settings to match those from the extracted ovf file
+        self.xml_state.xml_data.name = "OpenSUSE-Leap-15.0"
+        self.xml_state.get_description_section = MagicMock()
+        self.xml_state.get_description_section.return_value = \
+            namedtuple(
+                'description_type', ['author', 'contact', 'specification']
+            )(
+                author="not relevant",
+                contact="not relevant",
+                specification="OpenSUSE Leap 15.0"
+            )
+
+        assert self.disk_format.create_box_img('tmpdir') == [
+            'tmpdir/box.vmdk', 'tmpdir/box.ovf'
+        ]
+        vmdk.create_image_format.assert_called_once_with()
+        mock_command.assert_called_once_with(
+            [
+                'mv', 'target_dir/some-disk-image.x86_64-1.2.3.vmdk',
+                'tmpdir/box.vmdk'
+            ]
+        )
+        mock_open.assert_called_once_with('tmpdir/box.ovf', 'w')
+
+        assert file_handle.write.call_args_list[0] == call(self.Leap_15_ovf)
+
+    def test_get_additional_vagrant_config_settings(self):
+        self.xml_state.get_vagrant_config_virtualbox_guest_additions \
+            .return_value = None
+        assert self.disk_format.get_additional_vagrant_config_settings() == \
+            'config.vm.synced_folder ".", "/vagrant", type: "rsync"'
+
+    @patch('kiwi.storage.subformat.vagrant_base.Command.run')
+    @patch('kiwi.storage.subformat.vagrant_base.mkdtemp')
+    @patch('kiwi.storage.subformat.vagrant_base.random.randrange')
+    @patch.object(DiskFormatVagrantVirtualBox, 'create_box_img')
+    @patch_open
+    def test_create_image_format_with_and_without_guest_additions(
+        self, mock_open, mock_create_box_img, mock_rand,
+        mock_mkdtemp, mock_command
+    ):
+        mock_mkdtemp.return_value = 'tmpdir'
+        mock_create_box_img.return_value = ['arbitrary']
+        mock_open.return_value = MagicMock(spec=io.IOBase)
+        file_handle = mock_open.return_value.__enter__.return_value
+
+        # without guest additions
+        self.xml_state.get_vagrant_config_virtualbox_guest_additions \
+            .return_value = \
+            Defaults.get_vagrant_config_virtualbox_guest_additions()
+        self.disk_format.create_image_format()
+        vagrantfile = dedent('''
+            Vagrant.configure("2") do |config|
+              config.vm.base_mac = "00163E010101"
+              config.vm.synced_folder ".", "/vagrant", type: "rsync"
+            end
+        ''').strip()
+        assert file_handle.write.call_args_list[1] == call(vagrantfile)
+        file_handle.write.reset_mock()
+
+        # without guest additions
+        self.xml_state.get_vagrant_config_virtualbox_guest_additions \
+            .return_value = True
+        vagrantfile = dedent('''
+            Vagrant.configure("2") do |config|
+              config.vm.base_mac = "00163E010101"
+            end
+        ''').strip()
+        self.disk_format.create_image_format()
+        assert file_handle.write.call_args_list[1] == call(vagrantfile)

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -197,6 +197,15 @@ class TestXMLState(object):
         vagrant_config = self.state.get_build_type_vagrant_config_section()
         assert vagrant_config.get_provider() == 'libvirt'
 
+    def test_virtualbox_guest_additions_vagrant_config_section(self):
+        assert not self.state.get_vagrant_config_virtualbox_guest_additions()
+
+    def test_virtualbox_guest_additions_vagrant_config_section_missing(self):
+        self.state. \
+            get_build_type_vagrant_config_section() \
+            .virtualbox_guest_additions_present = True
+        assert self.state.get_vagrant_config_virtualbox_guest_additions()
+
     def test_get_build_type_system_disk_section(self):
         assert self.state.get_build_type_system_disk_section().get_name() == \
             'mydisk'


### PR DESCRIPTION
Fixes #532.

### Changes proposed in this pull request
* ~~split `DiskFormatVagrantLibVirt` into `DiskFormatVagrantBase` and `DiskFormatVagrantLibVirt` (and equally with the unit tests)~~ (done in #948)
* extend the xml schema: `vagrantconfig.provider` now accepts `virtualbox` as an option and add the attribute `vagrantconfig.virtualbox_os_type`
* add a new class `DiskFormatVagrantVirtualBox` which implements support for virtualbox vagrant boxes using @Conan-Kudo's ovf template
* ~~add the function `vagrantSetup` to `functions.sh`, it performs all the necessary setup of the vagrant user, ssh, sudoers, etc. (so the end user does not need to do that)~~

### current problems and short-commings
- it is currently impossible to build a libvirt and virtualbox vagrant box, but it would be nice to be able to do that, especially if we are to add vmware support (which should now become relatively easy).
- ~~I am not sold on my modification of the XML schema, especially `vagrantconfig.virtualbox_os_type` is pretty ugly~~
- ~~Virtualbox will by default mount the share as `vboxfs`, which only works if the virtualbox guest additions are installed in the box. We cannot assume that this is true, but it would be a mistake to turn this to rsync by default, as that is afaik slower. Maybe add an xml option via which the user tells kiwi that they will install the guest additions?~~
- ~~I am unhappy with the current way how one can customize the `Vagrantfile` that is put into the box (see `DiskFormatVagrantBase._create_box_vagrantconfig` in `kiwi/storage/subformat/vagrant_base.py`). It makes the tests look ugly as one can't use `dedent`.~~

### TODO
- [x] Rebase the fixup commits and fix the commit order
- [x] improve test coverage

