### PR TITLE
Update compression flag for qcow2 format

### DIFF
--- a/kiwi/builder/disk.py
+++ b/kiwi/builder/disk.py
@@ -420,7 +420,9 @@ class DiskBuilder(object):
             key='disk_image',
             filename=self.diskname,
             use_for_bundle=True if not self.image_format else False,
-            compress=True,
+            compress=self.runtime_config.get_bundle_compression(
+                default=True
+            ),
             shasum=True
         )
 

--- a/kiwi/builder/filesystem.py
+++ b/kiwi/builder/filesystem.py
@@ -126,7 +126,9 @@ class FileSystemBuilder(object):
             key='filesystem_image',
             filename=self.filename,
             use_for_bundle=True,
-            compress=True,
+            compress=self.runtime_config.get_bundle_compression(
+                default=True
+            ),
             shasum=True
         )
         self.result.add(

--- a/kiwi/builder/pxe.py
+++ b/kiwi/builder/pxe.py
@@ -196,7 +196,9 @@ class PxeBuilder(object):
             key='pxe_archive',
             filename=self.archive_name,
             use_for_bundle=True,
-            compress=False,
+            compress=self.runtime_config.get_bundle_compression(
+                default=False
+            ),
             shasum=True
         )
 

--- a/kiwi/runtime_config.py
+++ b/kiwi/runtime_config.py
@@ -90,7 +90,7 @@ class RuntimeConfig(object):
             obs_public = True
         return bool(obs_public)
 
-    def is_bundle_compression_requested(self):
+    def get_bundle_compression(self, default=True):
         """
         Return boolean value to express if the image bundle should
         contain XZ compressed image results or not.
@@ -102,7 +102,10 @@ class RuntimeConfig(object):
         of the bundle is smaller and the download speed increases.
         However the image must be uncompressed before use
 
-        By default the bundle will contain compressed results.
+        If no compression is explicitly configured, the provided
+        default value applies
+
+        :param bool default: Default value
 
         :return: True or False
 
@@ -112,9 +115,7 @@ class RuntimeConfig(object):
             element='bundle', attribute='compress'
         )
         if bundle_compress is None:
-            # if the bundle compression is not set,
-            # the default is compress image results
-            bundle_compress = True
+            bundle_compress = default
         return bool(bundle_compress)
 
     def get_xz_options(self):

--- a/kiwi/storage/subformat/base.py
+++ b/kiwi/storage/subformat/base.py
@@ -21,6 +21,7 @@ from collections import OrderedDict
 
 # project
 from kiwi.command import Command
+from kiwi.runtime_config import RuntimeConfig
 from kiwi.defaults import Defaults
 from kiwi.path import Path
 from kiwi.logger import log
@@ -50,6 +51,7 @@ class DiskFormatBase(object):
         self.temp_image_dir = None
         self.image_format = None
         self.diskname = self.get_target_file_path_for_format('raw')
+        self.runtime_config = RuntimeConfig()
 
         self.post_init(custom_args)
 
@@ -187,7 +189,9 @@ class DiskFormatBase(object):
                 self.image_format
             ),
             use_for_bundle=True,
-            compress=True,
+            compress=self.runtime_config.get_bundle_compression(
+                default=True
+            ),
             shasum=True
         )
 

--- a/kiwi/storage/subformat/ova.py
+++ b/kiwi/storage/subformat/ova.py
@@ -107,6 +107,8 @@ class DiskFormatOva(DiskFormatBase):
             key='disk_format_image',
             filename=self.get_target_file_path_for_format('ova'),
             use_for_bundle=True,
-            compress=False,
+            compress=self.runtime_config.get_bundle_compression(
+                default=False
+            ),
             shasum=True
         )

--- a/kiwi/storage/subformat/qcow2.py
+++ b/kiwi/storage/subformat/qcow2.py
@@ -48,3 +48,27 @@ class DiskFormatQcow2(DiskFormatBase):
                 self.get_target_file_path_for_format(self.image_format)
             ]
         )
+
+    def store_to_result(self, result):
+        """
+        Store result file of the format conversion into the
+        provided result instance.
+
+        In case of a qcow2 format we store the result uncompressed
+        Since the format conversion only takes the real bytes into
+        account such that the sparseness of the raw disk will not
+        result in the output format and can be taken one by one
+
+        :param object result: Instance of Result
+        """
+        result.add(
+            key='disk_format_image',
+            filename=self.get_target_file_path_for_format(
+                self.image_format
+            ),
+            use_for_bundle=True,
+            compress=self.runtime_config.get_bundle_compression(
+                default=False
+            ),
+            shasum=True
+        )

--- a/kiwi/storage/subformat/vhdfixed.py
+++ b/kiwi/storage/subformat/vhdfixed.py
@@ -85,7 +85,9 @@ class DiskFormatVhdFixed(DiskFormatBase):
                 self.image_format
             ),
             use_for_bundle=True,
-            compress=True,
+            compress=self.runtime_config.get_bundle_compression(
+                default=True
+            ),
             shasum=True
         )
 

--- a/kiwi/storage/subformat/vmdk.py
+++ b/kiwi/storage/subformat/vmdk.py
@@ -81,7 +81,9 @@ class DiskFormatVmdk(DiskFormatBase):
             key='disk_format_image',
             filename=self.get_target_file_path_for_format('vmdk'),
             use_for_bundle=True,
-            compress=True,
+            compress=self.runtime_config.get_bundle_compression(
+                default=True
+            ),
             shasum=True
         )
         result.add(

--- a/kiwi/tasks/result_bundle.py
+++ b/kiwi/tasks/result_bundle.py
@@ -128,8 +128,7 @@ class ResultBundleTask(CliTask):
                         'cp', result_file.filename, bundle_file
                     ]
                 )
-                if self.runtime_config.is_bundle_compression_requested() and \
-                   result_file.compress:
+                if result_file.compress:
                     log.info('--> XZ compressing')
                     compress = Compress(bundle_file)
                     compress.xz(self.runtime_config.get_xz_options())

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -38,13 +38,14 @@ class TestRuntimeConfig(object):
     def test_is_obs_public(self):
         assert self.runtime_config.is_obs_public() is True
 
-    def test_is_bundle_compression_requested(self):
-        assert self.runtime_config.is_bundle_compression_requested() is True
+    def test_get_bundle_compression(self):
+        assert self.runtime_config.get_bundle_compression() is True
 
-    def test_is_bundle_compression_requested_default(self):
+    def test_get_bundle_compression_default(self):
         with patch.dict('os.environ', {'HOME': './'}):
             runtime_config = RuntimeConfig()
-            assert runtime_config.is_bundle_compression_requested() is True
+            assert runtime_config.get_bundle_compression(default=True) is True
+            assert runtime_config.get_bundle_compression(default=False) is False
 
     def test_is_obs_public_default(self):
         with patch.dict('os.environ', {'HOME': './'}):

--- a/test/unit/storage_subformat_qcow2_test.py
+++ b/test/unit/storage_subformat_qcow2_test.py
@@ -36,3 +36,14 @@ class TestDiskFormatQcow2(object):
                 'target_dir/some-disk-image.x86_64-1.2.3.qcow2'
             ]
         )
+
+    def test_store_to_result(self):
+        result = mock.Mock()
+        self.disk_format.store_to_result(result)
+        result.add.assert_called_once_with(
+            compress=False,
+            filename='target_dir/some-disk-image.x86_64-1.2.3.qcow2',
+            key='disk_format_image',
+            shasum=True,
+            use_for_bundle=True
+        )


### PR DESCRIPTION
In case of a qcow2 format we store the result uncompressed
Since the format conversion only takes the real bytes into
account such that the sparseness of the raw disk will not
result in the output format and can be taken one by one
This Fixes bsc#1128146

