### PR TITLE
Use correct GRUB 2 and shim EFI packages for test CentOS 7 appliance

### DIFF
--- a/build-tests/x86/test-image-centos/appliance.kiwi
+++ b/build-tests/x86/test-image-centos/appliance.kiwi
@@ -103,9 +103,9 @@
         <package name="basesystem"/>
         <package name="yum-plugin-priorities"/>
         <package name="nextgen-yum4"/>
-        <package name="grub2-efi-modules"/>
-        <package name="grub2-efi"/>
-        <package name="shim" arch="x86_64"/>
+        <package name="grub2-efi-x64-modules" arch="x86_64"/>
+        <package name="grub2-efi-x64" arch="x86_64"/>
+        <package name="shim-x64" arch="x86_64"/>
         <package name="libdb-utils"/>
     </packages>
 </image>


### PR DESCRIPTION
CentOS 7 has inherited the changes from Fedora in how its EFI binaries
are packaged, so we need to adapt to handle those and build the appliance
properly.