### PR TITLE
Call isolinux-config only on supported archs

### DIFF
--- a/kiwi/filesystem/isofs.py
+++ b/kiwi/filesystem/isofs.py
@@ -15,6 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+import platform
+import re
+
 # project
 from kiwi.filesystem.base import FileSystemBase
 from kiwi.iso_tools.iso import Iso
@@ -36,11 +39,13 @@ class FileSystemIsoFs(FileSystemBase):
         :param string label: unused
         :param string exclude: unused
         """
+        arch = platform.machine()
         meta_data = self.custom_args['meta_data']
         iso_tool = IsoTools(self.root_dir)
 
         iso = Iso(self.root_dir)
-        iso.setup_isolinux_boot_path()
+        if re.match(r'x86_64|i[56]86', arch):
+            iso.setup_isolinux_boot_path()
 
         if not iso_tool.has_iso_hybrid_capability():
             iso.create_header_end_marker()

--- a/test/unit/filesystem_isofs_test.py
+++ b/test/unit/filesystem_isofs_test.py
@@ -20,7 +20,11 @@ class TestFileSystemIsoFs(object):
 
     @patch('kiwi.filesystem.isofs.IsoTools')
     @patch('kiwi.filesystem.isofs.Iso')
-    def test_create_on_file(self, mock_iso, mock_cdrtools):
+    @patch('kiwi.filesystem.isofs.platform.machine')
+    def test_create_on_file(
+        self, mock_platform_machine, mock_iso, mock_cdrtools
+    ):
+        mock_platform_machine.return_value = 'x86_64'
         iso_tool = mock.Mock()
         iso_tool.has_iso_hybrid_capability = mock.Mock(
             return_value=False


### PR DESCRIPTION
isolinux-config is used to update the built in search path in the isolinux loader binary. However this is provided by the syslinux package and that is not provided for any architecture.