### PR TITLE
Write sha256sum --check compatible shasum format

### DIFF
--- a/kiwi/tasks/result_bundle.py
+++ b/kiwi/tasks/result_bundle.py
@@ -162,7 +162,11 @@ class ResultBundleTask(CliTask):
                     log.info('--> Creating SHA 256 sum')
                     checksum = Checksum(bundle_file)
                     with open(bundle_file + '.sha256', 'w') as shasum:
-                        shasum.write(checksum.sha256())
+                        shasum.write(
+                            '{0}  {1}'.format(
+                                checksum.sha256(), bundle_file_basename
+                            )
+                        )
 
     def _help(self):
         if self.command_args['help']:

--- a/test/unit/tasks_result_bundle_test.py
+++ b/test/unit/tasks_result_bundle_test.py
@@ -135,6 +135,11 @@ class TestResultBundleTask(object):
             compress.compressed_filename
         )
         checksum.sha256.assert_called_once_with()
+        self.file_mock.write.assert_called_once_with(
+            '{0}  test-image-1.2.3-Build_42'.format(
+                checksum.sha256.return_value
+            )
+        )
 
     @patch('kiwi.tasks.result_bundle.Result.load')
     @patch('kiwi.tasks.result_bundle.Command.run')


### PR DESCRIPTION
Change the output format of the bundler shasum file to be
compatible with a 'sha256sum --check' call.
This fixes bsc#1127173


