### PR TITLE
add rd.kiwi.oem.maxdisk= boot parameter

### DIFF
--- a/doc/source/overview/workflow.rst
+++ b/doc/source/overview/workflow.rst
@@ -875,6 +875,16 @@ the available kernel boot parameters for this modules:
   Note that options starting with `rd.kiwi` are not passed on to avoid
   side effects.
 
+``rd.kiwi.oem.maxdisk=size[KMGT]``
+  This variable configures the maximum disk size an unattended oem
+  installation should consider for image deployment. Unattended oem
+  deployments default to deploying on /dev/sda (more exactly, the first
+  device not filtered out by `oem-device-filter`). With RAID
+  controllers, it can happen that your buch of big JBOD disks is for
+  example `/dev/sda` to `/dev/sdi` and the 480G RAID1 configured for
+  OS deployment is `/dev/sdj`. With `rd.kiwi.oem.maxdisk=500G` the
+  deployment will land on that RAID disk.
+
 ``rd.live.overlay.persistent``
   This variable tells a live iso image to prepare a persistent
   write partition.

--- a/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
@@ -113,3 +113,20 @@ function import_file {
         eval "export ${key}" &>/dev/null
     done < ${source_format}
 }
+
+function binsize_to_bytesize {
+    # """
+    # converts binary sizes (1024k, 2.4G) to bytes
+    # uses awk to handle floating point numbers
+    # """
+    local sz="$1"
+    local bs=${sz:0:-1}
+    case ${sz} in
+        *K|*k) mult=1024 ;;
+        *M) mult=$((1024*1024)) ;;
+        *G) mult=$((1024*1024*1024)) ;;
+        *T) mult=$((1024*1024*1024*1024)) ;;
+        *) bs=${sz}; mult=1 ;;
+    esac
+    awk "BEGIN {print int(${bs}*${mult})}"
+}


### PR DESCRIPTION
This limits the disks considered for oem deployment to a given size.

As hardware inventory (and disk sizes...) might change after an image was built, it is useful to have this available as a runtime config option for pxe deployment (as opposed to having it in config.xml)