### PR TITLE
Followup fix for disk detection from root device

### DIFF
--- a/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
@@ -46,9 +46,11 @@ function lookup_disk_device_from_root {
     ); do
         disk_matches=$((disk_matches + 1))
     done
-    if [ "${disk_matches}" -gt 1 ];then
-        # multiple disks matches the root_device. Let's lookup
-        # which multipath map combines them
+    # Check if root_device is managed by multipath. If this
+    # is the case prefer the multipath mapped device because
+    # directly accessing the mapped devices is no longer
+    # possible
+    if type multipath &> /dev/null; then
         for wwn in $(multipath -l -v1 "${disk_device}");do
             if [ -e "/dev/mapper/${wwn}" ];then
                 disk_device="/dev/mapper/${wwn}"


### PR DESCRIPTION
No matter if one ore more devices are used in a multipath map,
if the root device is managed by multipath kiwi has to use the
mapped device for all operations, otherwise we run into busy
or blocked state inside of the initrd operations. This is
related to Issue #954 and bsc#1126283 and bsc#1126318


