### PR TITLE
Limit scope of virtualbox_guest_additions_present

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,6 +70,8 @@ rpm:
       dnf install -y --refresh
       mock gzip tar git python3 python3-dateutil python3-docopt
       make which
+    # set localtime to timezone of reference changes file
+    - ln -sf /usr/share/zoneinfo/Europe/Berlin /etc/localtime
     - 'sed -i "s|build: clean tox|build:|" Makefile'
     - make build
     - mv dist/python-kiwi.spec .

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -2503,12 +2503,28 @@ div {
 # main block: <vagrantconfig>
 #
 div {
+    sch:pattern [
+        abstract = "true"
+        id = "vagrant_provider"
+        sch:rule [
+            context = "vagrantconfig[@$attr]"
+            sch:assert [
+                test = "contains('$providers', @provider)"
+                "$attr attribute is only available for the following "
+                "vagrant providers: $providers"
+            ]
+        ]
+    ]
     k.vagrantconfig.provider.attribute =
         ## The vagrant provider for this box
         attribute provider { "libvirt" | "virtualbox" }
     k.vagrantconfig.virtualbox_guest_additions_present.attribute =
         ## Guest additions are present in this box
         attribute virtualbox_guest_additions_present { xsd:boolean }
+        >> sch:pattern [ id = "virtualbox_guest_additions_present" is-a = "vagrant_provider"
+            sch:param [ name = "attr" value = "virtualbox_guest_additions_present" ]
+            sch:param [ name = "providers" value = "virtualbox" ]
+        ]
     k.vagrantconfig.virtualsize.attribute =
         ## virtualsize provides the value of the virtual_size key which
         ## is embedded in the metadata.json hash inside the box file, as

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -3887,6 +3887,11 @@ and setup the system disk.</a:documentation>
     
   -->
   <div>
+    <sch:pattern abstract="true" id="vagrant_provider">
+      <sch:rule context="vagrantconfig[@$attr]">
+        <sch:assert test="contains('$providers', @provider)">$attr attribute is only available for the following vagrant providers: $providers</sch:assert>
+      </sch:rule>
+    </sch:pattern>
     <define name="k.vagrantconfig.provider.attribute">
       <attribute name="provider">
         <a:documentation>The vagrant provider for this box</a:documentation>
@@ -3901,6 +3906,10 @@ and setup the system disk.</a:documentation>
         <a:documentation>Guest additions are present in this box</a:documentation>
         <data type="boolean"/>
       </attribute>
+      <sch:pattern id="virtualbox_guest_additions_present" is-a="vagrant_provider">
+        <sch:param name="attr" value="virtualbox_guest_additions_present"/>
+        <sch:param name="providers" value="virtualbox"/>
+      </sch:pattern>
     </define>
     <define name="k.vagrantconfig.virtualsize.attribute">
       <attribute name="virtualsize">


### PR DESCRIPTION
This attribute is only used with the virtualbox provider.
Added a schematron rule to limit the scope to the
virtualbox provider only. This Fixes #1003

