### PR TITLE
Improve the documentation of the runtime configuration file

### DIFF
--- a/doc/source/commands/kiwi.rst
+++ b/doc/source/commands/kiwi.rst
@@ -122,35 +122,8 @@ EXAMPLE
        --description kiwi-descriptions/suse/x86_64/suse-leap-42.3-JeOS \
        --target-dir /tmp/myimage
 
-RUNTIME CONFIG FILE
--------------------
+.. include:: ../working_with_kiwi/runtime_configuration_incl.rst
 
-To control custom paramters of the tool chain used by KIWI a user
-specific configuration file can be provided as:
-
-:file:`~/.config/kiwi/config.yml`
-
-The contents of the file is in YAML format and supports the following
-setup parameters:
-
-.. code-block:: yaml
-
-   xz:
-     - options: -a -b -c
-
-       # Specifies XZ-compression-options
-       # For details see man xz
-
-   obs:
-     - download_url: url
-
-       # Specifies download server url of an open buildservice instance
-       # defaults to: http://download.opensuse.org/repositories
-
-     - public: true|false
-
-       # Specifies if the buildservice instance is public or private
-       # defaults to: true
 
 COMPATIBILITY
 -------------

--- a/doc/source/working_with_kiwi.rst
+++ b/doc/source/working_with_kiwi.rst
@@ -10,6 +10,7 @@ Working with KIWI
    :maxdepth: 1
 
    working_with_kiwi/xml_description
+   working_with_kiwi/runtime_configuration
 
 
 Overview

--- a/doc/source/working_with_kiwi/runtime_configuration.rst
+++ b/doc/source/working_with_kiwi/runtime_configuration.rst
@@ -1,0 +1,3 @@
+.. _working-with-kiwi-runtime-configuration-file:
+
+.. include:: runtime_configuration_incl.rst

--- a/doc/source/working_with_kiwi/runtime_configuration_incl.rst
+++ b/doc/source/working_with_kiwi/runtime_configuration_incl.rst
@@ -1,0 +1,99 @@
+.. This file contains the documentation of the runtime configuration, but
+   it is not directly included into the toctree, because it needs to be
+   included in two places with only one label.
+   => In one location it is included with a label preceeding it and in the
+      other (the man page) without the label.
+
+The Runtime Configuration File
+------------------------------
+
+KIWI supports an additional configuration file for runtime specific
+settings that do not belong into the image description but which are
+persistent and would be unsuitable for command line parameters.
+
+The runtime configuration file must adhere to the `YAML
+<https://yaml.org/>`_ syntax. KIWI searches for the runtime configuration
+file in the following locations:
+
+1. :file:`~/.config/kiwi/config.yml`
+
+2. :file:`/etc/kiwi.yml`
+
+
+The parameters that can be changed via the runtime configuration file are
+illustrated in the following example:
+
+.. code-block:: yaml
+
+   xz:
+     # Additional command line flags for `xz`
+     # see `man xz` for details
+     - options: -9e
+
+   obs:
+     # Override the URL to the Open Build Service (i.e. how repository
+     # paths starting with `obs://` will be resolved).
+     # This setting is useful for building a KIWI appliance locally, which is
+     # hosted on a custom OBS instance.
+     # defaults to: http://download.opensuse.org/repositories
+     - download_url: https://build.my-domain.example/repositories
+
+     # Specifies whether the Open Build Service instance is public or
+     # private
+     # defaults to true
+     - public: true | false
+
+   bundle:
+     # Configure whether the image bundle should contain a XZ compressed
+     # image result or not.
+     # FIXME (@scheafi @davidcassany): What's the default, what's an image
+     #                                 bundle?
+     - compress: true | false
+
+   container:
+     # Specify the compression algorithm for compressing container
+     # images. Invalid entries are skipped.
+     # Defaults to `xz`.
+     - compress: xz | none
+
+   iso:
+     # Configure which tool KIWI will use to build ISO images. Invalid
+     # entries are ignored.
+     # Defaults to `xorriso`
+     - tool_category: cdrtools | xorriso
+
+   oci:
+     # Specify the OCI archive tool that will be used to create container
+     # archives for OCI compliant images.
+     # Defaults to `umoci`.
+     - archive_tool: umoci | buildah
+
+   build_constraints:
+     # Configure the maximum image size. Either provide a number in bytes
+     # or specify it with the suffix `m`/`M` for megabytes or `g`/`G` for
+     # gigabytes.
+     # If the resulting image exceeds the specified value, then KIWI will
+     # abort with an error.
+     # The default is no size constraint.
+     - max_size: 700m
+
+   runtime_checks:
+     # Provide a list of runtime checks that should be disabled. Checks
+     # that do not exist but are present in this list are silently
+     # ignored.
+     - disable: check_image_include_repos_publicly_resolvable | \
+         check_target_directory_not_in_shared_cache | \
+         check_volume_label_used_with_lvm | \
+         check_volume_setup_defines_multiple_fullsize_volumes | \
+         check_volume_setup_has_no_root_definition | \
+         check_container_tool_chain_installed | \
+         check_boot_description_exists | \
+         check_consistent_kernel_in_boot_and_system_image | \
+         check_dracut_module_for_oem_install_in_package_list | \
+         check_dracut_module_for_disk_oem_in_package_list | \
+         check_dracut_module_for_live_iso_in_package_list | \
+         check_dracut_module_for_disk_overlay_in_package_list | \
+         check_efi_mode_for_disk_overlay_correctly_setup | \
+         check_xen_uniquely_setup_as_server_or_guest | \
+         check_mediacheck_only_for_x86_arch | \
+         check_minimal_required_preferences

--- a/doc/source/working_with_kiwi/xml_description.rst
+++ b/doc/source/working_with_kiwi/xml_description.rst
@@ -676,13 +676,11 @@ following paths types:
   of the project `$PROJECT` available on the Open Build Service (OBS). By
   default KIWI will look for projects on `build.opensuse.org
   <https://build.opensuse.org>`_, but this can be overridden using the
-  runtime configuration file.
+  runtime configuration file (see :ref:`The Runtime Configuration
+  File<working-with-kiwi-runtime-configuration-file>`).
   Note that it is not possible to add repositories using the `obs://` path
   from **different** OBS instances (use direct URLs to the :file:`.repo`
   file instead in this case).
-
-.. FIXME:
-   add this back: .. (see :ref:`The Runtime Configuration File<working-with-kiwi-runtime-configuration-file>`)
 
 - `obsrepositories:/`: special path only available for builds using the
   Open Build Service. The repositories configured for the OBS project in


### PR DESCRIPTION
Split of from #1074.

TODO:
- [x] include `doc/source/working_with_kiwi/runtime_configuration.rst` in the toctree once #1074 get's merged

Changes proposed in this pull request:
* Move the runtime configuration file documentation into `working_with_kiwi` to make it more prominent (it is still present in the manpage)
* Include all missing runtime configuration options
