### PR TITLE
Split common vagrant tasks into base class DiskFormatVagrantBase

### DIFF
--- a/doc/source/development/api/kiwi.storage.subformat.rst
+++ b/doc/source/development/api/kiwi.storage.subformat.rst
@@ -43,6 +43,15 @@ Submodules
     :undoc-members:
     :show-inheritance:
 
+`kiwi.storage.subformat.vagrant_base` Module
+-----------------------------------------------
+
+.. automodule:: kiwi.storage.subformat.vagrant_base
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
 `kiwi.storage.subformat.vagrant_libvirt` Module
 -----------------------------------------------
 

--- a/doc/source/development/api/kiwi.storage.subformat.template.rst
+++ b/doc/source/development/api/kiwi.storage.subformat.template.rst
@@ -12,6 +12,13 @@ Submodules
     :undoc-members:
     :show-inheritance:
 
+`kiwi.storage.subformat.template.vagrant_config` Module
+--------------------------------------------------------
+
+.. automodule:: kiwi.storage.subformat.template.vagrant_config
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 Module contents
 ---------------

--- a/kiwi/storage/subformat/template/vagrant_config.py
+++ b/kiwi/storage/subformat/template/vagrant_config.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2019 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+import os
+
+from textwrap import dedent
+from string import Template
+
+
+class VagrantConfigTemplate(object):
+    """
+    **Generate a Vagrantfile configuration template**
+
+    This class creates a simple template for the Vagrantfile that is included
+    inside a vagrant box.
+
+    The included Vagrantfile carries additional information for vagrant: by
+    default that is just the boxes' MAC address, but depending on the provider
+    additional information need to be present. These can be passed via the
+    parameter ``custom_settings`` to the method :meth:`get_template`.
+
+    Example usage:
+
+    The default without any additional settings will result in this
+    Vagrantfile:
+
+    .. code:: python
+
+        >>> vagrant_config = VagrantConfigTemplate()
+        >>> print(
+        ...     vagrant_config.get_template()
+        ...     .substitute({'mac_address': 'deadbeef'})
+        ... )
+        Vagrant.configure("2") do |config|
+          config.vm.base_mac = "deadbeef"
+        end
+
+    If your provider/box requires additional settings, provide them as follows:
+
+    .. code:: python
+
+        >>> extra_settings = dedent('''
+        ... config.vm.hostname = "no-dead-beef"
+        ... config.vm.provider :special do |special|
+        ...   special.secret_settings = "please_work"
+        ... end
+        ... ''').strip()
+        >>> print(
+        ...     vagrant_config.get_template(extra_settings)
+        ...     .substitute({'mac_address': 'DEADBEEF'})
+        ... )
+        Vagrant.configure("2") do |config|
+          config.vm.base_mac = "DEADBEEF"
+          config.vm.hostname = "no-dead-beef"
+          config.vm.provider :special do |special|
+            special.secret_settings = "please_work"
+          end
+        end
+    """
+
+    def __init__(self):
+        self.INDENT = '  '
+
+        self.HEADER = dedent('''
+            Vagrant.configure("2") do |config|
+        ''').strip() + os.linesep
+
+        self.MAC = self.INDENT + dedent('''
+            config.vm.base_mac = "${mac_address}"
+        ''').strip() + os.linesep
+
+        self.END = dedent('''
+            end
+        ''').strip()
+
+    def get_template(self, custom_settings=None):
+        """
+        Return a new template with ``custom_settings`` included and
+        indented appropriately.
+
+        :param str custom_settings: String of additional settings that get
+            pasted into the Vagrantfile template. The string is put at the
+            correct indentation level for you, but the internal indentation has
+            to be provided by the caller.
+        :return: A template with ``custom_settings`` inserted at the
+            appropriate position. The template has one the variable
+            ``mac_address`` that must be substituted.
+        :rtype: string.Template
+        """
+        template_data = self.HEADER
+        template_data += self.MAC
+        if custom_settings:
+            template_data += self.INDENT
+            template_data += self.INDENT.join(
+                custom_settings.splitlines(True)
+            )
+            template_data += os.linesep
+        template_data += self.END
+        return Template(template_data)

--- a/kiwi/storage/subformat/vagrant_base.py
+++ b/kiwi/storage/subformat/vagrant_base.py
@@ -88,9 +88,11 @@ class DiskFormatVagrantBase(DiskFormatBase):
                 'no vagrantconfig provided'
             )
 
-        self.image_format = 'vagrant.' + self.provider + '.box'
-
         self.vagrantconfig = custom_args['vagrantconfig']
+        self.vagrant_post_init()
+
+    def vagrant_post_init(self):
+        pass
 
     def create_box_img(self, temp_image_dir):
         """

--- a/kiwi/storage/subformat/vagrant_base.py
+++ b/kiwi/storage/subformat/vagrant_base.py
@@ -1,0 +1,212 @@
+# Copyright (c) 2019 SUSE Linux GmbH.  All rights reserved.
+#
+# This file is part of kiwi.
+#
+# kiwi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# kiwi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with kiwi.  If not, see <http://www.gnu.org/licenses/>
+#
+import json
+import os
+import random
+from textwrap import dedent
+from tempfile import mkdtemp
+from string import Template
+
+from kiwi.storage.subformat.base import DiskFormatBase
+from kiwi.command import Command
+
+from kiwi.exceptions import (
+    KiwiFormatSetupError
+)
+
+
+class DiskFormatVagrantBase(DiskFormatBase):
+    """
+    Base class for creating vagrant boxes.
+
+    The documentation of the vagrant box format can be found here:
+    https://www.vagrantup.com/docs/boxes/format.html
+    In a nutshell, a vagrant box is a tar, tar.gz or zip archive of the
+    following:
+
+    1. ``metadata.json``: A json file that contains the name of the provider
+       and arbitrary additional data (that vagrant doesn't care about).
+    2. ``Vagrantfile``: A Vagrantfile which defines the boxes' MAC address. It
+       can be also used to define other settings of the box, e.g. the method
+       via which the ``/vagrant/`` directory is shared.
+    3. The actual virtual disk image: this is provider specific and vagrant
+       simply forwards it to your virtual machine provider.
+
+    Required methods/variables that child classes must implement:
+
+    - ``provider: str``:
+      A static variable or property, should contain the name of the provider.
+      This value is used to create the ``metadata.json`` file and the attribute
+      :attr:`image_format`.
+      (Note: you also must add the image format to
+      :func:`kiwi.defaults.Defaults.get_disk_format_types`)
+
+    - :meth:`create_box_img`
+
+    Optional methods:
+
+    - :meth:`get_additional_metadata`
+
+    - :meth:`get_additional_vagrant_config_settings`
+
+    """
+    def post_init(self, custom_args):
+        """
+        vagrant disk format post initialization method
+
+        store vagrantconfig information provided via custom_args
+
+        :param dict custom_args:
+            Contains instance of xml_parse::vagrantconfig
+
+            .. code:: python
+
+                {'vagrantconfig': object}
+        """
+        if not custom_args or 'vagrantconfig' not in custom_args:
+            raise KiwiFormatSetupError(
+                'object init requires custom_args hash with a vagrantconfig'
+            )
+
+        if not custom_args['vagrantconfig']:
+            raise KiwiFormatSetupError(
+                'no vagrantconfig provided'
+            )
+
+        self.image_format = 'vagrant.' + self.provider + '.box'
+
+        self.vagrantconfig = custom_args['vagrantconfig']
+
+    def create_box_img(self, temp_image_dir):
+        """
+        Provider specific image creation step: this function creates the actual
+        box image. It must be implemented by a child class.
+
+        :param str temp_image_dir: path to a temporary directory inside which the
+            image should be built
+        :return: A list of files that were create by this function and that
+            should be included in the vagrant box
+        :rtype: List(str)
+        """
+        raise NotImplementedError
+
+    def create_image_format(self):
+        """
+        Create a vagrant box for any provider. This includes:
+
+        * creation of box metadata.json
+        * creation of box Vagrantfile
+        * creation of result format tarball from the files created above
+        """
+        self.temp_image_dir = mkdtemp(prefix='kiwi_vagrant_box.')
+
+        box_img_files = self.create_box_img(self.temp_image_dir)
+
+        metadata_json = os.sep.join([self.temp_image_dir, 'metadata.json'])
+        with open(metadata_json, 'w') as meta:
+            meta.write(self._create_box_metadata())
+
+        vagrantfile = os.sep.join([self.temp_image_dir, 'Vagrantfile'])
+        with open(vagrantfile, 'w') as vagrant:
+            vagrant.write(self._create_box_vagrantconfig())
+
+        Command.run(
+            [
+                'tar', '-C', self.temp_image_dir,
+                '-czf', self.get_target_file_path_for_format(self.image_format),
+                os.path.basename(metadata_json),
+                os.path.basename(vagrantfile)
+            ] + [
+                os.path.basename(box_img_file)
+                for box_img_file in box_img_files
+            ]
+        )
+
+    def store_to_result(self, result):
+        """
+        Store result file of the vagrant format conversion into the
+        provided result instance. In this case compression is unwanted
+        because the box is already created as a compressed tarball
+
+        :param object result: Instance of Result
+        """
+        result.add(
+            key='disk_format_image',
+            filename=self.get_target_file_path_for_format(
+                self.image_format
+            ),
+            use_for_bundle=True,
+            compress=False,
+            shasum=True
+        )
+
+    @classmethod
+    def get_additional_metadata(cls):
+        """
+        Provide :meth:`create_image_format` with additional metadata that will
+        be included in ``metadata.json``.
+
+        The default implementation returns an empty dictionary.
+
+        :return: A dictionary that is serializable to JSON
+        :rtype: dict
+        """
+        return {}
+
+    @classmethod
+    def get_additional_vagrant_config_settings(cls):
+        """
+        Supply additional configuration settings for vagrant to be included in
+        the resulting box.
+
+        This function can be used by child classes to customize the behavior
+        for different providers: the supplied configuration settings get
+        forwarded to :func:`VagrantConfigTemplate.get_template` as the
+        parameter ``custom_settings`` and included in the ``Vagrantfile``.
+
+        The default implementation returns nothing.
+
+        :return: additional vagrant settings
+        :rtype: str
+        """
+        pass
+
+    def _create_box_metadata(self):
+        metadata = self.get_additional_metadata()
+        metadata['provider'] = self.provider
+        return json.dumps(
+            metadata, sort_keys=True, indent=2, separators=(',', ': ')
+        )
+
+    def _create_box_vagrantconfig(self):
+        template = VagrantConfigTemplate()
+        vagrant_config = template.get_template(
+            custom_settings=self.get_additional_vagrant_config_settings()
+        )
+        return vagrant_config.substitute(
+            {'mac_address': self._random_mac()}
+        )
+
+    @staticmethod
+    def _random_mac():
+        return '%02x%02x%02x%02x%02x%02x'.upper() % (
+            0x00, 0x16, 0x3e,
+            random.randrange(0, 0x7e),
+            random.randrange(0, 0xff),
+            random.randrange(0, 0xff)
+        )

--- a/kiwi/storage/subformat/vagrant_base.py
+++ b/kiwi/storage/subformat/vagrant_base.py
@@ -18,108 +18,16 @@
 import json
 import os
 import random
-from textwrap import dedent
+
 from tempfile import mkdtemp
-from string import Template
 
 from kiwi.storage.subformat.base import DiskFormatBase
+from kiwi.storage.subformat.template.vagrant_config import VagrantConfigTemplate
 from kiwi.command import Command
 
 from kiwi.exceptions import (
     KiwiFormatSetupError
 )
-
-
-class VagrantConfigTemplate(object):
-    """
-    **Generate a Vagrantfile configuration template**
-
-    This class creates a simple template for the Vagrantfile that is included
-    inside a vagrant box.
-
-    The included Vagrantfile carries additional information for vagrant: by
-    default that is just the boxes' MAC address, but depending on the provider
-    additional information need to be present. These can be passed via the
-    parameter ``custom_settings`` to the method :meth:`get_template`.
-
-    Example usage:
-
-    The default without any additional settings will result in this
-    Vagrantfile:
-
-    .. code:: python
-
-        >>> vagrant_config = VagrantConfigTemplate()
-        >>> print(
-        ...     vagrant_config.get_template()
-        ...     .substitute({'mac_address': 'deadbeef'})
-        ... )
-        Vagrant.configure("2") do |config|
-          config.vm.base_mac = "deadbeef"
-        end
-
-    If your provider/box requires additional settings, provide them as follows:
-
-    .. code:: python
-
-        >>> extra_settings = dedent('''
-        ... config.vm.hostname = "no-dead-beef"
-        ... config.vm.provider :special do |special|
-        ...   special.secret_settings = "please_work"
-        ... end
-        ... ''').strip()
-        >>> print(
-        ...     vagrant_config.get_template(extra_settings)
-        ...     .substitute({'mac_address': 'DEADBEEF'})
-        ... )
-        Vagrant.configure("2") do |config|
-          config.vm.base_mac = "DEADBEEF"
-          config.vm.hostname = "no-dead-beef"
-          config.vm.provider :special do |special|
-            special.secret_settings = "please_work"
-          end
-        end
-    """
-
-    _INDENT = '  '
-
-    _HEADER = dedent('''
-        Vagrant.configure("2") do |config|
-    ''').strip() + os.linesep
-
-    _MAC = _INDENT + dedent('''
-        config.vm.base_mac = "${mac_address}"
-    ''').strip() + os.linesep
-
-    _END = dedent('''
-        end
-    ''').strip()
-
-    @classmethod
-    def get_template(cls, custom_settings=None):
-        """
-        Return a new template with ``custom_settings`` included and
-        indented appropriately.
-
-        :param str custom_settings: String of additional settings that get pasted
-            into the Vagrantfile template. The string is put at the correct
-            indentation level for you, but the internal indentation has to be
-            provided by the caller.
-        :return: A template with ``custom_settings`` inserted at the
-            appropriate position. The template has one the variable
-            ``mac_address`` that must be substituted.
-        :rtype: string.Template
-        """
-        template_data = cls._HEADER
-        template_data += cls._MAC
-        if custom_settings:
-            template_data += cls._INDENT
-            template_data += cls._INDENT.join(
-                custom_settings.splitlines(True)
-            )
-            template_data += os.linesep
-        template_data += cls._END
-        return Template(template_data)
 
 
 class DiskFormatVagrantBase(DiskFormatBase):

--- a/kiwi/storage/subformat/vagrant_base.py
+++ b/kiwi/storage/subformat/vagrant_base.py
@@ -30,6 +30,98 @@ from kiwi.exceptions import (
 )
 
 
+class VagrantConfigTemplate(object):
+    """
+    **Generate a Vagrantfile configuration template**
+
+    This class creates a simple template for the Vagrantfile that is included
+    inside a vagrant box.
+
+    The included Vagrantfile carries additional information for vagrant: by
+    default that is just the boxes' MAC address, but depending on the provider
+    additional information need to be present. These can be passed via the
+    parameter ``custom_settings`` to the method :meth:`get_template`.
+
+    Example usage:
+
+    The default without any additional settings will result in this
+    Vagrantfile:
+
+    .. code:: python
+
+        >>> vagrant_config = VagrantConfigTemplate()
+        >>> print(
+        ...     vagrant_config.get_template()
+        ...     .substitute({'mac_address': 'deadbeef'})
+        ... )
+        Vagrant.configure("2") do |config|
+          config.vm.base_mac = "deadbeef"
+        end
+
+    If your provider/box requires additional settings, provide them as follows:
+
+    .. code:: python
+
+        >>> extra_settings = dedent('''
+        ... config.vm.hostname = "no-dead-beef"
+        ... config.vm.provider :special do |special|
+        ...   special.secret_settings = "please_work"
+        ... end
+        ... ''').strip()
+        >>> print(
+        ...     vagrant_config.get_template(extra_settings)
+        ...     .substitute({'mac_address': 'DEADBEEF'})
+        ... )
+        Vagrant.configure("2") do |config|
+          config.vm.base_mac = "DEADBEEF"
+          config.vm.hostname = "no-dead-beef"
+          config.vm.provider :special do |special|
+            special.secret_settings = "please_work"
+          end
+        end
+    """
+
+    _INDENT = '  '
+
+    _HEADER = dedent('''
+        Vagrant.configure("2") do |config|
+    ''').strip() + os.linesep
+
+    _MAC = _INDENT + dedent('''
+        config.vm.base_mac = "${mac_address}"
+    ''').strip() + os.linesep
+
+    _END = dedent('''
+        end
+    ''').strip()
+
+    @classmethod
+    def get_template(cls, custom_settings=None):
+        """
+        Return a new template with ``custom_settings`` included and
+        indented appropriately.
+
+        :param str custom_settings: String of additional settings that get pasted
+            into the Vagrantfile template. The string is put at the correct
+            indentation level for you, but the internal indentation has to be
+            provided by the caller.
+        :return: A template with ``custom_settings`` inserted at the
+            appropriate position. The template has one the variable
+            ``mac_address`` that must be substituted.
+        :rtype: string.Template
+        """
+        template_data = cls._HEADER
+        template_data += cls._MAC
+        if custom_settings:
+            template_data += cls._INDENT
+            template_data += cls._INDENT.join(
+                custom_settings.splitlines(True)
+            )
+            template_data += os.linesep
+        template_data += cls._END
+        return Template(template_data)
+
+
 class DiskFormatVagrantBase(DiskFormatBase):
     """
     Base class for creating vagrant boxes.

--- a/kiwi/storage/subformat/vagrant_libvirt.py
+++ b/kiwi/storage/subformat/vagrant_libvirt.py
@@ -25,10 +25,13 @@ from kiwi.command import Command
 
 
 class DiskFormatVagrantLibVirt(DiskFormatVagrantBase):
-    provider = 'libvirt'
     """
     **Create a vagrant box for the libvirt provider**
     """
+
+    def vagrant_post_init(self):
+        self.image_format = 'vagrant.libvirt.box'
+        self.provider = 'libvirt'
 
     def create_box_img(self, temp_image_dir):
         """

--- a/kiwi/storage/subformat/vagrant_libvirt.py
+++ b/kiwi/storage/subformat/vagrant_libvirt.py
@@ -15,63 +15,25 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
-import json
 import os
-import random
 from textwrap import dedent
-from tempfile import mkdtemp
 
 # project
-from kiwi.storage.subformat.base import DiskFormatBase
+from kiwi.storage.subformat.vagrant_base import DiskFormatVagrantBase
 from kiwi.storage.subformat.qcow2 import DiskFormatQcow2
 from kiwi.command import Command
 
-from kiwi.exceptions import (
-    KiwiFormatSetupError
-)
 
-
-class DiskFormatVagrantLibVirt(DiskFormatBase):
+class DiskFormatVagrantLibVirt(DiskFormatVagrantBase):
+    provider = 'libvirt'
     """
-    **Create vagrant box for libvirt provider**
+    **Create a vagrant box for the libvirt provider**
     """
-    def post_init(self, custom_args):
+
+    def create_box_img(self, temp_image_dir):
         """
-        vagrant disk format post initialization method
-
-        store vagrantconfig information provided via custom_args
-
-        :param dict custom_args:
-            Contains instance of xml_parse::vagrantconfig
-
-            .. code:: python
-
-                {'vagrantconfig': object}
+        Creates the qcow2 disk image box for libvirt vagrant provider
         """
-        if not custom_args or 'vagrantconfig' not in custom_args:
-            raise KiwiFormatSetupError(
-                'object init requires custom_args hash with a vagrantconfig'
-            )
-
-        if not custom_args['vagrantconfig']:
-            raise KiwiFormatSetupError(
-                'no vagrantconfig provided'
-            )
-
-        self.image_format = 'vagrant.libvirt.box'
-        self.vagrantconfig = custom_args['vagrantconfig']
-
-    def create_image_format(self):
-        """
-        Create vagrant box for libvirt provider. This includes
-
-        * creation of qcow2 disk image format as box.img
-        * creation of box metadata.json
-        * creation of box Vagrantfile
-        * creation of result format tarball from the files created above
-        """
-        self.temp_image_dir = mkdtemp(prefix='kiwi_vagrant_box.')
-
         qcow = DiskFormatQcow2(
             self.xml_state, self.root_dir, self.target_dir
         )
@@ -83,71 +45,24 @@ class DiskFormatVagrantLibVirt(DiskFormatBase):
                 box_img
             ]
         )
+        return [box_img]
 
-        metadata_json = os.sep.join([self.temp_image_dir, 'metadata.json'])
-        with open(metadata_json, 'w') as meta:
-            meta.write(self._create_box_metadata())
-
-        vagrantfile = os.sep.join([self.temp_image_dir, 'Vagrantfile'])
-        with open(vagrantfile, 'w') as vagrant:
-            vagrant.write(self._create_box_vagrantconfig())
-
-        Command.run(
-            [
-                'tar', '-C', self.temp_image_dir,
-                '-czf', self.get_target_file_path_for_format(self.image_format),
-                os.path.basename(box_img),
-                os.path.basename(metadata_json),
-                os.path.basename(vagrantfile)
-            ]
-        )
-
-    def store_to_result(self, result):
+    def get_additional_metadata(self):
         """
-        Store result file of the vagrant format conversion into the
-        provided result instance. In this case compression is unwanted
-        because the box is already created as a compressed tarball
-
-        :param object result: Instance of Result
+        Returns a dictionary containing the virtual image format and the size
+        of the image.
         """
-        result.add(
-            key='disk_format_image',
-            filename=self.get_target_file_path_for_format(
-                self.image_format
-            ),
-            use_for_bundle=True,
-            compress=False,
-            shasum=True
-        )
-
-    def _create_box_metadata(self):
-        metadata = {
-            'provider': 'libvirt',
+        return {
             'format': 'qcow2',
             'virtual_size': format(self.vagrantconfig.get_virtualsize() or 42)
         }
-        return json.dumps(
-            metadata, sort_keys=True, indent=2, separators=(',', ': ')
-        )
 
-    def _create_box_vagrantconfig(self):
-        vagrantconfig = dedent('''
-            Vagrant::Config.run do |config|
-              config.vm.base_mac = "{mac_address}"
-            end
-            include_vagrantfile = File.expand_path(
-              "../include/_Vagrantfile", __FILE__
-            )
-            load include_vagrantfile if File.exist?(include_vagrantfile)
+    def get_additional_vagrant_config_settings(self):
+        """
+        Returns settings for the libvirt provider telling vagrant to use kvm.
+        """
+        return dedent('''
+        config.vm.provider :libvirt do |libvirt|
+          libvirt.driver = "kvm"
+        end
         ''').strip()
-        return vagrantconfig.format(
-            mac_address=self._random_mac()
-        )
-
-    def _random_mac(self):
-        return '%02x%02x%02x%02x%02x%02x'.upper() % (
-            0x00, 0x16, 0x3e,
-            random.randrange(0, 0x7e),
-            random.randrange(0, 0xff),
-            random.randrange(0, 0xff)
-        )

--- a/test/unit/storage_subformat_template_vagrant_config_test.py
+++ b/test/unit/storage_subformat_template_vagrant_config_test.py
@@ -1,0 +1,41 @@
+from kiwi.storage.subformat.template.vagrant_config import (
+    VagrantConfigTemplate
+)
+
+from textwrap import dedent
+
+
+class TestVagrantConfigTemplate(object):
+
+    def setup(self):
+        self.vagrant_config = VagrantConfigTemplate()
+
+    def test_default_Vagrantfile(self):
+        Vagrantfile = dedent('''
+        Vagrant.configure("2") do |config|
+          config.vm.base_mac = "deadbeef"
+        end
+        ''').strip()
+        assert self.vagrant_config.get_template()\
+                                  .substitute({'mac_address': 'deadbeef'}) \
+            == Vagrantfile
+
+    def test_customized_Vagrantfile(self):
+        Vagrantfile = dedent('''
+        Vagrant.configure("2") do |config|
+          config.vm.base_mac = "DEADBEEF"
+          config.vm.hostname = "no-dead-beef"
+          config.vm.provider :special do |special|
+            special.secret_settings = "please_work"
+          end
+        end
+        ''').strip()
+        extra_settings = dedent('''
+        config.vm.hostname = "no-dead-beef"
+        config.vm.provider :special do |special|
+          special.secret_settings = "please_work"
+        end
+        ''').strip()
+        assert self.vagrant_config.get_template(extra_settings)\
+                                  .substitute({'mac_address': 'DEADBEEF'}) \
+            == Vagrantfile

--- a/test/unit/storage_subformat_vagrant_base_test.py
+++ b/test/unit/storage_subformat_vagrant_base_test.py
@@ -1,0 +1,124 @@
+from mock import call, patch
+import mock
+
+from .test_helper import patch_open, raises
+
+from kiwi.exceptions import KiwiFormatSetupError
+from kiwi.storage.subformat.vagrant_base import DiskFormatVagrantBase
+
+from textwrap import dedent
+
+
+class DiskFormatVagrantgMock(DiskFormatVagrantBase):
+
+    provider = "dummy"
+
+    FILES = ["one_file", "two_file", "red_file", "blue_file"]
+
+    def create_box_img(self, tmp_dir):
+        return self.FILES
+
+
+class TestDiskFormatVagrant(object):
+    def setup(self):
+        xml_data = mock.Mock()
+        xml_data.get_name = mock.Mock(
+            return_value='some-disk-image'
+        )
+        self.xml_state = mock.Mock()
+        self.xml_state.xml_data = xml_data
+        self.xml_state.get_image_version = mock.Mock(
+            return_value='1.2.3'
+        )
+        self.vagrantconfig = mock.Mock()
+        self.vagrantconfig.get_virtualsize = mock.Mock(
+            return_value=42
+        )
+
+
+class TestDiskFormatVagrantBase(TestDiskFormatVagrant):
+
+    def setup(self):
+        super(TestDiskFormatVagrantBase, self).setup()
+        # set provider as the base class does not provide this value, but
+        # post_init() requires it
+        DiskFormatVagrantBase.provider = "temporary"
+        self.disk_format = DiskFormatVagrantBase(
+            self.xml_state, 'root_dir', 'target_dir',
+            {'vagrantconfig': self.vagrantconfig}
+        )
+
+    @raises(NotImplementedError)
+    def test_create_box_img_not_implemented(self):
+        self.disk_format.create_box_img("arbitrary")
+
+
+class TestDiskFormatVagrantImplementation(TestDiskFormatVagrant):
+    def setup(self):
+        super(TestDiskFormatVagrantImplementation, self).setup()
+        self.disk_format = DiskFormatVagrantgMock(
+            self.xml_state, 'root_dir', 'target_dir',
+            {'vagrantconfig': self.vagrantconfig}
+        )
+
+    @raises(KiwiFormatSetupError)
+    def test_post_init_missing_custom_arguments(self):
+        self.disk_format.post_init(custom_args=None)
+
+    @raises(KiwiFormatSetupError)
+    def test_post_init_missing_vagrantconfig(self):
+        self.disk_format.post_init({'vagrantconfig': None})
+
+    def test_post_init_sets_image_format(self):
+        assert self.disk_format.image_format == 'vagrant.dummy.box'
+
+    @patch('kiwi.defaults.Defaults.get_disk_format_types')
+    @patch('kiwi.storage.subformat.vagrant_base.Command.run')
+    @patch('kiwi.storage.subformat.vagrant_base.mkdtemp')
+    @patch('kiwi.storage.subformat.vagrant_base.random.randrange')
+    @patch_open
+    def test_create_image_format(
+        self, mock_open, mock_rand, mock_mkdtemp, mock_command,
+        mock_get_disk_format_types
+    ):
+        # our dummy format will otherwise be rejected
+        mock_get_disk_format_types.return_value = \
+            [self.disk_format.image_format]
+
+        mock_rand.return_value = 0xa
+        mock_mkdtemp.return_value = 'tmpdir'
+        context_manager_mock = mock.Mock()
+        mock_open.return_value = context_manager_mock
+        file_mock = mock.Mock()
+        enter_mock = mock.Mock()
+        exit_mock = mock.Mock()
+        enter_mock.return_value = file_mock
+        setattr(context_manager_mock, '__enter__', enter_mock)
+        setattr(context_manager_mock, '__exit__', exit_mock)
+
+        metadata_json = dedent('''
+            {
+              "provider": "dummy"
+            }
+        ''').strip()
+        vagrantfile = dedent('''
+        Vagrant.configure("2") do |config|
+          config.vm.base_mac = "00163E0A0A0A"
+
+        end''').strip()
+
+        self.disk_format.create_image_format()
+
+        assert file_mock.write.call_args_list == [
+            call(metadata_json), call(vagrantfile)
+        ]
+
+        box_file_name = 'target_dir/some-disk-image.x86_64-1.2.3.vagrant.dummy.box'
+
+        assert mock_command.call_args_list == [
+            call([
+                'tar', '-C', 'tmpdir', '-czf', box_file_name,
+                'metadata.json', 'Vagrantfile'
+            ] + DiskFormatVagrantgMock.FILES
+            )
+        ]

--- a/test/unit/storage_subformat_vagrant_base_test.py
+++ b/test/unit/storage_subformat_vagrant_base_test.py
@@ -4,47 +4,9 @@ import mock
 from .test_helper import patch_open, raises
 
 from kiwi.exceptions import KiwiFormatSetupError
-from kiwi.storage.subformat.vagrant_base import (
-    DiskFormatVagrantBase, VagrantConfigTemplate
-)
+from kiwi.storage.subformat.vagrant_base import DiskFormatVagrantBase
 
 from textwrap import dedent
-
-
-class TestVagrantConfigTemplate(object):
-
-    def setup(self):
-        self.vagrant_config = VagrantConfigTemplate()
-
-    def test_default_Vagrantfile(self):
-        Vagrantfile = dedent('''
-        Vagrant.configure("2") do |config|
-          config.vm.base_mac = "deadbeef"
-        end
-        ''').strip()
-        assert self.vagrant_config.get_template()\
-                                  .substitute({'mac_address': 'deadbeef'}) \
-            == Vagrantfile
-
-    def test_customized_Vagrantfile(self):
-        Vagrantfile = dedent('''
-        Vagrant.configure("2") do |config|
-          config.vm.base_mac = "DEADBEEF"
-          config.vm.hostname = "no-dead-beef"
-          config.vm.provider :special do |special|
-            special.secret_settings = "please_work"
-          end
-        end
-        ''').strip()
-        extra_settings = dedent('''
-        config.vm.hostname = "no-dead-beef"
-        config.vm.provider :special do |special|
-          special.secret_settings = "please_work"
-        end
-        ''').strip()
-        assert self.vagrant_config.get_template(extra_settings)\
-                                  .substitute({'mac_address': 'DEADBEEF'}) \
-            == Vagrantfile
 
 
 class DiskFormatVagrantgMock(DiskFormatVagrantBase):

--- a/test/unit/storage_subformat_vagrant_base_test.py
+++ b/test/unit/storage_subformat_vagrant_base_test.py
@@ -11,12 +11,14 @@ from textwrap import dedent
 
 class DiskFormatVagrantgMock(DiskFormatVagrantBase):
 
-    provider = "dummy"
-
     FILES = ["one_file", "two_file", "red_file", "blue_file"]
 
     def create_box_img(self, tmp_dir):
         return self.FILES
+
+    def vagrant_post_init(self):
+        self.provider = 'dummy'
+        self.image_format = 'vagrant.dummy.box'
 
 
 class TestDiskFormatVagrant(object):
@@ -40,9 +42,6 @@ class TestDiskFormatVagrantBase(TestDiskFormatVagrant):
 
     def setup(self):
         super(TestDiskFormatVagrantBase, self).setup()
-        # set provider as the base class does not provide this value, but
-        # post_init() requires it
-        DiskFormatVagrantBase.provider = "temporary"
         self.disk_format = DiskFormatVagrantBase(
             self.xml_state, 'root_dir', 'target_dir',
             {'vagrantconfig': self.vagrantconfig}
@@ -61,6 +60,10 @@ class TestDiskFormatVagrantImplementation(TestDiskFormatVagrant):
             {'vagrantconfig': self.vagrantconfig}
         )
 
+    def test_post_init_vagrant(self):
+        assert self.disk_format.image_format == "vagrant.dummy.box"
+        assert self.disk_format.provider == "dummy"
+
     @raises(KiwiFormatSetupError)
     def test_post_init_missing_custom_arguments(self):
         self.disk_format.post_init(custom_args=None)
@@ -68,9 +71,6 @@ class TestDiskFormatVagrantImplementation(TestDiskFormatVagrant):
     @raises(KiwiFormatSetupError)
     def test_post_init_missing_vagrantconfig(self):
         self.disk_format.post_init({'vagrantconfig': None})
-
-    def test_post_init_sets_image_format(self):
-        assert self.disk_format.image_format == 'vagrant.dummy.box'
 
     @patch('kiwi.defaults.Defaults.get_disk_format_types')
     @patch('kiwi.storage.subformat.vagrant_base.Command.run')


### PR DESCRIPTION
Fixes part of the issues addressed in #947.

Changes proposed in this pull request:
* Split `DiskFormatVagrantLibVirt` into `DiskFormatVagrantLibVirt` and `DiskFormatVagrantBase`, as creating a vagrant box involves a few steps that have to be done independently of the provider. The base class performs these instead of the libvirt specific class.
* Split the unit test for `DiskFormatVagrantLibVirt` into tests for the base class (which I have tried to write so that they test the documented behavior of the base class) and test of the libvirt class
* I have modified the `Vagrantfile` that is bundled with the libvirt provider to match the one that packer produces.
