### PR TITLE
Adding custom curl options for dracut-kiwi-lib module

### DIFF
--- a/doc/source/building/build_oem_disk.rst
+++ b/doc/source/building/build_oem_disk.rst
@@ -207,6 +207,32 @@ target system:
    and initrd could be fetched from any server and doesn't have to be stored
    on the `PXE_SERVER`.
 
+   By default KIWI does not use specific `curl` options or flags. However it
+   is possible to add custom ones by adding the 
+   `rd.kiwi.install.pxe.curl_options` flag into the kernel command line.
+   `curl` options are passed as comma separated values. Consider the following
+   example:
+
+   .. code:: bash
+
+       rd.kiwi.install.pxe.curl_options=--retry,3,--retry-delay,3,--speed-limit,2048
+
+   The above tells KIWI to call `curl` with:
+
+   .. code:: bash
+
+       curl --retry 3 --retry-delay 3 --speed-limit 2048 -f <url>
+
+   This is specially handy when the deployment infraestructure requires
+   some fine tuned download behavior. For example, setting retries to be
+   more robust over flaky network connections.
+
+   .. note::
+
+      KIWI just replaces commas with spaces and appends it to the
+      `curl` call. This is relevant since command line options including
+      commas will always fail.
+
    .. note::
 
       The initrd and Linux Kernel for pxe boot are always loaded via tftp

--- a/doc/source/building/working_with_images/custom_volumes.rst
+++ b/doc/source/building/working_with_images/custom_volumes.rst
@@ -55,7 +55,7 @@ definition and some additional empty space for the root volume:
 
 .. code:: xml
 
-   <type ...>
+   <type>
      <systemdisk name="vgroup-name">
        <volume name="@root" freespace="5G"/>
        <volume name="home" size="40G"/>

--- a/dracut/modules.d/99kiwi-lib/kiwi-net-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-net-lib.sh
@@ -10,7 +10,14 @@ function fetch_file {
     local source_uncompressed_bytes=$2
     local fetch_info=/tmp/fetch.info
     local fetch
-    fetch="curl -f ${source_url}"
+    local curl_options
+    curl_options=$(getarg rd.kiwi.install.pxe.curl_options=)
+    if [ -n "${curl_options}" ]; then
+        curl_options=$(str_replace "${curl_options}" "," " ")
+        fetch="curl ${curl_options} -f ${source_url}"
+    else
+        fetch="curl -f ${source_url}"
+    fi
     if _is_compressed "${source_url}";then
         fetch="${fetch} | xz -d"
     fi


### PR DESCRIPTION
This commit parses the `rd.kiwi.install.pxe.curl_options` argument from
the kernel command line to read and use curl options for the
`fetch_file` function of `kiwi-net-lib.sh` utility. Options are passed
as comma separated values.

Fixes #891
