### PR TITLE
Split of a base class from TestDiskFormatVagrantBase

### DIFF
--- a/test/unit/storage_subformat_vagrant_base_test.py
+++ b/test/unit/storage_subformat_vagrant_base_test.py
@@ -13,7 +13,8 @@ from kiwi.storage.subformat.vagrant_base import DiskFormatVagrantBase
 from textwrap import dedent
 
 
-class TestDiskFormatVagrantBase(object):
+class VagrantTestBase(object):
+
     def setup(self):
         xml_data = Mock()
         xml_data.get_name = Mock(
@@ -28,6 +29,29 @@ class TestDiskFormatVagrantBase(object):
         self.vagrantconfig.get_virtualsize = Mock(
             return_value=42
         )
+
+    def config_create_image_format_mocks(
+            self, mock_rand, mock_mkdtemp, mock_open
+    ):
+        """
+        Creates mocks to test the function ``create_image_format`` in child
+        classes of DiskFormatVagrantBase.
+
+        :return: mock return_value of `open()`, this can be used to retrieve
+            values that were written to ``open``'d files
+        """
+        mock_rand.return_value = 0xa
+        mock_mkdtemp.return_value = 'tmpdir'
+
+        mock_open.return_value = MagicMock(spec=io.IOBase)
+        file_handle = mock_open.return_value.__enter__.return_value
+
+        return file_handle
+
+
+class TestDiskFormatVagrantBase(VagrantTestBase):
+    def setup(self):
+        super(TestDiskFormatVagrantBase, self).setup()
         self.disk_format = DiskFormatVagrantBase(
             self.xml_state, 'root_dir', 'target_dir',
             {'vagrantconfig': self.vagrantconfig}
@@ -80,11 +104,9 @@ class TestDiskFormatVagrantBase(object):
             end
         ''').strip()
 
-        mock_rand.return_value = 0xa
-        mock_mkdtemp.return_value = 'tmpdir'
-
-        mock_open.return_value = MagicMock(spec=io.IOBase)
-        file_handle = mock_open.return_value.__enter__.return_value
+        file_handle = self.config_create_image_format_mocks(
+            mock_rand, mock_mkdtemp, mock_open
+        )
 
         self.disk_format.create_image_format()
 

--- a/test/unit/storage_subformat_vagrant_libvirt_test.py
+++ b/test/unit/storage_subformat_vagrant_libvirt_test.py
@@ -1,29 +1,16 @@
-import io
 from textwrap import dedent
-from mock import (
-    patch, Mock, MagicMock, call
-)
+from mock import patch, Mock, call
 
 from .test_helper import patch_open
+from .storage_subformat_vagrant_base_test import VagrantTestBase
 
 from kiwi.storage.subformat.vagrant_libvirt import DiskFormatVagrantLibVirt
 
 
-class TestDiskFormatVagrantLibVirt(object):
+class TestDiskFormatVagrantLibVirt(VagrantTestBase):
     def setup(self):
-        xml_data = Mock()
-        xml_data.get_name = Mock(
-            return_value='some-disk-image'
-        )
-        self.xml_state = Mock()
-        self.xml_state.xml_data = xml_data
-        self.xml_state.get_image_version = Mock(
-            return_value='1.2.3'
-        )
-        self.vagrantconfig = Mock()
-        self.vagrantconfig.get_virtualsize = Mock(
-            return_value=42
-        )
+        super(TestDiskFormatVagrantLibVirt, self).setup()
+
         self.disk_format = DiskFormatVagrantLibVirt(
             self.xml_state, 'root_dir', 'target_dir',
             {'vagrantconfig': self.vagrantconfig}
@@ -72,15 +59,15 @@ class TestDiskFormatVagrantLibVirt(object):
         self, mock_open, mock_create_box_img, mock_rand,
         mock_mkdtemp, mock_command
     ):
-        mock_mkdtemp.return_value = 'tmpdir'
         mock_create_box_img.return_value = ['arbitrary']
-        mock_open.return_value = MagicMock(spec=io.IOBase)
-        file_handle = mock_open.return_value.__enter__.return_value
+        file_handle = self.config_create_image_format_mocks(
+            mock_rand, mock_mkdtemp, mock_open
+        )
         self.disk_format.create_image_format()
         assert file_handle.write.call_args_list[1] == call(
             dedent('''
                 Vagrant.configure("2") do |config|
-                  config.vm.base_mac = "00163E010101"
+                  config.vm.base_mac = "00163E0A0A0A"
                   config.vm.provider :libvirt do |libvirt|
                     libvirt.driver = "kvm"
                   end


### PR DESCRIPTION
Fixes huge number of changes from #947.

Changes proposed in this pull request:
* move the initialization of the testing Mocks into `VagrantTestBase` 
* provide an initialization of the mocks for `test_create_image_format()` in that base class too

This removes code duplication from the unit tests.