### PR TITLE
Fixed reading of container config

### DIFF
--- a/kiwi/container/oci.py
+++ b/kiwi/container/oci.py
@@ -142,7 +142,7 @@ class ContainerImageOCI(object):
                 self.oci_config['container_tag']
             )
             additional_refs = []
-            if self.oci_config['additional_tags']:
+            if self.oci_config.get('additional_tags'):
                 additional_refs = []
                 for tag in self.oci_config['additional_tags']:
                     additional_refs.append('{0}:{1}'.format(


### PR DESCRIPTION
The additional_tags attribute is optional. If not set
the container config hash does not contain this key.
Accessing the key without the get() method leads to
an unhandled python exception


