### PR TITLE
Disable check-valid-until with repository_gpgcheck

### DIFF
--- a/kiwi/repository/apt.py
+++ b/kiwi/repository/apt.py
@@ -159,12 +159,10 @@ class RepositoryApt(RepositoryBase):
         if not components:
             components = 'main'
         with open(list_file, 'w') as repo:
-            if repo_gpgcheck is None:
-                repo_line = 'deb {0}'.format(uri)
+            if repo_gpgcheck is False:
+                repo_line = 'deb [trusted=yes check-valid-until=no] {0}'.format(uri)
             else:
-                repo_line = 'deb [trusted={0}] {1}'.format(
-                    'no' if repo_gpgcheck else 'yes', uri
-                )
+                repo_line = 'deb {0}'.format(uri)
             if not dist:
                 # create a debian flat repository setup. We consider the
                 # repository metadata to exist on the toplevel of the

--- a/test/unit/repository_apt_test.py
+++ b/test/unit/repository_apt_test.py
@@ -140,17 +140,17 @@ class TestRepositoryApt(object):
 
     @patch('os.path.exists')
     @patch_open
-    def test_add_repo_distribution_with_gpgchecks(
+    def test_add_repo_distribution_without_gpgchecks(
         self, mock_open, mock_exists
     ):
         mock_open.return_value = self.context_manager_mock
         mock_exists.return_value = True
         self.repo.add_repo(
             'foo', 'kiwi_iso_mount/uri', 'deb', None, 'xenial', 'a b',
-            repo_gpgcheck=True, pkg_gpgcheck=False
+            repo_gpgcheck=False, pkg_gpgcheck=False
         )
         self.file_mock.write.assert_called_once_with(
-            'deb [trusted=no] file:/kiwi_iso_mount/uri xenial a b\n'
+            'deb [trusted=yes check-valid-until=no] file:/kiwi_iso_mount/uri xenial a b\n'
         )
         mock_open.assert_called_once_with(
             '/shared-dir/apt-get/sources.list.d/foo.list', 'w'


### PR DESCRIPTION
This commit is two fold:

* From one side fixes a wrong use of the `trusted` option for
  apt repositories. `trusted=no` does not force to run the gpg checks
  it just forces the repository to be considered untrusted regardless
  the result of the security checks.

* From the other side it disables the option `check-valid-until` in
  case gpg checks are disabled using the `repository_gpgcheck`. It
  works at repository level. This enables using unmaintained or
  expired repositories for the build.

Fixes #1028
