### PR TITLE
kiwi-live-lib: mount live ISO as read-only

### DIFF
--- a/dracut/modules.d/90kiwi-live/kiwi-live-lib.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-live-lib.sh
@@ -103,7 +103,7 @@ function mountIso {
     ln -s "${isodev}" /run/initramfs/isodev
     local iso_mount_point=/run/initramfs/live
     mkdir -m 0755 -p "${iso_mount_point}"
-    if ! mount -n -t "${isofs_type}" "${isodev}" "${iso_mount_point}"; then
+    if ! mount -o ro -n -t "${isofs_type}" "${isodev}" "${iso_mount_point}"; then
         die "Failed to mount live ISO device"
     fi
     echo "${iso_mount_point}"


### PR DESCRIPTION
During the boot process of a live image, dracut shows this WARNING:

dracut-initqueue: mount: /run/initramfs/live: WARNING: device write-protected, mounted read-only

This is not a problem, as the live ISO image is, indeed, read-only.

This patch fix this cosmetic issue being explicit in the mount
options in `mountIso` function.