### PR TITLE
Fixed import of signing keys

### DIFF
--- a/kiwi/repository/dnf.py
+++ b/kiwi/repository/dnf.py
@@ -24,7 +24,6 @@ from tempfile import NamedTemporaryFile
 from kiwi.defaults import Defaults
 from kiwi.repository.base import RepositoryBase
 from kiwi.path import Path
-from kiwi.command import Command
 from kiwi.utils.rpm_database import RpmDataBase
 
 
@@ -200,8 +199,9 @@ class RepositoryDnf(RepositoryBase):
 
         :param list signing_keys: list of the key files to import
         """
+        rpmdb = RpmDataBase(self.root_dir)
         for key in signing_keys:
-            Command.run(['rpm', '--root', self.root_dir, '--import', key])
+            rpmdb.import_signing_key_to_image(key)
 
     def delete_repo(self, name):
         """

--- a/kiwi/repository/yum.py
+++ b/kiwi/repository/yum.py
@@ -22,7 +22,6 @@ from tempfile import NamedTemporaryFile
 # project
 from kiwi.defaults import Defaults
 from kiwi.logger import log
-from kiwi.command import Command
 from kiwi.repository.base import RepositoryBase
 from kiwi.utils.rpm_database import RpmDataBase
 from kiwi.path import Path
@@ -202,8 +201,9 @@ class RepositoryYum(RepositoryBase):
 
         :param list signing_keys: list of the key files to import
         """
+        rpmdb = RpmDataBase(self.root_dir)
         for key in signing_keys:
-            Command.run(['rpm', '--root', self.root_dir, '--import', key])
+            rpmdb.import_signing_key_to_image(key)
 
     def delete_repo(self, name):
         """

--- a/test/unit/repository_dnf_test.py
+++ b/test/unit/repository_dnf_test.py
@@ -154,12 +154,15 @@ class TestRepositoryDnf(object):
             '/shared-dir/dnf/repos/foo.repo', 'w'
         )
 
-    @patch('kiwi.command.Command.run')
-    def test_import_trusted_keys(self, mock_run):
-        self.repo.import_trusted_keys(['key-file-a.asc', 'key-file-b.asc'])
-        assert mock_run.call_args_list == [
-            call(['rpm', '--root', '../data', '--import', 'key-file-a.asc']),
-            call(['rpm', '--root', '../data', '--import', 'key-file-b.asc'])
+    @patch('kiwi.repository.dnf.RpmDataBase')
+    def test_import_trusted_keys(self, mock_RpmDataBase):
+        rpmdb = mock.Mock()
+        mock_RpmDataBase.return_value = rpmdb
+        signing_keys = ['key-file-a.asc', 'key-file-b.asc']
+        self.repo.import_trusted_keys(signing_keys)
+        assert rpmdb.import_signing_key_to_image.call_args_list == [
+            call('key-file-a.asc'),
+            call('key-file-b.asc')
         ]
 
     @patch('kiwi.path.Path.wipe')

--- a/test/unit/repository_yum_test.py
+++ b/test/unit/repository_yum_test.py
@@ -160,12 +160,15 @@ class TestRepositoryYum(object):
             '/shared-dir/yum/repos/foo.repo', 'w'
         )
 
-    @patch('kiwi.command.Command.run')
-    def test_import_trusted_keys(self, mock_run):
-        self.repo.import_trusted_keys(['key-file-a.asc', 'key-file-b.asc'])
-        assert mock_run.call_args_list == [
-            call(['rpm', '--root', '../data', '--import', 'key-file-a.asc']),
-            call(['rpm', '--root', '../data', '--import', 'key-file-b.asc'])
+    @patch('kiwi.repository.yum.RpmDataBase')
+    def test_import_trusted_keys(self, mock_RpmDataBase):
+        rpmdb = mock.Mock()
+        mock_RpmDataBase.return_value = rpmdb
+        signing_keys = ['key-file-a.asc', 'key-file-b.asc']
+        self.repo.import_trusted_keys(signing_keys)
+        assert rpmdb.import_signing_key_to_image.call_args_list == [
+            call('key-file-a.asc'),
+            call('key-file-b.asc')
         ]
 
     @patch('kiwi.path.Path.wipe')


### PR DESCRIPTION
Make sure the key import works with different locations of the
rpm database compared to the host and the image rpmdb location.
The patch imports the given keys depending on the install phase
to the host rpm database and to the image rpm database.


