### PR TITLE
Fix zypper rpmdb linkage

### DIFF
--- a/kiwi/repository/apt.py
+++ b/kiwi/repository/apt.py
@@ -205,8 +205,9 @@ class RepositoryApt(RepositoryBase):
 
         :param list signing_keys: list of the key files to import
         """
-        for key in signing_keys:
-            self.signing_keys.append(key)
+        if signing_keys:
+            for key in signing_keys:
+                self.signing_keys.append(key)
 
     def delete_repo(self, name):
         """

--- a/kiwi/repository/dnf.py
+++ b/kiwi/repository/dnf.py
@@ -199,9 +199,10 @@ class RepositoryDnf(RepositoryBase):
 
         :param list signing_keys: list of the key files to import
         """
-        rpmdb = RpmDataBase(self.root_dir)
-        for key in signing_keys:
-            rpmdb.import_signing_key_to_image(key)
+        if signing_keys:
+            rpmdb = RpmDataBase(self.root_dir)
+            for key in signing_keys:
+                rpmdb.import_signing_key_to_image(key)
 
     def delete_repo(self, name):
         """

--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -286,8 +286,11 @@ class RepositoryZypper(RepositoryBase):
         :param list signing_keys: list of the key files to import
         """
         rpmdb = RpmDataBase(self.root_dir)
-        for key in signing_keys:
-            rpmdb.import_signing_key_to_image(key)
+        if signing_keys:
+            for key in signing_keys:
+                rpmdb.import_signing_key_to_image(key)
+        else:
+            rpmdb.init_database()
         # Zypper compat code:
         #
         # Manually adding the compat link /var/lib/rpm that points to the

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -112,8 +112,7 @@ class SystemPrepare(object):
             self.root_bind, package_manager, repository_options
         )
         repo.setup_package_database_configuration()
-        if signing_keys:
-            repo.import_trusted_keys(signing_keys)
+        repo.import_trusted_keys(signing_keys)
         for xml_repo in repository_sections:
             repo_type = xml_repo.get_type()
             repo_source = xml_repo.get_source().get_path()

--- a/kiwi/utils/rpm_database.py
+++ b/kiwi/utils/rpm_database.py
@@ -51,9 +51,14 @@ class RpmDataBase(object):
         """
         Rebuild image rpm database taking current macro setup into account
         """
-        Command.run([
-            'chroot', self.root_dir, 'rpmdb', '--rebuilddb'
-        ])
+        Command.run(
+            ['chroot', self.root_dir, 'rpmdb', '--rebuilddb']
+        )
+
+    def init_database(self):
+        Command.run(
+            ['rpm', '--root', self.root_dir, '--initdb']
+        )
 
     def set_macro_from_string(self, setting):
         """

--- a/kiwi/utils/rpm_database.py
+++ b/kiwi/utils/rpm_database.py
@@ -133,3 +133,16 @@ class RpmDataBase(object):
             self.rpmdb_image.write_config()
             self.rebuild_database()
             self.rpmdb_image.wipe_config()
+
+            root_rpm_host_dbpath = os.path.normpath(
+                os.sep.join([self.root_dir, rpm_host_dbpath])
+            )
+            root_rpm_alternatives = os.sep.join(
+                [root_rpm_host_dbpath, 'alternatives']
+            )
+            if os.path.exists(root_rpm_alternatives):
+                Command.run(
+                    ['mv', root_rpm_alternatives, root_rpm_image_dbpath]
+                )
+
+            Path.wipe(root_rpm_host_dbpath)

--- a/test/unit/repository_zypper_test.py
+++ b/test/unit/repository_zypper_test.py
@@ -259,6 +259,10 @@ class TestRepositoryZypper(object):
                 'ln', '-s', '../../usr/lib/sysimage/rpm', '../data/var/lib/rpm'
             ], raise_on_error=False
         )
+        signing_keys = None
+        rpmdb.reset_mock()
+        self.repo.import_trusted_keys(signing_keys)
+        rpmdb.init_database.assert_called_once_with()
 
     @patch('kiwi.command.Command.run')
     @patch('kiwi.repository.zypper.Path.wipe')

--- a/test/unit/utils_rpm_database_test.py
+++ b/test/unit/utils_rpm_database_test.py
@@ -28,6 +28,13 @@ class TestRpmDataBase(object):
             ['chroot', 'root_dir', 'rpmdb', '--rebuilddb']
         )
 
+    @patch('kiwi.command.Command.run')
+    def test_init_database(self, mock_Command_run):
+        self.rpmdb.init_database()
+        mock_Command_run.assert_called_once_with(
+            ['rpm', '--root', 'root_dir', '--initdb']
+        )
+
     def test_set_database_to_host_path(self):
         self.rpmdb.set_database_to_host_path()
         self.rpmdb.rpmdb_image.set_config_value.assert_called_once_with(

--- a/test/unit/utils_rpm_database_test.py
+++ b/test/unit/utils_rpm_database_test.py
@@ -46,12 +46,18 @@ class TestRpmDataBase(object):
     @patch('kiwi.utils.rpm_database.Path.wipe')
     @patch('kiwi.command.Command.run')
     @patch('os.path.islink')
+    @patch('os.path.exists')
     @patch('os.unlink')
     def test_set_database_to_image_path(
-        self, mock_os_unlink, mock_os_islink, mock_Command_run, mock_Path_wipe
+        self, mock_os_unlink, mock_os_exists, mock_os_islink,
+        mock_Command_run, mock_Path_wipe
     ):
+        mock_os_exists.return_value = True
         mock_os_islink.return_value = False
-        self.rpmdb.rpmdb_image.expand_query.return_value = '/var/lib/rpm'
+        self.rpmdb.rpmdb_image.expand_query.return_value = \
+            '/var/lib/rpm'
+        self.rpmdb.rpmdb_host.expand_query.return_value = \
+            '/usr/lib/sysimage/rpm'
         self.rpmdb.set_database_to_image_path()
         self.rpmdb.rpmdb_image.expand_query.assert_called_once_with('%_dbpath')
         assert self.rpmdb.rpmdb_image.set_config_value.call_args_list == [
@@ -62,13 +68,24 @@ class TestRpmDataBase(object):
                 '_dbpath_rebuild', self.rpmdb.rpmdb_image.get_query.return_value
             )
         ]
-        mock_Path_wipe.assert_called_once_with(
-            'root_dir/var/lib/rpm'
-        )
+        assert mock_Path_wipe.call_args_list == [
+            call('root_dir/var/lib/rpm'),
+            call('root_dir/usr/lib/sysimage/rpm')
+        ]
         self.rpmdb.rpmdb_image.write_config.assert_called_once_with()
-        mock_Command_run.assert_called_once_with(
-            ['chroot', 'root_dir', 'rpmdb', '--rebuilddb']
-        )
+        assert mock_Command_run.call_args_list == [
+            call(
+                [
+                    'chroot', 'root_dir', 'rpmdb', '--rebuilddb'
+                ]
+            ),
+            call(
+                [
+                    'mv', 'root_dir/usr/lib/sysimage/rpm/alternatives',
+                    'root_dir/var/lib/rpm'
+                ]
+            )
+        ]
         assert self.rpmdb.rpmdb_image.wipe_config.call_count == 2
         mock_os_islink.return_value = True
         self.rpmdb.set_database_to_image_path()


### PR DESCRIPTION
This patch is two fold

__Fixup zypper/suse link to rpm database__
    
The compat code generating the /var/lib/rpm link was only effective if a signing key was specified, however it should be effective in any case

__Care for update alternatives on rpmdb move__
    
In set_database_to_image_path we also have to care for the move of the alternatives path to the new rpmdb location

