### PR TITLE
Discard default dependencies for sysroot.mount

### DIFF
--- a/dracut/modules.d/90kiwi-live/kiwi-generator.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-generator.sh
@@ -33,6 +33,7 @@ ROOTFLAGS="$(getarg rootflags)"
 {
     echo "[Unit]"
     echo "Before=initrd-root-fs.target"
+    echo "DefaultDependencies=no"
     echo "[Mount]"
     echo "Where=/sysroot"
     echo "What=LiveOS_rootfs"


### PR DESCRIPTION
This commit makes default dependencies from sysroot.mount to be
explicitly omitted. This fixes potential inconsistencies in
ordering pre-mount.service with local-fs.target. This change is
also applied to upstream sysroot.mount generator here:

https://github.com/systemd/systemd/pull/12281

Fixes #1015