### PR TITLE
Make the user.password attribute mandatory

### DIFF
--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1772,7 +1772,7 @@ div {
         k.user.home.attribute &
         k.user.id.attribute? &
         k.user.name.attribute &
-        k.user.password.attribute? &
+        k.user.password.attribute &
         k.user.pwdformat? &
         k.user.realname.attribute? &
         k.user.shell.attribute?

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -2728,9 +2728,7 @@ to the user according to he specifing toolchain behaviour.</a:documentation>
           <ref name="k.user.id.attribute"/>
         </optional>
         <ref name="k.user.name.attribute"/>
-        <optional>
-          <ref name="k.user.password.attribute"/>
-        </optional>
+        <ref name="k.user.password.attribute"/>
         <optional>
           <ref name="k.user.pwdformat"/>
         </optional>


### PR DESCRIPTION
Not providing a user password results in an error when `usermod` or `openssl` is later called by kiwi (depending on the value of `pwdformat`).

Fixes #1061.
