### PR TITLE
fix network failure with "BOOTIF=" parameter

### DIFF
--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -316,6 +316,7 @@ function get_local_image_source_files {
 
 function get_remote_image_source_files {
     local image_uri
+    local bootdev
     local install_dir=/run/install
     local image_md5="${install_dir}/image.md5"
     local metadata_dir="${install_dir}/boot/remote/loader"
@@ -333,7 +334,10 @@ function get_remote_image_source_files {
         echo "${image_uri}" | awk '{ gsub("\\.xz",".kernel", $1); print $1 }'
     )
 
-    if ! ifup lan0 &>/tmp/net.info;then
+    read bootdev < /tmp/net.bootdev 2>/dev/null
+    if [ -n "${bootdev}" ] && [ -e /tmp/net.${bootdev}.did-setup ]; then
+        : # all good, dracut has already set up the interface
+    elif ! ifup lan0 &>/tmp/net.info;then
         report_and_quit "Network setup failed, see /tmp/net.info"
     fi
 

--- a/dracut/modules.d/90kiwi-live/kiwi-live-lib.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-live-lib.sh
@@ -57,7 +57,11 @@ function initGlobalDevices {
         die "No root device for operation given"
     fi
     if getargbool 0 rd.kiwi.live.pxe; then
-        if ! ifup lan0 &>/tmp/net.info;then
+        local bootdev
+        read bootdev < /tmp/net.bootdev 2>/dev/null
+        if [ -n "${bootdev}" ] && [ -e /tmp/net.${bootdev}.did-setup ]; then
+            : # already set up
+        elif ! ifup lan0 &>/tmp/net.info;then
             die "Network setup failed, see /tmp/net.info"
         fi
         modprobe aoe


### PR DESCRIPTION
If a BOOTIF= parameter (pxelinux "IPAPPEND 2" option) is present, dracut
handles the network already *and* overwrites the 90-net.rules that
kiwi-*-net-genrules.sh created, thus the interface is not named "lan0"
and ifup is destined to fail.
Work around the issue by detecting if the interface is already handled
by generic dracut code and just skipping the ifup call.
Fixes / improves issue #942