### PR TITLE
Added some style fixes to the vagrant classes

### DIFF
--- a/kiwi/storage/subformat/template/vagrant_config.py
+++ b/kiwi/storage/subformat/template/vagrant_config.py
@@ -73,17 +73,17 @@ class VagrantConfigTemplate(object):
     """
 
     def __init__(self):
-        self.INDENT = '  '
+        self.indent = '  '
 
-        self.HEADER = dedent('''
+        self.header = dedent('''
             Vagrant.configure("2") do |config|
         ''').strip() + os.linesep
 
-        self.MAC = self.INDENT + dedent('''
+        self.mac = self.indent + dedent('''
             config.vm.base_mac = "${mac_address}"
         ''').strip() + os.linesep
 
-        self.END = dedent('''
+        self.end = dedent('''
             end
         ''').strip()
 
@@ -101,13 +101,13 @@ class VagrantConfigTemplate(object):
             ``mac_address`` that must be substituted.
         :rtype: string.Template
         """
-        template_data = self.HEADER
-        template_data += self.MAC
+        template_data = self.header
+        template_data += self.mac
         if custom_settings:
-            template_data += self.INDENT
-            template_data += self.INDENT.join(
+            template_data += self.indent
+            template_data += self.indent.join(
                 custom_settings.splitlines(True)
             )
             template_data += os.linesep
-        template_data += self.END
+        template_data += self.end
         return Template(template_data)

--- a/kiwi/storage/subformat/vagrant_base.py
+++ b/kiwi/storage/subformat/vagrant_base.py
@@ -39,23 +39,25 @@ class DiskFormatVagrantBase(DiskFormatBase):
     In a nutshell, a vagrant box is a tar, tar.gz or zip archive of the
     following:
 
-    1. ``metadata.json``: A json file that contains the name of the provider
+    1. ``metadata.json``:
+       A json file that contains the name of the provider
        and arbitrary additional data (that vagrant doesn't care about).
-    2. ``Vagrantfile``: A Vagrantfile which defines the boxes' MAC address. It
-       can be also used to define other settings of the box, e.g. the method
-       via which the ``/vagrant/`` directory is shared.
-    3. The actual virtual disk image: this is provider specific and vagrant
-       simply forwards it to your virtual machine provider.
+    2. ``Vagrantfile``:
+       A Vagrantfile which defines the boxes' MAC address. It
+       can be also used to define other settings of the box, e.g.
+       the method via which the ``/vagrant/`` directory is shared.
+    3. The actual virtual disk image: this is provider specific and
+       vagrant simply forwards it to your virtual machine provider.
 
     Required methods/variables that child classes must implement:
 
-    * ``provider: str``:
-      A static variable or property, should contain the name of the provider.
-      This value is used to create the ``metadata.json`` file and the
-      attribute :attr:`image_format`.
+    * :meth:`vagrant_post_init`
 
-      Note: you also must add the image format
-      to :func:`kiwi.defaults.Defaults.get_disk_format_types`
+      post initializing method that has to specify the vagrant
+      provider name in :attr:`provider` and the box name in
+      :attr:`image_format`. Note: new providers also needs to
+      be specified in the schema and the box name needs to be
+      registered to :func:`kiwi.defaults.Defaults.get_disk_format_types`
 
     * :meth:`create_box_img`
 
@@ -110,7 +112,7 @@ class DiskFormatVagrantBase(DiskFormatBase):
             path to a temporary directory inside which the image
             should be built
         :return:
-            A list of files that were create by this function
+            A list of files that were created by this function
             and that should be included in the vagrant box
         :rtype: list
         """
@@ -124,32 +126,36 @@ class DiskFormatVagrantBase(DiskFormatBase):
         * creation of box Vagrantfile
         * creation of result format tarball from the files created above
         """
-        if self.image_format and self.provider:
-            self.temp_image_dir = mkdtemp(prefix='kiwi_vagrant_box.')
-
-            box_img_files = self.create_box_img(self.temp_image_dir)
-
-            metadata_json = os.sep.join([self.temp_image_dir, 'metadata.json'])
-            with open(metadata_json, 'w') as meta:
-                meta.write(self._create_box_metadata())
-
-            vagrantfile = os.sep.join([self.temp_image_dir, 'Vagrantfile'])
-            with open(vagrantfile, 'w') as vagrant:
-                vagrant.write(self._create_box_vagrantconfig())
-
-            Command.run(
-                [
-                    'tar', '-C', self.temp_image_dir,
-                    '-czf', self.get_target_file_path_for_format(
-                        self.image_format
-                    ),
-                    os.path.basename(metadata_json),
-                    os.path.basename(vagrantfile)
-                ] + [
-                    os.path.basename(box_img_file)
-                    for box_img_file in box_img_files
-                ]
+        if not self.image_format or not self.provider:
+            raise NotImplementedError(
+                'vagrant_post_init: Missing provider and/or box name setup'
             )
+
+        self.temp_image_dir = mkdtemp(prefix='kiwi_vagrant_box.')
+
+        box_img_files = self.create_box_img(self.temp_image_dir)
+
+        metadata_json = os.sep.join([self.temp_image_dir, 'metadata.json'])
+        with open(metadata_json, 'w') as meta:
+            meta.write(self._create_box_metadata())
+
+        vagrantfile = os.sep.join([self.temp_image_dir, 'Vagrantfile'])
+        with open(vagrantfile, 'w') as vagrant:
+            vagrant.write(self._create_box_vagrantconfig())
+
+        Command.run(
+            [
+                'tar', '-C', self.temp_image_dir,
+                '-czf', self.get_target_file_path_for_format(
+                    self.image_format
+                ),
+                os.path.basename(metadata_json),
+                os.path.basename(vagrantfile)
+            ] + [
+                os.path.basename(box_img_file)
+                for box_img_file in box_img_files
+            ]
+        )
 
     def store_to_result(self, result):
         """
@@ -159,16 +165,20 @@ class DiskFormatVagrantBase(DiskFormatBase):
 
         :param object result: Instance of Result
         """
-        if self.image_format:
-            result.add(
-                key='disk_format_image',
-                filename=self.get_target_file_path_for_format(
-                    self.image_format
-                ),
-                use_for_bundle=True,
-                compress=False,
-                shasum=True
+        if not self.image_format:
+            raise NotImplementedError(
+                'vagrant_post_init: Missing box name setup'
             )
+
+        result.add(
+            key='disk_format_image',
+            filename=self.get_target_file_path_for_format(
+                self.image_format
+            ),
+            use_for_bundle=True,
+            compress=False,
+            shasum=True
+        )
 
     def get_additional_metadata(self):
         """

--- a/kiwi/storage/subformat/vagrant_libvirt.py
+++ b/kiwi/storage/subformat/vagrant_libvirt.py
@@ -28,7 +28,6 @@ class DiskFormatVagrantLibVirt(DiskFormatVagrantBase):
     """
     **Create a vagrant box for the libvirt provider**
     """
-
     def vagrant_post_init(self):
         self.image_format = 'vagrant.libvirt.box'
         self.provider = 'libvirt'
@@ -65,7 +64,7 @@ class DiskFormatVagrantLibVirt(DiskFormatVagrantBase):
         Returns settings for the libvirt provider telling vagrant to use kvm.
         """
         return dedent('''
-        config.vm.provider :libvirt do |libvirt|
-          libvirt.driver = "kvm"
-        end
+            config.vm.provider :libvirt do |libvirt|
+              libvirt.driver = "kvm"
+            end
         ''').strip()

--- a/kiwi/storage/subformat/vagrant_libvirt.py
+++ b/kiwi/storage/subformat/vagrant_libvirt.py
@@ -40,7 +40,7 @@ class DiskFormatVagrantLibVirt(DiskFormatVagrantBase):
             self.xml_state, self.root_dir, self.target_dir
         )
         qcow.create_image_format()
-        box_img = os.sep.join([self.temp_image_dir, 'box.img'])
+        box_img = os.sep.join([temp_image_dir, 'box.img'])
         Command.run(
             [
                 'mv', self.get_target_file_path_for_format(qcow.image_format),

--- a/test/unit/storage_subformat_vagrant_base_test.py
+++ b/test/unit/storage_subformat_vagrant_base_test.py
@@ -37,7 +37,7 @@ class TestDiskFormatVagrantBase(object):
 
     def test_create_box_img_not_implemented(self):
         with raises(NotImplementedError):
-            self.disk_format.create_box_img("arbitrary")
+            self.disk_format.create_box_img('arbitrary')
 
     def test_post_init_missing_custom_arguments(self):
         with raises(KiwiFormatSetupError):
@@ -65,14 +65,8 @@ class TestDiskFormatVagrantBase(object):
         mock_mkdtemp, mock_command
     ):
         # select an example provider
-        self.disk_format.image_format = "vagrant.libvirt.box"
-        self.disk_format.provider = "libvirt"
-
-        additional_config = dedent('''
-            config.vm.provider :libvirt do |libvirt|
-              libvirt.driver = "kvm"
-            end
-        ''').strip()
+        self.disk_format.image_format = 'vagrant.libvirt.box'
+        self.disk_format.provider = 'libvirt'
 
         metadata_json = dedent('''
             {
@@ -83,15 +77,8 @@ class TestDiskFormatVagrantBase(object):
         expected_vagrantfile = dedent('''
             Vagrant.configure("2") do |config|
               config.vm.base_mac = "00163E0A0A0A"
-              config.vm.provider :libvirt do |libvirt|
-                libvirt.driver = "kvm"
-              end
             end
         ''').strip()
-
-        self.disk_format.get_additional_vagrant_config_settings = Mock(
-            return_value=additional_config
-        )
 
         mock_rand.return_value = 0xa
         mock_mkdtemp.return_value = 'tmpdir'
@@ -121,7 +108,7 @@ class TestDiskFormatVagrantBase(object):
 
     def test_store_to_result(self):
         # select an example provider
-        self.disk_format.image_format = "vagrant.libvirt.box"
+        self.disk_format.image_format = 'vagrant.libvirt.box'
         result = Mock()
         self.disk_format.store_to_result(result)
         result.add.assert_called_once_with(

--- a/test/unit/storage_subformat_vagrant_base_test.py
+++ b/test/unit/storage_subformat_vagrant_base_test.py
@@ -1,7 +1,11 @@
+import io
+from pytest import raises
 from mock import call, patch
-import mock
+from mock import (
+    Mock, MagicMock
+)
 
-from .test_helper import patch_open, raises
+from .test_helper import patch_open
 
 from kiwi.exceptions import KiwiFormatSetupError
 from kiwi.storage.subformat.vagrant_base import DiskFormatVagrantBase
@@ -9,115 +13,105 @@ from kiwi.storage.subformat.vagrant_base import DiskFormatVagrantBase
 from textwrap import dedent
 
 
-class DiskFormatVagrantgMock(DiskFormatVagrantBase):
-
-    FILES = ["one_file", "two_file", "red_file", "blue_file"]
-
-    def create_box_img(self, tmp_dir):
-        return self.FILES
-
-    def vagrant_post_init(self):
-        self.provider = 'dummy'
-        self.image_format = 'vagrant.dummy.box'
-
-
-class TestDiskFormatVagrant(object):
+class TestDiskFormatVagrantBase(object):
     def setup(self):
-        xml_data = mock.Mock()
-        xml_data.get_name = mock.Mock(
+        xml_data = Mock()
+        xml_data.get_name = Mock(
             return_value='some-disk-image'
         )
-        self.xml_state = mock.Mock()
+        self.xml_state = Mock()
         self.xml_state.xml_data = xml_data
-        self.xml_state.get_image_version = mock.Mock(
+        self.xml_state.get_image_version = Mock(
             return_value='1.2.3'
         )
-        self.vagrantconfig = mock.Mock()
-        self.vagrantconfig.get_virtualsize = mock.Mock(
+        self.vagrantconfig = Mock()
+        self.vagrantconfig.get_virtualsize = Mock(
             return_value=42
         )
-
-
-class TestDiskFormatVagrantBase(TestDiskFormatVagrant):
-
-    def setup(self):
-        super(TestDiskFormatVagrantBase, self).setup()
         self.disk_format = DiskFormatVagrantBase(
             self.xml_state, 'root_dir', 'target_dir',
             {'vagrantconfig': self.vagrantconfig}
         )
+        assert self.disk_format.image_format is None
+        assert self.disk_format.provider is None
 
-    @raises(NotImplementedError)
     def test_create_box_img_not_implemented(self):
-        self.disk_format.create_box_img("arbitrary")
+        with raises(NotImplementedError):
+            self.disk_format.create_box_img("arbitrary")
 
-
-class TestDiskFormatVagrantImplementation(TestDiskFormatVagrant):
-    def setup(self):
-        super(TestDiskFormatVagrantImplementation, self).setup()
-        self.disk_format = DiskFormatVagrantgMock(
-            self.xml_state, 'root_dir', 'target_dir',
-            {'vagrantconfig': self.vagrantconfig}
-        )
-
-    def test_post_init_vagrant(self):
-        assert self.disk_format.image_format == "vagrant.dummy.box"
-        assert self.disk_format.provider == "dummy"
-
-    @raises(KiwiFormatSetupError)
     def test_post_init_missing_custom_arguments(self):
-        self.disk_format.post_init(custom_args=None)
+        with raises(KiwiFormatSetupError):
+            self.disk_format.post_init(custom_args=None)
 
-    @raises(KiwiFormatSetupError)
     def test_post_init_missing_vagrantconfig(self):
-        self.disk_format.post_init({'vagrantconfig': None})
+        with raises(KiwiFormatSetupError):
+            self.disk_format.post_init({'vagrantconfig': None})
 
-    @patch('kiwi.defaults.Defaults.get_disk_format_types')
+    def test_create_image_format_missing_provider_setup(self):
+        with raises(NotImplementedError):
+            self.disk_format.create_image_format()
+
+    def test_store_to_result_missing_provider_setup(self):
+        with raises(NotImplementedError):
+            self.disk_format.store_to_result(Mock())
+
     @patch('kiwi.storage.subformat.vagrant_base.Command.run')
     @patch('kiwi.storage.subformat.vagrant_base.mkdtemp')
     @patch('kiwi.storage.subformat.vagrant_base.random.randrange')
+    @patch.object(DiskFormatVagrantBase, 'create_box_img')
     @patch_open
     def test_create_image_format(
-        self, mock_open, mock_rand, mock_mkdtemp, mock_command,
-        mock_get_disk_format_types
+        self, mock_open, mock_create_box_img, mock_rand,
+        mock_mkdtemp, mock_command
     ):
-        # our dummy format will otherwise be rejected
-        mock_get_disk_format_types.return_value = \
-            [self.disk_format.image_format]
+        # select an example provider
+        self.disk_format.image_format = "vagrant.libvirt.box"
+        self.disk_format.provider = "libvirt"
 
         mock_rand.return_value = 0xa
         mock_mkdtemp.return_value = 'tmpdir'
-        context_manager_mock = mock.Mock()
-        mock_open.return_value = context_manager_mock
-        file_mock = mock.Mock()
-        enter_mock = mock.Mock()
-        exit_mock = mock.Mock()
-        enter_mock.return_value = file_mock
-        setattr(context_manager_mock, '__enter__', enter_mock)
-        setattr(context_manager_mock, '__exit__', exit_mock)
+
+        mock_open.return_value = MagicMock(spec=io.IOBase)
+        file_handle = mock_open.return_value.__enter__.return_value
 
         metadata_json = dedent('''
             {
-              "provider": "dummy"
+              "provider": "libvirt"
             }
         ''').strip()
         vagrantfile = dedent('''
-        Vagrant.configure("2") do |config|
-          config.vm.base_mac = "00163E0A0A0A"
-        end''').strip()
+            Vagrant.configure("2") do |config|
+              config.vm.base_mac = "00163E0A0A0A"
+            end
+        ''').strip()
 
         self.disk_format.create_image_format()
 
-        assert file_mock.write.call_args_list == [
+        assert mock_open.call_args_list == [
+            call('tmpdir/metadata.json', 'w'),
+            call('tmpdir/Vagrantfile', 'w')
+        ]
+        assert file_handle.write.call_args_list == [
             call(metadata_json), call(vagrantfile)
         ]
-
-        box_file_name = 'target_dir/some-disk-image.x86_64-1.2.3.vagrant.dummy.box'
-
-        assert mock_command.call_args_list == [
-            call([
-                'tar', '-C', 'tmpdir', '-czf', box_file_name,
+        mock_command.assert_called_once_with(
+            [
+                'tar', '-C', 'tmpdir', '-czf',
+                'target_dir/some-disk-image.x86_64-1.2.3.vagrant.libvirt.box',
                 'metadata.json', 'Vagrantfile'
-            ] + DiskFormatVagrantgMock.FILES
-            )
-        ]
+            ]
+        )
+
+    def test_store_to_result(self):
+        # select an example provider
+        self.disk_format.image_format = "vagrant.libvirt.box"
+        result = Mock()
+        self.disk_format.store_to_result(result)
+        result.add.assert_called_once_with(
+            compress=False,
+            filename='target_dir/'
+            'some-disk-image.x86_64-1.2.3.vagrant.libvirt.box',
+            key='disk_format_image',
+            shasum=True,
+            use_for_bundle=True
+        )

--- a/test/unit/storage_subformat_vagrant_libvirt_test.py
+++ b/test/unit/storage_subformat_vagrant_libvirt_test.py
@@ -1,87 +1,61 @@
-from mock import call, patch
-import mock
-
-from .test_helper import patch_open
-from .storage_subformat_vagrant_base_test import TestDiskFormatVagrant
+from textwrap import dedent
+from mock import (
+    patch, Mock
+)
 
 from kiwi.storage.subformat.vagrant_libvirt import DiskFormatVagrantLibVirt
 
-from textwrap import dedent
 
-
-class TestDiskFormatVagrantLibVirt(TestDiskFormatVagrant):
+class TestDiskFormatVagrantLibVirt(object):
     def setup(self):
-        super(TestDiskFormatVagrantLibVirt, self).setup()
+        xml_data = Mock()
+        xml_data.get_name = Mock(
+            return_value='some-disk-image'
+        )
+        self.xml_state = Mock()
+        self.xml_state.xml_data = xml_data
+        self.xml_state.get_image_version = Mock(
+            return_value='1.2.3'
+        )
+        self.vagrantconfig = Mock()
+        self.vagrantconfig.get_virtualsize = Mock(
+            return_value=42
+        )
         self.disk_format = DiskFormatVagrantLibVirt(
             self.xml_state, 'root_dir', 'target_dir',
             {'vagrantconfig': self.vagrantconfig}
         )
-
-    def test_store_to_result(self):
-        result = mock.Mock()
-        self.disk_format.store_to_result(result)
-        result.add.assert_called_once_with(
-            compress=False,
-            filename='target_dir/'
-            'some-disk-image.x86_64-1.2.3.vagrant.libvirt.box',
-            key='disk_format_image',
-            shasum=True,
-            use_for_bundle=True
-        )
+        assert self.disk_format.image_format == 'vagrant.libvirt.box'
+        assert self.disk_format.provider == 'libvirt'
 
     @patch('kiwi.storage.subformat.vagrant_libvirt.Command.run')
-    @patch('kiwi.storage.subformat.vagrant_base.mkdtemp')
     @patch('kiwi.storage.subformat.vagrant_libvirt.DiskFormatQcow2')
-    @patch('kiwi.storage.subformat.vagrant_base.random.randrange')
-    @patch_open
-    def test_create_image_format(
-        self, mock_open, mock_rand, mock_qcow, mock_mkdtemp, mock_command
+    def test_create_box_img(
+        self, mock_qcow, mock_command
     ):
-        mock_rand.return_value = 0xa
-        mock_mkdtemp.return_value = 'tmpdir'
-        qcow = mock.Mock()
+        qcow = Mock()
         qcow.image_format = 'qcow2'
         mock_qcow.return_value = qcow
-        context_manager_mock = mock.Mock()
-        mock_open.return_value = context_manager_mock
-        file_mock = mock.Mock()
-        enter_mock = mock.Mock()
-        exit_mock = mock.Mock()
-        enter_mock.return_value = file_mock
-        setattr(context_manager_mock, '__enter__', enter_mock)
-        setattr(context_manager_mock, '__exit__', exit_mock)
-        metadata_json = dedent('''
-            {
-              "format": "qcow2",
-              "provider": "libvirt",
-              "virtual_size": "42"
-            }
-        ''').strip()
-        vagrantfile = dedent('''
-            Vagrant.configure("2") do |config|
-              config.vm.base_mac = "00163E0A0A0A"
-              config.vm.provider :libvirt do |libvirt|
-                libvirt.driver = "kvm"
-              end
-            end
-        ''').strip()
-
-        self.disk_format.create_image_format()
-
-        qcow.create_image_format.assert_called_once_with()
-
-        assert file_mock.write.call_args_list == [
-            call(metadata_json), call(vagrantfile)
+        assert self.disk_format.create_box_img('tmpdir') == [
+            'tmpdir/box.img'
         ]
-
-        assert mock_command.call_args_list == [
-            call([
+        qcow.create_image_format.assert_called_once_with()
+        mock_command.assert_called_once_with(
+            [
                 'mv', 'target_dir/some-disk-image.x86_64-1.2.3.qcow2',
                 'tmpdir/box.img'
-            ]),
-            call([
-                'tar', '-C', 'tmpdir', '-czf',
-                'target_dir/some-disk-image.x86_64-1.2.3.vagrant.libvirt.box',
-                'metadata.json', 'Vagrantfile', 'box.img'
-            ])
-        ]
+            ]
+        )
+
+    def test_get_additional_metadata(self):
+        assert self.disk_format.get_additional_metadata() == {
+            'format': 'qcow2', 'virtual_size': '42'
+        }
+
+    def test_get_additional_vagrant_config_settings(self):
+        assert self.disk_format.get_additional_vagrant_config_settings() == \
+            dedent('''
+                config.vm.provider :libvirt do |libvirt|
+                  libvirt.driver = "kvm"
+                end
+            ''').strip()


### PR DESCRIPTION
Adapt doc strings to match style on lists. Change variable
names not class global to be lowercase. Use 80 chars per
line. Don't reach code that potentially uses undefined
variables

