### PR TITLE
Allow xdist to run the tests in parallel for the Python 2.7 env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,7 @@ commands =
     bash -c 'cd ../../ && ./setup.py develop'
     pytest --no-cov-on-fail --cov=kiwi \
         --cov-report=term-missing \
-        --cov-fail-under=100 --cov-config .coveragerc
+        --cov-fail-under=100 --cov-config .coveragerc {posargs}
 
 
 # Unit Test run with basepython set to 3.4


### PR DESCRIPTION
Fixes: Test are no longer running in parallel for Python 2.7

Changes proposed in this pull request:
* This reverts an accidental change that was introduced with 942ed7a8eea65f1c99b5f51a8587cfbeae73b484, which removed the `{posargs}` from tox.ini for the python 2.7 environment.

