### PR TITLE
Make mediacheck runtime check arch independent

### DIFF
--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -16,7 +16,6 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
-import platform
 from textwrap import dedent
 
 # project
@@ -579,18 +578,12 @@ class RuntimeChecker(object):
             else:
                 raise KiwiRuntimeError(xen_message)
 
-    def check_mediacheck_only_for_x86_arch(self):
+    def check_mediacheck_installed(self):
         """
-        If the current architecture is not from the x86 family the
-        'mediacheck' feature available for iso images is not supported.
-        Checkmedia tool and its related boot code are only available
-        for x86 platforms.
+        If the image description enables the mediacheck attribute
+        the required tools to run this check must be installed
+        on the image build host
         """
-        message_arch_unsupported = dedent('''\n
-            The attribute 'mediacheck' is only supported for
-            x86 platforms, thus it can't be set to 'true'
-            for the current ({0}) architecture.
-        ''')
         message_tool_not_found = dedent('''\n
             Required tool {name} not found in caller environment
 
@@ -598,13 +591,8 @@ class RuntimeChecker(object):
             the above tool to be installed on the build system
         ''')
         if self.xml_state.build_type.get_mediacheck() is True:
-            arch = platform.machine()
             tool = 'tagmedia'
-            if arch not in ['x86_64', 'i586', 'i686']:
-                raise KiwiRuntimeError(
-                    message_arch_unsupported.format(arch)
-                )
-            elif not Path.which(filename=tool, access_mode=os.X_OK):
+            if not Path.which(filename=tool, access_mode=os.X_OK):
                 raise KiwiRuntimeError(
                     message_tool_not_found.format(name=tool)
                 )

--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -80,7 +80,7 @@ class CliTask(object):
             'check_volume_setup_has_no_root_definition': [],
             'check_volume_label_used_with_lvm': [],
             'check_xen_uniquely_setup_as_server_or_guest': [],
-            'check_mediacheck_only_for_x86_arch': [],
+            'check_mediacheck_installed': [],
             'check_dracut_module_for_live_iso_in_package_list': [],
             'check_dracut_module_for_disk_overlay_in_package_list': [],
             'check_dracut_module_for_disk_oem_in_package_list': [],

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -220,30 +220,14 @@ class TestRuntimeChecker(object):
         self.runtime_checker.check_efi_mode_for_disk_overlay_correctly_setup()
 
     @raises(KiwiRuntimeError)
-    @patch('platform.machine')
-    def test_check_mediacheck_only_for_x86_arch_invalid_arch(
-        self, mock_machine
-    ):
-        mock_machine.return_value = 'aarch64'
-        xml_state = XMLState(
-            self.description.load(), ['vmxFlavour'], 'iso'
-        )
-        runtime_checker = RuntimeChecker(xml_state)
-        runtime_checker.check_mediacheck_only_for_x86_arch()
-
-    @raises(KiwiRuntimeError)
-    @patch('platform.machine')
     @patch('kiwi.runtime_checker.Path.which')
-    def test_check_mediacheck_only_for_x86_arch_tagmedia_missing(
-        self, mock_which, mock_machine
-    ):
-        mock_machine.return_value = 'x86_64'
+    def test_check_mediacheck_installed_tagmedia_missing(self, mock_which):
         mock_which.return_value = False
         xml_state = XMLState(
             self.description.load(), ['vmxFlavour'], 'iso'
         )
         runtime_checker = RuntimeChecker(xml_state)
-        runtime_checker.check_mediacheck_only_for_x86_arch()
+        runtime_checker.check_mediacheck_installed()
 
     @raises(KiwiRuntimeError)
     def test_check_dracut_module_for_live_iso_in_package_list(self):

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -124,7 +124,7 @@ class TestSystemBuildTask(object):
             check_target_directory_not_in_shared_cache.\
             assert_called_once_with(self.abs_target_dir)
         self.runtime_checker.\
-            check_mediacheck_only_for_x86_arch.assert_called_once_with()
+            check_mediacheck_installed.assert_called_once_with()
         self.runtime_checker.\
             check_dracut_module_for_live_iso_in_package_list.\
             assert_called_once_with()

--- a/test/unit/tasks_system_prepare_test.py
+++ b/test/unit/tasks_system_prepare_test.py
@@ -114,7 +114,7 @@ class TestSystemPrepareTask(object):
                 self.abs_root_dir
             )
         self.runtime_checker.\
-            check_mediacheck_only_for_x86_arch.assert_called_once_with()
+            check_mediacheck_installed.assert_called_once_with()
         self.runtime_checker.\
             check_dracut_module_for_live_iso_in_package_list.\
             assert_called_once_with()


### PR DESCRIPTION
The check_mediacheck_only_for_x86_arch runtime check fails on
non x86 architectures but the tagmedia toolchain exists independent
of the platform architecture. This Fixes #1091

