### PR TITLE
Build with bootstrap only

### DIFF
--- a/build-tests/x86/test-image-tbz/appliance.kiwi
+++ b/build-tests/x86/test-image-tbz/appliance.kiwi
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<image schemaversion="6.9" name="TBZ-openSUSE-Tumbleweed">
+    <description type="system">
+        <author>Marcus Schäfer</author>
+        <contact>ms@suse.com</contact>
+        <specification>Simple tar archive build, bootstrap only</specification>
+    </description>
+    <preferences>
+        <version>1.15.1</version>
+        <packagemanager>zypper</packagemanager>
+        <type image="tbz"/>
+    </preferences>
+    <repository type="rpm-md" alias="kiwi-next-generation" priority="1">
+        <source path="obs://Virtualization:Appliances:Staging/openSUSE_Tumbleweed"/>
+    </repository>
+    <repository type="rpm-md" alias="Tumbleweed" priority="2">
+        <source path="obs://openSUSE:Factory/snapshot"/>
+    </repository>
+    <packages type="bootstrap">
+        <package name="vim"/>
+        <package name="openSUSE-release"/>
+        <package name="openSUSE-release-dvd"/>
+    </packages>
+</image>

--- a/kiwi/package_manager/dnf.py
+++ b/kiwi/package_manager/dnf.py
@@ -263,4 +263,5 @@ class PackageManagerDnf(PackageManagerBase):
         rpm package installed during bootstrap phase
         """
         rpmdb = RpmDataBase(self.root_dir)
-        rpmdb.set_database_to_image_path()
+        if rpmdb.has_rpm():
+            rpmdb.set_database_to_image_path()

--- a/kiwi/package_manager/zypper.py
+++ b/kiwi/package_manager/zypper.py
@@ -252,7 +252,8 @@ class PackageManagerZypper(PackageManagerBase):
         rpm package installed during bootstrap phase
         """
         rpmdb = RpmDataBase(self.root_dir)
-        rpmdb.set_database_to_image_path()
+        if rpmdb.has_rpm():
+            rpmdb.set_database_to_image_path()
 
     def has_failed(self, returncode):
         """

--- a/test/unit/package_manager_dnf_test.py
+++ b/test/unit/package_manager_dnf_test.py
@@ -154,6 +154,7 @@ class TestPackageManagerDnf(object):
     @patch('kiwi.package_manager.dnf.RpmDataBase')
     def test_post_process_install_requests_bootstrap(self, mock_RpmDataBase):
         rpmdb = mock.Mock()
+        rpmdb.has_rpm.return_value = True
         mock_RpmDataBase.return_value = rpmdb
         self.manager.post_process_install_requests_bootstrap()
         rpmdb.set_database_to_image_path.assert_called_once_with()

--- a/test/unit/package_manager_zypper_test.py
+++ b/test/unit/package_manager_zypper_test.py
@@ -150,6 +150,7 @@ class TestPackageManagerZypper(object):
     @patch('kiwi.package_manager.zypper.RpmDataBase')
     def test_post_process_install_requests_bootstrap(self, mock_RpmDataBase):
         rpmdb = mock.Mock()
+        rpmdb.has_rpm.return_value = True
         mock_RpmDataBase.return_value = rpmdb
         self.manager.post_process_install_requests_bootstrap()
         rpmdb.set_database_to_image_path.assert_called_once_with()


### PR DESCRIPTION
Fixed bootstrap only building
    
Image descriptions that define packages in the bootstrap section
only don't need a package manager inside of the image. However
the code to update the location of the rpm database did not
check the presence of rpm and failed on such image descriptions.
This Fixes #1030