### PR TITLE
Support optional fstab.patch file

### DIFF
--- a/doc/source/building/working_with_images.rst
+++ b/doc/source/building/working_with_images.rst
@@ -21,3 +21,4 @@ different image types.
    working_with_images/oem_ramdisk_deployment
    working_with_images/custom_partitions
    working_with_images/custom_volumes
+   working_with_images/custom_fstab_extension

--- a/doc/source/building/working_with_images/custom_fstab_extension.rst
+++ b/doc/source/building/working_with_images/custom_fstab_extension.rst
@@ -1,0 +1,66 @@
+.. _custom_fstab_extension:
+
+Add or Update the Fstab File
+============================
+
+.. sidebar:: Abstract
+
+   This page provides further information for customizing
+   the `/etc/fstab` file which controls the mounting of
+   filesystems at boot time.
+
+In KIWI, all major filesystems that were created at image
+build time are handled by KIWI itself and setup in `/etc/fstab`.
+Thus there is usually no need to add entries or change the
+ones added by KIWI. However depending on where the image is
+deployed later it might be required to pre-populate fstab
+entries that are unknown at the time the image is build.
+
+Possible use cases are for example:
+
+* Adding NFS locations that should be mounted at boot time.
+  Using autofs would be an alternative to avoid additional
+  entries to fstab. The information about the NFS location
+  will make this image specific to the target network. This
+  will be independent of the mount method, either fstab or
+  the automount map has to provide it.
+ 
+* Adding or changing entries in a read-only root system
+  which becomes effective on first boot but can't be added
+  at that time because of the read-only characteristics.
+
+.. note::
+
+   Modifications to the fstab file are a critical change. If
+   done wrongly the risk exists that the system will not boot.
+   In addition this type of modification makes the image
+   specific to its target and creates a dependency to the
+   target hardware, network, etc... Thus this feature should
+   be used with care.
+
+The optimal way to provide custom fstab information is through a
+package. If this can't be done the files can also be provided via
+the overlay file tree of the image description.
+
+KIWI supports two ways to modify the contents of the `/etc/fstab`
+file:
+
+1. Providing an `/etc/fstab.append` file
+
+   If that file exists in the image root tree, KIWI will take its
+   contents and append it to the existing `/etc/fstab` file. The
+   provided `/etc/fstab.append` file will be deleted after successful
+   modification.
+
+2. Providing an `/etc/fstab.patch` file
+
+   The `/etc/fstab.patch` represents a patch file that will be
+   applied to `/etc/fstab` using the `patch` program. This method
+   also allows to change the existing contents of `/etc/fstab`.
+   On success `/etc/fstab.patch` will be deleted.
+
+.. note::
+
+   `/etc/fstab.append` and `/etc/fstab.patch` can be used together.
+   If both files are provided, appending happens first and patching
+   afterwards.

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -612,14 +612,20 @@ class SystemSetup(object):
         """
         Create etc/fstab from given list of entries
 
-        Also lookup for an optional fstab.append file which allows
+        Also look for an optional fstab.append file which allows
         to append custom fstab entries to the final fstab. Once
         embedded the fstab.append file will be deleted
+
+        Also look for an optional fstab.patch file which allows
+        to patch the current contents of the fstab file with
+        a given patch file. Once patched the fstab.patch file will
+        be deleted
 
         :param list entries: list of line entries for fstab
         """
         fstab_file = self.root_dir + '/etc/fstab'
         fstab_append_file = self.root_dir + '/etc/fstab.append'
+        fstab_patch_file = self.root_dir + '/etc/fstab.patch'
 
         with open(fstab_file, 'w') as fstab:
             for entry in entries:
@@ -628,6 +634,12 @@ class SystemSetup(object):
                 with open(fstab_append_file, 'r') as append:
                     fstab.write(append.read())
                 Path.wipe(fstab_append_file)
+
+        if os.path.exists(fstab_patch_file):
+            Command.run(
+                ['patch', fstab_file, fstab_patch_file]
+            )
+            Path.wipe(fstab_patch_file)
 
     def create_init_link_from_linuxrc(self):
         """

--- a/test/unit/system_setup_test.py
+++ b/test/unit/system_setup_test.py
@@ -662,7 +662,10 @@ class TestSystemSetup(object):
     @patch_open
     @patch('os.path.exists')
     @patch('kiwi.system.setup.Path.wipe')
-    def test_create_fstab(self, mock_wipe, mock_exists, mock_open):
+    @patch('kiwi.command.Command.run')
+    def test_create_fstab(
+        self, mock_command, mock_wipe, mock_exists, mock_open
+    ):
         mock_exists.return_value = True
         mock_open.return_value = self.context_manager_mock
         self.file_mock.read.return_value = 'append_entry'
@@ -676,7 +679,13 @@ class TestSystemSetup(object):
             call('fstab_entry\n'),
             call('append_entry')
         ]
-        mock_wipe.assert_called_once_with('root_dir/etc/fstab.append')
+        mock_command.assert_called_once_with(
+            ['patch', 'root_dir/etc/fstab', 'root_dir/etc/fstab.patch']
+        )
+        assert mock_wipe.call_args_list == [
+            call('root_dir/etc/fstab.append'),
+            call('root_dir/etc/fstab.patch')
+        ]
 
     @patch('kiwi.command.Command.run')
     @patch('kiwi.system.setup.NamedTemporaryFile')


### PR DESCRIPTION
In addition to the support for fstab.append, users can now also
provide a patch file to change the contents of the fstab file
as it got written by kiwi. The feature is probably rarely used
but needed in the area of suse's transactional update mechanism.
This Fixes #945

