### PR TITLE
No bare except Exception

### DIFF
--- a/kiwi/system/prepare.py
+++ b/kiwi/system/prepare.py
@@ -452,8 +452,16 @@ class SystemPrepare(object):
             manager.exclude_requests
 
     def __del__(self):
-        log.info('Cleaning up %s instance', type(self).__name__)
+        log.info('Cleaning up {:s} instance'.format(type(self).__name__))
         try:
             self.root_bind.cleanup()
-        except Exception:
-            pass
+        except Exception as exc:
+            log.info(
+                'Cleaning up {self_name:s} instance failed, got an exception '
+                'of type {exc_type:s}: {exc:s}'
+                .format(
+                    self_name=type(self).__name__,
+                    exc_type=type(exc).__name__,
+                    exc=str(exc)
+                )
+            )

--- a/kiwi/utils/compress.py
+++ b/kiwi/utils/compress.py
@@ -117,9 +117,9 @@ class Compress(object):
         """
         Detect compression format
 
-        :return: compression format name
+        :return: compression format name or None if it couldn't be inferred
 
-        :rtype: str
+        :rtype: Optional[str]
         """
         for zipper in self.supported_zipper:
             try:

--- a/kiwi/utils/compress.py
+++ b/kiwi/utils/compress.py
@@ -21,6 +21,7 @@ from tempfile import NamedTemporaryFile
 # project
 from kiwi.command import Command
 from kiwi.defaults import Defaults
+from kiwi.logger import log
 
 from kiwi.exceptions import (
     KiwiFileNotFound,
@@ -122,8 +123,16 @@ class Compress(object):
         :rtype: Optional[str]
         """
         for zipper in self.supported_zipper:
+            cmd = [zipper, '-l', self.source_filename]
             try:
-                Command.run([zipper, '-l', self.source_filename])
+                Command.run(cmd)
                 return zipper
-            except Exception:
-                pass
+            except Exception as exc:
+                log.debug(
+                    'Error running "{cmd:s}", got a {exc_t:s}: {exc:s}'
+                    .format(
+                        cmd=' '.join(cmd),
+                        exc_t=type(exc).__name__,
+                        exc=str(exc)
+                    )
+                )

--- a/test/unit/system_prepare_test.py
+++ b/test/unit/system_prepare_test.py
@@ -374,7 +374,16 @@ class TestSystemPrepare(object):
         self.system.__del__()
         self.system.root_bind.cleanup.assert_called_once_with()
 
-    def test_destructor_raising(self):
+    @patch('kiwi.logger.log.info')
+    def test_destructor_raising(self, mock_log):
         self.system.root_bind = mock.Mock()
-        self.system.root_bind.cleanup.side_effect = Exception
+        self.system.root_bind.cleanup.side_effect = ValueError("nothing")
         del self.system
+
+        assert mock_log.call_args_list[0] == call(
+            'Cleaning up SystemPrepare instance'
+        )
+        assert mock_log.call_args_list[1] == call(
+            'Cleaning up SystemPrepare instance failed, got an exception of'
+            ' type ValueError: nothing'
+        )

--- a/test/unit/utils_compress_test.py
+++ b/test/unit/utils_compress_test.py
@@ -89,3 +89,20 @@ class TestCompress(object):
         assert xz.get_format() == 'xz'
         gzip = Compress('../data/gz_data.gz')
         assert gzip.get_format() == 'gzip'
+
+    @patch('kiwi.logger.log.debug')
+    @patch('kiwi.command.Command.run')
+    def test_get_format_invalid_format(self, mock_run, mock_log):
+        mock_run.side_effect = ValueError("nothing")
+        invalid = Compress("../data/gz_data.gz")
+        invalid.supported_zipper = ["mock_zip"]
+
+        assert invalid.get_format() is None
+
+        mock_run.assert_called_once_with(
+            ['mock_zip', '-l', '../data/gz_data.gz']
+        )
+        mock_log.assert_called_once_with(
+            'Error running "mock_zip -l ../data/gz_data.gz", got a'
+            ' ValueError: nothing'
+        )


### PR DESCRIPTION
Changes proposed in this pull request:
* log exceptions thrown by `self.root_bind.cleanup()` in `SystemPrepare.__del__`
* log exceptions thrown by `Command.run()` in `Compress.get_format()`
* fix the docstring of `Compress.get_format()` clarifying that it can return `None`
