### PR TITLE
Delete obsolete repository types

### DIFF
--- a/build-tests/arm/test-image-rpi-oem/appliance.kiwi
+++ b/build-tests/arm/test-image-rpi-oem/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="OEM-openSUSE-Tumbleweed">
+<image schemaversion="7.1" name="OEM-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/s390/test-image-oem/appliance.kiwi
+++ b/build-tests/s390/test-image-oem/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="LimeJeOS-DASD-ECKD-SLE12-Community">
+<image schemaversion="7.1" name="LimeJeOS-DASD-ECKD-SLE12-Community">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/test-image-azure/appliance.kiwi
+++ b/build-tests/x86/test-image-azure/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="Azure-openSUSE-Tumbleweed">
+<image schemaversion="7.1" name="Azure-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/test-image-centos/appliance.kiwi
+++ b/build-tests/x86/test-image-centos/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.0" name="LimeJeOS-CentOS-07.0">
+<image schemaversion="7.1" name="LimeJeOS-CentOS-07.0">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/test-image-docker-derived/appliance.kiwi
+++ b/build-tests/x86/test-image-docker-derived/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="docker-builder-image">
+<image schemaversion="7.1" name="docker-builder-image">
     <description type="system">
         <author>David Cassany</author>
         <contact>dcassany@suse.de</contact>

--- a/build-tests/x86/test-image-docker/appliance.kiwi
+++ b/build-tests/x86/test-image-docker/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="Docker-openSUSE-Tumbleweed">
+<image schemaversion="7.1" name="Docker-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/test-image-ec2/appliance.kiwi
+++ b/build-tests/x86/test-image-ec2/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="EC2-openSUSE-Tumbleweed">
+<image schemaversion="7.1" name="EC2-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/test-image-fedora/appliance.kiwi
+++ b/build-tests/x86/test-image-fedora/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.0" name="VMX-Fedora-28.0">
+<image schemaversion="7.1" name="VMX-Fedora-28.0">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/test-image-gce/appliance.kiwi
+++ b/build-tests/x86/test-image-gce/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="GCE-openSUSE-Tumbleweed">
+<image schemaversion="7.1" name="GCE-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.de</contact>

--- a/build-tests/x86/test-image-iso/appliance.kiwi
+++ b/build-tests/x86/test-image-iso/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="ISO-openSUSE-Tumbleweed">
+<image schemaversion="7.1" name="ISO-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/test-image-oem/appliance.kiwi
+++ b/build-tests/x86/test-image-oem/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="OEM-openSUSE-Tumbleweed">
+<image schemaversion="7.1" name="OEM-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/test-image-orthos-oem/appliance.kiwi
+++ b/build-tests/x86/test-image-orthos-oem/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="factory-kiwi">
+<image schemaversion="7.1" name="factory-kiwi">
     <description type="system">
         <author>Julian Wolf</author>
         <contact>juwolf@suse.de</contact>

--- a/build-tests/x86/test-image-pxe/appliance.kiwi
+++ b/build-tests/x86/test-image-pxe/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="PXE-openSUSE-Tumbleweed">
+<image schemaversion="7.1" name="PXE-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/test-image-qcow-openstack/appliance.kiwi
+++ b/build-tests/x86/test-image-qcow-openstack/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="TW-OpenStack">
+<image schemaversion="7.1" name="TW-OpenStack">
     <description type="system">
         <author>KIWI Team</author>
         <contact>kiwi-images@googlegroups.com</contact>

--- a/build-tests/x86/test-image-tbz/appliance.kiwi
+++ b/build-tests/x86/test-image-tbz/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="TBZ-openSUSE-Tumbleweed">
+<image schemaversion="7.1" name="TBZ-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/test-image-ubuntu/appliance.kiwi
+++ b/build-tests/x86/test-image-ubuntu/appliance.kiwi
@@ -3,7 +3,7 @@
 <!-- The line below is required in order to use the multibuild OBS features -->
 <!-- OBS-Profiles: @BUILD_FLAVOR@ -->
 
-<image schemaversion="7.0" name="LimeJeOS-Ubuntu-18.04">
+<image schemaversion="7.1" name="LimeJeOS-Ubuntu-18.04">
     <description type="system">
         <author>Marcus Schaefer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/test-image-vmx-lvm/appliance.kiwi
+++ b/build-tests/x86/test-image-vmx-lvm/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="VMX-openSUSE-Tumbleweed">
+<image schemaversion="7.1" name="VMX-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/build-tests/x86/test-image-vmx/appliance.kiwi
+++ b/build-tests/x86/test-image-vmx/appliance.kiwi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="VMX-openSUSE-Tumbleweed">
+<image schemaversion="7.1" name="VMX-openSUSE-Tumbleweed">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>

--- a/doc/source/development/schema.rst
+++ b/doc/source/development/schema.rst
@@ -1,6 +1,6 @@
 .. _schema-docs:
 
-Schema Documentation 7.0
+Schema Documentation 7.1
 ========================
 
 .. raw:: html

--- a/helper/schema_docs.sh
+++ b/helper/schema_docs.sh
@@ -14,7 +14,7 @@ else
     cat > ../doc/source/development/schema.rst <<- EOF
 	.. _schema-docs:
 
-	Schema Documentation 6.9
+	Schema Documentation 7.1
 	========================
 
 	.. raw:: html

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -59,7 +59,7 @@ div {
         attribute xsi:schemaLocation { xsd:anyURI }
     k.image.schemaversion.attribute =
         ## The allowed Schema version (fixed value)
-        attribute schemaversion { "7.0" }
+        attribute schemaversion { "7.1" }
     k.image.id =
         ## An identification number which is represented in a file
         ## named /etc/ImageID
@@ -870,10 +870,8 @@ div {
     k.repository.type.attribute =
         ## Type of repository
         attribute type {
-        "apt-deb" | "apt-rpm" | "deb-dir" | "mirrors" | "red-carpet" |
-        "rpm-dir" | "rpm-md"  | "slack-site" | "up2date-mirrors" | "urpmi" |
-        "yast2"
-    }
+            "apt-deb" | "apt-rpm" | "deb-dir" | "mirrors" | "rpm-dir" | "rpm-md"
+        }
     k.repository.alias.attribute =
         ## Alias name to be used for this repository. This is an
         ## optional free form text. If not set the source attribute

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -115,7 +115,7 @@ second the location of the XSD Schema
     <define name="k.image.schemaversion.attribute">
       <attribute name="schemaversion">
         <a:documentation>The allowed Schema version (fixed value)</a:documentation>
-        <value>7.0</value>
+        <value>7.1</value>
       </attribute>
     </define>
     <define name="k.image.id">
@@ -1346,13 +1346,8 @@ definition can be composed by other existing profiles.</a:documentation>
           <value>apt-rpm</value>
           <value>deb-dir</value>
           <value>mirrors</value>
-          <value>red-carpet</value>
           <value>rpm-dir</value>
           <value>rpm-md</value>
-          <value>slack-site</value>
-          <value>up2date-mirrors</value>
-          <value>urpmi</value>
-          <value>yast2</value>
         </choice>
       </attribute>
     </define>

--- a/kiwi/xsl/convert70to71.xsl
+++ b/kiwi/xsl/convert70to71.xsl
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="xml"
+        indent="yes" omit-xml-declaration="no" encoding="utf-8"/>
+
+<!-- default rule -->
+<xsl:template match="*" mode="conv70to71">
+    <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="conv70to71"/>
+    </xsl:copy>
+</xsl:template>
+
+<!-- version update -->
+<!-- remove kiwirevision attribute from image -->
+<para xmlns="http://docbook.org/ns/docbook">
+    Changed attribute <tag class="attribute">schemaversion</tag>
+    to <tag class="attribute">schemaversion</tag> from
+    <literal>7.0</literal> to <literal>7.1</literal>.
+</para>
+<xsl:template match="image" mode="conv70to71">
+    <xsl:choose>
+        <!-- nothing to do if already at 7.1 -->
+        <xsl:when test="@schemaversion > 7.0">
+            <xsl:copy-of select="/"/>
+        </xsl:when>
+        <!-- otherwise apply templates -->
+        <xsl:otherwise>
+            <image schemaversion="7.1">
+                <xsl:copy-of select="@*[local-name() != 'schemaversion' and local-name() != 'kiwirevision']"/>
+                <xsl:apply-templates  mode="conv70to71"/>
+            </image>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<!-- delete type from repository if obsolete type spec is used -->
+<xsl:template match="repository" mode="conv70to71">
+    <xsl:choose>
+        <xsl:when test="@type='red-carpet' or @type='slack-site' or @type='up2date-mirrors' or @type='urpmi' or @type='yast2'">
+            <repository>
+                <xsl:copy-of select="@*[not(local-name(.) = 'type')]"/>
+                <xsl:apply-templates mode="conv70to71"/>
+            </repository>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:copy-of select="."/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/kiwi/xsl/master.xsl
+++ b/kiwi/xsl/master.xsl
@@ -41,6 +41,7 @@
 <xsl:import href="convert67to68.xsl"/>
 <xsl:import href="convert68to69.xsl"/>
 <xsl:import href="convert69to70.xsl"/>
+<xsl:import href="convert70to71.xsl"/>
 <xsl:import href="pretty.xsl"/>
 
 
@@ -191,8 +192,12 @@
         <xsl:apply-templates select="exslt:node-set($v69)" mode="conv69to70"/>
     </xsl:variable>
 
+    <xsl:variable name="v71">
+        <xsl:apply-templates select="exslt:node-set($v70)" mode="conv70to71"/>
+    </xsl:variable>
+
     <xsl:apply-templates
-        select="exslt:node-set($v70)" mode="pretty"
+        select="exslt:node-set($v71)" mode="pretty"
     />
 </xsl:template>
 

--- a/test/data/example_arm_disk_size_config.xml
+++ b/test/data/example_arm_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -20,7 +20,7 @@
         <bootloader-theme>openSUSE</bootloader-theme>
         <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" bootloader="grub2" spare_part="42M"/>
     </preferences>
-    <repository type="yast2">
+    <repository>
         <source path="obs://13.2/repo/oss"/>
     </repository>
     <packages type="image">

--- a/test/data/example_btrfs_config.xml
+++ b/test/data/example_btrfs_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -33,7 +33,7 @@
     <users>
         <user groups="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
     </users>
-    <repository type="yast2">
+    <repository>
         <source path="obs://13.2/repo/oss"/>
     </repository>
     <packages type="image">

--- a/test/data/example_config.xml
+++ b/test/data/example_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
     <drivers>
         <file name="crypto/*"/>
         <file name="drivers/acpi/*"/>
@@ -147,7 +147,7 @@
         <user groups="users" pwdformat="plain" password="mypwd" home="/home/tux" name="tux"/>
         <user groups="kiwi,admin,users" pwdformat="plain" password="mypwd" home="/home/kiwi" name="kiwi"/>
     </users>
-    <repository type="yast2" priority="42">
+    <repository priority="42">
         <source path="iso:///image/CDs/dvd.iso"/>
     </repository>
     <repository type="rpm-md" imageinclude="true">

--- a/test/data/example_disk_config.xml
+++ b/test/data/example_disk_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -24,7 +24,7 @@
             </oemconfig>
         </type>
     </preferences>
-    <repository type="yast2">
+    <repository>
         <source path="obs://13.2/repo/oss"/>
     </repository>
     <packages type="image">

--- a/test/data/example_disk_size_config.xml
+++ b/test/data/example_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -25,7 +25,7 @@
             </oemconfig>
         </type>
     </preferences>
-    <repository type="yast2">
+    <repository>
         <source path="obs://13.2/repo/oss"/>
     </repository>
     <packages type="image">

--- a/test/data/example_disk_size_empty_vol_config.xml
+++ b/test/data/example_disk_size_empty_vol_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -22,7 +22,7 @@
             <systemdisk/>
         </type>
     </preferences>
-    <repository type="yast2">
+    <repository>
         <source path="obs://13.2/repo/oss"/>
     </repository>
     <packages type="image">

--- a/test/data/example_disk_size_oem_volume_config.xml
+++ b/test/data/example_disk_size_oem_volume_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -28,7 +28,7 @@
             </systemdisk>
         </type>
     </preferences>
-    <repository type="yast2">
+    <repository>
         <source path="obs://13.2/repo/oss"/>
     </repository>
     <packages type="image">

--- a/test/data/example_disk_size_vol_root_config.xml
+++ b/test/data/example_disk_size_vol_root_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -24,7 +24,7 @@
             </systemdisk>
         </type>
     </preferences>
-    <repository type="yast2">
+    <repository>
         <source path="obs://13.2/repo/oss"/>
     </repository>
     <packages type="image">

--- a/test/data/example_disk_size_volume_config.xml
+++ b/test/data/example_disk_size_volume_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -29,7 +29,7 @@
             </systemdisk>
         </type>
     </preferences>
-    <repository type="yast2">
+    <repository>
         <source path="obs://13.2/repo/oss"/>
     </repository>
     <packages type="image">

--- a/test/data/example_dot_profile_config.xml
+++ b/test/data/example_dot_profile_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2" displayname="schäfer">
+<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2" displayname="schäfer">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -42,7 +42,7 @@
     <users>
         <user groups="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
     </users>
-    <repository type="yast2">
+    <repository>
         <source path="obs://13.2/repo/oss"/>
     </repository>
     <packages type="image">

--- a/test/data/example_lvm_default_config.xml
+++ b/test/data/example_lvm_default_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -38,7 +38,7 @@
     <users>
         <user groups="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
     </users>
-    <repository type="yast2">
+    <repository>
         <source path="obs://13.2/repo/oss"/>
     </repository>
     <packages type="image">

--- a/test/data/example_lvm_no_root_config.xml
+++ b/test/data/example_lvm_no_root_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -33,7 +33,7 @@
     <users>
         <user groups="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
     </users>
-    <repository type="yast2">
+    <repository>
         <source path="obs://13.2/repo/oss"/>
     </repository>
     <packages type="image">

--- a/test/data/example_lvm_no_root_full_usr_config.xml
+++ b/test/data/example_lvm_no_root_full_usr_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -35,7 +35,7 @@
     <users>
         <user groups="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
     </users>
-    <repository type="yast2">
+    <repository>
         <source path="obs://13.2/repo/oss"/>
     </repository>
     <packages type="image">

--- a/test/data/example_lvm_preferred_config.xml
+++ b/test/data/example_lvm_preferred_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -33,7 +33,7 @@
     <users>
         <user groups="root" password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root"/>
     </users>
-    <repository type="yast2">
+    <repository>
         <source path="obs://13.2/repo/oss"/>
     </repository>
     <packages type="image">

--- a/test/data/example_multiple_users_config.xml
+++ b/test/data/example_multiple_users_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -34,7 +34,7 @@
         <user groups="users" pwdformat="plain" password="mypwd" home="/home/tux" name="tux"/>
         <user groups="kiwi,admin" pwdformat="plain" password="mypwd" home="/home/kiwi" name="kiwi"/>
     </users>
-    <repository type="yast2">
+    <repository>
         <source path="obs://13.2/repo/oss"/>
     </repository>
     <packages type="image">

--- a/test/data/example_no_default_type.xml
+++ b/test/data/example_no_default_type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -31,7 +31,7 @@
     <users>
         <user pwdformat="plain" password="mypwd" shell="/bin/bash" id="815" realname="Bob" home="/root" name="root"/>
     </users>
-    <repository type="yast2">
+    <repository>
         <source path="obs://13.2/repo/oss"/>
     </repository>
     <packages type="image" profiles="minimal">

--- a/test/data/example_no_image_packages_config.xml
+++ b/test/data/example_no_image_packages_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -20,7 +20,7 @@
         <bootloader-theme>openSUSE</bootloader-theme>
         <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" installiso="true" bootloader="grub2" kernelcmdline="splash" firmware="efi" btrfs_root_is_snapshot="true" btrfs_root_is_readonly_snapshot="true"/>
     </preferences>
-    <repository type="yast2">
+    <repository>
         <source path="obs://13.2/repo/oss"/>
     </repository>
     <packages type="bootstrap">

--- a/test/data/example_no_imageinclude_config.xml
+++ b/test/data/example_no_imageinclude_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -38,7 +38,7 @@
     <users>
         <user pwdformat="plain" password="mypwd" shell="/bin/bash" id="815" realname="Bob" home="/root" name="root"/>
     </users>
-    <repository type="yast2" priority="42">
+    <repository priority="42">
         <source path="iso:///image/CDs/dvd.iso"/>
     </repository>
     <repository type="rpm-md">

--- a/test/data/example_ppc_disk_size_config.xml
+++ b/test/data/example_ppc_disk_size_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -20,7 +20,7 @@
         <bootloader-theme>openSUSE</bootloader-theme>
         <type image="oem" filesystem="btrfs" boot="oemboot/suse-13.2" bootloader="grub2" firmware="ofw" rootfs_label="MYLABEL"/>
     </preferences>
-    <repository type="yast2">
+    <repository>
         <source path="obs://13.2/repo/oss"/>
     </repository>
     <packages type="image">

--- a/test/data/example_pxe_config.xml
+++ b/test/data/example_pxe_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2">
+<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -20,7 +20,7 @@
         <bootloader-theme>openSUSE</bootloader-theme>
         <type image="pxe" filesystem="squashfs" boot="netboot/suse-13.2"/>
     </preferences>
-    <repository type="yast2">
+    <repository>
         <source path="obs://13.2/repo/oss"/>
     </repository>
     <packages type="image">

--- a/test/data/example_runtime_checker_boot_desc_not_found.xml
+++ b/test/data/example_runtime_checker_boot_desc_not_found.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="JeOS">
+<image schemaversion="7.1" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -18,7 +18,7 @@
         <bootloader-theme>openSUSE</bootloader-theme>
         <type image="oem" initrd_system="kiwi" filesystem="ext3" boot="oemboot/foo"/>
     </preferences>
-    <repository type="yast2">
+    <repository>
         <source path="obs://13.2/repo/oss"/>
     </repository>
     <packages type="image">

--- a/test/data/example_runtime_checker_config.xml
+++ b/test/data/example_runtime_checker_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
+<image schemaversion="7.1" name="LimeJeOS-openSUSE-13.2" displayname="Bob">
     <drivers>
         <file name="crypto/*"/>
         <file name="drivers/acpi/*"/>
@@ -103,7 +103,7 @@
     <users>
         <user groups="root" pwdformat="plain" password="mypwd" shell="/bin/bash" id="815" realname="Bob" home="/root" name="root"/>
     </users>
-    <repository type="yast2" priority="42" imageinclude="true">
+    <repository priority="42" imageinclude="true">
         <source path="iso:///image/CDs/dvd.iso"/>
     </repository>
     <repository type="rpm-md">

--- a/test/data/example_runtime_checker_no_boot_reference.xml
+++ b/test/data/example_runtime_checker_no_boot_reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="JeOS">
+<image schemaversion="7.1" name="JeOS">
     <description type="system">
         <author>Marcus Schäfer</author>
         <contact>ms@suse.com</contact>
@@ -18,7 +18,7 @@
         <bootloader-theme>openSUSE</bootloader-theme>
         <type image="oem" initrd_system="kiwi" filesystem="ext3"/>
     </preferences>
-    <repository type="yast2">
+    <repository>
         <source path="obs://13.2/repo/oss"/>
     </repository>
     <packages type="image">

--- a/test/data/isoboot/example-distribution-no-delete-section/config.xml
+++ b/test/data/isoboot/example-distribution-no-delete-section/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="initrd-isoboot-suse-13.2">
+<image schemaversion="7.1" name="initrd-isoboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>
@@ -77,7 +77,7 @@
     <drivers profiles="xen">
         <file name="drivers/xen/*"/>
     </drivers>
-    <repository type="yast2">
+    <repository>
         <source path="obs://13.1/repo/oss"/>
     </repository>
     <packages type="image" profiles="std">

--- a/test/data/isoboot/example-distribution/config.xml
+++ b/test/data/isoboot/example-distribution/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="initrd-isoboot-suse-13.2">
+<image schemaversion="7.1" name="initrd-isoboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>
@@ -77,7 +77,7 @@
     <drivers profiles="xen">
         <file name="drivers/xen/*"/>
     </drivers>
-    <repository type="yast2">
+    <repository>
         <source path="obs://13.1/repo/oss"/>
     </repository>
     <packages type="image" profiles="std">

--- a/test/data/oemboot/example-distribution/config.xml
+++ b/test/data/oemboot/example-distribution/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="7.0" name="initrd-oemboot-suse-13.2">
+<image schemaversion="7.1" name="initrd-oemboot-suse-13.2">
     <description type="boot">
         <author>Marcus Schaefer</author>
         <contact>ms@novell.com</contact>
@@ -85,7 +85,7 @@
     <drivers profiles="xen,ec2">
         <file name="drivers/xen/*"/>
     </drivers>
-    <repository type="yast2">
+    <repository>
         <source path="obs://13.2/repo/oss"/>
     </repository>
     <packages type="image" profiles="std">

--- a/test/unit/system_prepare_test.py
+++ b/test/unit/system_prepare_test.py
@@ -199,7 +199,7 @@ class TestSystemPrepare(object):
         ]
         assert repo.add_repo.call_args_list == [
             call(
-                'uri-alias', 'uri', 'yast2', 42,
+                'uri-alias', 'uri', None, 42,
                 None, None, None, None, 'credentials-file', None, None
             ),
             call(

--- a/test/unit/tasks_image_info_test.py
+++ b/test/unit/tasks_image_info_test.py
@@ -118,7 +118,7 @@ class TestImageInfoTask(object):
         self.task.process()
         assert self.solver.add_repository.called
         assert mock_uri.call_args_list == [
-            call('iso:///image/CDs/dvd.iso', 'yast2'),
+            call('iso:///image/CDs/dvd.iso', None),
             call('obs://Devel:PubCloud:AmazonEC2/SLE_12_GA', 'rpm-md')
         ]
         mock_out.assert_called_once_with(self.result_info)
@@ -128,11 +128,11 @@ class TestImageInfoTask(object):
     def test_process_image_info_add_repo(self, mock_out, mock_state):
         self._init_command_args()
         self.task.command_args['--add-repo'] = [
-            'http://example.com,yast2,alias'
+            'http://example.com,rpm-md,alias'
         ]
         self.task.process()
         mock_state.assert_called_once_with(
-            'http://example.com', 'yast2', 'alias', None
+            'http://example.com', 'rpm-md', 'alias', None
         )
 
     @patch('kiwi.xml_state.XMLState.delete_repository_sections')


### PR DESCRIPTION
Deleted red-carpet, slack-site, up2date-mirrors, urpmi and yast2
from the allowed values list of the repository type attribute.
This Fixes #1029


