### PR TITLE
Fixed disk detection from root device

### DIFF
--- a/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
+++ b/dracut/modules.d/90kiwi-repart/kiwi-repart-disk.sh
@@ -73,15 +73,6 @@ function deactivate_device_mappings {
     if luks_system "${disk}";then
         deactivate_luks
     fi
-    # delete all remaining device maps
-    deactivate_all_device_maps
-}
-
-function activate_device_mappings {
-    if type multipath &> /dev/null; then
-        multipath -r
-        systemctl daemon-reload
-    fi
 }
 
 function finalize_disk_repart {
@@ -318,6 +309,3 @@ fi
 
 # create swap space
 create_swap "$(get_swap_map)"
-
-# recreate device maps and retrigger systemd generators
-activate_device_mappings


### PR DESCRIPTION
The method lookup_disk_device_from_root assigns the disk device
matching the root device uuid. However in a multipath environment
multiple disk devices matches the same root device. The code to
assign the multipath map in this case was missing in the dracut
code base. This Fixes #954 and Fixes bsc#1126283


