### PR TITLE
Fix suseRemoveYaST to work with set -e

### DIFF
--- a/kiwi/config/functions.sh
+++ b/kiwi/config/functions.sh
@@ -1212,7 +1212,12 @@ function suseRemoveYaST {
     if [ -e /var/lib/autoinstall/autoconf/autoconf.xml ];then
         return
     fi
-    rpm -qa | grep yast | xargs rpm -e --nodeps
+    local yast_pkgs
+    # prevent non-zero exit status when no yast packages were found
+    yast_pkgs=$(rpm -qa | grep yast || :)
+    if [ "${yast_pkgs}" != "" ];then
+        echo "${yast_pkgs}" | xargs rpm -e --nodeps
+    fi
 }
 
 #======================================


### PR DESCRIPTION
Fixes `suseRemoveYaST` causing `config.sh` to abort when invoked with `set -e`

Changes proposed in this pull request:
* When `config.sh` is invoked with `set -e` then `suseRemoveYaST` causes the whole script to fail when no yast packages are present. The problem is that `grep yast` returns 1 in that case.
=> Explicitly ignore the return value of grep

* Furthermore, if no YaST packages were found, we don't want to invoke rpm, as that would fail too (as it is called without any parameters).


