### PR TITLE
Remove obsolete repository type attributes

### DIFF
--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -870,9 +870,8 @@ div {
     k.repository.type.attribute =
         ## Type of repository
         attribute type {
-        "apt-deb" | "apt-rpm" | "deb-dir" | "mirrors" | "red-carpet" |
-        "rpm-dir" | "rpm-md"  | "slack-site" | "up2date-mirrors" | "urpmi" |
-        "yast2"
+        "apt-deb" | "apt-rpm" | "deb-dir" | "mirrors" | "rpm-dir" |
+        "rpm-md"
     }
     k.repository.alias.attribute =
         ## Alias name to be used for this repository. This is an

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -1346,13 +1346,8 @@ definition can be composed by other existing profiles.</a:documentation>
           <value>apt-rpm</value>
           <value>deb-dir</value>
           <value>mirrors</value>
-          <value>red-carpet</value>
           <value>rpm-dir</value>
           <value>rpm-md</value>
-          <value>slack-site</value>
-          <value>up2date-mirrors</value>
-          <value>urpmi</value>
-          <value>yast2</value>
         </choice>
       </attribute>
     </define>


### PR DESCRIPTION
Fixes #1029

Changes proposed in this pull request:
* Remove `red-carpet`, `slack-site`, `up2date-mirrors` and `urpmi` from `repository.type.attribute`
