### PR TITLE
Fix config.sh calling

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -33,7 +33,8 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     'sphinxcontrib.spelling',
-    'sphinx.ext.autodoc'
+    'sphinx.ext.autodoc',
+    'sphinx.ext.intersphinx',
 ]
 
 docopt_ignore = [
@@ -265,6 +266,8 @@ man_pages = [
         8
     )
 ]
+
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
 # If true, show URL addresses after external links.
 #man_show_urls = False

--- a/doc/source/overview/workflow.rst
+++ b/doc/source/overview/workflow.rst
@@ -222,11 +222,14 @@ These are the optional components of an image description:
    :ref:`prepare step <prepare-step>` if present. It can be used to
    fine tune the unpacked image.
 
+   Note that the script is directly invoked by the operating system if its
+   executable bit is set. Otherwise it is called by :file:`bash` instead.
+
 #. ``images.sh`` shell script
 
-   Is the configuration shell script that runs at the begining of the
+   Is the configuration shell script that runs at the beginning of the
    create step. So it is expected to be used to handle image type specific
-   tasks.
+   tasks. It is called in a similar fashion as ``config.sh``
 
 #. Overlay tree directory
 

--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -778,3 +778,9 @@ class KiwiDecodingError(KiwiError):
     """
     Exception is raised on decoding literals failure
     """
+
+
+class KiwiFileAccessError(KiwiError):
+    """
+    Exception raised if accessing a file or its metadata failed
+    """

--- a/kiwi/system/setup.py
+++ b/kiwi/system/setup.py
@@ -877,10 +877,13 @@ class SystemSetup(object):
             )
 
     def _call_script(self, name):
-        if os.path.exists(self.root_dir + '/image/' + name):
-            config_script = Command.call(
-                ['chroot', self.root_dir, 'bash', '/image/' + name]
-            )
+        script_path = os.path.join(self.root_dir, 'image', name)
+        if os.path.exists(script_path):
+            command = ['chroot', self.root_dir]
+            if not Path.access(script_path, os.X_OK):
+                command += ['bash']
+            command += ['/image/' + name]
+            config_script = Command.call(command)
             process = CommandProcess(
                 command=config_script, log_topic='Calling ' + name + ' script'
             )

--- a/test/unit/path_test.py
+++ b/test/unit/path_test.py
@@ -1,8 +1,10 @@
 from mock import patch, call
+from pytest import raises
 
 import os
 
 from kiwi.path import Path
+from kiwi.exceptions import KiwiFileAccessError
 
 
 class TestPath(object):
@@ -97,3 +99,28 @@ class TestPath(object):
             '"file": in paths "%s" exists: "True" mode match: "False"' %
             mock_env.return_value
         )
+
+    def test_access_invalid_mode(self):
+        with raises(ValueError) as val_err_exc:
+            Path.access("/some/non-existent-file/", 128)
+
+        assert "0x80" in str(val_err_exc)
+
+    def test_access_with_non_existent_file(self):
+        non_existent = "/some/file/that/should/not/exist"
+        with raises(KiwiFileAccessError) as kfae_exc:
+            Path.access(non_existent, os.F_OK)
+
+        assert non_existent in str(kfae_exc)
+
+    @patch('os.stat')
+    @patch('os.access')
+    def test_access_with_args(self, mock_access, mock_stat):
+        mock_access.return_value = True
+
+        fname = "arbitrary"
+        mode = os.R_OK
+        assert Path.access(fname, mode, effective_ids=True)
+
+        mock_stat.assert_called_once_with(fname)
+        mock_access.assert_called_once_with(fname, mode, effective_ids=True)


### PR DESCRIPTION
Fixes #984.

Changes proposed in this pull request:
* modify `SystemSetup._call_script` to call scripts only through bash if the executable bit is not set, otherwise let the OS call them
* adapt unit tests & docs
