### PR TITLE
s390-test-image: add factory base project (same as on arm)

### DIFF
--- a/build-tests/s390/test-image-oem/appliance.kiwi
+++ b/build-tests/s390/test-image-oem/appliance.kiwi
@@ -37,6 +37,9 @@
     <repository type="rpm-md" alias="Tumbleweed" priority="2">
         <source path="obs://openSUSE:Factory:zSystems/standard"/>
     </repository>
+    <repository type="rpm-md" alias="Tumbleweed-base" priority="4">
+        <source path="obs://openSUSE:Factory/ports"/>
+    </repository>
     <packages type="image">
         <package name="patterns-openSUSE-base"/>
         <package name="cmsfs"/>


### PR DESCRIPTION
start fixing the build on s390x