### PR TITLE
Update bootstrap macro management

### DIFF
--- a/kiwi/repository/dnf.py
+++ b/kiwi/repository/dnf.py
@@ -105,7 +105,8 @@ class RepositoryDnf(RepositoryBase):
         1. Create the rpm image macro which persists during the build
         2. Create the rpm bootstrap macro to make sure for bootstrapping
            the rpm database location matches the host rpm database setup.
-           This macro only persists during the bootstrap phase
+           This macro only persists during the bootstrap phase. If the
+           image was already bootstrapped a compat link is created instead.
         """
         rpmdb = RpmDataBase(
             self.root_dir, Defaults.get_custom_rpm_image_macro_name()
@@ -114,7 +115,11 @@ class RepositoryDnf(RepositoryBase):
             rpmdb.set_macro_from_string(self.locale[0])
         rpmdb.write_config()
 
-        RpmDataBase(self.root_dir).set_database_to_host_path()
+        rpmdb = RpmDataBase(self.root_dir)
+        if rpmdb.has_rpm():
+            rpmdb.link_database_to_host_path()
+        else:
+            rpmdb.set_database_to_host_path()
 
     def use_default_location(self):
         """

--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -154,7 +154,8 @@ class RepositoryZypper(RepositoryBase):
         1. Create the rpm image macro which persists during the build
         2. Create the rpm bootstrap macro to make sure for bootstrapping
            the rpm database location matches the host rpm database setup.
-           This macro only persists during the bootstrap phase
+           This macro only persists during the bootstrap phase. If the
+           image was already bootstrapped a compat link is created instead.
         3. Create zypper compat link
         """
         rpmdb = RpmDataBase(
@@ -164,7 +165,11 @@ class RepositoryZypper(RepositoryBase):
             rpmdb.set_macro_from_string(self.locale[0])
         rpmdb.write_config()
 
-        RpmDataBase(self.root_dir).set_database_to_host_path()
+        rpmdb = RpmDataBase(self.root_dir)
+        if rpmdb.has_rpm():
+            rpmdb.link_database_to_host_path()
+        else:
+            rpmdb.set_database_to_host_path()
         # Zypper compat code:
         #
         # Manually adding the compat link /var/lib/rpm that points to the

--- a/kiwi/utils/rpm_database.py
+++ b/kiwi/utils/rpm_database.py
@@ -108,6 +108,33 @@ class RpmDataBase(object):
         )
         self.rpmdb_image.write_config()
 
+    def link_database_to_host_path(self):
+        """
+        Create a link from host database location to image database
+        location. The link is only created if both locations differ
+        and if the host database location does not exist.
+        """
+        rpm_host_dbpath = self.rpmdb_host.expand_query('%_dbpath')
+        rpm_image_dbpath = self.rpmdb_image.expand_query('%_dbpath')
+        if rpm_host_dbpath != rpm_image_dbpath:
+            root_rpm_host_dbpath = os.path.normpath(
+                os.sep.join([self.root_dir, rpm_host_dbpath])
+            )
+            if not os.path.exists(root_rpm_host_dbpath):
+                Path.create(os.path.dirname(root_rpm_host_dbpath))
+                host_to_root = ''.join(
+                    '../' for i in os.path.dirname(
+                        rpm_host_dbpath
+                    ).lstrip(os.sep).split(os.sep)
+                )
+                Command.run(
+                    [
+                        'ln', '-s', os.path.normpath(
+                            os.sep.join([host_to_root, rpm_image_dbpath])
+                        ), root_rpm_host_dbpath
+                    ]
+                )
+
     def set_database_to_image_path(self):
         """
         Setup dbpath to point to the image rpm dbpath configuration
@@ -118,26 +145,33 @@ class RpmDataBase(object):
         rpm_image_dbpath = self.rpmdb_image.expand_query('%_dbpath')
         rpm_host_dbpath = self.rpmdb_host.expand_query('%_dbpath')
         if rpm_image_dbpath != rpm_host_dbpath:
+            root_rpm_image_dbpath = os.path.normpath(
+                os.sep.join([self.root_dir, rpm_image_dbpath])
+            )
+            root_rpm_host_dbpath = os.path.normpath(
+                os.sep.join([self.root_dir, rpm_host_dbpath])
+            )
+
+            if os.path.islink(root_rpm_host_dbpath):
+                self.rebuild_database()
+                return
+
+            if os.path.islink(root_rpm_image_dbpath):
+                os.unlink(root_rpm_image_dbpath)
+            else:
+                Path.wipe(root_rpm_image_dbpath)
+
             self.rpmdb_image.set_config_value(
                 '_dbpath', rpm_host_dbpath
             )
             self.rpmdb_image.set_config_value(
                 '_dbpath_rebuild', self.rpmdb_image.get_query('_dbpath')
             )
-            root_rpm_image_dbpath = os.path.normpath(
-                os.sep.join([self.root_dir, rpm_image_dbpath])
-            )
-            if os.path.islink(root_rpm_image_dbpath):
-                os.unlink(root_rpm_image_dbpath)
-            else:
-                Path.wipe(root_rpm_image_dbpath)
+
             self.rpmdb_image.write_config()
             self.rebuild_database()
             self.rpmdb_image.wipe_config()
 
-            root_rpm_host_dbpath = os.path.normpath(
-                os.sep.join([self.root_dir, rpm_host_dbpath])
-            )
             root_rpm_alternatives = os.sep.join(
                 [root_rpm_host_dbpath, 'alternatives']
             )

--- a/test/unit/repository_dnf_test.py
+++ b/test/unit/repository_dnf_test.py
@@ -111,6 +111,7 @@ class TestRepositoryDnf(object):
     @patch('kiwi.repository.dnf.RpmDataBase')
     def test_setup_package_database_configuration(self, mock_RpmDataBase):
         rpmdb = mock.Mock()
+        rpmdb.has_rpm.return_value = False
         mock_RpmDataBase.return_value = rpmdb
         self.repo.setup_package_database_configuration()
         assert mock_RpmDataBase.call_args_list == [
@@ -122,6 +123,24 @@ class TestRepositoryDnf(object):
         )
         rpmdb.write_config.assert_called_once_with()
         rpmdb.set_database_to_host_path.assert_called_once_with()
+
+    @patch('kiwi.repository.dnf.RpmDataBase')
+    def test_setup_package_database_configuration_bootstrapped_system(
+        self, mock_RpmDataBase
+    ):
+        rpmdb = mock.Mock()
+        rpmdb.has_rpm.return_value = True
+        mock_RpmDataBase.return_value = rpmdb
+        self.repo.setup_package_database_configuration()
+        assert mock_RpmDataBase.call_args_list == [
+            call('../data', 'macros.kiwi-image-config'),
+            call('../data')
+        ]
+        rpmdb.set_macro_from_string.assert_called_once_with(
+            '_install_langs%en_US:de_DE'
+        )
+        rpmdb.write_config.assert_called_once_with()
+        rpmdb.link_database_to_host_path.assert_called_once_with()
 
     @patch('kiwi.repository.dnf.ConfigParser')
     @patch('os.path.exists')


### PR DESCRIPTION
This PR extends the bootstrap macro management to also consider
the case where image was already bootstrap. Note this is a common case
for building derived container images and also the situation when
`--allow-existing-root` flag is in use.