### PR TITLE
add rd.kiwi.install.pass.bootparam boot parameter

### DIFF
--- a/doc/source/overview/workflow.rst
+++ b/doc/source/overview/workflow.rst
@@ -868,6 +868,13 @@ the available kernel boot parameters for this modules:
   This variable specifies the remote location of the system image in
   a pxe based oem installation
 
+``rd.kiwi.install.pass.bootparam``
+  This variable tells an oem installation image to pass on additional
+  boot parameters to the kernel used to boot the installed image. This
+  can be used e.g. to pass on first boot configuration for a PXE image.
+  Note that options starting with `rd.kiwi` are not passed on to avoid
+  side effects.
+
 ``rd.live.overlay.persistent``
   This variable tells a live iso image to prepare a persistent
   write partition.

--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -362,7 +362,20 @@ function get_remote_image_source_files {
 
 function boot_installed_system {
     local boot_options
-    boot_options="$(cat /config.bootoptions)"
+    # if rd.kiwi.install.pass.bootparam is given, pass on most
+    # boot options to the kexec kernel
+    if getargbool 0 rd.kiwi.install.pass.bootparam; then
+        local cmdline
+        local option
+        read -r cmdline < /proc/cmdline
+        for option in ${cmdline}; do
+            case ${option} in
+                rd.kiwi.*) ;; # skip all rd.kiwi options, they might do harm
+                *)  boot_options="${boot_options}${option} ";;
+            esac
+        done
+    fi
+    boot_options="${boot_options}$(cat /config.bootoptions)"
     if getargbool 0 rd.kiwi.debug; then
         boot_options="${boot_options} rd.kiwi.debug"
     fi


### PR DESCRIPTION
if this boolean is set, most boot parameters are passed on
to the kexec kernel on OEM image deployments
