### PR TITLE
Update suse integration tests per Factory changes

### DIFF
--- a/build-tests/x86/test-image-iso/appliance.kiwi
+++ b/build-tests/x86/test-image-iso/appliance.kiwi
@@ -14,7 +14,7 @@
         <timezone>Europe/Berlin</timezone>
         <rpm-excludedocs>true</rpm-excludedocs>
         <rpm-check-signatures>false</rpm-check-signatures>
-        <bootsplash-theme>openSUSE</bootsplash-theme>
+        <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
         <type image="iso" flags="overlay" firmware="efi" kernelcmdline="console=ttyS0 splash" hybridpersistent_filesystem="ext4" hybridpersistent="true" mediacheck="true"/>
     </preferences>
@@ -31,7 +31,7 @@
         <package name="bind-utils"/>
         <package name="patterns-openSUSE-base"/>
         <package name="systemd"/>
-        <package name="plymouth-branding-openSUSE"/>
+        <package name="plymouth-theme-bgrt"/>
         <package name="grub2-branding-openSUSE"/>
         <package name="ifplugd"/>
         <package name="iputils"/>

--- a/build-tests/x86/test-image-oem/appliance.kiwi
+++ b/build-tests/x86/test-image-oem/appliance.kiwi
@@ -14,7 +14,7 @@
         <timezone>Europe/Berlin</timezone>
         <rpm-excludedocs>true</rpm-excludedocs>
         <rpm-check-signatures>false</rpm-check-signatures>
-        <bootsplash-theme>openSUSE</bootsplash-theme>
+        <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
         <type image="oem" filesystem="btrfs" initrd_system="dracut" bootloader="grub2" bootloader_console="serial" kernelcmdline="console=ttyS0 splash" firmware="efi" installiso="true" bootpartition="false" btrfs_root_is_snapshot="true" installboot="install">
             <oemconfig>
@@ -39,7 +39,7 @@
     <packages type="image">
         <package name="patterns-openSUSE-base"/>
         <package name="systemd"/>
-        <package name="plymouth-branding-openSUSE"/>
+        <package name="plymouth-theme-bgrt"/>
         <package name="grub2-branding-openSUSE"/>
         <package name="ifplugd"/>
         <package name="iputils"/>

--- a/build-tests/x86/test-image-pxe/appliance.kiwi
+++ b/build-tests/x86/test-image-pxe/appliance.kiwi
@@ -14,7 +14,7 @@
         <timezone>Europe/Berlin</timezone>
         <rpm-excludedocs>true</rpm-excludedocs>
         <rpm-check-signatures>false</rpm-check-signatures>
-        <bootsplash-theme>openSUSE</bootsplash-theme>
+        <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
         <type image="pxe" filesystem="ext3" boot="netboot/suse-tumbleweed"/>
     </preferences>
@@ -30,7 +30,7 @@
     <packages type="image">
         <package name="patterns-openSUSE-base"/>
         <package name="systemd"/>
-        <package name="plymouth-branding-openSUSE"/>
+        <package name="plymouth-theme-bgrt"/>
         <package name="grub2-branding-openSUSE"/>
         <package name="ifplugd"/>
         <package name="iputils"/>

--- a/build-tests/x86/test-image-vmx-lvm/appliance.kiwi
+++ b/build-tests/x86/test-image-vmx-lvm/appliance.kiwi
@@ -14,7 +14,7 @@
         <timezone>Europe/Berlin</timezone>
         <rpm-excludedocs>true</rpm-excludedocs>
         <rpm-check-signatures>false</rpm-check-signatures>
-        <bootsplash-theme>openSUSE</bootsplash-theme>
+        <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
         <type image="vmx" filesystem="ext3" bootloader="grub2" kernelcmdline="console=ttyS0 splash" firmware="uefi" format="vmdk">
             <systemdisk>
@@ -35,7 +35,7 @@
         <package name="patterns-base-minimal_base"/>
         <package name="bind-utils"/>
         <package name="systemd"/>
-        <package name="plymouth-branding-openSUSE"/>
+        <package name="plymouth-theme-bgrt"/>
         <package name="grub2-branding-openSUSE"/>
         <package name="ifplugd"/>
         <package name="iputils"/>

--- a/build-tests/x86/test-image-vmx/appliance.kiwi
+++ b/build-tests/x86/test-image-vmx/appliance.kiwi
@@ -14,7 +14,7 @@
         <timezone>Europe/Berlin</timezone>
         <rpm-excludedocs>true</rpm-excludedocs>
         <rpm-check-signatures>false</rpm-check-signatures>
-        <bootsplash-theme>openSUSE</bootsplash-theme>
+        <bootsplash-theme>bgrt</bootsplash-theme>
         <bootloader-theme>openSUSE</bootloader-theme>
         <type image="vmx" filesystem="ext3" bootloader="grub2" kernelcmdline="console=ttyS0 splash" firmware="uefi" format="vmdk"/>
     </preferences>
@@ -31,7 +31,7 @@
         <package name="patterns-base-minimal_base"/>
         <package name="bind-utils"/>
         <package name="systemd"/>
-        <package name="plymouth-branding-openSUSE"/>
+        <package name="plymouth-theme-bgrt"/>
         <package name="grub2-branding-openSUSE"/>
         <package name="ifplugd"/>
         <package name="iputils"/>


### PR DESCRIPTION
The way plymouth themes are provided has changed on suse.
The package plymouth-branding-openSUSE is no longer providing
the theme named openSUSE. In fact the plan is to switch to
the upstream bgrt theme which is provided in another package.
This commit adapts to the changes in the distribution

