### PR TITLE
Simplify shell pipe expression with shell builtin

### DIFF
--- a/dracut/modules.d/90kiwi-dump/parse-kiwi-install.sh
+++ b/dracut/modules.d/90kiwi-dump/parse-kiwi-install.sh
@@ -24,7 +24,7 @@ modprobe -q loop
 case "${installroot}" in
     install:CDLABEL=*|CDLABEL=*) \
         root="${root#install:}"
-        root="$(echo "${root}" | sed 's,/,\\x2f,g')"
+        root="${root//\//\\x2f}"
         root="install:/dev/disk/by-label/${root#CDLABEL=}"
         rootok=1 ;;
 

--- a/dracut/modules.d/90kiwi-live/kiwi-generator.sh
+++ b/dracut/modules.d/90kiwi-live/kiwi-generator.sh
@@ -13,12 +13,12 @@ fi
 case "${liveroot}" in
     live:CDLABEL=*|CDLABEL=*) \
         root="${root#live:}"
-        root="$(echo "${root}" | sed 's,/,\\x2f,g')"
+        root="${root//\//\\x2f}"
         root="live:/dev/disk/by-label/${root#CDLABEL=}"
         rootok=1 ;;
     live:AOEINTERFACE=*|AOEINTERFACE=*) \
         root="${root#live:}"
-        root="$(echo "${root}" | sed 's,/,\\x2f,g')"
+        root="${root//\//\\x2f}"
         root="live:aoe:/dev/etherd/${root#AOEINTERFACE=}"
         rootok=1 ;;
 esac

--- a/dracut/modules.d/90kiwi-live/parse-kiwi-live.sh
+++ b/dracut/modules.d/90kiwi-live/parse-kiwi-live.sh
@@ -16,12 +16,12 @@ modprobe -q loop
 case "${liveroot}" in
     live:CDLABEL=*|CDLABEL=*) \
         root="${root#live:}"
-        root="$(echo "${root}" | sed 's,/,\\x2f,g')"
+        root="${root//\//\\x2f}"
         root="live:/dev/disk/by-label/${root#CDLABEL=}"
         rootok=1 ;;
     live:AOEINTERFACE=*|AOEINTERFACE=*) \
         root="${root#live:}"
-        root="$(echo "${root}" | sed 's,/,\\x2f,g')"
+        root="${root//\//\\x2f}"
         root="live:aoe:/dev/etherd/${root#AOEINTERFACE=}"
         rootok=1 ;;
 esac

--- a/dracut/modules.d/90kiwi-overlay/kiwi-generator.sh
+++ b/dracut/modules.d/90kiwi-overlay/kiwi-generator.sh
@@ -13,7 +13,7 @@ fi
 case "${overlayroot}" in
     overlay:UUID=*|UUID=*) \
         root="${root#overlay:}"
-        root="$(echo "${root}" | sed 's,/,\\x2f,g')"
+        root="${root//\//\\x2f}"
         root="overlay:/dev/disk/by-uuid/${root#UUID=}"
         rootok=1 ;;
 esac

--- a/dracut/modules.d/90kiwi-overlay/parse-kiwi-overlay.sh
+++ b/dracut/modules.d/90kiwi-overlay/parse-kiwi-overlay.sh
@@ -15,7 +15,7 @@ modprobe -q loop
 case "${overlayroot}" in
     overlay:UUID=*|UUID=*) \
         root="${root#overlay:}"
-        root="$(echo "${root}" | sed 's,/,\\x2f,g')"
+        root="${root//\//\\x2f}"
         root="overlay:/dev/disk/by-uuid/${root#UUID=}"
         rootok=1 ;;
 esac

--- a/kiwi/config/functions.sh
+++ b/kiwi/config/functions.sh
@@ -743,7 +743,7 @@ function baseStripFirmware {
         for fname in $name ; do
             for match in /lib/firmware/"${fname}" /lib/firmware/*/"${fname}";do
                 if [ -e "${match}" ];then
-                    match=$(echo "${match}" | sed -e 's@\/lib\/firmware\/@@')
+                    match="${match//^\/lib\/firmware\//}"
                     bmdir=$(dirname "${match}")
                     mkdir -p "/lib/firmware-required/${bmdir}"
                     mv "/lib/firmware/${match}" "/lib/firmware-required/${bmdir}"
@@ -754,7 +754,7 @@ function baseStripFirmware {
     # Preserve licenses and txt files (which are needed for some firmware blobs)
     find /lib/firmware \( -name 'LICENSE*' -o -name '*txt' \) -print | while read -r match; do
         if [ -e "${match}" ];then
-            match=$(echo "${match}" | sed -e 's@\/lib\/firmware\/@@')
+            match="${match//\/lib\/firmware\//}"
             bmdir=$(dirname "${match}")
             mkdir -p "/lib/firmware-required/${bmdir}"
             mv "/lib/firmware/${match}" "/lib/firmware-required/${bmdir}"


### PR DESCRIPTION
No related issue (but I can open one, if you like).

Changes proposed in this pull request:

* Replace `echo $var | sed ...` expression with `${var//SEARCH/REPLACE}` shell builtin as suggested by Codacy

Not sure if this is useful (compatibility?), but it is something that I've found by accident in [Codacy](https://app.codacy.com/app/Appliances/kiwi/file/34900611092/issues/source?bid=8000657&fileBranchId=8000657#l757).

