### PR TITLE
Add environment for running the unit tests with Python 3.7 to tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ jobs:
   include:
   - python: 3.6
     env: TOXENV=unit_py3_6,check,doc
+  - python: 3.7
+    dist: xenial
+    sudo: true
+    env: TOXENV=unit_py3_7,check,doc
   - python: 2.7
     env: TOXENV=unit_py2_7,check,doc
   - stage: deploy

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ skip_missing_interpreters = True
 skipsdist = True
 envlist =
     check,
+    unit_py3_7,
     unit_py3_6,
     unit_py3_4,
     unit_py2_7,
@@ -31,11 +32,13 @@ whitelist_externals =
     /bin/bash
 basepython =
     {check,packagedoc,doc,doc_travis}: python3
+    unit_py3_7: python3.7
     unit_py3_6: python3.6
     unit_py3_4: python3.4
     unit_py2_7: python2.7
 envdir =
     {check,packagedoc,doc,doc_travis}: {toxworkdir}/3
+    unit_py3_7: {toxworkdir}/3.7
     unit_py3_6: {toxworkdir}/3.6
     unit_py3_4: {toxworkdir}/3.4
     unit_py2_7: {toxworkdir}/2.7
@@ -102,6 +105,23 @@ commands =
         --cov-report=term-missing \
         --cov-fail-under=100 --cov-config .coveragerc {posargs}
 
+# Unit Test run with basepython set to 3.7
+[testenv:unit_py3_7]
+skip_install = True
+usedevelop = True
+setenv =
+    PYTHONPATH={toxinidir}/test
+    PYTHONUNBUFFERED=yes
+    WITH_COVERAGE=yes
+passenv =
+    *
+deps = {[testenv]deps}
+changedir=test/unit
+commands =
+    bash -c 'cd ../../ && ./setup.py develop'
+    pytest --doctest-modules --no-cov-on-fail --cov=kiwi \
+        --cov-report=term-missing --cov-fail-under=100 \
+        --cov-config .coveragerc {posargs}
 
 # Documentation build run suitable for doc deployment in package(rpm)
 [testenv:packagedoc]


### PR DESCRIPTION
Changes proposed in this pull request:
* Add an environment called `unit_py3_7` to `tox.ini` which runs the unit tests with Python 3.7
* Add a test run with Python 3.7 to Travis
