### PR TITLE
Remove FIXME from the runtime configuration file example

### DIFF
--- a/doc/source/working_with_kiwi/runtime_configuration_incl.rst
+++ b/doc/source/working_with_kiwi/runtime_configuration_incl.rst
@@ -46,8 +46,6 @@ illustrated in the following example:
    bundle:
      # Configure whether the image bundle should contain a XZ compressed
      # image result or not.
-     # FIXME (@scheafi @davidcassany): What's the default, what's an image
-     #                                 bundle?
      - compress: true | false
 
    container:


### PR DESCRIPTION
Changes proposed in this pull request:
* Remove a FIXME that was accidentally left in the docs.

I can also instead add the info that the FIXME mentions.