### PR TITLE
Delete suseRemovePackagesMarkedForDeletion

### DIFF
--- a/kiwi/config/functions.sh
+++ b/kiwi/config/functions.sh
@@ -1187,22 +1187,6 @@ function suseCleanup {
 }
 
 #======================================
-# suseRemovePackagesMarkedForDeletion
-#--------------------------------------
-function suseRemovePackagesMarkedForDeletion {
-    # /.../
-    # This function removes all packages which are
-    # added into the <packages type="delete"> section
-    # ----
-    local packs
-    local final
-    packs=$(baseGetPackagesForDeletion)
-    final=$(rpm -q "${packs}" | grep -v "is not installed")
-    echo "suseRemovePackagesMarkedForDeletion: ${final}"
-    Rpm -e --nodeps --noscripts "${final}"
-}
-
-#======================================
 # suseRemoveYaST
 #--------------------------------------
 function suseRemoveYaST {


### PR DESCRIPTION
Any package removal is controlled by kiwi itself. There is no
need to provide a shell helper method that is rpm specific.
This Fixes #1054


