### PR TITLE
centos-appliance: reorder repos to fix build

### DIFF
--- a/build-tests/x86/test-image-centos/appliance.kiwi
+++ b/build-tests/x86/test-image-centos/appliance.kiwi
@@ -46,12 +46,6 @@
         <source path="obs://Virtualization:Appliances:Staging/CentOS_7"/>
     </repository>
     <repository type="rpm-md">
-        <source path="obs://Fedora:EPEL:7/CentOS"/>
-    </repository>
-    <repository type="rpm-md">
-        <source path="obs://Fedora:EPEL:7/standard"/>
-    </repository>
-    <repository type="rpm-md">
         <source path="obs://CentOS:CentOS-7/extras"/>
     </repository>
     <repository type="rpm-md">
@@ -59,6 +53,12 @@
     </repository>
     <repository type="rpm-md">
         <source path="obs://CentOS:CentOS-7/standard"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="obs://Fedora:EPEL:7/CentOS"/>
+    </repository>
+    <repository type="rpm-md">
+        <source path="obs://Fedora:EPEL:7/standard"/>
     </repository>
     <packages type="image">
         <package name="syslinux"/>


### PR DESCRIPTION
EPEL has older package versions of e.g. librepo, which breaks dnf.
Re-prioritize to prefer the good CentOS packages instead of bad EPEL.

Fixes centos example appliance build in OBS.
