### PR TITLE
relax the live iso root dir permissions

### DIFF
--- a/kiwi/iso_tools/xorriso.py
+++ b/kiwi/iso_tools/xorriso.py
@@ -150,6 +150,7 @@ class IsoToolsXorrIso(IsoToolsBase):
             [
                 self.get_tool_name()
             ] + self.iso_parameters + [
-                '-outdev', filename, '-map', self.source_dir, '/'
+                '-outdev', filename, '-map', self.source_dir, '/',
+                '-chmod', '0755', '/', '--'
             ] + self.iso_loaders + hidden_files_parameters
         )

--- a/test/unit/iso_tools_xorriso_test.py
+++ b/test/unit/iso_tools_xorriso_test.py
@@ -94,6 +94,7 @@ class TestIsoToolsXorrIso(object):
                 '/usr/bin/xorriso',
                 '-outdev', 'myiso',
                 '-map', 'source-dir', '/',
+                '-chmod', '0755', '/', '--',
                 '--', '-find', 'hide_me', '-exec', 'hide', 'on'
             ]
         )


### PR DESCRIPTION
The root of the live ISO has permissions 0700, which is inconvenient if
you mount it to explore its contents. Relax to 0755 instead.