### PR TITLE
kiwi-dump-image: fix kiwi_oemdevicefilter for rd.debug

### DIFF
--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -91,7 +91,8 @@ function get_disk_list {
         # check for custom filter rule
         if [ -n "${kiwi_oemdevicefilter}" ];then
             if [[ ${disk_device} =~ ${kiwi_oemdevicefilter} ]];then
-                info "${disk_device} filtered out by: ${kiwi_oemdevicefilter}"
+                # info is more or less "echo" if debug is on, and it clutters stdout
+                info "${disk_device} filtered out by: ${kiwi_oemdevicefilter}" >&2
                 continue
             fi
         fi


### PR DESCRIPTION
Testcase:

* oemdevicefilter = /dev/sda
* oem_unattended = true
* two disks, sda and sdb
* rd.debug
* see that the oem image is deployed on sda

The reason is, that the get_disk_list normally returns lines:

```
/dev/sda 20G /dev/sdb 20G
```

with oemdevicefilter=/dev/sda it returns:

```
/dev/sda filtered out by: ... /dev/sdb 20G
```

And this is enough to make the code just accept /dev/sda as device to install onto ;-)

Changes proposed in this pull request:
* redirect info message to stderr to not spoil get_disk_list