### PR TITLE
Drop duplicate EPEL7 reference in the test CentOS appliance

### DIFF
--- a/build-tests/x86/test-image-centos/appliance.kiwi
+++ b/build-tests/x86/test-image-centos/appliance.kiwi
@@ -55,9 +55,6 @@
         <source path="obs://CentOS:CentOS-7/standard"/>
     </repository>
     <repository type="rpm-md">
-        <source path="obs://Fedora:EPEL:7/CentOS"/>
-    </repository>
-    <repository type="rpm-md">
         <source path="obs://Fedora:EPEL:7/standard"/>
     </repository>
     <packages type="image">


### PR DESCRIPTION
We already request the standard, update, and extras repos and
the EPEL7 repo separately. There's no reason to request the
"centos" EPEL7 repo which combines standard+update and EPEL7
repos already.
