### PR TITLE
Fix filesystem labels

### DIFF
--- a/kiwi/filesystem/base.py
+++ b/kiwi/filesystem/base.py
@@ -16,6 +16,7 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
+import copy
 
 # project
 from kiwi.logger import log
@@ -80,7 +81,7 @@ class FileSystemBase(object):
                 }
         """
         if custom_args:
-            self.custom_args = custom_args
+            self.custom_args = copy.deepcopy(custom_args)
 
         if 'create_options' not in self.custom_args:
             self.custom_args['create_options'] = []


### PR DESCRIPTION
If multiple volumes were defined they were not properly labeled. This
commit fixes a miss use of custom_args dictonary by the filesystem
base class. This class was modifying the given custom_args that is
passed by reference, thus modifiyng the custom_args instance of the
caller. This issue was causing to propagate the modified
create_options of a filesystem across all the volumes, causing all
volumes to be labelled as ROOT. With this commit Filesystem class
performs a deepcopy of the custom_args dictionary to limit the scope of
any change inside each Filesystem instance.

Fixes #1044