### PR TITLE
Deleted pxedeploy section

### DIFF
--- a/build-tests/arm/test-image-rpi-oem/appliance.kiwi
+++ b/build-tests/arm/test-image-rpi-oem/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="OEM-openSUSE-Tumbleweed">
+<image schemaversion="7.0" name="OEM-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/s390/test-image-oem/appliance.kiwi
+++ b/build-tests/s390/test-image-oem/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="LimeJeOS-DASD-ECKD-SLE12-Community">
+<image schemaversion="7.0" name="LimeJeOS-DASD-ECKD-SLE12-Community">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/test-image-azure/appliance.kiwi
+++ b/build-tests/x86/test-image-azure/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="Azure-openSUSE-Tumbleweed">
+<image schemaversion="7.0" name="Azure-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/test-image-centos/appliance.kiwi
+++ b/build-tests/x86/test-image-centos/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="6.9" name="LimeJeOS-CentOS-07.0">
+<image schemaversion="7.0" name="LimeJeOS-CentOS-07.0">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/test-image-docker-derived/appliance.kiwi
+++ b/build-tests/x86/test-image-docker-derived/appliance.kiwi
@@ -1,30 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
-<image schemaversion="6.9" name="docker-builder-image">
-  <description type="system">
-    <author>David Cassany</author>
-    <contact>dcassany@suse.de</contact>
-    <specification>Builder image based on Tumbleweed</specification>
-  </description>
-  <preferences>
-    <type image="docker" derived_from="obs://openSUSE:Factory/images/opensuse/tumbleweed#latest">
-      <containerconfig name="builder" tag="1.0" additionaltags="latest"/>
-    </type>
-    <version>1.0</version>
-    <packagemanager>zypper</packagemanager>
-    <rpm-excludedocs>true</rpm-excludedocs>
-  </preferences>
-  <repository type="rpm-md" alias="kiwi-next-generation" priority="1">
-    <source path="obs://Virtualization:Appliances:Staging/openSUSE_Tumbleweed"/>
-  </repository>
-  <repository type="rpm-md" alias="openSUSE Tumbleweed" priority="2">
-    <source path="obs://openSUSE:Factory/snapshot"/>
-  </repository>
-  <packages type="image">
-    <package name="python3-kiwi"/>
-    <package name="kiwi-image-docker-requires"/>
-    <package name="kiwi-image-iso-requires"/>
-    <package name="kiwi-image-oem-requires"/>
-    <package name="kiwi-image-pxe-requires"/>
-    <package name="kiwi-image-vmx-requires"/>
-  </packages>
+
+<image schemaversion="7.0" name="docker-builder-image">
+    <description type="system">
+        <author>David Cassany</author>
+        <contact>dcassany@suse.de</contact>
+        <specification>Builder image based on Tumbleweed</specification>
+    </description>
+    <preferences>
+        <type image="docker" derived_from="obs://openSUSE:Factory/images/opensuse/tumbleweed#latest">
+            <containerconfig name="builder" tag="1.0" additionaltags="latest"/>
+        </type>
+        <version>1.0</version>
+        <packagemanager>zypper</packagemanager>
+        <rpm-excludedocs>true</rpm-excludedocs>
+    </preferences>
+    <repository type="rpm-md" alias="kiwi-next-generation" priority="1">
+        <source path="obs://Virtualization:Appliances:Staging/openSUSE_Tumbleweed"/>
+    </repository>
+    <repository type="rpm-md" alias="openSUSE Tumbleweed" priority="2">
+        <source path="obs://openSUSE:Factory/snapshot"/>
+    </repository>
+    <packages type="image">
+        <package name="python3-kiwi"/>
+        <package name="kiwi-image-docker-requires"/>
+        <package name="kiwi-image-iso-requires"/>
+        <package name="kiwi-image-oem-requires"/>
+        <package name="kiwi-image-pxe-requires"/>
+        <package name="kiwi-image-vmx-requires"/>
+    </packages>
 </image>

--- a/build-tests/x86/test-image-docker/appliance.kiwi
+++ b/build-tests/x86/test-image-docker/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="Docker-openSUSE-Tumbleweed">
+<image schemaversion="7.0" name="Docker-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/test-image-ec2/appliance.kiwi
+++ b/build-tests/x86/test-image-ec2/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="EC2-openSUSE-Tumbleweed">
+<image schemaversion="7.0" name="EC2-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/test-image-fedora/appliance.kiwi
+++ b/build-tests/x86/test-image-fedora/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="6.9" name="VMX-Fedora-28.0">
+<image schemaversion="7.0" name="VMX-Fedora-28.0">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/test-image-gce/appliance.kiwi
+++ b/build-tests/x86/test-image-gce/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="GCE-openSUSE-Tumbleweed">
+<image schemaversion="7.0" name="GCE-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/test-image-iso/appliance.kiwi
+++ b/build-tests/x86/test-image-iso/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="ISO-openSUSE-Tumbleweed">
+<image schemaversion="7.0" name="ISO-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/test-image-oem/appliance.kiwi
+++ b/build-tests/x86/test-image-oem/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="OEM-openSUSE-Tumbleweed">
+<image schemaversion="7.0" name="OEM-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/test-image-orthos-oem/appliance.kiwi
+++ b/build-tests/x86/test-image-orthos-oem/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="factory-kiwi">
+<image schemaversion="7.0" name="factory-kiwi">
     <description type="system">
         <author>Julian Wolf</author>
         <contact>juwolf@suse.de</contact>

--- a/build-tests/x86/test-image-pxe/appliance.kiwi
+++ b/build-tests/x86/test-image-pxe/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="PXE-openSUSE-Tumbleweed">
+<image schemaversion="7.0" name="PXE-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/test-image-tbz/appliance.kiwi
+++ b/build-tests/x86/test-image-tbz/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="TBZ-openSUSE-Tumbleweed">
+<image schemaversion="7.0" name="TBZ-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/test-image-ubuntu/appliance.kiwi
+++ b/build-tests/x86/test-image-ubuntu/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="6.9" name="LimeJeOS-Ubuntu-18.04">
+<image schemaversion="7.0" name="LimeJeOS-Ubuntu-18.04">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>
@@ -48,7 +48,7 @@
     </repository>
     <repository type="apt-deb" alias="Ubuntu-Bionic-Universe" distribution="bionic" components="main multiverse restricted universe" repository_gpgcheck="false">
         <source path="obs://Ubuntu:18.04/universe"/>
-     </repository>
+    </repository>
     <repository type="apt-deb" alias="Ubuntu-Bionic" distribution="bionic" components="main multiverse restricted universe" repository_gpgcheck="false">
         <source path="obs://Ubuntu:18.04/standard"/>
     </repository>

--- a/build-tests/x86/test-image-vmx-lvm/appliance.kiwi
+++ b/build-tests/x86/test-image-vmx-lvm/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="VMX-openSUSE-Tumbleweed">
+<image schemaversion="7.0" name="VMX-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/test-image-vmx/appliance.kiwi
+++ b/build-tests/x86/test-image-vmx/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="VMX-openSUSE-Tumbleweed">
+<image schemaversion="7.0" name="VMX-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/doc/source/development/schema.rst
+++ b/doc/source/development/schema.rst
@@ -1,6 +1,6 @@
 .. _schema-docs:
 
-Schema Documentation 6.9
+Schema Documentation 7.0
 ========================
 
 .. raw:: html

--- a/kiwi/builder/pxe.py
+++ b/kiwi/builder/pxe.py
@@ -51,7 +51,6 @@ class PxeBuilder(object):
         self.target_dir = target_dir
         self.compressed = xml_state.build_type.get_compressed()
         self.xen_server = xml_state.is_xen_server()
-        self.pxedeploy = xml_state.get_build_type_pxedeploy_section()
         self.filesystem = FileSystemBuilder(
             xml_state, target_dir, root_dir + '/'
         )
@@ -221,10 +220,4 @@ class PxeBuilder(object):
             compress=False,
             shasum=False
         )
-
-        if self.pxedeploy:
-            log.warning(
-                'Creation of client config file from pxedeploy not implemented'
-            )
-
         return self.result

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -59,7 +59,7 @@ div {
         attribute xsi:schemaLocation { xsd:anyURI }
     k.image.schemaversion.attribute =
         ## The allowed Schema version (fixed value)
-        attribute schemaversion { "6.9" }
+        attribute schemaversion { "7.0" }
     k.image.id =
         ## An identification number which is represented in a file
         ## named /etc/ImageID
@@ -242,28 +242,6 @@ div {
 }
 
 #==========================================
-# common element <configuration>
-#
-div {
-    k.configuration.source.attribute = k.source.attribute
-    k.configuration.dest.attribute = k.dest.attribute
-    k.configuration.arch.attribute = k.arch.attribute
-    k.configuration.attlist = 
-        k.configuration.source.attribute &
-        k.configuration.dest.attribute &
-        k.configuration.arch.attribute?
-
-    k.configuration =
-        ## As part of the network deploy configuration this section
-        ## specifies the configuration files which should be included
-        ## into the image after deployment
-        element configuration {
-            k.configuration.attlist,
-            empty
-        }
-}
-
-#==========================================
 # common element <contact>
 #
 div {
@@ -307,34 +285,6 @@ div {
         element ignore {
             k.ignore.attlist,
             empty
-        }
-}
-
-#==========================================
-# common element <initrd>
-#
-div {
-    k.initrd.attlist = empty
-    k.initrd =
-        ## As part of the network deploy configuration this element
-        ## specifies where the boot image (initrd) can be found
-        element initrd {
-            k.initrd.attlist,
-            text
-        }
-}
-
-#==========================================
-# common element <kernel>
-#
-div {
-    k.kernel.attlist = empty
-    k.kernel =
-        ## As part of the network deploy configuration this section
-        ## specifies the where to find the boot kernel
-        element kernel {
-            k.kernel.attlist,
-            text
         }
 }
 
@@ -865,23 +815,6 @@ div {
 }
 
 #==========================================
-# common element <partitions>
-#
-div {
-    k.partitions.device.attribute =
-        ## As part of the network deploy configuration this section
-        ## specifies the disk device name
-        attribute device { text }
-    k.partitions.attlist = k.partitions.device.attribute?
-    k.partitions =
-        ## A List of Partitions
-        element partitions { 
-            k.partitions.attlist, 
-            k.partition+
-        }
-}
-
-#==========================================
 # common element <profile>
 #
 div {
@@ -1150,19 +1083,6 @@ div {
         element systemdisk {
             k.systemdisk.attlist &
             k.volume*
-        }
-}
-
-#==========================================
-# common element <timeout>
-#
-div {
-    k.timeout.attlist = empty
-    k.timeout = 
-        ## Specifies an ATFTP Download Timeout
-        element timeout {
-            k.timeout.attlist,
-            text
         }
 }
 
@@ -1816,40 +1736,9 @@ div {
             k.containerconfig? &
             k.machine? &
             k.oemconfig? &
-            k.pxedeploy? &
             k.size? &
             k.systemdisk? &
             k.vagrantconfig*
-        }
-}
-
-#==========================================
-# common element <union>
-#
-div {
-    k.union.ro.attribute =
-        ## Device only for read-only 
-        attribute ro { text }
-    k.union.rw.attribute =
-        ## Device for Read-Write
-        attribute rw { text }
-    k.union.type.attribute =
-        ## Union type to use to overlay read-write and read-only parts
-        attribute type { "overlayfs" }
-    k.union.attlist =
-        k.union.ro.attribute &
-        k.union.rw.attribute &
-        k.union.type.attribute
-    
-    k.union =  
-        ## As part of the network deploy configuration this section
-        ## specifies the overlay filesystem setup if required by the
-        ## filesystem type of the system image.An overlay setup is
-        ## only required if the system image uses a squashfs
-        ## compressed filesystem.
-        element union {
-            k.union.attlist,
-            empty
         }
 }
 
@@ -2064,32 +1953,6 @@ div {
         element volume {
             k.volume.attlist,
             empty
-        }
-}
-
-#==========================================
-# main block: <pxedeploy>
-#
-div {
-    k.pxedeploy.server.attribute =
-        ## Name or IP Address of server for downloading the data
-        attribute server { text }
-    k.pxedeploy.blocksize.attribute = 
-        ## Blocksize value used for atftp downloads
-        attribute blocksize { xsd:nonNegativeInteger }
-    k.pxedeploy.attlist =
-        k.pxedeploy.server.attribute? &
-        k.pxedeploy.blocksize.attribute?
-    k.pxedeploy =
-        ## Controls the Image Deploy Process
-        element pxedeploy {
-            k.pxedeploy.attlist &
-            k.timeout? &
-            k.kernel? &
-            k.initrd? &
-            k.partitions? &
-            k.union? &
-            k.configuration*
         }
 }
 

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -115,7 +115,7 @@ second the location of the XSD Schema
     <define name="k.image.schemaversion.attribute">
       <attribute name="schemaversion">
         <a:documentation>The allowed Schema version (fixed value)</a:documentation>
-        <value>6.9</value>
+        <value>7.0</value>
       </attribute>
     </define>
     <define name="k.image.id">
@@ -433,40 +433,6 @@ file was fetched</a:documentation>
   </div>
   <!--
     ==========================================
-    common element <configuration>
-    
-  -->
-  <div>
-    <define name="k.configuration.source.attribute">
-      <ref name="k.source.attribute"/>
-    </define>
-    <define name="k.configuration.dest.attribute">
-      <ref name="k.dest.attribute"/>
-    </define>
-    <define name="k.configuration.arch.attribute">
-      <ref name="k.arch.attribute"/>
-    </define>
-    <define name="k.configuration.attlist">
-      <interleave>
-        <ref name="k.configuration.source.attribute"/>
-        <ref name="k.configuration.dest.attribute"/>
-        <optional>
-          <ref name="k.configuration.arch.attribute"/>
-        </optional>
-      </interleave>
-    </define>
-    <define name="k.configuration">
-      <element name="configuration">
-        <a:documentation>As part of the network deploy configuration this section
-specifies the configuration files which should be included
-into the image after deployment</a:documentation>
-        <ref name="k.configuration.attlist"/>
-        <empty/>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
     common element <contact>
     
   -->
@@ -535,42 +501,6 @@ into the image after deployment</a:documentation>
         <a:documentation>Ignores a Package</a:documentation>
         <ref name="k.ignore.attlist"/>
         <empty/>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
-    common element <initrd>
-    
-  -->
-  <div>
-    <define name="k.initrd.attlist">
-      <empty/>
-    </define>
-    <define name="k.initrd">
-      <element name="initrd">
-        <a:documentation>As part of the network deploy configuration this element
-specifies where the boot image (initrd) can be found</a:documentation>
-        <ref name="k.initrd.attlist"/>
-        <text/>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
-    common element <kernel>
-    
-  -->
-  <div>
-    <define name="k.kernel.attlist">
-      <empty/>
-    </define>
-    <define name="k.kernel">
-      <element name="kernel">
-        <a:documentation>As part of the network deploy configuration this section
-specifies the where to find the boot kernel</a:documentation>
-        <ref name="k.kernel.attlist"/>
-        <text/>
       </element>
     </define>
   </div>
@@ -1328,33 +1258,6 @@ the /etc/fstab file or not</a:documentation>
   </div>
   <!--
     ==========================================
-    common element <partitions>
-    
-  -->
-  <div>
-    <define name="k.partitions.device.attribute">
-      <attribute name="device">
-        <a:documentation>As part of the network deploy configuration this section
-specifies the disk device name</a:documentation>
-      </attribute>
-    </define>
-    <define name="k.partitions.attlist">
-      <optional>
-        <ref name="k.partitions.device.attribute"/>
-      </optional>
-    </define>
-    <define name="k.partitions">
-      <element name="partitions">
-        <a:documentation>A List of Partitions</a:documentation>
-        <ref name="k.partitions.attlist"/>
-        <oneOrMore>
-          <ref name="k.partition"/>
-        </oneOrMore>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
     common element <profile>
     
   -->
@@ -1773,23 +1676,6 @@ volume management system</a:documentation>
             <ref name="k.volume"/>
           </zeroOrMore>
         </interleave>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
-    common element <timeout>
-    
-  -->
-  <div>
-    <define name="k.timeout.attlist">
-      <empty/>
-    </define>
-    <define name="k.timeout">
-      <element name="timeout">
-        <a:documentation>Specifies an ATFTP Download Timeout</a:documentation>
-        <ref name="k.timeout.attlist"/>
-        <text/>
       </element>
     </define>
   </div>
@@ -2774,9 +2660,6 @@ default.</a:documentation>
             <ref name="k.oemconfig"/>
           </optional>
           <optional>
-            <ref name="k.pxedeploy"/>
-          </optional>
-          <optional>
             <ref name="k.size"/>
           </optional>
           <optional>
@@ -2786,47 +2669,6 @@ default.</a:documentation>
             <ref name="k.vagrantconfig"/>
           </zeroOrMore>
         </interleave>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
-    common element <union>
-    
-  -->
-  <div>
-    <define name="k.union.ro.attribute">
-      <attribute name="ro">
-        <a:documentation>Device only for read-only </a:documentation>
-      </attribute>
-    </define>
-    <define name="k.union.rw.attribute">
-      <attribute name="rw">
-        <a:documentation>Device for Read-Write</a:documentation>
-      </attribute>
-    </define>
-    <define name="k.union.type.attribute">
-      <attribute name="type">
-        <a:documentation>Union type to use to overlay read-write and read-only parts</a:documentation>
-        <value>overlayfs</value>
-      </attribute>
-    </define>
-    <define name="k.union.attlist">
-      <interleave>
-        <ref name="k.union.ro.attribute"/>
-        <ref name="k.union.rw.attribute"/>
-        <ref name="k.union.type.attribute"/>
-      </interleave>
-    </define>
-    <define name="k.union">
-      <element name="union">
-        <a:documentation>As part of the network deploy configuration this section
-specifies the overlay filesystem setup if required by the
-filesystem type of the system image.An overlay setup is
-only required if the system image uses a squashfs
-compressed filesystem.</a:documentation>
-        <ref name="k.union.attlist"/>
-        <empty/>
       </element>
     </define>
   </div>
@@ -3192,60 +3034,6 @@ add "M" and/or "G" as postfix</a:documentation>
 on an extra volume.</a:documentation>
         <ref name="k.volume.attlist"/>
         <empty/>
-      </element>
-    </define>
-  </div>
-  <!--
-    ==========================================
-    main block: <pxedeploy>
-    
-  -->
-  <div>
-    <define name="k.pxedeploy.server.attribute">
-      <attribute name="server">
-        <a:documentation>Name or IP Address of server for downloading the data</a:documentation>
-      </attribute>
-    </define>
-    <define name="k.pxedeploy.blocksize.attribute">
-      <attribute name="blocksize">
-        <a:documentation>Blocksize value used for atftp downloads</a:documentation>
-        <data type="nonNegativeInteger"/>
-      </attribute>
-    </define>
-    <define name="k.pxedeploy.attlist">
-      <interleave>
-        <optional>
-          <ref name="k.pxedeploy.server.attribute"/>
-        </optional>
-        <optional>
-          <ref name="k.pxedeploy.blocksize.attribute"/>
-        </optional>
-      </interleave>
-    </define>
-    <define name="k.pxedeploy">
-      <element name="pxedeploy">
-        <a:documentation>Controls the Image Deploy Process</a:documentation>
-        <interleave>
-          <ref name="k.pxedeploy.attlist"/>
-          <optional>
-            <ref name="k.timeout"/>
-          </optional>
-          <optional>
-            <ref name="k.kernel"/>
-          </optional>
-          <optional>
-            <ref name="k.initrd"/>
-          </optional>
-          <optional>
-            <ref name="k.partitions"/>
-          </optional>
-          <optional>
-            <ref name="k.union"/>
-          </optional>
-          <zeroOrMore>
-            <ref name="k.configuration"/>
-          </zeroOrMore>
-        </interleave>
       </element>
     </define>
   </div>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -223,8 +223,8 @@ except ImportError as exp:
                         minutes = (total_seconds - (hours * 3600)) // 60
                         _svalue += '{0:02d}:{1:02d}'.format(hours, minutes)
             return _svalue
-        @staticmethod
-        def gds_parse_datetime(input_data):
+        @classmethod
+        def gds_parse_datetime(cls, input_data):
             tz = None
             if input_data[-1] == 'Z':
                 tz = GeneratedsSuper._FixedOffsetTZ(0, 'UTC')
@@ -278,8 +278,8 @@ except ImportError as exp:
             except AttributeError:
                 pass
             return _svalue
-        @staticmethod
-        def gds_parse_date(input_data):
+        @classmethod
+        def gds_parse_date(cls, input_data):
             tz = None
             if input_data[-1] == 'Z':
                 tz = GeneratedsSuper._FixedOffsetTZ(0, 'UTC')
@@ -344,8 +344,8 @@ except ImportError as exp:
                     found1 = False
                     break
             return found1
-        @staticmethod
-        def gds_parse_time(input_data):
+        @classmethod
+        def gds_parse_time(cls, input_data):
             tz = None
             if input_data[-1] == 'Z':
                 tz = GeneratedsSuper._FixedOffsetTZ(0, 'UTC')
@@ -396,8 +396,8 @@ except ImportError as exp:
             return class_obj1
         def gds_build_any(self, node, type_name=None):
             return None
-        @staticmethod
-        def gds_reverse_node_mapping(mapping):
+        @classmethod
+        def gds_reverse_node_mapping(cls, mapping):
             return dict(((v, k) for k, v in mapping.iteritems()))
         @staticmethod
         def gds_encode(instring):
@@ -1241,107 +1241,6 @@ class archive(GeneratedsSuper):
 # end class archive
 
 
-class configuration(GeneratedsSuper):
-    """As part of the network deploy configuration this section specifies
-    the configuration files which should be included into the image
-    after deployment"""
-    subclass = None
-    superclass = None
-    def __init__(self, source=None, dest=None, arch=None):
-        self.original_tagname_ = None
-        self.source = _cast(None, source)
-        self.dest = _cast(None, dest)
-        self.arch = _cast(None, arch)
-    def factory(*args_, **kwargs_):
-        if CurrentSubclassModule_ is not None:
-            subclass = getSubclassFromModule_(
-                CurrentSubclassModule_, configuration)
-            if subclass is not None:
-                return subclass(*args_, **kwargs_)
-        if configuration.subclass:
-            return configuration.subclass(*args_, **kwargs_)
-        else:
-            return configuration(*args_, **kwargs_)
-    factory = staticmethod(factory)
-    def get_source(self): return self.source
-    def set_source(self, source): self.source = source
-    def get_dest(self): return self.dest
-    def set_dest(self, dest): self.dest = dest
-    def get_arch(self): return self.arch
-    def set_arch(self, arch): self.arch = arch
-    def validate_arch_name(self, value):
-        # Validate type arch-name, a restriction on xs:token.
-        if value is not None and Validate_simpletypes_:
-            if not self.gds_validate_simple_patterns(
-                    self.validate_arch_name_patterns_, value):
-                warnings_.warn('Value "%s" does not match xsd pattern restrictions: %s' % (value.encode('utf-8'), self.validate_arch_name_patterns_, ))
-    validate_arch_name_patterns_ = [['^.*$']]
-    def hasContent_(self):
-        if (
-
-        ):
-            return True
-        else:
-            return False
-    def export(self, outfile, level, namespace_='', name_='configuration', namespacedef_='', pretty_print=True):
-        imported_ns_def_ = GenerateDSNamespaceDefs_.get('configuration')
-        if imported_ns_def_ is not None:
-            namespacedef_ = imported_ns_def_
-        if pretty_print:
-            eol_ = '\n'
-        else:
-            eol_ = ''
-        if self.original_tagname_ is not None:
-            name_ = self.original_tagname_
-        showIndent(outfile, level, pretty_print)
-        outfile.write('<%s%s%s' % (namespace_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
-        already_processed = set()
-        self.exportAttributes(outfile, level, already_processed, namespace_, name_='configuration')
-        if self.hasContent_():
-            outfile.write('>%s' % (eol_, ))
-            self.exportChildren(outfile, level + 1, namespace_='', name_='configuration', pretty_print=pretty_print)
-            outfile.write('</%s%s>%s' % (namespace_, name_, eol_))
-        else:
-            outfile.write('/>%s' % (eol_, ))
-    def exportAttributes(self, outfile, level, already_processed, namespace_='', name_='configuration'):
-        if self.source is not None and 'source' not in already_processed:
-            already_processed.add('source')
-            outfile.write(' source=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.source), input_name='source')), ))
-        if self.dest is not None and 'dest' not in already_processed:
-            already_processed.add('dest')
-            outfile.write(' dest=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.dest), input_name='dest')), ))
-        if self.arch is not None and 'arch' not in already_processed:
-            already_processed.add('arch')
-            outfile.write(' arch=%s' % (quote_attrib(self.arch), ))
-    def exportChildren(self, outfile, level, namespace_='', name_='configuration', fromsubclass_=False, pretty_print=True):
-        pass
-    def build(self, node):
-        already_processed = set()
-        self.buildAttributes(node, node.attrib, already_processed)
-        for child in node:
-            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
-            self.buildChildren(child, node, nodeName_)
-        return self
-    def buildAttributes(self, node, attrs, already_processed):
-        value = find_attr_value_('source', node)
-        if value is not None and 'source' not in already_processed:
-            already_processed.add('source')
-            self.source = value
-        value = find_attr_value_('dest', node)
-        if value is not None and 'dest' not in already_processed:
-            already_processed.add('dest')
-            self.dest = value
-        value = find_attr_value_('arch', node)
-        if value is not None and 'arch' not in already_processed:
-            already_processed.add('arch')
-            self.arch = value
-            self.arch = ' '.join(self.arch.split())
-            self.validate_arch_name(self.arch)    # validate type arch-name
-    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
-        pass
-# end class configuration
-
-
 class file(GeneratedsSuper):
     """A Pointer to a File"""
     subclass = None
@@ -1939,95 +1838,6 @@ class partition(GeneratedsSuper):
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         pass
 # end class partition
-
-
-class partitions(GeneratedsSuper):
-    """A List of Partitions"""
-    subclass = None
-    superclass = None
-    def __init__(self, device=None, partition=None):
-        self.original_tagname_ = None
-        self.device = _cast(None, device)
-        if partition is None:
-            self.partition = []
-        else:
-            self.partition = partition
-    def factory(*args_, **kwargs_):
-        if CurrentSubclassModule_ is not None:
-            subclass = getSubclassFromModule_(
-                CurrentSubclassModule_, partitions)
-            if subclass is not None:
-                return subclass(*args_, **kwargs_)
-        if partitions.subclass:
-            return partitions.subclass(*args_, **kwargs_)
-        else:
-            return partitions(*args_, **kwargs_)
-    factory = staticmethod(factory)
-    def get_partition(self): return self.partition
-    def set_partition(self, partition): self.partition = partition
-    def add_partition(self, value): self.partition.append(value)
-    def insert_partition_at(self, index, value): self.partition.insert(index, value)
-    def replace_partition_at(self, index, value): self.partition[index] = value
-    def get_device(self): return self.device
-    def set_device(self, device): self.device = device
-    def hasContent_(self):
-        if (
-            self.partition
-        ):
-            return True
-        else:
-            return False
-    def export(self, outfile, level, namespace_='', name_='partitions', namespacedef_='', pretty_print=True):
-        imported_ns_def_ = GenerateDSNamespaceDefs_.get('partitions')
-        if imported_ns_def_ is not None:
-            namespacedef_ = imported_ns_def_
-        if pretty_print:
-            eol_ = '\n'
-        else:
-            eol_ = ''
-        if self.original_tagname_ is not None:
-            name_ = self.original_tagname_
-        showIndent(outfile, level, pretty_print)
-        outfile.write('<%s%s%s' % (namespace_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
-        already_processed = set()
-        self.exportAttributes(outfile, level, already_processed, namespace_, name_='partitions')
-        if self.hasContent_():
-            outfile.write('>%s' % (eol_, ))
-            self.exportChildren(outfile, level + 1, namespace_='', name_='partitions', pretty_print=pretty_print)
-            showIndent(outfile, level, pretty_print)
-            outfile.write('</%s%s>%s' % (namespace_, name_, eol_))
-        else:
-            outfile.write('/>%s' % (eol_, ))
-    def exportAttributes(self, outfile, level, already_processed, namespace_='', name_='partitions'):
-        if self.device is not None and 'device' not in already_processed:
-            already_processed.add('device')
-            outfile.write(' device=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.device), input_name='device')), ))
-    def exportChildren(self, outfile, level, namespace_='', name_='partitions', fromsubclass_=False, pretty_print=True):
-        if pretty_print:
-            eol_ = '\n'
-        else:
-            eol_ = ''
-        for partition_ in self.partition:
-            partition_.export(outfile, level, namespace_, name_='partition', pretty_print=pretty_print)
-    def build(self, node):
-        already_processed = set()
-        self.buildAttributes(node, node.attrib, already_processed)
-        for child in node:
-            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
-            self.buildChildren(child, node, nodeName_)
-        return self
-    def buildAttributes(self, node, attrs, already_processed):
-        value = find_attr_value_('device', node)
-        if value is not None and 'device' not in already_processed:
-            already_processed.add('device')
-            self.device = value
-    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
-        if nodeName_ == 'partition':
-            obj_ = partition.factory()
-            obj_.build(child_)
-            self.partition.append(obj_)
-            obj_.original_tagname_ = 'partition'
-# end class partitions
 
 
 class profile(GeneratedsSuper):
@@ -2732,7 +2542,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, boottimeout=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, containerconfig=None, machine=None, oemconfig=None, pxedeploy=None, size=None, systemdisk=None, vagrantconfig=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, boottimeout=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, vagrantconfig=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2804,10 +2614,6 @@ class type_(GeneratedsSuper):
             self.oemconfig = []
         else:
             self.oemconfig = oemconfig
-        if pxedeploy is None:
-            self.pxedeploy = []
-        else:
-            self.pxedeploy = pxedeploy
         if size is None:
             self.size = []
         else:
@@ -2846,11 +2652,6 @@ class type_(GeneratedsSuper):
     def add_oemconfig(self, value): self.oemconfig.append(value)
     def insert_oemconfig_at(self, index, value): self.oemconfig.insert(index, value)
     def replace_oemconfig_at(self, index, value): self.oemconfig[index] = value
-    def get_pxedeploy(self): return self.pxedeploy
-    def set_pxedeploy(self, pxedeploy): self.pxedeploy = pxedeploy
-    def add_pxedeploy(self, value): self.pxedeploy.append(value)
-    def insert_pxedeploy_at(self, index, value): self.pxedeploy.insert(index, value)
-    def replace_pxedeploy_at(self, index, value): self.pxedeploy[index] = value
     def get_size(self): return self.size
     def set_size(self, size): self.size = size
     def add_size(self, value): self.size.append(value)
@@ -3008,7 +2809,6 @@ class type_(GeneratedsSuper):
             self.containerconfig or
             self.machine or
             self.oemconfig or
-            self.pxedeploy or
             self.size or
             self.systemdisk or
             self.vagrantconfig
@@ -3223,8 +3023,6 @@ class type_(GeneratedsSuper):
             machine_.export(outfile, level, namespace_, name_='machine', pretty_print=pretty_print)
         for oemconfig_ in self.oemconfig:
             oemconfig_.export(outfile, level, namespace_, name_='oemconfig', pretty_print=pretty_print)
-        for pxedeploy_ in self.pxedeploy:
-            pxedeploy_.export(outfile, level, namespace_, name_='pxedeploy', pretty_print=pretty_print)
         for size_ in self.size:
             size_.export(outfile, level, namespace_, name_='size', pretty_print=pretty_print)
         for systemdisk_ in self.systemdisk:
@@ -3632,11 +3430,6 @@ class type_(GeneratedsSuper):
             obj_.build(child_)
             self.oemconfig.append(obj_)
             obj_.original_tagname_ = 'oemconfig'
-        elif nodeName_ == 'pxedeploy':
-            obj_ = pxedeploy.factory()
-            obj_.build(child_)
-            self.pxedeploy.append(obj_)
-            obj_.original_tagname_ = 'pxedeploy'
         elif nodeName_ == 'size':
             obj_ = size.factory()
             obj_.build(child_)
@@ -3653,100 +3446,6 @@ class type_(GeneratedsSuper):
             self.vagrantconfig.append(obj_)
             obj_.original_tagname_ = 'vagrantconfig'
 # end class type_
-
-
-class union(GeneratedsSuper):
-    """As part of the network deploy configuration this section specifies
-    the overlay filesystem setup if required by the filesystem type
-    of the system image.An overlay setup is only required if the
-    system image uses a squashfs compressed filesystem."""
-    subclass = None
-    superclass = None
-    def __init__(self, ro=None, rw=None, type_=None):
-        self.original_tagname_ = None
-        self.ro = _cast(None, ro)
-        self.rw = _cast(None, rw)
-        self.type_ = _cast(None, type_)
-    def factory(*args_, **kwargs_):
-        if CurrentSubclassModule_ is not None:
-            subclass = getSubclassFromModule_(
-                CurrentSubclassModule_, union)
-            if subclass is not None:
-                return subclass(*args_, **kwargs_)
-        if union.subclass:
-            return union.subclass(*args_, **kwargs_)
-        else:
-            return union(*args_, **kwargs_)
-    factory = staticmethod(factory)
-    def get_ro(self): return self.ro
-    def set_ro(self, ro): self.ro = ro
-    def get_rw(self): return self.rw
-    def set_rw(self, rw): self.rw = rw
-    def get_type(self): return self.type_
-    def set_type(self, type_): self.type_ = type_
-    def hasContent_(self):
-        if (
-
-        ):
-            return True
-        else:
-            return False
-    def export(self, outfile, level, namespace_='', name_='union', namespacedef_='', pretty_print=True):
-        imported_ns_def_ = GenerateDSNamespaceDefs_.get('union')
-        if imported_ns_def_ is not None:
-            namespacedef_ = imported_ns_def_
-        if pretty_print:
-            eol_ = '\n'
-        else:
-            eol_ = ''
-        if self.original_tagname_ is not None:
-            name_ = self.original_tagname_
-        showIndent(outfile, level, pretty_print)
-        outfile.write('<%s%s%s' % (namespace_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
-        already_processed = set()
-        self.exportAttributes(outfile, level, already_processed, namespace_, name_='union')
-        if self.hasContent_():
-            outfile.write('>%s' % (eol_, ))
-            self.exportChildren(outfile, level + 1, namespace_='', name_='union', pretty_print=pretty_print)
-            outfile.write('</%s%s>%s' % (namespace_, name_, eol_))
-        else:
-            outfile.write('/>%s' % (eol_, ))
-    def exportAttributes(self, outfile, level, already_processed, namespace_='', name_='union'):
-        if self.ro is not None and 'ro' not in already_processed:
-            already_processed.add('ro')
-            outfile.write(' ro=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.ro), input_name='ro')), ))
-        if self.rw is not None and 'rw' not in already_processed:
-            already_processed.add('rw')
-            outfile.write(' rw=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.rw), input_name='rw')), ))
-        if self.type_ is not None and 'type_' not in already_processed:
-            already_processed.add('type_')
-            outfile.write(' type=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.type_), input_name='type')), ))
-    def exportChildren(self, outfile, level, namespace_='', name_='union', fromsubclass_=False, pretty_print=True):
-        pass
-    def build(self, node):
-        already_processed = set()
-        self.buildAttributes(node, node.attrib, already_processed)
-        for child in node:
-            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
-            self.buildChildren(child, node, nodeName_)
-        return self
-    def buildAttributes(self, node, attrs, already_processed):
-        value = find_attr_value_('ro', node)
-        if value is not None and 'ro' not in already_processed:
-            already_processed.add('ro')
-            self.ro = value
-        value = find_attr_value_('rw', node)
-        if value is not None and 'rw' not in already_processed:
-            already_processed.add('rw')
-            self.rw = value
-        value = find_attr_value_('type', node)
-        if value is not None and 'type' not in already_processed:
-            already_processed.add('type')
-            self.type_ = value
-            self.type_ = ' '.join(self.type_.split())
-    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
-        pass
-# end class union
 
 
 class user(GeneratedsSuper):
@@ -4351,195 +4050,6 @@ class volume(GeneratedsSuper):
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
         pass
 # end class volume
-
-
-class pxedeploy(GeneratedsSuper):
-    """Controls the Image Deploy Process"""
-    subclass = None
-    superclass = None
-    def __init__(self, server=None, blocksize=None, timeout=None, kernel=None, initrd=None, partitions=None, union=None, configuration=None):
-        self.original_tagname_ = None
-        self.server = _cast(None, server)
-        self.blocksize = _cast(int, blocksize)
-        if timeout is None:
-            self.timeout = []
-        else:
-            self.timeout = timeout
-        if kernel is None:
-            self.kernel = []
-        else:
-            self.kernel = kernel
-        if initrd is None:
-            self.initrd = []
-        else:
-            self.initrd = initrd
-        if partitions is None:
-            self.partitions = []
-        else:
-            self.partitions = partitions
-        if union is None:
-            self.union = []
-        else:
-            self.union = union
-        if configuration is None:
-            self.configuration = []
-        else:
-            self.configuration = configuration
-    def factory(*args_, **kwargs_):
-        if CurrentSubclassModule_ is not None:
-            subclass = getSubclassFromModule_(
-                CurrentSubclassModule_, pxedeploy)
-            if subclass is not None:
-                return subclass(*args_, **kwargs_)
-        if pxedeploy.subclass:
-            return pxedeploy.subclass(*args_, **kwargs_)
-        else:
-            return pxedeploy(*args_, **kwargs_)
-    factory = staticmethod(factory)
-    def get_timeout(self): return self.timeout
-    def set_timeout(self, timeout): self.timeout = timeout
-    def add_timeout(self, value): self.timeout.append(value)
-    def insert_timeout_at(self, index, value): self.timeout.insert(index, value)
-    def replace_timeout_at(self, index, value): self.timeout[index] = value
-    def get_kernel(self): return self.kernel
-    def set_kernel(self, kernel): self.kernel = kernel
-    def add_kernel(self, value): self.kernel.append(value)
-    def insert_kernel_at(self, index, value): self.kernel.insert(index, value)
-    def replace_kernel_at(self, index, value): self.kernel[index] = value
-    def get_initrd(self): return self.initrd
-    def set_initrd(self, initrd): self.initrd = initrd
-    def add_initrd(self, value): self.initrd.append(value)
-    def insert_initrd_at(self, index, value): self.initrd.insert(index, value)
-    def replace_initrd_at(self, index, value): self.initrd[index] = value
-    def get_partitions(self): return self.partitions
-    def set_partitions(self, partitions): self.partitions = partitions
-    def add_partitions(self, value): self.partitions.append(value)
-    def insert_partitions_at(self, index, value): self.partitions.insert(index, value)
-    def replace_partitions_at(self, index, value): self.partitions[index] = value
-    def get_union(self): return self.union
-    def set_union(self, union): self.union = union
-    def add_union(self, value): self.union.append(value)
-    def insert_union_at(self, index, value): self.union.insert(index, value)
-    def replace_union_at(self, index, value): self.union[index] = value
-    def get_configuration(self): return self.configuration
-    def set_configuration(self, configuration): self.configuration = configuration
-    def add_configuration(self, value): self.configuration.append(value)
-    def insert_configuration_at(self, index, value): self.configuration.insert(index, value)
-    def replace_configuration_at(self, index, value): self.configuration[index] = value
-    def get_server(self): return self.server
-    def set_server(self, server): self.server = server
-    def get_blocksize(self): return self.blocksize
-    def set_blocksize(self, blocksize): self.blocksize = blocksize
-    def hasContent_(self):
-        if (
-            self.timeout or
-            self.kernel or
-            self.initrd or
-            self.partitions or
-            self.union or
-            self.configuration
-        ):
-            return True
-        else:
-            return False
-    def export(self, outfile, level, namespace_='', name_='pxedeploy', namespacedef_='', pretty_print=True):
-        imported_ns_def_ = GenerateDSNamespaceDefs_.get('pxedeploy')
-        if imported_ns_def_ is not None:
-            namespacedef_ = imported_ns_def_
-        if pretty_print:
-            eol_ = '\n'
-        else:
-            eol_ = ''
-        if self.original_tagname_ is not None:
-            name_ = self.original_tagname_
-        showIndent(outfile, level, pretty_print)
-        outfile.write('<%s%s%s' % (namespace_, name_, namespacedef_ and ' ' + namespacedef_ or '', ))
-        already_processed = set()
-        self.exportAttributes(outfile, level, already_processed, namespace_, name_='pxedeploy')
-        if self.hasContent_():
-            outfile.write('>%s' % (eol_, ))
-            self.exportChildren(outfile, level + 1, namespace_='', name_='pxedeploy', pretty_print=pretty_print)
-            showIndent(outfile, level, pretty_print)
-            outfile.write('</%s%s>%s' % (namespace_, name_, eol_))
-        else:
-            outfile.write('/>%s' % (eol_, ))
-    def exportAttributes(self, outfile, level, already_processed, namespace_='', name_='pxedeploy'):
-        if self.server is not None and 'server' not in already_processed:
-            already_processed.add('server')
-            outfile.write(' server=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.server), input_name='server')), ))
-        if self.blocksize is not None and 'blocksize' not in already_processed:
-            already_processed.add('blocksize')
-            outfile.write(' blocksize="%s"' % self.gds_format_integer(self.blocksize, input_name='blocksize'))
-    def exportChildren(self, outfile, level, namespace_='', name_='pxedeploy', fromsubclass_=False, pretty_print=True):
-        if pretty_print:
-            eol_ = '\n'
-        else:
-            eol_ = ''
-        for timeout_ in self.timeout:
-            showIndent(outfile, level, pretty_print)
-            outfile.write('<timeout>%s</timeout>%s' % (self.gds_encode(self.gds_format_string(quote_xml(timeout_), input_name='timeout')), eol_))
-        for kernel_ in self.kernel:
-            showIndent(outfile, level, pretty_print)
-            outfile.write('<kernel>%s</kernel>%s' % (self.gds_encode(self.gds_format_string(quote_xml(kernel_), input_name='kernel')), eol_))
-        for initrd_ in self.initrd:
-            showIndent(outfile, level, pretty_print)
-            outfile.write('<initrd>%s</initrd>%s' % (self.gds_encode(self.gds_format_string(quote_xml(initrd_), input_name='initrd')), eol_))
-        for partitions_ in self.partitions:
-            partitions_.export(outfile, level, namespace_, name_='partitions', pretty_print=pretty_print)
-        for union_ in self.union:
-            union_.export(outfile, level, namespace_, name_='union', pretty_print=pretty_print)
-        for configuration_ in self.configuration:
-            configuration_.export(outfile, level, namespace_, name_='configuration', pretty_print=pretty_print)
-    def build(self, node):
-        already_processed = set()
-        self.buildAttributes(node, node.attrib, already_processed)
-        for child in node:
-            nodeName_ = Tag_pattern_.match(child.tag).groups()[-1]
-            self.buildChildren(child, node, nodeName_)
-        return self
-    def buildAttributes(self, node, attrs, already_processed):
-        value = find_attr_value_('server', node)
-        if value is not None and 'server' not in already_processed:
-            already_processed.add('server')
-            self.server = value
-        value = find_attr_value_('blocksize', node)
-        if value is not None and 'blocksize' not in already_processed:
-            already_processed.add('blocksize')
-            try:
-                self.blocksize = int(value)
-            except ValueError as exp:
-                raise_parse_error(node, 'Bad integer attribute: %s' % exp)
-            if self.blocksize < 0:
-                raise_parse_error(node, 'Invalid NonNegativeInteger')
-    def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):
-        if nodeName_ == 'timeout':
-            timeout_ = child_.text
-            timeout_ = self.gds_validate_string(timeout_, node, 'timeout')
-            self.timeout.append(timeout_)
-        elif nodeName_ == 'kernel':
-            kernel_ = child_.text
-            kernel_ = self.gds_validate_string(kernel_, node, 'kernel')
-            self.kernel.append(kernel_)
-        elif nodeName_ == 'initrd':
-            initrd_ = child_.text
-            initrd_ = self.gds_validate_string(initrd_, node, 'initrd')
-            self.initrd.append(initrd_)
-        elif nodeName_ == 'partitions':
-            obj_ = partitions.factory()
-            obj_.build(child_)
-            self.partitions.append(obj_)
-            obj_.original_tagname_ = 'partitions'
-        elif nodeName_ == 'union':
-            obj_ = union.factory()
-            obj_.build(child_)
-            self.union.append(obj_)
-            obj_.original_tagname_ = 'union'
-        elif nodeName_ == 'configuration':
-            obj_ = configuration.factory()
-            obj_.build(child_)
-            self.configuration.append(obj_)
-            obj_.original_tagname_ = 'configuration'
-# end class pxedeploy
 
 
 class description(GeneratedsSuper):
@@ -7853,7 +7363,6 @@ if __name__ == '__main__':
 __all__ = [
     "archive",
     "argument",
-    "configuration",
     "containerconfig",
     "description",
     "drivers",
@@ -7875,13 +7384,11 @@ __all__ = [
     "package",
     "packages",
     "partition",
-    "partitions",
     "port",
     "preferences",
     "product",
     "profile",
     "profiles",
-    "pxedeploy",
     "repository",
     "requires",
     "size",
@@ -7890,7 +7397,6 @@ __all__ = [
     "subcommand",
     "systemdisk",
     "type_",
-    "union",
     "user",
     "users",
     "vagrantconfig",

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -650,18 +650,6 @@ class XMLState(object):
         if systemdisk_sections:
             return systemdisk_sections[0]
 
-    def get_build_type_pxedeploy_section(self):
-        """
-        First pxedeploy section from the build type section
-
-        :return: <pxedeploy> section reference
-
-        :rtype: xml_parse::pxedeploy
-        """
-        pxedeploy_sections = self.build_type.get_pxedeploy()
-        if pxedeploy_sections:
-            return pxedeploy_sections[0]
-
     def get_build_type_machine_section(self):
         """
         First machine section from the build type section

--- a/kiwi/xsl/convert69to70.xsl
+++ b/kiwi/xsl/convert69to70.xsl
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv69to70">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv69to70"/>
+    </xsl:copy>  
+</xsl:template>
+
+<!-- version update -->
+<!-- remove kiwirevision attribute from image -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>6.9</literal> to <literal>7.0</literal>.
+</para>
+<xsl:template match="image" mode="conv69to70">
+    <xsl:choose>
+        <!-- nothing to do if already at 7.0 -->
+        <xsl:when test="@schemaversion > 6.9">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="7.0">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion' and local-name() != 'kiwirevision']"/>
+                <xsl:apply-templates  mode="conv69to70"/>  
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- delete pxedeploy element from type -->
+<xsl:template match="type/pxedeploy" mode="conv69to70">
+</xsl:template>
+
+</xsl:stylesheet>

--- a/kiwi/xsl/master.xsl
+++ b/kiwi/xsl/master.xsl
@@ -40,6 +40,7 @@
 <xsl:import href="convert66to67.xsl"/>
 <xsl:import href="convert67to68.xsl"/>
 <xsl:import href="convert68to69.xsl"/>
+<xsl:import href="convert69to70.xsl"/>
 <xsl:import href="pretty.xsl"/>
 
 
@@ -186,8 +187,12 @@
         <xsl:apply-templates select="exslt:node-set($v68)" mode="conv68to69"/>
     </xsl:variable>
 
+    <xsl:variable name="v70">
+        <xsl:apply-templates select="exslt:node-set($v69)" mode="conv69to70"/>
+    </xsl:variable>
+
     <xsl:apply-templates
-        select="exslt:node-set($v69)" mode="pretty"
+        select="exslt:node-set($v70)" mode="pretty"
     />
 </xsl:template>
 

--- a/test/data/example_arm_disk_size_config.xml
+++ b/test/data/example_arm_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_btrfs_config.xml
+++ b/test/data/example_btrfs_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
     <drivers>
         <file name="crypto/*"/>
         <file name="drivers/acpi/*"/>

--- a/test/data/example_disk_config.xml
+++ b/test/data/example_disk_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_config.xml
+++ b/test/data/example_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_empty_vol_config.xml
+++ b/test/data/example_disk_size_empty_vol_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_oem_volume_config.xml
+++ b/test/data/example_disk_size_oem_volume_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_vol_root_config.xml
+++ b/test/data/example_disk_size_vol_root_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_disk_size_volume_config.xml
+++ b/test/data/example_disk_size_volume_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_dot_profile_config.xml
+++ b/test/data/example_dot_profile_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2" displayname="schäfer">
+<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2" displayname="schäfer">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_default_config.xml
+++ b/test/data/example_lvm_default_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_no_root_config.xml
+++ b/test/data/example_lvm_no_root_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_no_root_full_usr_config.xml
+++ b/test/data/example_lvm_no_root_full_usr_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_lvm_preferred_config.xml
+++ b/test/data/example_lvm_preferred_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_multiple_users_config.xml
+++ b/test/data/example_multiple_users_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_no_default_type.xml
+++ b/test/data/example_no_default_type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_no_image_packages_config.xml
+++ b/test/data/example_no_image_packages_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_no_imageinclude_config.xml
+++ b/test/data/example_no_imageinclude_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_ppc_disk_size_config.xml
+++ b/test/data/example_ppc_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_pxe_config.xml
+++ b/test/data/example_pxe_config.xml
@@ -18,16 +18,7 @@
         <rpm-check-signatures>false</rpm-check-signatures>
         <bootsplash-theme>openSUSE</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
-        <type image="pxe" filesystem="squashfs" boot="netboot/suse-13.2">
-            <pxedeploy server="192.168.100.2" blocksize="4096">
-                <partitions device="/dev/sda">
-                    <partition type="swap" number="1" size="5"/>
-                    <partition type="L" number="2" size="image" mountpoint="/" target="true"/>
-                    <partition type="L" number="3" target="false"/>
-                </partitions>
-                <union ro="/dev/sda2" rw="/dev/sda3" type="overlayfs"/>
-            </pxedeploy>
-        </type>
+        <type image="pxe" filesystem="squashfs" boot="netboot/suse-13.2"/>
     </preferences>
     <repository type="yast2">
         <source path="obs://13.2/repo/oss"/>

--- a/test/data/example_pxe_config.xml
+++ b/test/data/example_pxe_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_runtime_checker_boot_desc_not_found.xml
+++ b/test/data/example_runtime_checker_boot_desc_not_found.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="JeOS">
+<image schemaversion="7.0" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/example_runtime_checker_config.xml
+++ b/test/data/example_runtime_checker_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
     <drivers>
         <file name="crypto/*"/>
         <file name="drivers/acpi/*"/>

--- a/test/data/example_runtime_checker_no_boot_reference.xml
+++ b/test/data/example_runtime_checker_no_boot_reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="JeOS">
+<image schemaversion="7.0" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/test/data/isoboot/example-distribution-no-delete-section/config.xml
+++ b/test/data/isoboot/example-distribution-no-delete-section/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="initrd-isoboot-suse-13.2">
+<image schemaversion="7.0" name="initrd-isoboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/data/isoboot/example-distribution/config.xml
+++ b/test/data/isoboot/example-distribution/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="initrd-isoboot-suse-13.2">
+<image schemaversion="7.0" name="initrd-isoboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/data/oemboot/example-distribution/config.xml
+++ b/test/data/oemboot/example-distribution/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.9" name="initrd-oemboot-suse-13.2">
+<image schemaversion="7.0" name="initrd-oemboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>

--- a/test/unit/builder_pxe_test.py
+++ b/test/unit/builder_pxe_test.py
@@ -105,8 +105,6 @@ class TestPxeBuilder(object):
                 'target_dir/some-image.x86_64-1.2.3.tar.xz'
             ]
         )
-        # warning for not implemented pxedeploy handling
-        assert mock_log_warn.called
 
     @patch('kiwi.builder.pxe.Checksum')
     @patch('kiwi.builder.pxe.Compress')

--- a/test/unit/xml_state_test.py
+++ b/test/unit/xml_state_test.py
@@ -394,13 +394,6 @@ class TestXMLState(object):
         state = XMLState(xml_data, None, 'vmx')
         assert state.get_build_type_machine_section().get_guestOS() == 'suse'
 
-    def test_get_build_type_pxedeploy_section(self):
-        description = XMLDescription('../data/example_pxe_config.xml')
-        xml_data = description.load()
-        state = XMLState(xml_data, None, 'pxe')
-        assert state.get_build_type_pxedeploy_section().get_server() == \
-            '192.168.100.2'
-
     def test_get_drivers_list(self):
         assert self.state.get_drivers_list() == \
             ['crypto/*', 'drivers/acpi/*', 'bar']


### PR DESCRIPTION
There is no further demand in the client config creation for the
legacy netboot code. Customers using the netboot initrd already
create the client ```config.<MAC>``` file manually or through another
system. With the next generation kiwi we also recommend the disk
based network deployment using the dracut capabilities and marked
the netboot code as still supported but on the legacy stream.
Along with the deletion in the schema the following changes
were also done:
    
* Deleted use of pxedeploy section in implementation
* Increase schema version to v7.0
* Update documentation on schema version update
* Added xsl stylesheet conversion from v6.9 to v7.0
  Automatic schema version upgrade from v6.9 to v7.0 deletes
  the pxedeploy section from any type specification
    
This Fixes #19