### PR TITLE
Split code_style_plus_unit_test into two jobs for parallel runs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,10 @@ stages:
   - test
   - package
 
+image: fedora:latest
+variables:
+  LANG: en_US.UTF-8
+
 .install_deps: &install_system_deps
   before_script:
     - >
@@ -9,39 +13,44 @@ stages:
       python3 python3-devel 'python3dist(pip)' 'python3dist(tox)'
       gcc xz libxml2-devel libxslt-devel enchant
 
+.add_cache: &set_cache_dir
+  cache:
+    key: "$CI_JOB_NAME"
+    paths:
+      - .tox
+
 code_style_plus_unit_test:
-  stage: test
-  image: fedora:latest
-  variables:
-    LANG: en_US.UTF-8
   <<: *install_system_deps
   script:
     - >
       dnf install -y
-      python36 python34 python2 python2-devel python2-virtualenv
-      python2-pip xorriso genisoimage ShellCheck
+      python36 xorriso genisoimage ShellCheck
     # Flake
     - tox -e check
-    # Python 2.7
-    - export PYTHON=python2.7
-    - tox -e unit_py2_7 "-n $(nproc)"
-    # Python 3.4
-    - export PYTHON=python3.4
-    - tox -e unit_py3_4 "-n $(nproc)"
     # Python 3.6
     - export PYTHON=python3.6
     - tox -e unit_py3_6 "-n $(nproc)"
     # Python 3.7
     - export PYTHON=python3.7
     - tox -e unit_py3_7 "-n $(nproc)"
-  cache:
-    key: "$CI_JOB_NAME"
-    paths:
-      - .tox
+  <<: *set_cache_dir
+
+unit_test_2_and_34:
+  <<: *install_system_deps
+  script:
+    - >
+      dnf install -y
+      python34 python2 python2-devel python2-virtualenv
+      python2-pip xorriso genisoimage
+    # Python 2.7
+    - export PYTHON=python2.7
+    - tox -e unit_py2_7 "-n $(nproc)"
+    # Python 3.4
+    - export PYTHON=python3.4
+    - tox -e unit_py3_4 "-n $(nproc)"
+  <<: *set_cache_dir
 
 build_doc:
-  stage: test
-  image: fedora:latest
   <<: *install_system_deps
   script:
     - >
@@ -64,7 +73,6 @@ build_doc:
 
 rpm:
   stage: package
-  image: fedora:latest
   script:
     - >
       dnf install -y --refresh


### PR DESCRIPTION
Fixes `code_style_plus_unit_test` takes quite long to run on GitLab CI.

Changes proposed in this pull request:
* Split the job into two jobs that can run in parallel.
