### PR TITLE
Fixup has_rpm method from RpmDataBase class

### DIFF
--- a/kiwi/utils/rpm_database.py
+++ b/kiwi/utils/rpm_database.py
@@ -35,13 +35,14 @@ class RpmDataBase(object):
 
     def has_rpm(self):
         """
-        Check if rpm binary was found in root_dir
+        Check if rpmdb binary was found in root_dir to indicate
+        that the rpm system is present.
         """
         rpm_search_env = {
             'PATH': os.sep.join([self.root_dir, 'usr', 'bin'])
         }
         rpm_bin = Path.which(
-            'rpm', custom_env=rpm_search_env, access_mode=os.X_OK
+            'rpmdb', custom_env=rpm_search_env, access_mode=os.X_OK
         )
         if not rpm_bin:
             return False

--- a/test/unit/utils_rpm_database_test.py
+++ b/test/unit/utils_rpm_database_test.py
@@ -16,7 +16,7 @@ class TestRpmDataBase(object):
         mock_Path_which.return_value = None
         assert self.rpmdb.has_rpm() is False
         mock_Path_which.assert_called_once_with(
-            'rpm', access_mode=1, custom_env={'PATH': 'root_dir/usr/bin'}
+            'rpmdb', access_mode=1, custom_env={'PATH': 'root_dir/usr/bin'}
         )
         mock_Path_which.return_value = 'rpm'
         assert self.rpmdb.has_rpm() is True


### PR DESCRIPTION
The method checked for the presence of /usr/bin/rpm. But
that binary is also provided by another toolkit named
busybox. Thus to check if the rpm we are aiming for is
present the check has been modified to look for /usr/bin/rpmdb
which is exclusively provided by rpm only. This Fixes #1037

