### PR TITLE
Update tools from strip list for oemboot

### DIFF
--- a/kiwi/config/strip.xml
+++ b/kiwi/config/strip.xml
@@ -316,6 +316,8 @@
         <file name="zfcp_host_configure"/>
         <file name="kmod"/>
         <file name="zpool"/>
+        <file name="getopt"/>
+        <file name="chzdev"/>
     </strip>
 <!--
     check with ldd and remove all those libraries with


### PR DESCRIPTION
For legacy oemboot kiwi descriptions the strip list for
tools to keep in the initrd is still active. On s390
required tools for dasd_configure were missing and got
added by this commit. This Fixes #963

