### PR TITLE
Add pytest-xdist to dev-virtualenv to run the unit tests in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,4 +47,4 @@ install:
 - pip install tox
 
 script:
-- tox
+- tox "-n $(nproc)"

--- a/.virtualenv.dev-requirements.txt
+++ b/.virtualenv.dev-requirements.txt
@@ -19,6 +19,7 @@ tox
 # python unit testing framework
 pytest
 pytest-cov
+pytest-xdist
 
 # Rolling backport of unittest.mock for all Pythons
 mock

--- a/doc/source/development.rst
+++ b/doc/source/development.rst
@@ -145,6 +145,20 @@ the following command:
 
     $ tox
 
+We also include ``pytest-xdist`` in the development virtualenv which allows
+to run the unit tests in parallel. It is turned of by default but can be
+enabled via:
+
+.. code:: bash
+
+    $ tox "-n NUMBER_OF_PROCESSES"
+
+where you can insert an arbitrary number as ``NUMBER_OF_PROCESSES`` (or a
+shell command like ``$(nproc)``). Please also note that the double quotes
+around ``-n NUMBER_OF_PROCESSES`` are required (otherwise :command:`tox`
+will consume this command line flag instead of forwarding it to
+:command:`pytest`).
+
 The previous call would run :command:`tox` for different Python versions,
 checks the source code for errors, and builds the documentation.
 

--- a/tox.ini
+++ b/tox.ini
@@ -79,7 +79,7 @@ changedir=test/unit
 commands =
     bash -c 'cd ../../ && ./setup.py develop'
     pytest --no-cov-on-fail --cov=kiwi \
-        --cov-report=term-missing --cov-fail-under=100 --cov-config .coveragerc
+        --cov-report=term-missing --cov-fail-under=100 --cov-config .coveragerc {posargs}
 
 
 # Unit Test run with basepython set to 3.6
@@ -97,7 +97,7 @@ changedir=test/unit
 commands =
     bash -c 'cd ../../ && ./setup.py develop'
     pytest --no-cov-on-fail --cov=kiwi \
-        --cov-report=term-missing --cov-fail-under=100 --cov-config .coveragerc
+        --cov-report=term-missing --cov-fail-under=100 --cov-config .coveragerc {posargs}
 
 
 # Documentation build run suitable for doc deployment in package(rpm)


### PR DESCRIPTION
Fixes (no issue): the unit tests take a while to finish, since they are run in a single process & thread.

Changes proposed in this pull request:
* fix CLI args not being passed to pytest by tox for `unit_py3_4` and `unit_py3_6`
* enable parallel run on travis
* document how to run the unit tests in parallel

