### PR TITLE
Add the possibility to disable runtime checks

### DIFF
--- a/kiwi/runtime_config.py
+++ b/kiwi/runtime_config.py
@@ -239,6 +239,21 @@ class RuntimeConfig(object):
         )
         return StringToSize.to_bytes(max_size) if max_size else None
 
+    def get_disabled_runtime_checks(self):
+        """
+        Returns disabled runtime checks. Checks can be disabled with:
+
+        runtime_checks:
+            - disable: check_container_tool_chain_installed
+
+        if the provided string does not match any RuntimeChecker method it is
+        just ignored.
+        """
+        disabled_checks = self._get_attribute(
+            element='runtime_checks', attribute='disable'
+        )
+        return disabled_checks or ''
+
     def _get_attribute(self, element, attribute):
         if self.config_data:
             try:

--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -18,6 +18,7 @@
 import os
 import logging
 import glob
+from operator import attrgetter
 
 # project
 from kiwi.cli import Cli
@@ -176,6 +177,22 @@ class CliTask(object):
                 0, 6
             )
         ]
+
+    def run_checks(self, checks):
+        """
+        This method runs the given runtime checks excluding the ones disabled
+        in the runtime configuration file.
+
+        :param dict checks: A dictionary with the runtime method names as keys
+            and their arguments list as the values.
+        """
+        exclude_list = self.runtime_config.get_disabled_runtime_checks()
+        if self.runtime_checker is not None:
+            for method, args in {
+                key: value for key, value in checks.items()
+                    if key not in exclude_list
+            }.items():
+                attrgetter(method)(self.runtime_checker)(*args)
 
     def _pop_token(self, tokens):
         token = tokens.pop(0)

--- a/kiwi/tasks/system_build.py
+++ b/kiwi/tasks/system_build.py
@@ -135,23 +135,26 @@ class SystemBuildTask(CliTask):
         self.load_xml_description(
             self.command_args['--description']
         )
-        self.runtime_checker.check_minimal_required_preferences()
-        self.runtime_checker.check_efi_mode_for_disk_overlay_correctly_setup()
-        self.runtime_checker.check_boot_description_exists()
-        self.runtime_checker.check_consistent_kernel_in_boot_and_system_image()
-        self.runtime_checker.check_docker_tool_chain_installed()
-        self.runtime_checker.check_volume_setup_defines_multiple_fullsize_volumes()
-        self.runtime_checker.check_volume_setup_has_no_root_definition()
-        self.runtime_checker.check_volume_label_used_with_lvm()
-        self.runtime_checker.check_xen_uniquely_setup_as_server_or_guest()
-        self.runtime_checker.check_target_directory_not_in_shared_cache(
-            abs_target_dir_path
-        )
-        self.runtime_checker.check_mediacheck_only_for_x86_arch()
-        self.runtime_checker.check_dracut_module_for_live_iso_in_package_list()
-        self.runtime_checker.check_dracut_module_for_disk_overlay_in_package_list()
-        self.runtime_checker.check_dracut_module_for_disk_oem_in_package_list()
-        self.runtime_checker.check_dracut_module_for_oem_install_in_package_list()
+
+        checks = {
+            'check_minimal_required_preferences': [],
+            'check_efi_mode_for_disk_overlay_correctly_setup': [],
+            'check_grub_efi_installed_for_efi_firmware': [],
+            'check_boot_description_exists': [],
+            'check_consistent_kernel_in_boot_and_system_image': [],
+            'check_container_tool_chain_installed': [],
+            'check_volume_setup_defines_multiple_fullsize_volumes': [],
+            'check_volume_setup_has_no_root_definition': [],
+            'check_volume_label_used_with_lvm': [],
+            'check_xen_uniquely_setup_as_server_or_guest': [],
+            'check_target_directory_not_in_shared_cache': [abs_target_dir_path],
+            'check_mediacheck_only_for_x86_arch': [],
+            'check_dracut_module_for_live_iso_in_package_list': [],
+            'check_dracut_module_for_disk_overlay_in_package_list': [],
+            'check_dracut_module_for_disk_oem_in_package_list': [],
+            'check_dracut_module_for_oem_install_in_package_list': []
+        }
+        self.run_checks(checks)
 
         if self.command_args['--ignore-repos']:
             self.xml_state.delete_repository_sections()
@@ -190,8 +193,11 @@ class SystemBuildTask(CliTask):
                 self.command_args['--set-container-derived-from']
             )
 
-        self.runtime_checker.check_repositories_configured()
-        self.runtime_checker.check_image_include_repos_publicly_resolvable()
+        checks = {
+            'check_repositories_configured': [],
+            'check_image_include_repos_publicly_resolvable': []
+        }
+        self.run_checks(checks)
 
         log.info('Preparing new root system')
         system = SystemPrepare(

--- a/kiwi/tasks/system_create.py
+++ b/kiwi/tasks/system_create.py
@@ -79,9 +79,10 @@ class SystemCreateTask(CliTask):
         self.load_xml_description(
             abs_root_path
         )
-        self.runtime_checker.check_target_directory_not_in_shared_cache(
-            abs_target_dir_path
-        )
+        checks = {
+            'check_target_directory_not_in_shared_cache': [abs_root_path]
+        }
+        self.run_checks(checks)
 
         log.info('Creating system image')
         if not os.path.exists(abs_target_dir_path):

--- a/kiwi/tasks/system_prepare.py
+++ b/kiwi/tasks/system_prepare.py
@@ -121,24 +121,25 @@ class SystemPrepareTask(CliTask):
 
         abs_root_path = os.path.abspath(self.command_args['--root'])
 
-        self.runtime_checker.check_minimal_required_preferences()
-        self.runtime_checker.check_efi_mode_for_disk_overlay_correctly_setup()
-        self.runtime_checker.check_grub_efi_installed_for_efi_firmware()
-        self.runtime_checker.check_boot_description_exists()
-        self.runtime_checker.check_consistent_kernel_in_boot_and_system_image()
-        self.runtime_checker.check_docker_tool_chain_installed()
-        self.runtime_checker.check_volume_setup_defines_multiple_fullsize_volumes()
-        self.runtime_checker.check_volume_setup_has_no_root_definition()
-        self.runtime_checker.check_volume_label_used_with_lvm()
-        self.runtime_checker.check_xen_uniquely_setup_as_server_or_guest()
-        self.runtime_checker.check_target_directory_not_in_shared_cache(
-            abs_root_path
-        )
-        self.runtime_checker.check_mediacheck_only_for_x86_arch()
-        self.runtime_checker.check_dracut_module_for_live_iso_in_package_list()
-        self.runtime_checker.check_dracut_module_for_disk_overlay_in_package_list()
-        self.runtime_checker.check_dracut_module_for_disk_oem_in_package_list()
-        self.runtime_checker.check_dracut_module_for_oem_install_in_package_list()
+        checks = {
+            'check_minimal_required_preferences': [],
+            'check_efi_mode_for_disk_overlay_correctly_setup': [],
+            'check_grub_efi_installed_for_efi_firmware': [],
+            'check_boot_description_exists': [],
+            'check_consistent_kernel_in_boot_and_system_image': [],
+            'check_container_tool_chain_installed': [],
+            'check_volume_setup_defines_multiple_fullsize_volumes': [],
+            'check_volume_setup_has_no_root_definition': [],
+            'check_volume_label_used_with_lvm': [],
+            'check_xen_uniquely_setup_as_server_or_guest': [],
+            'check_target_directory_not_in_shared_cache': [abs_root_path],
+            'check_mediacheck_only_for_x86_arch': [],
+            'check_dracut_module_for_live_iso_in_package_list': [],
+            'check_dracut_module_for_disk_overlay_in_package_list': [],
+            'check_dracut_module_for_disk_oem_in_package_list': [],
+            'check_dracut_module_for_oem_install_in_package_list': []
+        }
+        self.run_checks(checks)
 
         if self.command_args['--ignore-repos']:
             self.xml_state.delete_repository_sections()
@@ -177,8 +178,11 @@ class SystemPrepareTask(CliTask):
                 self.command_args['--set-container-derived-from']
             )
 
-        self.runtime_checker.check_repositories_configured()
-        self.runtime_checker.check_image_include_repos_publicly_resolvable()
+        checks = {
+            'check_repositories_configured': [],
+            'check_image_include_repos_publicly_resolvable': []
+        }
+        self.run_checks(checks)
 
         log.info('Preparing system')
         system = SystemPrepare(

--- a/test/data/.config/kiwi/config.yml
+++ b/test/data/.config/kiwi/config.yml
@@ -16,3 +16,8 @@ oci:
 
 container:
   - compress: none
+
+runtime_checks:
+  - disable:
+      - check_dracut_module_for_oem_install_in_package_list
+      - check_container_tool_chain_installed

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -74,18 +74,32 @@ class TestRuntimeChecker(object):
 
     @patch('kiwi.runtime_checker.Path.which')
     @raises(KiwiRuntimeError)
-    def test_check_docker_tool_chain_installed(self, mock_which):
+    def test_check_container_tool_chain_installed(self, mock_which):
         mock_which.return_value = False
         xml_state = XMLState(
             self.description.load(), ['docker'], 'docker'
         )
         runtime_checker = RuntimeChecker(xml_state)
-        runtime_checker.check_docker_tool_chain_installed()
+        runtime_checker.check_container_tool_chain_installed()
 
     @patch('kiwi.runtime_checker.RuntimeConfig.get_oci_archive_tool')
     @patch('kiwi.runtime_checker.Path.which')
     @raises(KiwiRuntimeError)
-    def test_check_docker_tool_chain_installed_buildah(
+    def test_check_container_tool_chain_installed_unknown_tool(
+        self, mock_which, mock_oci_tool
+    ):
+        mock_oci_tool.return_value = 'budah'
+        mock_which.return_value = False
+        xml_state = XMLState(
+            self.description.load(), ['docker'], 'docker'
+        )
+        runtime_checker = RuntimeChecker(xml_state)
+        runtime_checker.check_container_tool_chain_installed()
+
+    @patch('kiwi.runtime_checker.RuntimeConfig.get_oci_archive_tool')
+    @patch('kiwi.runtime_checker.Path.which')
+    @raises(KiwiRuntimeError)
+    def test_check_container_tool_chain_installed_buildah(
         self, mock_which, mock_oci_tool
     ):
         mock_oci_tool.return_value = 'buildah'
@@ -94,12 +108,12 @@ class TestRuntimeChecker(object):
             self.description.load(), ['docker'], 'docker'
         )
         runtime_checker = RuntimeChecker(xml_state)
-        runtime_checker.check_docker_tool_chain_installed()
+        runtime_checker.check_container_tool_chain_installed()
 
     @patch('kiwi.runtime_checker.Path.which')
     @patch('kiwi.runtime_checker.CommandCapabilities.check_version')
     @raises(KiwiRuntimeError)
-    def test_check_docker_tool_chain_installed_with_version(
+    def test_check_container_tool_chain_installed_with_version(
         self, mock_cmdver, mock_which
     ):
         mock_which.return_value = True
@@ -108,13 +122,13 @@ class TestRuntimeChecker(object):
             self.description.load(), ['docker'], 'docker'
         )
         runtime_checker = RuntimeChecker(xml_state)
-        runtime_checker.check_docker_tool_chain_installed()
+        runtime_checker.check_container_tool_chain_installed()
 
     @patch('kiwi.runtime_checker.Path.which')
     @patch('kiwi.runtime_checker.CommandCapabilities.check_version')
     @patch('kiwi.runtime_checker.CommandCapabilities.has_option_in_help')
     @raises(KiwiRuntimeError)
-    def test_check_docker_tool_chain_installed_with_multitags(
+    def test_check_container_tool_chain_installed_with_multitags(
         self, mock_cmdoptions, mock_cmdver, mock_which
     ):
         mock_which.return_value = True
@@ -124,7 +138,7 @@ class TestRuntimeChecker(object):
             self.description.load(), ['docker'], 'docker'
         )
         runtime_checker = RuntimeChecker(xml_state)
-        runtime_checker.check_docker_tool_chain_installed()
+        runtime_checker.check_container_tool_chain_installed()
 
     @raises(KiwiRuntimeError)
     @patch('platform.machine')

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -111,3 +111,9 @@ class TestRuntimeConfig(object):
         with patch.dict('os.environ', {'HOME': './'}):
             runtime_config = RuntimeConfig()
             assert runtime_config.get_oci_archive_tool() == 'umoci'
+
+    def test_get_disabled_runtime_checks(self):
+        assert self.runtime_config.get_disabled_runtime_checks() == [
+            'check_dracut_module_for_oem_install_in_package_list',
+            'check_container_tool_chain_installed'
+        ]

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -39,6 +39,7 @@ class TestSystemBuildTask(object):
         )
 
         self.runtime_config = mock.Mock()
+        self.runtime_config.get_disabled_runtime_checks.return_value = []
         kiwi.tasks.base.RuntimeConfig = mock.Mock(
             return_value=self.runtime_config
         )
@@ -107,7 +108,7 @@ class TestSystemBuildTask(object):
             check_consistent_kernel_in_boot_and_system_image.\
             assert_called_once_with()
         self.runtime_checker.\
-            check_docker_tool_chain_installed.assert_called_once_with()
+            check_container_tool_chain_installed.assert_called_once_with()
         self.runtime_checker.\
             check_volume_setup_defines_multiple_fullsize_volumes.\
             assert_called_once_with()

--- a/test/unit/tasks_system_create_test.py
+++ b/test/unit/tasks_system_create_test.py
@@ -33,6 +33,7 @@ class TestSystemCreateTask(object):
         )
 
         self.runtime_config = mock.Mock()
+        self.runtime_config.get_disabled_runtime_checks.return_value = []
         kiwi.tasks.base.RuntimeConfig = mock.Mock(
             return_value=self.runtime_config
         )

--- a/test/unit/tasks_system_prepare_test.py
+++ b/test/unit/tasks_system_prepare_test.py
@@ -29,6 +29,7 @@ class TestSystemPrepareTask(object):
         )
 
         self.runtime_config = mock.Mock()
+        self.runtime_config.get_disabled_runtime_checks.return_value = []
         kiwi.tasks.base.RuntimeConfig = mock.Mock(
             return_value=self.runtime_config
         )
@@ -97,7 +98,7 @@ class TestSystemPrepareTask(object):
             check_consistent_kernel_in_boot_and_system_image.\
             assert_called_once_with()
         self.runtime_checker.\
-            check_docker_tool_chain_installed.assert_called_once_with()
+            check_container_tool_chain_installed.assert_called_once_with()
         self.runtime_checker.\
             check_volume_setup_defines_multiple_fullsize_volumes.\
             assert_called_once_with()


### PR DESCRIPTION
This commit adds runtime configuration parameters to disable the runtime
checks. This is specially handy if someone does not want to use the kiwi
dracut modules and provide custom ones instead. In order disable some
runtime check consider a runtime config yaml like:

```yaml
runtime_checks:
    - disable:
        - check_dracut_module_for_oem_install_in_package_list
        - check_dracut_module_for_live_iso_in_package_list
```

This commit fixes #893
