### PR TITLE
Extend documentation

### DIFF
--- a/doc/source/building.rst
+++ b/doc/source/building.rst
@@ -24,7 +24,7 @@ Building Images
 * ISO Hybrid Live Image
 
   An iso image which can be dumped on a CD/DVD or USB stick
-  and boots off from this media without interferring with other
+  and boots off from this media without interfering with other
   system storage components. A useful pocket system for testing
   and demo and debugging purposes.
 
@@ -44,7 +44,7 @@ Building Images
 * PXE root File System Image
 
   A root filesystem image which can be deployed via KIWI's PXE netboot
-  infrastructure. A client configuration file on the pxe server controlls
+  infrastructure. A client configuration file on the pxe server controls
   how the root filesystem image should be deployed. Many different
   deployment strategies are possible, e.g root over NBD, AoE or NFS for
   diskless and diskfull clients.
@@ -68,8 +68,8 @@ which are **equal** or **newer** compared to the following list:
 *  openSUSE Leap 42
 *  Red Hat Enterprise 7
 *  SUSE Linux Enterprise 12
-*  Tumbleweed
-*  Ubuntu Xenial
+*  openSUSE Tumbleweed
+*  Ubuntu 16.04 (Xenial Xerus)
 
 For anything older please consider to use the legacy KIWI version *v7.x*
 For more details on the legacy kiwi, see: :ref:`legacy_kiwi`.

--- a/doc/source/building/build_in_buildservice.rst
+++ b/doc/source/building/build_in_buildservice.rst
@@ -1,27 +1,197 @@
-Building in the Open Buildservice
-=================================
+Building in the Open Build Service
+==================================
 
 .. hint:: **Abstract**
 
    This document gives a brief overview how to build images with
-   KIWI in version |version| inside of the Open Buildservice.
+   KIWI in version |version| inside of the Open Build Service.
    A tutorial on the Open Buildservice itself can be found here:
    https://en.opensuse.org/openSUSE:Build_Service_Tutorial
 
 
-The next generation KIWI is fully integrated with the build service.
+The next generation KIWI is fully integrated with the Open Build Service.
 In order to start it's best to checkout one of the integration test
 image build projects from the base Testing project
-`Virtualization:Appliances:Images:Testing_ARCH` at:
+`Virtualization:Appliances:Images:Testing_$ARCH` at:
 
 https://build.opensuse.org
 
-In order to use the next generation KIWI to build an appliance in the
-build service it is required to add the Builder project as
-repository to the KIWI XML configuration like in the following example:
+For example the test images for x86 can be found `here
+<https://build.opensuse.org/project/show/Virtualization:Appliances:Images:Testing_x86>`__.
+
+
+Advantages of using the Open Build Service (OBS)
+------------------------------------------------
+
+The Open Build Service offers multiple advantages over running KIWI
+locally:
+
+* OBS will host the latest successful build for you without having to setup
+  a server yourself.
+
+* As KIWI is fully integrated into OBS, OBS will automatically rebuild your
+  images if one of the included packages or one of its dependencies or KIWI
+  itself get updated.
+
+* The builds will no longer have to be executed on your own machine, but
+  will run on OBS, thereby saving you resources. Nevertheless, if a build
+  fails, you get a notification via email (if enabled in your user's
+  preferences).
+
+
+Differences Between Building Locally and on OBS
+-----------------------------------------------
+
+Note, there is a number of differences when building images with KIWI using
+the Open Build Service. Your image that build locally just fine, might not
+build without modifications.
+
+The notable differences to running KIWI locally include:
+
+* OBS will pick the KIWI package from the available repositories that you
+  specified in :file:`config.xml`/:file:`config.kiwi`. This means, that you
+  will be very likely building with a different KIWI version in the Open
+  Build Service.
+  This is especially relevant when building images for older versions like
+  SUSE Linux Enterprise. Therefore, include the custom appliances
+  repository as described in the following section:
+  :ref:`obs-recommended-settings`.
+
+* When KIWI runs on OBS, OBS will extract the list of packages from
+  :file:`config.xml` and use it to create a build root. In contrast to a
+  local build (where your distributions package manager will resolve the
+  dependencies and install the packages), OBS will **not** build your image
+  if there are multiple packages that could be chosen to satisfy the
+  dependencies of your packages. This manifests as errors like this:
+
+  .. code:: bash
+
+     unresolvable: have choice for SOMEPACKAGE: SOMEPAKAGE_1 SOMEPACKAGE_2
+
+  This can be solved by explicitly specifying one of the two packages in
+  the project configuration via the following setting:
+
+  .. code:: bash
+
+     Prefer: SOMEPACKAGE_1
+
+  Place the above line into the project configuration, which can be
+  accessed either via the web interface (click on the tab ``Project
+  Config`` on your project's main page) or via ``osc meta -e prjconf``.
+
+* OBS can only build a single image type, for example it cannot build a VMX
+  disk and a live ISO from one :file:`config.xml`. A configuration file
+  that contains multiple image types will therefore not work in the Open
+  Build Service.
+  Split the configuration file into two (or more) :file:`.kiwi` files and
+  provide them as separate packages inside your project.
+
+* OBS projects do not support subfolders, thus you must provide the overlay
+  files packed as an archive called :file:`root.tar.gz`.
+
+* OBS projects do not support the use of the ``namedCollection`` section.
+
+  A specification of ``<namedCollection name="collection_name"/>`` is used
+  to pass the information to install a collection of packages to the used
+  package manager. The package manager can resolve that information only if
+  the repository metadata contains the information about that collection
+  and its packages. If the Open Build Service builds the image, it resolves
+  the given package list using its own SAT based solver. That result is
+  used by the Open Build Service to create temporary repositories of the
+  same names as they got configured in the KIWI XML description. Those
+  repositories don't contain the metadata to resolve collections.
+
+  Even though KIWI uses the package manager to register the repositories,
+  one should keep in mind that the repositories the Open Build Service
+  creates, contain just a subset of the data that the real repositories
+  provide.
+
+  Furthermore, the Open Build Service applies a different dependency
+  resolution mechanism to create the repositories before KIWI is
+  called. The differences compared to the dependency resolution of the
+  selected package manager when KIWI calls it are:
+
+  * In the Open Build Service the order of repositories in the XML description
+    matters
+  * In the Open Build Service package dependencies from file provides are not
+    resolved
+
+  Because of this reason an image build that resolves well outside of the
+  Open Build Service might no longer do so on OBS.
+
+
+.. _obs-recommended-settings:
+
+Recommendations
+---------------
+
+Working with OBS
+^^^^^^^^^^^^^^^^
+
+Although OBS is an online service, it is not necessary to test every change
+by uploading it. OBS will use the same process as ``osc build`` does, so if
+your image builds locally via ``osc build`` it should also build online on
+OBS.
+
+
+Repository Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+We strongly encourage everyone to include the following repository in the
+KIWI :file:`config.xml` configuration file:
 
 .. code:: xml
 
- <repository type="rpm-md" alias="kiwi-next-generation">
-     <source path="obs://Virtualization:Appliances:Builder/Factory"/>
- </repository>
+  <repository type="rpm-md" alias="kiwi-next-generation">
+      <source path="obs://Virtualization:Appliances:Builder/$DISTRO"/>
+  </repository>
+
+Replace ``$DISTRO`` with the appropriate name for the distribution that you
+are currently building. This repository contains the latest stable build of
+KIWI (which is in fact the same repository that was recommended to be added
+in :ref:`kiwi-installation`) and will ensure that OBS will use the most up
+to date version of KIWI when building your appliance, thereby reducing the
+possible differences to a local build.
+
+
+Project Configuration
+^^^^^^^^^^^^^^^^^^^^^
+
+When setting up the project enable the ``images`` repository: it can be
+found at the bottom of the selection screen that appears when clicking
+``Add from a Distribution`` in the ``Repositories`` tab. Or specify it
+manually in the project configuration (it can be accessed via ``osc meta -e
+prj``):
+
+.. code:: xml
+
+  <repository name="images">
+    <arch>x86_64</arch>
+  </repository>
+
+
+Due to the nature of OBS' dependency resolution mechanism a lot of
+``Prefer:``, ``Substitute:``, ``Preinstall:`` and ``Support:`` directives
+are required for an image to build successfully without having choices or
+conflicts for packages. We therefore recommend to initially copy the
+current project configuration of the testing project
+`Virtualization:Appliances:Images:Testing_$ARCH` into your own project as a
+start and tweak it from there instead of starting from scratch.
+
+The Open Build Service will by default create the same output file as KIWI
+when run locally, but with a custom filename ending (that is unfortunately
+unpredictable). This has the consequence that the download URL of your
+image will change with every rebuild (and thus break automated
+scripts). This behavior can be deactivated by adding the following line
+into the project's configuration:
+
+.. code:: bash
+
+   Repotype: staticlinks
+
+Furthermore, if you are building images of openSUSE Leap 15 the above
+setting is not sufficient. The following additional line is required:
+
+.. code:: bash
+
+   Release: <CI_CNT>.<B_CNT>

--- a/doc/source/building/working_with_images/vagrant_setup.rst
+++ b/doc/source/building/working_with_images/vagrant_setup.rst
@@ -17,17 +17,18 @@ Virtualization technologies. To run a system, Vagrant needs so-called
 **boxes**. A box is a TAR archive containing a virtual disk image and
 some metadata.
 
-To build Vagrant boxes, use
+To build Vagrant boxes, you can use
 `veewee <https://github.com/jedi4ever/veewee>`_ which builds boxes
-based on AutoYaST. As an alternative, use `Packer <https://www.packer.io>`_,
-which is providedby Vagrant itself.
+based on AutoYaST. As an alternative, `Packer <https://www.packer.io>`_ can
+be utilized, which is provided by Hashicorp itself.
 
 Both tools are based on the official installation media (DVDs) as shipped
 by the distribution vendor.
 
-The KIWI way of building images might be helpful, if such a media does
-not exist. For example, if the distribution is still under development or
-you want to use a collection of your own repositories.
+The KIWI way of building images might be helpful, if such a media does not
+exist or does not suit your needs. For example, if the distribution is
+still under development or you want to use a collection of your own
+repositories.
 
 In addition, you can use the KIWI image description as source for the
 `Open Build Service <https://openbuildservice.org>`_ which allows
@@ -69,21 +70,40 @@ the following changes are required:
       </users>
 
    This adds the **vagrant** user to the system and applies the
-   name of the user as the password for login. Change this as you
-   see fit.
+   name of the user as the password for login.
 
 4. Integrate public SSH key
 
-   Reach out to
-   `Insecure Keys <https://github.com/hashicorp/vagrant/tree/master/keys>`_
-   for details on this keys. Add the public key to the
-   box as overlay file in your image description at
-   :file:`home/vagrant/.ssh/authorized_keys`
+   Vagrant requires an insecure public key pair [#f1]_ to be added to the
+   authorized keys for the user ``vagrant`` so that Vagrant itself can
+   connect to the box via ssh.
+   The key can be obtained from `GitHub
+   <https://github.com/hashicorp/vagrant/blob/master/keys/vagrant.pub>`_
+   and should be inserted into the file
+   :file:`home/vagrant/.ssh/authorized_keys`, which can be added as an
+   overlay file into the image description.
 
-5. Setup and start SSH daemon
+   Keep in mind to set the file system permissions of
+   :file:`home/vagrant/.ssh/` and :file:`home/vagrant/.ssh/authorized_keys`
+   correctly, otherwise Vagrant will not be able to connect to your
+   box. The following snippet can be added to :file:`config.sh`:
 
-   In :file:`config.sh` add the start of the sshd and the initial
-   creation of machine keys as follows:
+   .. code:: bash
+
+      chmod 0600 /home/vagrant/.ssh/authorized_keys
+      chown -R vagrant:vagrant /home/vagrant/
+
+5. Create the default shared folder
+
+   Vagrant boxes usually provide a default shared folder under
+   :file:`/vagrant`. Consider adding this empty folder to your overlay
+   files and ensure that the user ``vagrant`` has write permissions to
+   it.
+
+6. Setup and start SSH daemon
+
+   In :file:`config.sh`, add the start of sshd and the initial creation of
+   machine keys as follows:
 
    .. code:: bash
 
@@ -97,15 +117,30 @@ the following changes are required:
       #--------------------------------------
       suseInsertService sshd
 
-   Also make sure to setup **UseDNS=no** in :file:`etc/ssh/sshd_config`
-   This can be done by an overlay file or clever patching of
-   the file in the above mentioned :file:`config.sh` file.
+   Also make sure to add the line **UseDNS=no** into
+   :file:`/etc/ssh/sshd_config`. This can be done by an overlay file or by
+   patching the file in the above mentioned :file:`config.sh` file.
 
-6. Configure sudo for Vagrant user
+7. Configure sudo for the Vagrant user
 
-   Add the :file:`etc/sudoers` file to the box as overlay file and make
-   sure the user: **vagrant** is configured to allow passwordless root
-   permissions.
+   Vagrant expects to have passwordless root permissions via ``sudo`` to be
+   able to setup your box. Add the following line to :file:`/etc/sudoers`
+   or add it into a new file :file:`/etc/sudoers.d/vagrant`:
+
+   .. code::
+
+      vagrant ALL=(ALL) NOPASSWD: ALL
+
+   You can also use :command:`visudo` to verify that the resulting
+   :file:`/etc/sudoers` or :file:`/etc/sudoers.d/vagrant` are valid:
+
+   .. code:: bash
+
+      visudo -cf /etc/sudoers
+      if [ $? -ne 0 ]; then
+          exit 1
+      fi
+
 
 An image built with the above setup creates a box file with the
 extension :file:`.vagrant.libvirt.box`. That box file can now be
@@ -117,8 +152,9 @@ added to vagrant with the command:
 
 .. note::
 
-   Using the box requires a correct Vagrant installation on your machine.
-   The libvirtd daemon and the libvirt default network need to be running.
+   Using the box requires a correct Vagrant installation on your machine,
+   the plugin ``vagrant-libvirt`` to be installed and the libvirtd daemon
+   to be running.
 
 Once added to Vagrant, boot the box and log in
 with the following sequence of :command:`vagrant` commands:
@@ -132,5 +168,9 @@ with the following sequence of :command:`vagrant` commands:
 .. note:: Vagrant Providers
 
    Currently, KIWI only supports the libvirt provider. There are
-   other providers like virtualbox and also vmware available which
-   requires a different box layout currently not supported by KIWI.
+   also other providers available, like virtualbox and vmware, which
+   require a different box layout (currently not supported by KIWI).
+
+
+.. [#f1] The insecure key is removed from the box when the it is first
+         booted via Vagrant.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -18,9 +18,9 @@ build Linux system appliances.
 .. toctree::
    :maxdepth: 1
 
-   overview
-   installation
    quickstart
+   installation
+   overview
    building
    commands
    development

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -33,10 +33,41 @@ a pre-configured application for a specific use case. The appliance is
 provided as an image file and needs to be deployed to, or activated in
 the target system or service.
 
-In KIWI the appliance is specified by a collection of human readable files
-in a directory, also called as the `image description`. At least one XML
-file :file:`config.xml` or :file:`.kiwi` is required. In addition
-there may be as well other files like scripts or configuration data.
+KIWI can create appliances in various forms: beside classical installation
+ISOs and images for virtual machines it can also build images that boot via
+PXE or Vagrant boxes.
+
+In KIWI, the appliance is specified via a collection of human readable files
+in a directory, also called the `image description`. At least one XML file
+:file:`config.xml` or :file:`.kiwi` is required. In addition there may as
+well be other files like scripts or configuration data.
+
+
+Use Cases
+---------
+
+Not convinced yet? You can find a selection of the possible uses cases
+below:
+
+* You are a system administrator and wish to create a customized installer
+  for your network that includes additional software and your organizations
+  certificates? KIWI allows you to select which packages will be included
+  in the final image. On top of that you can add files to arbitrary
+  locations in the filesystem, for example to include SSL or SSH keys. You
+  can also tell KIWI to create an image that can be booted via PXE, so that
+  you don't even have to leave your desk to reinstall a system.
+
+* You want to create a custom spin of your favorite Linux distribution with
+  additional repositories and packages that are not present by default?
+  With KIWI you can configure the repositories of your final image via the
+  image description and tweak the list of packages that are going to be
+  installed to match your target audience.
+
+* The Raspberry Pi that is coordinating your home's Internet of Thing (IoT)
+  devices got very popular among your friends and every single one of them
+  wants a copy of that? KIWI will build you ready to deploy images for your
+  Raspberry Pi, tweaked to your needs.
+
 
 Contact
 -------
@@ -49,7 +80,7 @@ Contact
 
 * `Matrix <https://matrix.org/blog/home/>`__
 
-  An open network for secure, decentralized communication. Please find
-  the `kiwi` room via `Riot <https://riot.im/app/>`__ on the web or by
-  using the `WeeChat <https://matrix.org/docs/projects/client/weechat.html>`__
-  client.
+  An open network for secure, decentralized communication. Please find the
+  `kiwi` room via `Riot <https://riot.im/app/>`__ on the web or by using
+  the supported `clients
+  <https://matrix.org/docs/projects/clients-matrix>`__.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -4,7 +4,7 @@ KIWI Documentation
 ==================
 
 Welcome to the documentation for KIWI |version|- the command line utility to
-build linux system appliances.
+build Linux system appliances.
 
 .. sidebar:: Links
 
@@ -29,7 +29,7 @@ Appliance ?
 -----------
 
 An appliance is a ready to use image of an operating system including
-a preconfigured application for a specific use case. The appliance is
+a pre-configured application for a specific use case. The appliance is
 provided as an image file and needs to be deployed to, or activated in
 the target system or service.
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -6,8 +6,8 @@ Installation
 .. hint::
 
    This document describes how to install KIWI. Apart from the preferred
-   method to install KIWI via rpm, it is also provided on pypi and can
-   be installed via pip.
+   method to install KIWI via rpm, it is also available on `pypi
+   <https://pypi.org/project/kiwi/>`__ and can be installed via pip.
 
 KIWI can be installed via different methods. For this guide, only the
 installation as a packages through a package manager is described.
@@ -17,7 +17,7 @@ buildservice <http://download.opensuse.org/repositories/Virtualization:/Applianc
 
 To install KIWI, do:
 
-1. Open the URL http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder
+1. Open the URL https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder
    in your browser.
 
 2. Right-click on the link of your preferred operating system and

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -9,10 +9,10 @@ Installation
    method to install KIWI via rpm, it is also provided on pypi and can
    be installed via pip.
 
-KIWI can be installed with different methods. For this guide, only the
+KIWI can be installed via different methods. For this guide, only the
 installation as a packages through a package manager is described.
 
-Packages for the new KIWI version are provided at the `openSUSE
+Packages for the new KIWI version are provided by the `openSUSE
 buildservice <http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder>`__.
 
 To install KIWI, do:
@@ -48,9 +48,9 @@ To install KIWI, do:
 Example Appliance Descriptions
 ------------------------------
 
-For use with the next generation KIWI there is also a GitHub project
-hosting example appliance descriptions. Users who need an example to
-start with should checkout the project as follows:
+There is a GitHub project hosting example appliance descriptions to be used
+with the next generation KIWI. Users who need an example to start with
+should clone the project as follows:
 
 .. code:: bash
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -9,13 +9,16 @@ Installation
    method to install KIWI via rpm, it is also available on `pypi
    <https://pypi.org/project/kiwi/>`__ and can be installed via pip.
 
-KIWI can be installed via different methods. For this guide, only the
-installation as a packages through a package manager is described.
 
-Packages for the new KIWI version are provided by the `openSUSE
-buildservice <http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder>`__.
+Installation from OBS
+---------------------
 
-To install KIWI, do:
+The most up to date packages of KIWI can be found on the Open Build Service
+in the `Virtualization:Appliances:Builder
+<https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder>`__
+project.
+
+To install KIWI, follow these steps:
 
 1. Open the URL https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder
    in your browser.
@@ -23,25 +26,89 @@ To install KIWI, do:
 2. Right-click on the link of your preferred operating system and
    copy the URL. In Firefox it is the menu :menuselection:`Copy link address`.
 
-3. Insert the copied URL from the last step in your shell. The ``DIST``
+3. Insert the copied URL from the last step into your shell. The ``DIST``
    placeholder contains the respective distribution.
-   Use :command:`zypper addrepo` to add it to your list of repositories:
+   Use :command:`zypper addrepo` to add it to the list of your repositories:
 
    .. code-block:: shell-session
 
        $ sudo zypper addrepo http://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/<DIST> appliance-builder
 
-4. Install KIWI:
+   If your distribution is not using :command:`zypper`, please use your
+   package manager's appropriate command instead. For :command:`dnf` that
+   is:
+
+   .. code-block:: shell-session
+
+      $ sudo dnf config-manager --add-repo https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/<DIST>/Virtualization:Appliances:Builder.repo
+
+4. Add the repositories' signing-key to your package manager's
+   database. For rpm run:
+
+   .. code-block:: shell-session
+
+      $ sudo rpm --import https://build.opensuse.org/projects/Virtualization:Appliances:Builder/public_key
+
+   And verify that you got the correct key:
+
+   .. code-block:: shell-session
+
+      $ rpm -qi gpg-pubkey-74cbe823-* | gpg2
+      gpg: WARNING: no command supplied.  Trying to guess what you mean ...
+      pub   dsa1024 2009-05-04 [SC] [expires: 2020-10-09]
+            F7E82012C74FD0B85F5334DC994B195474CBE823
+      uid           Virtualization:Appliances OBS Project <Virtualization:Appliances@build.opensuse.org>
+
+5. Install KIWI:
 
    .. note:: Multipython packages
 
-      This version of KIWI is provided for python 2 and python 3 versions.
-      The following information is based on the installation of the
-      python3-kiwi package
+      This version of KIWI is provided as packages for python 2 and
+      python 3. The following assumes that you will install the python 3 package.
 
    .. code-block:: shell-session
 
        $ sudo zypper in python3-kiwi
+
+
+Installation from your distribution's repositories
+--------------------------------------------------
+
+.. note::
+
+   There are many packages that contain the name KIWI in their name, some
+   of these are even python packages. Please double check the packages'
+   description whether it is actually the KIWI Appliance builder before
+   installing it.
+
+
+Some Linux distributions ship KIWI in their official
+repositories. These include openSUSE Tumbleweed, openSUSE Leap and Fedora
+since version 28.
+
+To install KIWI on openSUSE, run the following command:
+
+.. code-block:: shell-session
+
+   $ sudo zypper install python3-kiwi
+
+On Fedora, use the following command instead:
+
+.. code-block:: shell-session
+
+   $ sudo dnf install kiwi-cli
+
+
+Installation from PyPI
+----------------------
+
+KIWI can be obtained from the Python Package Index (PyPi) via Python's
+package manager pip:
+
+.. code-block:: shell-session
+
+   $ pip install kiwi
+
 
 .. _example-descriptions:
 

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -16,6 +16,7 @@ Overview
 
 Conceptual Overview
 -------------------
+
 A system image (usually called "image"), is a *complete installation* of a Linux
 system within a file. The image represents an operation system and,
 optionally, contains the "final" configuration.
@@ -40,7 +41,7 @@ Terminology
 
 Appliance
    An appliance is a ready to use image of an operating system
-   including a preconfigured application for a specific use case.
+   including a pre-configured application for a specific use case.
    The appliance is provided as an image file and needs to be
    deployed to, or activated in the target system or service.
 
@@ -58,10 +59,10 @@ Image Description
 Overlay Files
    A directory structure with files and subdirectories stored as part
    of the Image Description. This directory structure is packaged as
-   a file :file:`root.tar.gz` or stored below a directory named
-   :file:`root`. The content of the directory structure is copied over
-   the existing file system (overlayed) of the appliance root.
-   This includes permissions and attributes as a supplement.
+   a file :file:`root.tar.gz` or stored inside a directory named
+   :file:`root`. The content of the directory structure is copied on top of
+   the the existing file system (overlayed) of the appliance root.
+   This also includes permissions and attributes as a supplement.
 
 KIWI
    An OS appliance builder.
@@ -69,24 +70,25 @@ KIWI
 Virtualization Technology
    Software simulated computer hardware. A virtual machine acts like
    a real computer, but is separated from the physical hardware.
-   Within this documentation the Qemu virtualization system is used.
+   Within this documentation the QEMU virtualization system is
+   used. Another popular alternative is Virtualbox.
 
 System Requirements
 -------------------
 
 To use and run KIWI, you need:
 
-* A recent Linux distribution, see :ref:`supported-distributions` for details.
-  Alternatively a Linux distribution which supports the docker container
-  system as it would be required when running KIWI in a container, see:
+* A recent Linux distribution, see :ref:`supported-distributions` for
+  details. Alternatively a Linux distribution which supports the docker
+  container system, where KIWI can be run inside a container, see:
   :ref:`container-building`
 
 * Enough free disk space to build and store the image. We recommend a
   minimum of 10GB.
 
 * Python version 2.7, 3.4 or higher; as KIWI supports both Python
-  versions, the information in this guide applies also to both
-  packages, be it ``python3-kiwi`` or ``python2-kiwi``.
+  versions, the information in this guide applies to both packages, be it
+  ``python3-kiwi`` or ``python2-kiwi``.
 
 * Git (package ``git-core``) to clone a repository.
 

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -11,8 +11,8 @@ Overview
 .. toctree::
    :maxdepth: 1
 
-   overview/legacy_kiwi
    overview/workflow
+   overview/legacy_kiwi
 
 Conceptual Overview
 -------------------

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -84,7 +84,7 @@ To use and run KIWI, you need:
   :ref:`container-building`
 
 * Enough free disk space to build and store the image. We recommend a
-  minimum of 10GB.
+  minimum of 15GB.
 
 * Python version 2.7, 3.4 or higher; as KIWI supports both Python
   versions, the information in this guide applies to both packages, be it

--- a/doc/source/overview/workflow.rst
+++ b/doc/source/overview/workflow.rst
@@ -33,7 +33,7 @@ images that:
 
 The image creation process with KIWI is automated and does not require any
 user interaction. The information required for the image creation process is
-provided by the primary configuration file named :file:`config.xml`. 
+provided by the primary configuration file named :file:`config.xml`.
 This file is validated against the schema documented in
 :ref:`Schema Documentation <schema-docs>` section.
 In addition, the image can optionally be customized
@@ -42,7 +42,7 @@ and by using an *overlay tree (directory)* called :file:`root`.
 See `Components of an Image Description`_ section for further details.
 
 .. note:: Previous Knowledge
-    
+
     This documentation assumes that you are familiar with the general
     concepts of Linux, including the boot process, and distribution concepts
     such as package management.
@@ -78,7 +78,7 @@ provided in the :file:`config.xml` configuration file.
 .. note:: KIWI configuration file name convention
 
    KIWI at first place looks for a configuration file named
-   :file:`config.xml`. If there is no such file, KIWI looks for files with a 
+   :file:`config.xml`. If there is no such file, KIWI looks for files with a
    :regexp:`*.kiwi` extension. In that case, the first match is the loaded file.
 
 .. _prepare-step:
@@ -106,7 +106,7 @@ The prepare step consists of the following substeps:
 #. **Create Target Root Directory.**
 
    KIWI will exit with an error if the target root tree already exists to
-   avoid accidental deletion of an existing unpacked image. 
+   avoid accidental deletion of an existing unpacked image.
 
 #. **Install Packages.**
 
@@ -196,14 +196,14 @@ KIWI:
    the target root tree. The script is usually used to remove files that are no
    needed in the final image. For example, if an appliance is being built for a
    specific hardware, unnecessary kernel drivers can be removed using this
-   script. 
-   
-#. **Create Requested Image Type.** 
+   script.
+
+#. **Create Requested Image Type.**
 
    The image types that can be created from a prepared image tree depend on the
    types specified in the image description :file:`config.xml` file. The
    configuration file must contain at least one ``type`` element. see: :ref:`building_types`
-  
+
 .. _description_components:
 
 Components of an Image Description
@@ -230,7 +230,7 @@ These are the optional components of an image description:
 
 #. Overlay tree directory
 
-   The *overlay tree* is a folder (called :file:`root`) 
+   The *overlay tree* is a folder (called :file:`root`)
    or a tarball file (called :file:`root.tar.gz`) that contains
    files and directories that will be copied to the target image build tree
    during the :ref:`prepare step <prepare-step>`. It is executed
@@ -283,22 +283,22 @@ See below a common template for `config.sh` script:
    #--------------------------------------
    test -f /.kconfig && . /.kconfig
    test -f /.profile && . /.profile
-   
+
    #======================================
    # Greeting...
    #--------------------------------------
    echo "Configure image: [$kiwi_iname]..."
-   
+
    #======================================
    # Mount system filesystems
    #--------------------------------------
    baseMount
-   
+
    #======================================
    # Call configuration code/functions
    #--------------------------------------
    ...
-   
+
    #======================================
    # Umount kernel filesystems
    #--------------------------------------
@@ -312,7 +312,7 @@ See below a common template for `config.sh` script:
 Common Functions
 ''''''''''''''''
 
-The :file:`.kconfig` file allows to make use of a common set of functions. 
+The :file:`.kconfig` file allows to make use of a common set of functions.
 Functions specific to SUSE Linux specific begin with the name suse.
 Functions applicable to all linux systems starts with the name base.
 The following list describes the functions available inside the
@@ -381,7 +381,7 @@ The following list describes the functions available inside the
   example:
 
   .. code:: bash
- 
+
      baseStripMans more less
 
 ``baseStripRPM``
@@ -411,7 +411,7 @@ The following list describes the functions available inside the
 
 ``Echo {echo commandline}``
   Helper function to print a message to the controlling terminal.
- 
+
 ``Rm {list of files}``
   Helper function to delete files and announce it to log.
 
@@ -530,15 +530,15 @@ fine tune the resulting unpacked image are quickly described:
   whipes any :file:`/etc/machine-id` content, leaving it as an empty file.
   Note this is only applied for images based on dracut initrd, on container
   images, for instance, this setting is not applied.
-  
+
   In case this setting is required also for a non dracut based image
   this could be also achieved by clearing :file:`/etc/machine-id`
   in :file:`config.sh`.
 
   .. note:: Avoid interactive boot
 
-     It is important to remark that the file :file:`/etc/machine-id`    
-     is set to an empty file instead of deleting it. Systemd may trigger 
+     It is important to remark that the file :file:`/etc/machine-id`
+     is set to an empty file instead of deleting it. Systemd may trigger
      :command:`systemd-firstboot` service if this file is not present,
      which leads to an interactive firstboot where the user is
      asked to provide some data.
@@ -552,7 +552,7 @@ fine tune the resulting unpacked image are quickly described:
      different files. This is the case for SLE-12 based images, so
      in those cases it is recommended to add into the :file:`config.sh`
      the symlink creation:
-  
+
      .. code:: bash
 
         #======================================
@@ -589,17 +589,17 @@ See below a common template for :file:`images.sh` script:
    #--------------------------------------
    test -f /.kconfig && . /.kconfig
    test -f /.profile && . /.profile
-   
+
    #======================================
    # Greeting...
    #--------------------------------------
    echo "Configure image: [$kiwi_iname]..."
-   
+
    #======================================
    # Call configuration code/functions
    #--------------------------------------
    ...
-   
+
    #======================================
    # Exit safely
    #--------------------------------------
@@ -687,7 +687,7 @@ variables.
 
 ``$kiwi_size``
   The predefined size value for this image. This is not the computed size
-  but only the optional size value of the preferences section in 
+  but only the optional size value of the preferences section in
   :file:`config.xml`.
 
 ``$kiwi_compressed``
@@ -769,7 +769,7 @@ of KIWI the following dracut modules are used:
    what and how the initrd behaves by its own implementation. This concept
    is mostly used in PXE environments which are usually highly customized
    and requires a specific boot and deployment workflow.
-   
+
 
 Boot Image Hook-Scripts
 .......................

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -12,15 +12,35 @@ Quick Start
 Before you start
 ----------------
 
-Make sure you have installed KIWI and the example collection as
-explained in :ref:`kiwi-installation`
+1. Install KIWI first, either via your distributions' package manager (see
+   :ref:`kiwi-installation`) or via:
 
-Build your first image
+   .. code:: bash
+
+      $ pip install kiwi
+
+2. Clone the repository containing example appliances (see
+   :ref:`example-descriptions`):
+
+   .. code:: bash
+
+      $ git clone https://github.com/SUSE/kiwi-descriptions
+
+
+Choose a First Image
+--------------------
+
+Take a look which images are available in the example appliances repository
+and select one that matches your desired image as close as possible. Or
+just use the one given in the examples below.
+
+
+Build your First Image
 ----------------------
 
 Your first image will be a simple system disk image which can run
-in any full virtualization system like for example QEMU. Call the following
-KIWI command in order to build it
+in any full virtualization system like QEMU. Invoke the following KIWI
+command in order to build it:
 
 .. code:: bash
 
@@ -28,14 +48,20 @@ KIWI command in order to build it
         --description kiwi-descriptions/suse/x86_64/suse-leap-42.3-JeOS \
         --target-dir /tmp/myimage
 
-Find the image with the suffix :file:`.raw` below :file:`/tmp/myimage`.
+The resulting image will be placed into the folder :file:`/tmp/myimage`
+with the suffix :file:`.raw`.
 
-Run your image
+If you don't wish to create a openSUSE Leap 42.3 image, substitute the
+folder following the ``--description`` option with another folder that
+contains the image description which you selected.
+
+
+Run your Image
 --------------
 
-Running an image actually means booting the operating system. In order
-to do that attach the disk image to a virtual system, in our case QEMU
-is used, and boot it as follows:
+Running an image actually means booting the operating system. In order to
+do that attach the disk image to a virtual system. In this example we use
+QEMU and boot it as follows:
 
 .. code:: bash
 
@@ -43,3 +69,12 @@ is used, and boot it as follows:
         -boot c
         -drive file=LimeJeOS-Leap-42.3.x86_64-1.42.3.raw,format=raw,if=virtio \
         -m 4096
+
+Tweak and Customize your Image
+------------------------------
+
+Now that you have successfully built and started your first image, you can
+start tweaking it to match your needs.
+
+Find the documentation of the appliance description files in the following
+sections.

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -5,7 +5,8 @@ Quick Start
 
 .. hint:: **Abstract**
 
-   This document describes how to start with KIWI, an OS appliance builder.
+   This document describes how to start working with KIWI, an OS appliance
+   builder.
    This description applies for version |version|.
 
 Before you start


### PR DESCRIPTION
This PR proposes some extensions to the documentation.

Changes proposed in this pull request:
* Summary of my pain points & the solution of these when working with KIWI + OBS added to `build_in_buildservice.rst`
* Extension of `vagrant_setup.rst`
* Addition of an "advertising" section to `index.rst` (I can drop this one, not so sure whether this is a good idea)
* Reordering of some TOCs: I have switched the order of a few articles, so that the (imho) more important one appears **first** and thus lazy people (like me) are more likely to read them as I found them more important.
* minor spelling, grammar fixes, whitespace cleanup
