### PR TITLE
Use rsync by default

### DIFF
--- a/doc/source/building/working_with_images/vagrant_setup.rst
+++ b/doc/source/building/working_with_images/vagrant_setup.rst
@@ -136,6 +136,9 @@ required:
    files and ensure that the user ``vagrant`` has write permissions to
    it.
 
+   Note, that the boxes that KIWI produces **require** this folder to
+   exist, otherwise Vagrant will not be able to start them properly.
+
 7. Setup and start SSH daemon
 
    In :file:`config.sh`, add the start of sshd and the initial creation of

--- a/kiwi/storage/subformat/vagrant_libvirt.py
+++ b/kiwi/storage/subformat/vagrant_libvirt.py
@@ -64,6 +64,7 @@ class DiskFormatVagrantLibVirt(DiskFormatVagrantBase):
         Returns settings for the libvirt provider telling vagrant to use kvm.
         """
         return dedent('''
+            config.vm.synced_folder ".", "/vagrant", type: "rsync"
             config.vm.provider :libvirt do |libvirt|
               libvirt.driver = "kvm"
             end

--- a/test/unit/storage_subformat_vagrant_libvirt_test.py
+++ b/test/unit/storage_subformat_vagrant_libvirt_test.py
@@ -58,6 +58,7 @@ class TestDiskFormatVagrantLibVirt(object):
     def test_get_additional_vagrant_config_settings(self):
         assert self.disk_format.get_additional_vagrant_config_settings() == \
             dedent('''
+                config.vm.synced_folder ".", "/vagrant", type: "rsync"
                 config.vm.provider :libvirt do |libvirt|
                   libvirt.driver = "kvm"
                 end
@@ -81,6 +82,7 @@ class TestDiskFormatVagrantLibVirt(object):
             dedent('''
                 Vagrant.configure("2") do |config|
                   config.vm.base_mac = "00163E010101"
+                  config.vm.synced_folder ".", "/vagrant", type: "rsync"
                   config.vm.provider :libvirt do |libvirt|
                     libvirt.driver = "kvm"
                   end


### PR DESCRIPTION
Fixes: inconsistency between the documentation and the libvirt vagrant boxes' shared folder.

Changes proposed in this pull request:
* Use rsync by default for the shared folder `/vagrant` with libvirt. Otherwise nfs is used, which is not documented.
* Add a warning to the documentation that a missing `/vagrant` folder will break your box.
