### PR TITLE
Ensure DNF is installed for kiwi itself and the test CentOS 7 appliance

### DIFF
--- a/build-tests/x86/test-image-centos/appliance.kiwi
+++ b/build-tests/x86/test-image-centos/appliance.kiwi
@@ -52,6 +52,9 @@
         <source path="obs://Fedora:EPEL:7/standard"/>
     </repository>
     <repository type="rpm-md">
+        <source path="obs://CentOS:CentOS-7/extras"/>
+    </repository>
+    <repository type="rpm-md">
         <source path="obs://CentOS:CentOS-7/update"/>
     </repository>
     <repository type="rpm-md">
@@ -99,6 +102,7 @@
         <package name="filesystem"/>
         <package name="basesystem"/>
         <package name="yum-plugin-priorities"/>
+        <package name="nextgen-yum4"/>
         <package name="grub2-efi-modules"/>
         <package name="grub2-efi"/>
         <package name="shim" arch="x86_64"/>

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -130,6 +130,10 @@ Requires:       dnf
 Provides:       kiwi-packagemanager:dnf
 Provides:       kiwi-packagemanager:yum
 %endif
+%if 0%{?suse_version}
+# If it's available, let's pull it in
+Recommends:     dnf
+%endif
 %if 0%{?fedora} >= 26 || 0%{?suse_version}
 Requires:       zypper
 Provides:       kiwi-packagemanager:zypper
@@ -207,11 +211,13 @@ Requires(postun): chkconfig
 Requires:       qemu-img
 Requires:       squashfs-tools
 Requires:       gdisk
-%endif
-%if 0%{?fedora} || 0%{?rhel}
 Requires:       dnf
 Provides:       kiwi-packagemanager:dnf
 Provides:       kiwi-packagemanager:yum
+%endif
+%if 0%{?suse_version}
+# If it's available, let's pull it in
+Recommends:     dnf
 %endif
 %if 0%{?fedora} >= 26 || 0%{?suse_version}
 Requires:       zypper


### PR DESCRIPTION
In e33f53aa4513c38a42736c82db3ec5e0b9da41d4, we switched to DNF when requesting YUM.
This now means we need to ensure DNF is installed for images where
we previously used YUM for that.

Fixes #972.

Changes proposed in this pull request:
* Adds `dnf` as a dependency on SUSE distros for kiwi
* Adds `nextgen-yum4` to the bootstrap for the test CentOS 7 appliance
