### PR TITLE
Preserve license and other txt files in baseStripFirmware (bsc#1132455)

### DIFF
--- a/kiwi/config/functions.sh
+++ b/kiwi/config/functions.sh
@@ -751,6 +751,15 @@ function baseStripFirmware {
             done
         done
     done
+    # Preserve licenses and txt files (which are needed for some firmware blobs)
+    find /lib/firmware \( -name 'LICENSE*' -o -name '*txt' \) -print | while read -r match; do
+        if [ -e "${match}" ];then
+            match=$(echo "${match}" | sed -e 's@\/lib\/firmware\/@@')
+            bmdir=$(dirname "${match}")
+            mkdir -p "/lib/firmware-required/${bmdir}"
+            mv "/lib/firmware/${match}" "/lib/firmware-required/${bmdir}"
+        fi
+    done
     rm -rf /lib/firmware
     mv /lib/firmware-required /lib/firmware
 }


### PR DESCRIPTION
LICENSES are usually not large and should be kept alongside
of the binaries. Also some firmware files sideload additional
txt files (like for example brcmfmac43430 needs the sdio description
txt files). We should just always include them because they're
not listed as needed files.

Fixes # 1132455.
