### PR TITLE
Respect lvm root size

### DIFF
--- a/dracut/modules.d/99kiwi-lib/kiwi-lvm-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-lvm-lib.sh
@@ -160,7 +160,6 @@ function read_volume_setup_all_free {
             return
         fi
     done < "${profile}"
-    echo LVRoot,
 }
 
 function get_all_free_volume {

--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -428,6 +428,12 @@ class KiwiLoopSetupError(KiwiError):
     """
 
 
+class KiwiLvmSetupError(KiwiError):
+    """
+    Exception raised if the LVM setup is not valid.
+    """
+
+
 class KiwiMappedDeviceError(KiwiError):
     """
     Exception raised if the device to become mapped does not exist.

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -1130,6 +1130,10 @@ class XMLState(object):
                     realpath = '/'
                     name = 'LVRoot'
                     have_root_volume_setup = True
+                    # compatibility: if no size= is given use the full VG
+                    if not size and not freespace:
+                        log.info('--> LVM: @root volume without size attribute, assuming size="all"')
+                        size = 'all'
                 elif not mountpoint:
                     # setup volume without mountpoint. In this case the name
                     # attribute is used as mountpoint path and a name for the

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -31,7 +31,8 @@ from .utils.size import StringToSize
 from .exceptions import (
     KiwiProfileNotFound,
     KiwiTypeNotFound,
-    KiwiDistributionNameError
+    KiwiDistributionNameError,
+    KiwiLvmSetupError
 )
 
 
@@ -1051,7 +1052,7 @@ class XMLState(object):
 
         container_config_section.set_labels(labels)
 
-    def get_volumes(self):
+    def get_volumes(self):  # noqa: C901
         """
         List of configured systemdisk volumes.
 
@@ -1158,6 +1159,10 @@ class XMLState(object):
                 if ':all' in size:
                     size = None
                     fullsize = True
+                    if have_full_size_volume:
+                        raise KiwiLvmSetupError(
+                            'More than one LVM volume with size="all" attribute'
+                        )
                     have_full_size_volume = True
 
                 volume_type_list.append(

--- a/test/data/example_lvm_implicit_root_all_config.xml
+++ b/test/data/example_lvm_implicit_root_all_config.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
+    <description type="system">
+        <author>Marcus Schäfer</author>
+        <contact>ms@suse.com</contact>
+        <specification>
+            openSUSE 13.2 JeOS, is a small text based image
+        </specification>
+    </description>
+    <preferences>
+        <version>1.13.2</version>
+        <packagemanager>zypper</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us.map.gz</keytable>
+        <timezone>Europe/Berlin</timezone>
+        <rpm-excludedocs>true</rpm-excludedocs>
+        <rpm-check-signatures>false</rpm-check-signatures>
+        <bootsplash-theme>openSUSE</bootsplash-theme>
+        <bootloader-theme>openSUSE</bootloader-theme>
+        <type image="oem" filesystem="ext3" boot="oemboot/suse-13.2" installiso="true" bootloader="grub2" kernelcmdline="splash" firmware="efi">
+            <systemdisk>
+                <volume name="@root"/>
+            </systemdisk>
+            <oemconfig>
+                <oem-systemsize>2048</oem-systemsize>
+                <oem-swap>true</oem-swap>
+            </oemconfig>
+            <machine memory="512" guestOS="suse" HWversion="4">
+                <vmdisk id="0" controller="ide"/>
+                <vmnic driver="e1000" interface="0" mode="bridged"/>
+            </machine>
+        </type>
+    </preferences>
+    <users>
+        <user groups="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+    </users>
+    <repository type="yast2">
+        <source path="obs://13.2/repo/oss"/>
+    </repository>
+    <packages type="image">
+        <package name="patterns-openSUSE-base"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="udev"/>
+        <package name="filesystem"/>
+        <package name="glibc-locale"/>
+    </packages>
+</image>

--- a/test/data/example_lvm_implicit_root_size_all_config.xml
+++ b/test/data/example_lvm_implicit_root_size_all_config.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
+    <description type="system">
+        <author>Marcus Schäfer</author>
+        <contact>ms@suse.com</contact>
+        <specification>
+            openSUSE 13.2 JeOS, is a small text based image
+        </specification>
+    </description>
+    <preferences>
+        <version>1.13.2</version>
+        <packagemanager>zypper</packagemanager>
+        <locale>en_US</locale>
+        <keytable>us.map.gz</keytable>
+        <timezone>Europe/Berlin</timezone>
+        <rpm-excludedocs>true</rpm-excludedocs>
+        <rpm-check-signatures>false</rpm-check-signatures>
+        <bootsplash-theme>openSUSE</bootsplash-theme>
+        <bootloader-theme>openSUSE</bootloader-theme>
+        <type image="oem" filesystem="ext3" boot="oemboot/suse-13.2" installiso="true" bootloader="grub2" kernelcmdline="splash" firmware="efi">
+            <systemdisk>
+                <volume name="@root"/>
+                <volume name="var" mountpoint="/var" size="all"/>
+            </systemdisk>
+            <oemconfig>
+                <oem-systemsize>2048</oem-systemsize>
+                <oem-swap>true</oem-swap>
+            </oemconfig>
+            <machine memory="512" guestOS="suse" HWversion="4">
+                <vmdisk id="0" controller="ide"/>
+                <vmnic driver="e1000" interface="0" mode="bridged"/>
+            </machine>
+        </type>
+    </preferences>
+    <users>
+        <user groups="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
+    </users>
+    <repository type="yast2">
+        <source path="obs://13.2/repo/oss"/>
+    </repository>
+    <packages type="image">
+        <package name="patterns-openSUSE-base"/>
+    </packages>
+    <packages type="bootstrap">
+        <package name="udev"/>
+        <package name="filesystem"/>
+        <package name="glibc-locale"/>
+    </packages>
+</image>

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -7,7 +7,8 @@ from kiwi.xml_description import XMLDescription
 from kiwi.exceptions import (
     KiwiTypeNotFound,
     KiwiDistributionNameError,
-    KiwiProfileNotFound
+    KiwiProfileNotFound,
+    KiwiLvmSetupError
 )
 from collections import namedtuple
 
@@ -342,6 +343,38 @@ class TestXMLState(object):
                 attributes=[]
             )
         ]
+
+    def test_get_implicit_root_volume(self):
+        description = XMLDescription('../data/example_lvm_implicit_root_all_config.xml')
+        xml_data = description.load()
+        state = XMLState(xml_data)
+        volume_type = namedtuple(
+            'volume_type', [
+                'name',
+                'size',
+                'realpath',
+                'mountpoint',
+                'fullsize',
+                'label',
+                'attributes'
+            ]
+        )
+        # size == 'all' gets converted to size=None, fullsize=True
+        assert state.get_volumes() == [
+            volume_type(
+                name='LVRoot', size=None, realpath='/',
+                mountpoint=None, fullsize=True,
+                label=None,
+                attributes=[]
+            )
+        ]
+
+    @raises(KiwiLvmSetupError)
+    def test_get_volumes_dual_size_all_setup(self):
+        description = XMLDescription('../data/example_lvm_implicit_root_size_all_config.xml')
+        xml_data = description.load()
+        state = XMLState(xml_data)
+        state.get_volumes()
 
     def test_get_volumes_no_explicit_root_setup_other_fullsize_volume(self):
         description = XMLDescription(


### PR DESCRIPTION
Fixes #983 

Changes proposed in this pull request:
* if "@root size=..." is configured, respect that configuration
* if no size is given, fall back to old 'size=all' implicit config
* add a check if more than one 'size=all' volume exists and error out in that case
