### PR TITLE
Follow up fix for zypper compat link

### DIFF
--- a/kiwi/repository/apt.py
+++ b/kiwi/repository/apt.py
@@ -205,9 +205,8 @@ class RepositoryApt(RepositoryBase):
 
         :param list signing_keys: list of the key files to import
         """
-        if signing_keys:
-            for key in signing_keys:
-                self.signing_keys.append(key)
+        for key in signing_keys:
+            self.signing_keys.append(key)
 
     def delete_repo(self, name):
         """

--- a/kiwi/repository/dnf.py
+++ b/kiwi/repository/dnf.py
@@ -199,10 +199,9 @@ class RepositoryDnf(RepositoryBase):
 
         :param list signing_keys: list of the key files to import
         """
-        if signing_keys:
-            rpmdb = RpmDataBase(self.root_dir)
-            for key in signing_keys:
-                rpmdb.import_signing_key_to_image(key)
+        rpmdb = RpmDataBase(self.root_dir)
+        for key in signing_keys:
+            rpmdb.import_signing_key_to_image(key)
 
     def delete_repo(self, name):
         """

--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -155,6 +155,7 @@ class RepositoryZypper(RepositoryBase):
         2. Create the rpm bootstrap macro to make sure for bootstrapping
            the rpm database location matches the host rpm database setup.
            This macro only persists during the bootstrap phase
+        3. Create zypper compat link
         """
         rpmdb = RpmDataBase(
             self.root_dir, Defaults.get_custom_rpm_image_macro_name()
@@ -164,6 +165,41 @@ class RepositoryZypper(RepositoryBase):
         rpmdb.write_config()
 
         RpmDataBase(self.root_dir).set_database_to_host_path()
+        # Zypper compat code:
+        #
+        # Manually adding the compat link /var/lib/rpm that points to the
+        # rpmdb location as it is configured in the host rpm setup. The
+        # host rpm setup is taken into account because import_trusted_keys
+        # is called during the bootstrap phase where rpm (respectively zypper)
+        # is called from the host
+        #
+        # Usually it is expected that the package manager reads the
+        # signing keys from the rpm database setup provisioned by rpm
+        # itself (macro level) but zypper doesn't take the rpm macro
+        # setup into account and relies on a hard coded path which we
+        # can only provide as a symlink.
+        #
+        # That symlink is usually created by the rpm package when it gets
+        # installed. However at that early phase when we import the
+        # signing keys no rpm is installed yet nor any symlink exists.
+        # Thus we have to create it here and hope to get rid of it in the
+        # future.
+        #
+        # For further details on the motivation in zypper please
+        # refer to bsc#1112357
+        rpmdb.init_database()
+        Path.create(
+            os.sep.join([self.root_dir, 'var', 'lib'])
+        )
+        Command.run(
+            [
+                'ln', '-s', ''.join(
+                    ['../..', rpmdb.rpmdb_host.expand_query('%_dbpath')]
+                ), os.sep.join(
+                    [self.root_dir, 'var', 'lib', 'rpm']
+                )
+            ], raise_on_error=False
+        )
 
     def use_default_location(self):
         """
@@ -286,45 +322,8 @@ class RepositoryZypper(RepositoryBase):
         :param list signing_keys: list of the key files to import
         """
         rpmdb = RpmDataBase(self.root_dir)
-        if signing_keys:
-            for key in signing_keys:
-                rpmdb.import_signing_key_to_image(key)
-        else:
-            rpmdb.init_database()
-        # Zypper compat code:
-        #
-        # Manually adding the compat link /var/lib/rpm that points to the
-        # rpmdb location as it is configured in the host rpm setup. The
-        # host rpm setup is taken into account because import_trusted_keys
-        # is called during the bootstrap phase where rpm (respectively zypper)
-        # is called from the host
-        #
-        # Usually it is expected that the package manager reads the
-        # signing keys from the rpm database setup provisioned by rpm
-        # itself (macro level) but zypper doesn't take the rpm macro
-        # setup into account and relies on a hard coded path which we
-        # can only provide as a symlink.
-        #
-        # That symlink is usually created by the rpm package when it gets
-        # installed. However at that early phase when we import the
-        # signing keys no rpm is installed yet nor any symlink exists.
-        # Thus we have to create it here and hope to get rid of it in the
-        # future.
-        #
-        # For further details on the motivation in zypper please
-        # refer to bsc#1112357
-        Path.create(
-            os.sep.join([self.root_dir, 'var', 'lib'])
-        )
-        Command.run(
-            [
-                'ln', '-s', ''.join(
-                    ['../..', rpmdb.rpmdb_host.expand_query('%_dbpath')]
-                ), os.sep.join(
-                    [self.root_dir, 'var', 'lib', 'rpm']
-                )
-            ], raise_on_error=False
-        )
+        for key in signing_keys:
+            rpmdb.import_signing_key_to_image(key)
 
     def delete_repo(self, name):
         """

--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -112,7 +112,8 @@ class SystemPrepare(object):
             self.root_bind, package_manager, repository_options
         )
         repo.setup_package_database_configuration()
-        repo.import_trusted_keys(signing_keys)
+        if signing_keys:
+            repo.import_trusted_keys(signing_keys)
         for xml_repo in repository_sections:
             repo_type = xml_repo.get_type()
             repo_source = xml_repo.get_source().get_path()


### PR DESCRIPTION
Move the code handling the compat setup of the rpm database
to the correct method of the repository API. Call the
import of the signing keys only if there are signing
keys

