### PR TITLE
Fixed relocation of GPT

### DIFF
--- a/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-partitions-lib.sh
@@ -302,12 +302,7 @@ function get_partition_uuid {
 }
 
 function relocate_gpt_at_end_of_disk {
-    local cmd
-    local cmd_file=/part.input
-    rm -f ${cmd_file} && for cmd in x e w y; do
-        echo $cmd >> ${cmd_file}
-    done
-    if ! gdisk "$1" < ${cmd_file} &>/dev/null; then
+    if ! sgdisk -e "$1";then
         die "Failed to write backup GPT at end of disk"
     fi
 }

--- a/dracut/modules.d/99kiwi-lib/module-setup.sh
+++ b/dracut/modules.d/99kiwi-lib/module-setup.sh
@@ -16,7 +16,7 @@ install() {
     declare moddir=${moddir}
     inst_multiple \
         blkid blockdev parted dd mkdir grep cut tail head tr bc \
-        basename partprobe gdisk sgdisk mkswap readlink lsblk \
+        basename partprobe sgdisk mkswap readlink lsblk \
         btrfs xfs_growfs resize2fs \
         e2fsck btrfsck xfs_repair \
         vgs vgchange lvextend lvcreate lvresize pvresize \


### PR DESCRIPTION
Simplify the relocation of the GPT to the end of the current
disk by using sgdisk -e instead of gdisk. The possitive after
effect of this is that the broken return value handling of
gdisk in centos will be fixed and did not harm the kiwi
deployment anymore. This Fixes #958


