### PR TITLE
Use yaml.safe_load instead of yaml.load

### DIFF
--- a/kiwi/runtime_config.py
+++ b/kiwi/runtime_config.py
@@ -49,7 +49,7 @@ class RuntimeConfig(object):
         if os.path.exists(config_file):
             log.info('Reading runtime config file: {0}'.format(config_file))
             with open(config_file, 'r') as config:
-                self.config_data = yaml.load(config)
+                self.config_data = yaml.safe_load(config)
 
     def get_obs_download_server_url(self):
         """

--- a/test/unit/runtime_config_test.py
+++ b/test/unit/runtime_config_test.py
@@ -15,7 +15,7 @@ class TestRuntimeConfig(object):
             self.runtime_config = RuntimeConfig()
 
     @patch('os.path.exists')
-    @patch('yaml.load')
+    @patch('yaml.safe_load')
     def test_reading_system_wide_config_file(self, mock_yaml, mock_exists):
         exists_call_results = [True, False]
 


### PR DESCRIPTION
`yaml.load` is relatively dangerous when the loaded data comes from untrusted
sources, as it can allow for arbitrary code execution, see:
https://pyyaml.org/wiki/PyYAMLDocumentation#LoadingYAML

`safe_load` limits the created python objects to the basic Python types like
integers and strings, which is all that we need for the runtime configuration
file.