### PR TITLE
Fixed repo setup for cloud integration test builds

### DIFF
--- a/build-tests/x86/test-image-ec2/appliance.kiwi
+++ b/build-tests/x86/test-image-ec2/appliance.kiwi
@@ -21,13 +21,10 @@
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" alias="kiwi-next-generation" priority="1">
+    <repository alias="kiwi-next-generation" priority="1">
         <source path="obs://Virtualization:Appliances:Staging/openSUSE_Tumbleweed"/>
     </repository>
-    <repository type="rpm-md" alias="python-modules" priority="2">
-        <source path="obs://devel:languages:python/openSUSE_Tumbleweed"/>
-    </repository>
-    <repository type="rpm-md" alias="Tumbleweed" priority="2">
+    <repository alias="Tumbleweed">
         <source path="obs://openSUSE:Factory/snapshot"/>
     </repository>
     <packages type="image" patternType="plusRecommended">

--- a/build-tests/x86/test-image-gce/appliance.kiwi
+++ b/build-tests/x86/test-image-gce/appliance.kiwi
@@ -20,13 +20,10 @@
     <users>
         <user password="$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0" home="/root" name="root" groups="root"/>
     </users>
-    <repository type="rpm-md" alias="kiwi-next-generation" priority="1">
+    <repository alias="kiwi-next-generation" priority="1">
         <source path="obs://Virtualization:Appliances:Staging/openSUSE_Tumbleweed"/>
     </repository>
-    <repository type="rpm-md" alias="python-modules" priority="2">
-        <source path="obs://devel:languages:python/openSUSE_Tumbleweed"/>
-    </repository>
-    <repository type="rpm-md" alias="Tumbleweed" priority="2">
+    <repository alias="Tumbleweed">
         <source path="obs://openSUSE:Factory/snapshot"/>
     </repository>
     <packages type="image">


### PR DESCRIPTION
Using the devel:languages:python repos leads to inconsistencies
on the module dependencies

