### PR TITLE
Extension of the Gitlab CI pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,14 +1,78 @@
-test:
-  image: "python:3.6-stretch"
+stages:
+  - test
+  - package
+
+.install_deps: &install_system_deps
+  before_script:
+    - >
+      dnf install -y --refresh python3 python3-devel 'python3dist(pip)'
+      'python3dist(tox)' make gcc which xz xorriso libxml2-devel libxslt-devel
+      enchant genisoimage ShellCheck
+
+tox_check:
+  stage: test
+  image: fedora:latest
+  variables:
+    LANG: en_US.UTF-8
+  <<: *install_system_deps
   script:
-    - apt-get update -qq
-    - apt-get install -y git
-    - apt-get install -y xsltproc
-    - apt-get install -y genisoimage
-    - apt-get install -y enchant
-    - apt-get install -y shellcheck
-    - apt-get install -y python3-pip
-    - pip3 install --upgrade pip
-    - pip install tox
-    - tox -e check
+    - dnf install -y python36 python34 python2 python2-devel python2-virtualenv python2-pip
+    # Python 2.7
+    - export PYTHON=python2.7
+    - tox -e unit_py2_7 "-n $(nproc)"
+    # Python 3.4
+    - export PYTHON=python3.4
+    - tox -e unit_py3_4 "-n $(nproc)"
+    # Python 3.6
+    - export PYTHON=python3.6
     - tox -e unit_py3_6 "-n $(nproc)"
+    # Python 3.7
+    - export PYTHON=python3.7
+    - tox -e 'unit_py3_7,check' "-n $(nproc)"
+  cache:
+    key: "$CI_JOB_NAME"
+    paths:
+      - .tox
+
+build_doc:
+  stage: test
+  image: fedora:latest
+  variables:
+    TOXENV: 'packagedoc'
+    PYTHON: 'python3.7'
+  <<: *install_system_deps
+  script:
+    - >
+      dnf -y install latexmk texlive-cmap texlive-metafont texlive-ec
+      texlive-babel-english texlive-fncychap texlive-fancyhdr texlive-titlesec
+      texlive-tabulary texlive-framed texlive-wrapfig texlive-parskip
+      texlive-upquote texlive-capt-of texlive-needspace texlive-makeindex
+      texlive-times texlive-helvetic texlive-courier texlive-gsftopk
+      texlive-updmap-map texlive-dvips
+    - tox
+  artifacts:
+    paths:
+      - doc/build/
+  cache:
+    key: "$CI_JOB_NAME"
+    paths:
+      - .tox/
+      - doc/build/
+
+RPM:
+  stage: package
+  image: fedora:latest
+  before_script:
+    - dnf --refresh -y install mock perl-TimeDate which make gzip tar perl git
+  script:
+    - 'sed -i "s|build: clean tox|build:|" Makefile'
+    - make build
+    - mv dist/python-kiwi.spec .
+    - rm dist/python-kiwi.changes
+    - mock --old-chroot -r /etc/mock/fedora-29-x86_64.cfg --buildsrpm --sources ./dist --spec ./python-kiwi.spec 2>&1 | tee srpm_build_out
+    - "export SRC_RPM=$(ls $(grep 'INFO: Results ' srpm_build_out | awk -F ':' '{print $3}')/*.src.rpm)"
+    - mv $SRC_RPM .
+    - mock --old-chroot -r /etc/mock/opensuse-tumbleweed-x86_64.cfg $(basename $SRC_RPM)
+    - mock --old-chroot -r /etc/mock/fedora-29-x86_64.cfg $(basename $SRC_RPM)
+  dependencies:
+    - build_doc

--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,8 @@ KIWI - Next Generation
 
 .. |Build Status| image:: https://travis-ci.com/SUSE/kiwi.svg?branch=master
    :target: https://travis-ci.com/SUSE/kiwi
+.. |GitLab CI Pipeline| image:: https://gitlab.com/schaefi/kiwi-ci/badges/master/pipeline.svg
+   :target: https://gitlab.com/schaefi/kiwi-ci/pipelines
 .. |Health| image:: https://api.codacy.com/project/badge/Grade/8ebd8ce362294fabb0870f50358e564f
    :target: https://www.codacy.com/app/Appliances/kiwi?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=SUSE/kiwi&amp;utm_campaign=Badge_Grade
 .. |Doc| replace:: `Documentation <https://opensource.suse.com/kiwi>`__

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -60,6 +60,7 @@ Source:         %{name}.tar.gz
 Source1:        %{name}-rpmlintrc
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 %if 0%{?fedora} || 0%{?suse_version}
+BuildRequires:  gcc
 BuildRequires:  python3-devel
 %endif
 %if 0%{?fedora} || 0%{?suse_version} || 0%{?ubuntu} >= 1804 || 0%{?debian} >= 9


### PR DESCRIPTION
Fixes: Migration to GitLab CI.

Changes proposed in this pull request:
* Add a multistage gitlab CI pipeline:
1. Test stage: this stage contains jobs that run the unit tests. I have added two jobs that use the recommended development environment via virtualenv & run the tests via tox and two additional jobs (one for Tumbleweed and the other for Fedora 29) that use the packages provided by the system's package manager.
2. Build doc stage: this stage builds the documentation (man pages, dirhtml, pdf) and runs the linkcheck & spell checks. Note though that the spell check reports 1001 spelling mistakes but doesn't cause a build failure, so I am not sure whether it's worth keeping. I have to test whether the linkchecker actually causes a failure when a link is dead. This stage is currently run in a Fedora container, as Tumbleweed lacks the sphinxcontrib-spelling package (and python-xdist is too outdated).
   The doc stage passes the built documentation further to the package stage.
3. Package stage: Here I added a Fedora container, that builds a source RPM and builds it locally via mock. This gives us immediate feedback, whether an accidental change broke the rpm build. This is run inside a Fedora container because osc cannot work without a repository and an account, which I don't think is worth adding via secret variables. A possible extension would be to try to install the resulting packages in the next stage.
4. Deploy stage: This stage copies the html documentation to GitLab pages (but only on the master branch, so I couldn't test this yet). This can be used as a "nightly" documentation (this would need to be enabled on GitLab) or we can just drop it.

The result looks like this: https://gitlab.com/D4N/kiwi-ci/pipelines/50328107