### PR TITLE
Adding a derived docker image build test

### DIFF
--- a/build-tests/x86/test-image-docker-derived/appliance.kiwi
+++ b/build-tests/x86/test-image-docker-derived/appliance.kiwi
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<image schemaversion="6.9" name="docker-builder-image">
+  <description type="system">
+    <author>David Cassany</author>
+    <contact>dcassany@suse.de</contact>
+    <specification>Builder image based on Tumbleweed</specification>
+  </description>
+  <preferences>
+    <type image="docker" derived_from="obs://openSUSE:Factory/images/opensuse/tumbleweed#latest">
+      <containerconfig name="builder" tag="1.0" additionaltags="latest"/>
+    </type>
+    <version>1.0</version>
+    <packagemanager>zypper</packagemanager>
+    <rpm-excludedocs>true</rpm-excludedocs>
+  </preferences>
+  <repository type="rpm-md" alias="kiwi-next-generation" priority="1">
+    <source path="obs://Virtualization:Appliances:Staging/openSUSE_Tumbleweed"/>
+  </repository>
+  <repository type="rpm-md" alias="openSUSE Tumbleweed" priority="2">
+    <source path="obs://openSUSE:Factory/snapshot"/>
+  </repository>
+  <packages type="image">
+    <package name="python3-kiwi"/>
+    <package name="kiwi-image-docker-requires"/>
+    <package name="kiwi-image-iso-requires"/>
+    <package name="kiwi-image-oem-requires"/>
+    <package name="kiwi-image-pxe-requires"/>
+    <package name="kiwi-image-vmx-requires"/>
+  </packages>
+</image>


### PR DESCRIPTION
This is a test for derived docker image. It uses the openSUSE Tumbleweed base image and appends a new layer with kiwi-ng and its runtime dependencies for vmx, iso, oem and docker image types.
