### PR TITLE
Fixed race condition on live overlay mount

### DIFF
--- a/dracut/modules.d/90kiwi-live/parse-kiwi-live.sh
+++ b/dracut/modules.d/90kiwi-live/parse-kiwi-live.sh
@@ -34,5 +34,7 @@ info "root was ${liveroot}, is now ${root}"
 [ -z "${root}" ] && root="live"
 
 wait_for_dev -n /run/rootfsbase
+wait_for_dev -n /run/overlayfs/rw
+wait_for_dev -n /run/overlayfs/work
 
 return 0


### PR DESCRIPTION
Make sure to wait for all targets of the overlay mount
This Fixes #1015

