### PR TITLE
Improve error messages

### DIFF
--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -60,10 +60,13 @@ class RuntimeChecker(object):
         can be resolved into a http based web URL
         """
         message = dedent('''\n
-            Repository: %s is not publicly available.
-            Therefore it can't be included into the system image
-            repository configuration. Please check the setup of
-            the <imageinclude> attribute for this repository.
+            The use of imageinclude="true" in the repository definition
+            for the Repository: {0} requires the repository to by publicly
+            available. The source locator of the repository however
+            indicates it is private to your local system. Therefore it
+            can't be included into the system image repository configuration.
+            Please define a publicly available repository in your image
+            XML description: {1}
         ''')
 
         repository_sections = self.xml_state.get_repository_sections()
@@ -75,7 +78,11 @@ class RuntimeChecker(object):
                 repo_type = xml_repo.get_type()
                 uri = Uri(repo_source, repo_type)
                 if not uri.is_public():
-                    raise KiwiRuntimeError(message % repo_source)
+                    raise KiwiRuntimeError(
+                        message.format(
+                            repo_source, self.xml_state.xml_data.description
+                        )
+                    )
 
     def check_target_directory_not_in_shared_cache(self, target_dir):
         """

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1942,7 +1942,9 @@ class XMLState(object):
                 if build_type == image_type.get_image():
                     return image_type
             raise KiwiTypeNotFound(
-                'build type %s not found' % build_type
+                'build type {0} not found in {1}'.format(
+                    build_type, self.xml_data.description
+                )
             )
 
         # lookup if build type matches primary type
@@ -1954,7 +1956,7 @@ class XMLState(object):
         if image_type_sections:
             return image_type_sections[0]
         raise KiwiTypeNotFound(
-            'No build type defined. At least one type section is mandatory'
+            'No build type defined in {0}'.format(self.xml_data.description)
         )
 
     def _profiled(self, xml_abstract):


### PR DESCRIPTION
The error messages for running a build against an undefined
image definition as well as the error message to explain why
the imageinclude attribute can only be used with public repos
has been improved by suggestions from J. Mixer

