### PR TITLE
Replace @staticmethod with @classmethod when needed

### DIFF
--- a/helper/schema_parser.py
+++ b/helper/schema_parser.py
@@ -23,8 +23,8 @@ class SchemaNode(object):
 
     Child = namedtuple('Child', ['node', 'properties'])
 
-    @classmethod
-    def is_type(self, node):
+    @staticmethod
+    def is_type(node):
         pass
 
     def __init__(self, node, namespaces):
@@ -118,8 +118,8 @@ class SchemaNode(object):
 
 class Reference(SchemaNode):
 
-    @classmethod
-    def is_type(self, node):
+    @staticmethod
+    def is_type(node):
         if 'name' in node.attrib and node.tag.endswith('ref'):
             return True
         return False
@@ -158,8 +158,8 @@ class Reference(SchemaNode):
 
 class Attribute(SchemaNode):
 
-    @classmethod
-    def is_type(self, node):
+    @staticmethod
+    def is_type(node):
         if 'name' in node.attrib and node.tag.endswith('attribute'):
             return True
         return False
@@ -176,8 +176,8 @@ class Element(SchemaNode):
 
     Child = namedtuple('Child', ['x_path', 'properties'])
 
-    @classmethod
-    def is_type(self, node):
+    @staticmethod
+    def is_type(node):
         if 'name' in node.attrib and node.tag.endswith('element'):
             return True
         return False

--- a/kiwi/command.py
+++ b/kiwi/command.py
@@ -42,8 +42,8 @@ class Command(object):
     commands in blocking and non blocking mode. Control of
     stdout and stderr is given to the caller
     """
-    @classmethod
-    def run(cls, command, custom_env=None, raise_on_error=True):
+    @staticmethod
+    def run(command, custom_env=None, raise_on_error=True):
         """
         Execute a program and block the caller. The return value
         is a hash containing the stdout, stderr and return code
@@ -125,8 +125,8 @@ class Command(object):
             returncode=process.returncode
         )
 
-    @classmethod
-    def call(cls, command, custom_env=None):
+    @staticmethod
+    def call(command, custom_env=None):
         """
         Execute a program and return an io file handle pair back.
         stdout and stderr are both on different channels. The caller

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -37,7 +37,7 @@ class Defaults(object):
     """
     **Implements default values**
 
-    Provides class methods for default values and state information
+    Provides static methods for default values and state information
     """
     def __init__(self):
         self.defaults = {
@@ -63,8 +63,8 @@ class Defaults(object):
             'kiwi_revision'
         ]
 
-    @classmethod
-    def get_xz_compression_options(cls):
+    @staticmethod
+    def get_xz_compression_options():
         """
         Provides compression options for the xz compressor
 
@@ -81,8 +81,8 @@ class Defaults(object):
             '--threads=0'
         ]
 
-    @classmethod
-    def is_buildservice_worker(cls):
+    @staticmethod
+    def is_buildservice_worker():
         """
         Checks if build host is an open buildservice machine
 
@@ -97,8 +97,8 @@ class Defaults(object):
             os.sep + Defaults.get_buildservice_env_name()
         )
 
-    @classmethod
-    def get_buildservice_env_name(cls):
+    @staticmethod
+    def get_buildservice_env_name():
         """
         Provides the base name of the environment file in a
         buildservice worker
@@ -109,8 +109,8 @@ class Defaults(object):
         """
         return '.buildenv'
 
-    @classmethod
-    def get_obs_download_server_url(cls):
+    @staticmethod
+    def get_obs_download_server_url():
         """
         Provides the default download server url hosting the public open
         buildservice repositories
@@ -121,8 +121,8 @@ class Defaults(object):
         """
         return 'http://download.opensuse.org/repositories'
 
-    @classmethod
-    def get_s390_disk_block_size(cls):
+    @staticmethod
+    def get_s390_disk_block_size():
         """
         Provides the default block size for s390 storage disks
 
@@ -132,8 +132,8 @@ class Defaults(object):
         """
         return '4096'
 
-    @classmethod
-    def get_s390_disk_type(cls):
+    @staticmethod
+    def get_s390_disk_type():
         """
         Provides the default disk type for s390 storage disks
 
@@ -143,8 +143,8 @@ class Defaults(object):
         """
         return 'CDL'
 
-    @classmethod
-    def get_solvable_location(cls):
+    @staticmethod
+    def get_solvable_location():
         """
         Provides the directory to store SAT solvables for repositories.
         The solvable files are used to perform package
@@ -156,8 +156,8 @@ class Defaults(object):
         """
         return '/var/tmp/kiwi/satsolver'
 
-    @classmethod
-    def get_shared_cache_location(cls):
+    @staticmethod
+    def get_shared_cache_location():
         """
         Provides the shared cache location
 
@@ -176,8 +176,8 @@ class Defaults(object):
             Cli().get_global_args().get('--shared-cache-dir')
         )).lstrip(os.sep)
 
-    @classmethod
-    def get_exclude_list_for_root_data_sync(cls):
+    @staticmethod
+    def get_exclude_list_for_root_data_sync():
         """
         Provides the list of files or folders that are created
         by KIWI for its own purposes. Those files should be not
@@ -194,8 +194,8 @@ class Defaults(object):
         ]
         return exclude_list
 
-    @classmethod
-    def get_failsafe_kernel_options(cls):
+    @staticmethod
+    def get_failsafe_kernel_options():
         """
         Provides failsafe boot kernel options
 
@@ -219,8 +219,8 @@ class Defaults(object):
             ]
         )
 
-    @classmethod
-    def get_video_mode_map(cls):
+    @staticmethod
+    def get_video_mode_map():
         """
         Provides video mode map
 
@@ -258,8 +258,8 @@ class Defaults(object):
             '0x31b': video_type(grub2='1280x1024', isolinux='1280 1024'),
         }
 
-    @classmethod
-    def get_volume_id(cls):
+    @staticmethod
+    def get_volume_id():
         """
         Provides default value for ISO volume ID
 
@@ -269,8 +269,8 @@ class Defaults(object):
         """
         return 'CDROM'
 
-    @classmethod
-    def get_install_volume_id(cls):
+    @staticmethod
+    def get_install_volume_id():
         """
         Provides default value for ISO volume ID for install media
 
@@ -280,8 +280,8 @@ class Defaults(object):
         """
         return 'INSTALL'
 
-    @classmethod
-    def get_snapper_config_template_file(cls):
+    @staticmethod
+    def get_snapper_config_template_file():
         """
         Provides the default configuration template file for snapper
 
@@ -291,8 +291,8 @@ class Defaults(object):
         """
         return '/etc/snapper/config-templates/default'
 
-    @classmethod
-    def get_default_video_mode(cls):
+    @staticmethod
+    def get_default_video_mode():
         """
         Provides 800x600 default video mode as hex value for the kernel
 
@@ -302,8 +302,8 @@ class Defaults(object):
         """
         return '0x303'
 
-    @classmethod
-    def get_grub_boot_directory_name(cls, lookup_path):
+    @staticmethod
+    def get_grub_boot_directory_name(lookup_path):
         """
         Provides grub2 data directory name in boot/ directory
 
@@ -328,8 +328,8 @@ class Defaults(object):
             # boot data should live below boot/grub
             return 'grub'
 
-    @classmethod
-    def get_grub_basic_modules(cls, multiboot):
+    @staticmethod
+    def get_grub_basic_modules(multiboot):
         """
         Provides list of basic grub modules
 
@@ -370,8 +370,8 @@ class Defaults(object):
             modules.append('multiboot')
         return modules
 
-    @classmethod
-    def get_grub_efi_modules(cls, multiboot=False):
+    @staticmethod
+    def get_grub_efi_modules(multiboot=False):
         """
         Provides list of grub efi modules
 
@@ -394,8 +394,8 @@ class Defaults(object):
             ]
         return modules
 
-    @classmethod
-    def get_grub_bios_modules(cls, multiboot=False):
+    @staticmethod
+    def get_grub_bios_modules(multiboot=False):
         """
         Provides list of grub bios modules
 
@@ -416,8 +416,8 @@ class Defaults(object):
         ]
         return modules
 
-    @classmethod
-    def get_grub_ofw_modules(cls):
+    @staticmethod
+    def get_grub_ofw_modules():
         """
         Provides list of grub ofw modules (ppc)
 
@@ -432,8 +432,8 @@ class Defaults(object):
         ]
         return modules
 
-    @classmethod
-    def get_grub_path(cls, root_path, filename, raise_on_error=True):
+    @staticmethod
+    def get_grub_path(root_path, filename, raise_on_error=True):
         """
         Provides grub path to given search file
 
@@ -473,8 +473,8 @@ class Defaults(object):
                 'grub path {0} not found in {1}'.format(filename, lookup_list)
             )
 
-    @classmethod
-    def get_preparer(cls):
+    @staticmethod
+    def get_preparer():
         """
         Provides ISO preparer name
 
@@ -484,8 +484,8 @@ class Defaults(object):
         """
         return 'KIWI - http://suse.github.com/kiwi'
 
-    @classmethod
-    def get_publisher(cls):
+    @staticmethod
+    def get_publisher():
         """
         Provides ISO publisher name
 
@@ -495,8 +495,8 @@ class Defaults(object):
         """
         return 'SUSE LINUX GmbH'
 
-    @classmethod
-    def get_shim_loader(cls, root_path):
+    @staticmethod
+    def get_shim_loader(root_path):
         """
         Provides shim loader file path
 
@@ -518,8 +518,8 @@ class Defaults(object):
             for shim_file in glob.iglob(root_path + shim_file_pattern):
                 return shim_file
 
-    @classmethod
-    def get_unsigned_grub_loader(cls, root_path):
+    @staticmethod
+    def get_unsigned_grub_loader(root_path):
         """
         Provides unsigned grub efi loader file path
 
@@ -542,8 +542,8 @@ class Defaults(object):
             ):
                 return unsigned_grub_file
 
-    @classmethod
-    def get_signed_grub_loader(cls, root_path):
+    @staticmethod
+    def get_signed_grub_loader(root_path):
         """
         Provides shim signed grub loader file path
 
@@ -565,8 +565,8 @@ class Defaults(object):
             for signed_grub in glob.iglob(root_path + signed_grub_pattern):
                 return signed_grub
 
-    @classmethod
-    def get_shim_vendor_directory(cls, root_path):
+    @staticmethod
+    def get_shim_vendor_directory(root_path):
         """
         Provides shim vendor directory
 
@@ -588,8 +588,8 @@ class Defaults(object):
             for shim_file in glob.iglob(root_path + shim_vendor_pattern):
                 return os.path.dirname(shim_file)
 
-    @classmethod
-    def get_default_volume_group_name(cls):
+    @staticmethod
+    def get_default_volume_group_name():
         """
         Provides default LVM volume group name
 
@@ -599,8 +599,8 @@ class Defaults(object):
         """
         return 'systemVG'
 
-    @classmethod
-    def get_min_volume_mbytes(cls):
+    @staticmethod
+    def get_min_volume_mbytes():
         """
         Provides default minimum LVM volume size in mbytes
 
@@ -610,8 +610,8 @@ class Defaults(object):
         """
         return 30
 
-    @classmethod
-    def get_lvm_overhead_mbytes(cls):
+    @staticmethod
+    def get_lvm_overhead_mbytes():
         """
         Provides empiric LVM overhead size in mbytes
 
@@ -621,8 +621,8 @@ class Defaults(object):
         """
         return 80
 
-    @classmethod
-    def get_default_boot_mbytes(cls):
+    @staticmethod
+    def get_default_boot_mbytes():
         """
         Provides default boot partition size in mbytes
 
@@ -632,8 +632,8 @@ class Defaults(object):
         """
         return 300
 
-    @classmethod
-    def get_default_efi_boot_mbytes(cls):
+    @staticmethod
+    def get_default_efi_boot_mbytes():
         """
         Provides default EFI partition size in mbytes
 
@@ -643,8 +643,8 @@ class Defaults(object):
         """
         return 20
 
-    @classmethod
-    def get_recovery_spare_mbytes(cls):
+    @staticmethod
+    def get_recovery_spare_mbytes():
         """
         Provides spare size of recovery partition in mbytes
 
@@ -654,8 +654,8 @@ class Defaults(object):
         """
         return 300
 
-    @classmethod
-    def get_default_legacy_bios_mbytes(cls):
+    @staticmethod
+    def get_default_legacy_bios_mbytes():
         """
         Provides default size of bios_grub partition in mbytes
 
@@ -665,8 +665,8 @@ class Defaults(object):
         """
         return 2
 
-    @classmethod
-    def get_default_prep_mbytes(cls):
+    @staticmethod
+    def get_default_prep_mbytes():
         """
         Provides default size of prep partition in mbytes
 
@@ -676,8 +676,8 @@ class Defaults(object):
         """
         return 8
 
-    @classmethod
-    def get_disk_format_types(cls):
+    @staticmethod
+    def get_disk_format_types():
         """
         Provides supported disk format types
 
@@ -690,8 +690,8 @@ class Defaults(object):
             'vhdfixed', 'vdi', 'vagrant.libvirt.box', 'vagrant.virtualbox.box'
         ]
 
-    @classmethod
-    def get_vagrant_config_virtualbox_guest_additions(cls):
+    @staticmethod
+    def get_vagrant_config_virtualbox_guest_additions():
         """
         Provides the default value for
         ``vagrantconfig.virtualbox_guest_additions_present``
@@ -703,8 +703,8 @@ class Defaults(object):
         """
         return False
 
-    @classmethod
-    def get_firmware_types(cls):
+    @staticmethod
+    def get_firmware_types():
         """
         Provides supported architecture specific firmware types
 
@@ -731,8 +731,8 @@ class Defaults(object):
             's390x': []
         }
 
-    @classmethod
-    def get_default_firmware(cls, arch):
+    @staticmethod
+    def get_default_firmware(arch):
         """
         Provides default firmware for specified architecture
 
@@ -760,8 +760,8 @@ class Defaults(object):
         if arch in default_firmware:
             return default_firmware[arch]
 
-    @classmethod
-    def get_efi_capable_firmware_names(cls):
+    @staticmethod
+    def get_efi_capable_firmware_names():
         """
         Provides list of EFI capable firmware names. These are
         those for which kiwi supports the creation of an EFI
@@ -773,8 +773,8 @@ class Defaults(object):
         """
         return ['efi', 'uefi']
 
-    @classmethod
-    def get_ec2_capable_firmware_names(cls):
+    @staticmethod
+    def get_ec2_capable_firmware_names():
         """
         Provides list of EC2 capable firmware names. These are
         those for which kiwi supports the creation of disk images
@@ -786,8 +786,8 @@ class Defaults(object):
         """
         return ['ec2']
 
-    @classmethod
-    def get_efi_module_directory_name(cls, arch):
+    @staticmethod
+    def get_efi_module_directory_name(arch):
         """
         Provides architecture specific EFI directory name which
         stores the EFI binaries for the desired architecture.
@@ -816,8 +816,8 @@ class Defaults(object):
         if arch in default_module_directory_names:
             return default_module_directory_names[arch]
 
-    @classmethod
-    def get_efi_image_name(cls, arch):
+    @staticmethod
+    def get_efi_image_name(arch):
         """
         Provides architecture specific EFI boot binary name
 
@@ -839,8 +839,8 @@ class Defaults(object):
         if arch in default_efi_image_names:
             return default_efi_image_names[arch]
 
-    @classmethod
-    def get_default_boot_timeout_seconds(cls):
+    @staticmethod
+    def get_default_boot_timeout_seconds():
         """
         Provides default boot timeout in seconds
 
@@ -850,8 +850,8 @@ class Defaults(object):
         """
         return 10
 
-    @classmethod
-    def get_default_disk_start_sector(cls):
+    @staticmethod
+    def get_default_disk_start_sector():
         """
         Provides the default initial disk sector for the first disk
         partition.
@@ -862,8 +862,8 @@ class Defaults(object):
         """
         return Defaults().defaults['kiwi_startsector']
 
-    @classmethod
-    def get_default_efi_partition_table_type(cls):
+    @staticmethod
+    def get_default_efi_partition_table_type():
         """
         Provides the default partition table type for efi firmwares.
 
@@ -873,8 +873,8 @@ class Defaults(object):
         """
         return 'gpt'
 
-    @classmethod
-    def get_default_inode_size(cls):
+    @staticmethod
+    def get_default_inode_size():
         """
         Provides default size of inodes in bytes. This is only
         relevant for inode based filesystems
@@ -885,8 +885,8 @@ class Defaults(object):
         """
         return Defaults().defaults['kiwi_inode_size']
 
-    @classmethod
-    def get_archive_image_types(cls):
+    @staticmethod
+    def get_archive_image_types():
         """
         Provides list of supported archive image types
 
@@ -896,8 +896,8 @@ class Defaults(object):
         """
         return ['tbz']
 
-    @classmethod
-    def get_container_image_types(cls):
+    @staticmethod
+    def get_container_image_types():
         """
         Provides list of supported container image types
 
@@ -907,8 +907,8 @@ class Defaults(object):
         """
         return ['docker', 'oci']
 
-    @classmethod
-    def get_filesystem_image_types(cls):
+    @staticmethod
+    def get_filesystem_image_types():
         """
         Provides list of supported filesystem image types
 
@@ -921,8 +921,8 @@ class Defaults(object):
             'xfs', 'fat16', 'fat32'
         ]
 
-    @classmethod
-    def get_default_live_iso_type(cls):
+    @staticmethod
+    def get_default_live_iso_type():
         """
         Provides default live iso union type
 
@@ -932,8 +932,8 @@ class Defaults(object):
         """
         return 'overlay'
 
-    @classmethod
-    def get_default_uri_type(cls):
+    @staticmethod
+    def get_default_uri_type():
         """
         Provides default URI type
 
@@ -946,8 +946,8 @@ class Defaults(object):
         """
         return 'dir:/'
 
-    @classmethod
-    def get_dracut_conf_name(cls):
+    @staticmethod
+    def get_dracut_conf_name():
         """
         Provides file path of dracut config file to be used with KIWI
 
@@ -957,8 +957,8 @@ class Defaults(object):
         """
         return '/etc/dracut.conf.d/02-kiwi.conf'
 
-    @classmethod
-    def get_live_dracut_module_from_flag(cls, flag_name):
+    @staticmethod
+    def get_live_dracut_module_from_flag(flag_name):
         """
         Provides flag_name to dracut module name map
 
@@ -978,8 +978,8 @@ class Defaults(object):
         else:
             return 'kiwi-live'
 
-    @classmethod
-    def get_default_live_iso_root_filesystem(cls):
+    @staticmethod
+    def get_default_live_iso_root_filesystem():
         """
         Provides default live iso root filesystem type
 
@@ -989,8 +989,8 @@ class Defaults(object):
         """
         return 'ext4'
 
-    @classmethod
-    def get_live_iso_persistent_boot_options(cls, persistent_filesystem=None):
+    @staticmethod
+    def get_live_iso_persistent_boot_options(persistent_filesystem=None):
         """
         Provides list of boot options passed to the dracut
         kiwi-live module to setup persistent writing
@@ -1008,8 +1008,8 @@ class Defaults(object):
             )
         return live_iso_persistent_boot_options
 
-    @classmethod
-    def get_disk_image_types(cls):
+    @staticmethod
+    def get_disk_image_types():
         """
         Provides supported disk image types
 
@@ -1019,8 +1019,8 @@ class Defaults(object):
         """
         return ['oem', 'vmx']
 
-    @classmethod
-    def get_live_image_types(cls):
+    @staticmethod
+    def get_live_image_types():
         """
         Provides supported live image types
 
@@ -1030,8 +1030,8 @@ class Defaults(object):
         """
         return ['iso']
 
-    @classmethod
-    def get_network_image_types(cls):
+    @staticmethod
+    def get_network_image_types():
         """
         Provides supported pxe image types
 
@@ -1041,8 +1041,8 @@ class Defaults(object):
         """
         return ['pxe']
 
-    @classmethod
-    def get_boot_image_description_path(cls):
+    @staticmethod
+    def get_boot_image_description_path():
         """
         Provides the path to find custom kiwi boot descriptions
 
@@ -1052,8 +1052,8 @@ class Defaults(object):
         """
         return '/usr/share/kiwi/custom_boot'
 
-    @classmethod
-    def get_boot_image_strip_file(cls):
+    @staticmethod
+    def get_boot_image_strip_file():
         """
         Provides the file path to bootloader strip metadata.
         This file contains information about the files and directories
@@ -1065,8 +1065,8 @@ class Defaults(object):
         """
         return Defaults.project_file('config/strip.xml')
 
-    @classmethod
-    def get_schema_file(cls):
+    @staticmethod
+    def get_schema_file():
         """
         Provides file path to kiwi RelaxNG schema
 
@@ -1076,8 +1076,8 @@ class Defaults(object):
         """
         return Defaults.project_file('schema/kiwi.rng')
 
-    @classmethod
-    def get_common_functions_file(cls):
+    @staticmethod
+    def get_common_functions_file():
         """
         Provides the file path to config functions metadata.
 
@@ -1090,8 +1090,8 @@ class Defaults(object):
         """
         return Defaults.project_file('config/functions.sh')
 
-    @classmethod
-    def get_xsl_stylesheet_file(cls):
+    @staticmethod
+    def get_xsl_stylesheet_file():
         """
         Provides the file path to the KIWI XSLT style sheets
 
@@ -1101,8 +1101,8 @@ class Defaults(object):
         """
         return Defaults.project_file('xsl/master.xsl')
 
-    @classmethod
-    def project_file(cls, filename):
+    @staticmethod
+    def project_file(filename):
         """
         Provides the python module base directory search path
 
@@ -1117,8 +1117,8 @@ class Defaults(object):
         """
         return resource_filename('kiwi', filename)
 
-    @classmethod
-    def get_imported_root_image(cls, root_dir):
+    @staticmethod
+    def get_imported_root_image(root_dir):
         """
         Provides the path to an imported root system image
 
@@ -1134,8 +1134,8 @@ class Defaults(object):
         """
         return os.sep.join([root_dir, 'image', 'imported_root'])
 
-    @classmethod
-    def get_iso_boot_path(cls):
+    @staticmethod
+    def get_iso_boot_path():
         """
         Provides arch specific relative path to boot files
         on kiwi iso filesystems
@@ -1149,8 +1149,8 @@ class Defaults(object):
             arch = 'ix86'
         return os.sep.join(['boot', arch])
 
-    @classmethod
-    def get_iso_tool_category(cls):
+    @staticmethod
+    def get_iso_tool_category():
         """
         Provides default iso tool category
 
@@ -1160,8 +1160,8 @@ class Defaults(object):
         """
         return 'xorriso'
 
-    @classmethod
-    def get_container_compression(cls):
+    @staticmethod
+    def get_container_compression():
         """
         Provides default container compression algorithm
 
@@ -1171,8 +1171,8 @@ class Defaults(object):
         """
         return 'xz'
 
-    @classmethod
-    def get_default_container_name(cls):
+    @staticmethod
+    def get_default_container_name():
         """
         Provides the default container name.
 
@@ -1182,8 +1182,8 @@ class Defaults(object):
         """
         return 'kiwi-container'
 
-    @classmethod
-    def get_container_base_image_tag(cls):
+    @staticmethod
+    def get_container_base_image_tag():
         """
         Provides the tag used to identify base layers during the build
         of derived images.
@@ -1194,8 +1194,8 @@ class Defaults(object):
         """
         return 'base_layer'
 
-    @classmethod
-    def get_oci_archive_tool(cls):
+    @staticmethod
+    def get_oci_archive_tool():
         """
         Provides the default OCI archive tool name.
 
@@ -1205,8 +1205,8 @@ class Defaults(object):
         """
         return 'umoci'
 
-    @classmethod
-    def get_default_container_tag(cls):
+    @staticmethod
+    def get_default_container_tag():
         """
         Provides the default container tag.
 
@@ -1216,8 +1216,8 @@ class Defaults(object):
         """
         return 'latest'
 
-    @classmethod
-    def get_default_container_subcommand(cls):
+    @staticmethod
+    def get_default_container_subcommand():
         """
         Provides the default container subcommand.
 
@@ -1227,8 +1227,8 @@ class Defaults(object):
         """
         return ['/bin/bash']
 
-    @classmethod
-    def get_default_container_created_by(cls):
+    @staticmethod
+    def get_default_container_created_by():
         """
         Provides the default 'created by' history entry for containers.
 
@@ -1238,8 +1238,8 @@ class Defaults(object):
         """
         return 'KIWI {0}'.format(__version__)
 
-    @classmethod
-    def set_python_default_encoding_to_utf8(cls):
+    @staticmethod
+    def set_python_default_encoding_to_utf8():
         """
         Set python default encoding to utf-8 if not already done
 
@@ -1254,8 +1254,8 @@ class Defaults(object):
             reload_module(sys)  # Reload required to get setdefaultencoding back
             sys.setdefaultencoding('utf-8')
 
-    @classmethod
-    def get_custom_rpm_macros_path(cls):
+    @staticmethod
+    def get_custom_rpm_macros_path():
         """
         Returns the custom macros directory for the rpm database.
 
@@ -1265,8 +1265,8 @@ class Defaults(object):
         """
         return 'usr/lib/rpm/macros.d'
 
-    @classmethod
-    def get_custom_rpm_bootstrap_macro_name(cls):
+    @staticmethod
+    def get_custom_rpm_bootstrap_macro_name():
         """
         Returns the rpm bootstrap macro file name created
         in the custom rpm macros path
@@ -1277,8 +1277,8 @@ class Defaults(object):
         """
         return 'macros.kiwi-bootstrap-config'
 
-    @classmethod
-    def get_custom_rpm_image_macro_name(cls):
+    @staticmethod
+    def get_custom_rpm_image_macro_name():
         """
         Returns the rpm image macro file name created
         in the custom rpm macros path
@@ -1289,8 +1289,8 @@ class Defaults(object):
         """
         return 'macros.kiwi-image-config'
 
-    @classmethod
-    def get_default_packager_tool(cls, package_manager):
+    @staticmethod
+    def get_default_packager_tool(package_manager):
         """
         Provides the packager tool according to the package manager
 

--- a/kiwi/iso_tools/iso.py
+++ b/kiwi/iso_tools/iso.py
@@ -53,8 +53,8 @@ class Iso(object):
         self.header_end_file = self.source_dir + '/' + self.header_end_name
         self.boot_path = Defaults.get_iso_boot_path()
 
-    @classmethod
-    def create_hybrid(cls, offset, mbrid, isofile, efi_mode=False):
+    @staticmethod
+    def create_hybrid(offset, mbrid, isofile, efi_mode=False):
         """
         Create hybrid ISO
 
@@ -107,8 +107,8 @@ class Iso(object):
                     )
                 )
 
-    @classmethod
-    def set_media_tag(cls, isofile):
+    @staticmethod
+    def set_media_tag(isofile):
         """
         Include checksum tag in the ISO so it can be verified with
         the mediacheck program.
@@ -125,8 +125,8 @@ class Iso(object):
             ]
         )
 
-    @classmethod
-    def relocate_boot_catalog(cls, isofile):
+    @staticmethod
+    def relocate_boot_catalog(isofile):
         """
         Move ISO boot catalog to the standardized place
 
@@ -185,8 +185,8 @@ class Iso(object):
                         new_boot_catalog_sector
                     )
 
-    @classmethod
-    def fix_boot_catalog(cls, isofile):
+    @staticmethod
+    def fix_boot_catalog(isofile):
         """
         Fixup inconsistencies in boot catalog
 

--- a/kiwi/kiwi_compat.py
+++ b/kiwi/kiwi_compat.py
@@ -211,12 +211,12 @@ class Translate(object):
 
 
 class Command(object):
-    @classmethod
-    def execute(cls, arguments):
+    @staticmethod
+    def execute(arguments):
         os.execvp(Command.lookup_kiwi(), ['kiwi'] + arguments)
 
-    @classmethod
-    def lookup_kiwi(cls):
+    @staticmethod
+    def lookup_kiwi():
         for kiwi_name in ['kiwi-ng-3', 'kiwi-ng-2']:
             kiwi = Path.which(kiwi_name, access_mode=os.X_OK)
             if kiwi:

--- a/kiwi/oci_tools/base.py
+++ b/kiwi/oci_tools/base.py
@@ -142,8 +142,8 @@ class OCIBase(object):
         """
         raise NotImplementedError
 
-    @classmethod
-    def _sync_data(cls, origin, destination, exclude_list=None, options=None):
+    @staticmethod
+    def _sync_data(origin, destination, exclude_list=None, options=None):
         """
         Synchronizes the origin and destination paths to be equivalent
 

--- a/kiwi/oci_tools/umoci.py
+++ b/kiwi/oci_tools/umoci.py
@@ -170,8 +170,8 @@ class OCIUmoci(OCIBase):
             self.container_dir, oci_config['container_tag']
         )
 
-    @classmethod                                                # noqa:C901
-    def _process_oci_config_to_arguments(cls, oci_config):
+    @staticmethod                                                # noqa:C901
+    def _process_oci_config_to_arguments(oci_config):
         """
         Process the oci configuration dictionary into a list of arguments
         for the 'umoci config' command
@@ -234,8 +234,8 @@ class OCIUmoci(OCIBase):
 
         return arguments
 
-    @classmethod
-    def _process_oci_history_to_arguments(cls, oci_config):
+    @staticmethod
+    def _process_oci_history_to_arguments(oci_config):
         history_args = []
         if 'history' in oci_config:
             if 'comment' in oci_config['history']:

--- a/kiwi/path.py
+++ b/kiwi/path.py
@@ -28,8 +28,8 @@ class Path(object):
     """
     **Directory path helpers**
     """
-    @classmethod
-    def sort_by_hierarchy(cls, path_list):
+    @staticmethod
+    def sort_by_hierarchy(path_list):
         """
         Sort given list of path names by their hierachy in the tree
 
@@ -61,8 +61,8 @@ class Path(object):
                 ordered_paths.append(path)
         return ordered_paths
 
-    @classmethod
-    def access(cls, path, mode, **kwargs):
+    @staticmethod
+    def access(path, mode, **kwargs):
         """
         Check whether path can be accessed with the given mode.
 
@@ -95,8 +95,8 @@ class Path(object):
 
         return os.access(path, mode, **kwargs)
 
-    @classmethod
-    def create(cls, path):
+    @staticmethod
+    def create(path):
         """
         Create path and all sub directories to target
 
@@ -106,8 +106,8 @@ class Path(object):
             ['mkdir', '-p', path]
         )
 
-    @classmethod
-    def wipe(cls, path):
+    @staticmethod
+    def wipe(path):
         """
         Delete path and all contents
 
@@ -117,8 +117,8 @@ class Path(object):
             ['rm', '-r', '-f', path]
         )
 
-    @classmethod
-    def remove(cls, path):
+    @staticmethod
+    def remove(path):
         """
         Delete empty path, causes an error if target is not empty
 
@@ -128,8 +128,8 @@ class Path(object):
             ['rmdir', path]
         )
 
-    @classmethod
-    def remove_hierarchy(cls, path):
+    @staticmethod
+    def remove_hierarchy(path):
         """
         Recursively remove an empty path and its sub directories
         ignore non empty or protected paths and leave them untouched
@@ -157,9 +157,9 @@ class Path(object):
                     ['rmdir', '--ignore-fail-on-non-empty', sub_path]
                 )
 
-    @classmethod
+    @staticmethod
     def which(
-        cls, filename, alternative_lookup_paths=None,
+        filename, alternative_lookup_paths=None,
         custom_env=None, access_mode=None
     ):
         """

--- a/kiwi/privileges.py
+++ b/kiwi/privileges.py
@@ -27,8 +27,8 @@ class Privileges(object):
     """
     **Implements check for root privileges**
     """
-    @classmethod
-    def check_for_root_permissions(cls):
+    @staticmethod
+    def check_for_root_permissions():
         """
         Check if we are effectively root on the system. If not
         an exception is thrown

--- a/kiwi/system/result.py
+++ b/kiwi/system/result.py
@@ -102,8 +102,8 @@ class Result(object):
                 'Failed to pickle dump results: %s' % format(e)
             )
 
-    @classmethod
-    def load(cls, filename):
+    @staticmethod
+    def load(filename):
         """
         Load pickle dumped filename into a Result instance
 

--- a/kiwi/system/shell.py
+++ b/kiwi/system/shell.py
@@ -26,8 +26,8 @@ class Shell(object):
     """
     **Special character handling for shell evaluated code**
     """
-    @classmethod
-    def quote(cls, message):
+    @staticmethod
+    def quote(message):
         """
         Quote characters which have a special meaning for bash
         but should be used as normal characters. actually I had
@@ -47,8 +47,8 @@ class Shell(object):
             message = message.replace(quote, '\\' + quote)
         return message
 
-    @classmethod
-    def quote_key_value_file(cls, filename):
+    @staticmethod
+    def quote_key_value_file(filename):
         """
         Quote given input file which has to be of the form
         key=value to be able to become sourced by the shell
@@ -65,8 +65,8 @@ class Shell(object):
         with open(temp_copy.name) as quoted:
             return quoted.read().splitlines()
 
-    @classmethod
-    def run_common_function(cls, name, parameters):
+    @staticmethod
+    def run_common_function(name, parameters):
         """
         Run a function implemented in config/functions.sh
 

--- a/kiwi/utils/codec.py
+++ b/kiwi/utils/codec.py
@@ -24,8 +24,8 @@ class Codec(object):
     """
     **Performs conversions of literal byte sequences to strings**
     """
-    @classmethod
-    def decode(cls, literal):
+    @staticmethod
+    def decode(literal):
         """
         Decodes the given literal with the default charset. In case of
         failure attemps to decode using utf-8 charset.
@@ -46,8 +46,8 @@ class Codec(object):
                     'Locale setup is not utf-8 compatible'
                 )
 
-    @classmethod
-    def _wrapped_decode(cls, literal, charset=None):
+    @staticmethod
+    def _wrapped_decode(literal, charset=None):
         # This decode wrapper is only implemented to facilitate unit testing
         if charset:
             return literal.decode(charset)

--- a/kiwi/utils/command_capabilities.py
+++ b/kiwi/utils/command_capabilities.py
@@ -31,9 +31,9 @@ class CommandCapabilities(object):
     so it can look specific flags on help message, check
     command version, etc.
     """
-    @classmethod
+    @staticmethod
     def has_option_in_help(
-        cls, call, flag, help_flags=None,
+        call, flag, help_flags=None,
         root=None, raise_on_error=True
     ):
         """
@@ -70,9 +70,9 @@ class CommandCapabilities(object):
             log.warning(message)
         return False
 
-    @classmethod
+    @staticmethod
     def check_version(
-        cls, call, version_waterline, version_flags=None,
+        call, version_waterline, version_flags=None,
         root=None, raise_on_error=True
     ):
         """

--- a/kiwi/utils/size.py
+++ b/kiwi/utils/size.py
@@ -25,8 +25,8 @@ class StringToSize(object):
     """
     **Performs size convertions from strings to numbers**
     """
-    @classmethod
-    def to_bytes(cls, size_value):
+    @staticmethod
+    def to_bytes(size_value):
         """
         Convert the given string representig a size into the appropriate
         number of bytes.

--- a/kiwi/volume_manager/btrfs.py
+++ b/kiwi/volume_manager/btrfs.py
@@ -376,8 +376,8 @@ class VolumeManagerBtrfs(VolumeManagerBase):
                 'QGROUP=1/0'
             ])
 
-    @classmethod
-    def _set_snapper_sysconfig_file(cls, root_path):
+    @staticmethod
+    def _set_snapper_sysconfig_file(root_path):
         sysconf_file = SysConfig(
             os.sep.join([root_path, 'etc/sysconfig/snapper'])
         )

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -223,8 +223,8 @@ except ImportError as exp:
                         minutes = (total_seconds - (hours * 3600)) // 60
                         _svalue += '{0:02d}:{1:02d}'.format(hours, minutes)
             return _svalue
-        @classmethod
-        def gds_parse_datetime(cls, input_data):
+        @staticmethod
+        def gds_parse_datetime(input_data):
             tz = None
             if input_data[-1] == 'Z':
                 tz = GeneratedsSuper._FixedOffsetTZ(0, 'UTC')
@@ -278,8 +278,8 @@ except ImportError as exp:
             except AttributeError:
                 pass
             return _svalue
-        @classmethod
-        def gds_parse_date(cls, input_data):
+        @staticmethod
+        def gds_parse_date(input_data):
             tz = None
             if input_data[-1] == 'Z':
                 tz = GeneratedsSuper._FixedOffsetTZ(0, 'UTC')
@@ -344,8 +344,8 @@ except ImportError as exp:
                     found1 = False
                     break
             return found1
-        @classmethod
-        def gds_parse_time(cls, input_data):
+        @staticmethod
+        def gds_parse_time(input_data):
             tz = None
             if input_data[-1] == 'Z':
                 tz = GeneratedsSuper._FixedOffsetTZ(0, 'UTC')
@@ -396,8 +396,8 @@ except ImportError as exp:
             return class_obj1
         def gds_build_any(self, node, type_name=None):
             return None
-        @classmethod
-        def gds_reverse_node_mapping(cls, mapping):
+        @staticmethod
+        def gds_reverse_node_mapping(mapping):
             return dict(((v, k) for k, v in mapping.iteritems()))
         @staticmethod
         def gds_encode(instring):


### PR DESCRIPTION
@classmethod are used in Python to represent methods that can
query and update the class (cls parameter). Is expected to be
used for metaprograming, or advanced techniques that require the
access to the class itself, before we have an instance.

@staticmethod are used to associate a function to a class. It will
not be have access to the instance (self) not the class (cls). In
other programming languages are known as class methods.

This patch replace all the @classmethod with @staticmethod when
there is not need to access to the cls parameter, because the
intention is to be used as normal functions.
