### PR TITLE
Extend spare partition setup

### DIFF
--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -600,6 +600,17 @@ class Defaults(object):
         return 'systemVG'
 
     @staticmethod
+    def get_min_partition_mbytes():
+        """
+        Provides default minimum partition size in mbytes
+
+        :return: mbsize value
+
+        :rtype: int
+        """
+        return 50
+
+    @staticmethod
     def get_min_volume_mbytes():
         """
         Provides default minimum LVM volume size in mbytes

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -608,7 +608,7 @@ class Defaults(object):
 
         :rtype: int
         """
-        return 50
+        return 10
 
     @staticmethod
     def get_min_volume_mbytes():

--- a/kiwi/schema/kiwi.rnc
+++ b/kiwi/schema/kiwi.rnc
@@ -1236,6 +1236,35 @@ div {
             sch:param [ name = "attr" value = "spare_part" ]
             sch:param [ name = "types" value = "oem vmx" ]
         ]
+    k.type.spare_part_mountpoint.attribute =
+        ## Specify mount point for spare partition in the system.
+        ## Can only be configured for the disk image types oem and vmx
+        attribute spare_part_mountpoint { text }
+        >> sch:pattern [ id = "spare_part_mountpoint" is-a = "image_type"
+            sch:param [ name = "attr" value = "spare_part_mountpoint" ]
+            sch:param [ name = "types" value = "oem vmx" ]
+        ]
+    k.type.spare_part_fs.attribute =
+        ## Specify filesystem for spare partition in the system.
+        ## Can only be configured for the disk image types oem and vmx
+        attribute spare_part_fs {
+            "btrfs" | "ext2" | "ext3" | "ext4" | "xfs"
+        }
+        >> sch:pattern [ id = "spare_part_fs" is-a = "image_type"
+            sch:param [ name = "attr" value = "spare_part_fs" ]
+            sch:param [ name = "types" value = "oem vmx" ]
+        ]
+    k.type.spare_part_is_last.attribute =
+        ## Specify if the spare partition should be the last one in
+        ## the partition table. Can only be configured for the vmx
+        ## disk image type. By default the root partition is the last
+        ## one and the spare partition lives behind it. With this
+        ## attribute that setup can be toggled.
+        attribute spare_part_is_last { xsd:boolean }
+        >> sch:pattern [ id = "spare_part_is_last" is-a = "image_type"
+            sch:param [ name = "attr" value = "spare_part_is_last" ]
+            sch:param [ name = "types" value = "vmx" ]
+        ]
     k.type.zipl_targettype.attribute =
         ## The device type of the disk zipl should boot. On zFCP
         ## devices use SCSI, on DASD devices use CDL or LDL on
@@ -1717,6 +1746,9 @@ div {
         k.type.ramonly.attribute? &
         k.type.rootfs_label.attribute? &
         k.type.spare_part.attribute? &
+        k.type.spare_part_mountpoint.attribute? &
+        k.type.spare_part_fs.attribute? &
+        k.type.spare_part_is_last.attribute? &
         k.type.target_blocksize.attribute? &
         k.type.target_removable.attribute? &
         k.type.vga.attribute? &

--- a/kiwi/schema/kiwi.rng
+++ b/kiwi/schema/kiwi.rng
@@ -1397,7 +1397,7 @@ appended into the repository configuration file.</a:documentation>
     </define>
     <define name="k.repository.package_gpgcheck.attribute">
       <attribute name="package_gpgcheck">
-        <a:documentation>Specify whether or not this specific repository is configured to
+        <a:documentation>Specify whether or not this specific repository is configured
 to run package signature validation. If not set, no value is
 appended into the repository configuration file.</a:documentation>
         <data type="boolean"/>
@@ -1852,6 +1852,47 @@ can only be configured for the disk image types oem and vmx</a:documentation>
       <sch:pattern id="spare_part" is-a="image_type">
         <sch:param name="attr" value="spare_part"/>
         <sch:param name="types" value="oem vmx"/>
+      </sch:pattern>
+    </define>
+    <define name="k.type.spare_part_mountpoint.attribute">
+      <attribute name="spare_part_mountpoint">
+        <a:documentation>Specify mount point for spare partition in the system.
+Can only be configured for the disk image types oem and vmx</a:documentation>
+      </attribute>
+      <sch:pattern id="spare_part_mountpoint" is-a="image_type">
+        <sch:param name="attr" value="spare_part_mountpoint"/>
+        <sch:param name="types" value="oem vmx"/>
+      </sch:pattern>
+    </define>
+    <define name="k.type.spare_part_fs.attribute">
+      <attribute name="spare_part_fs">
+        <a:documentation>Specify filesystem for spare partition in the system.
+Can only be configured for the disk image types oem and vmx</a:documentation>
+        <choice>
+          <value>btrfs</value>
+          <value>ext2</value>
+          <value>ext3</value>
+          <value>ext4</value>
+          <value>xfs</value>
+        </choice>
+      </attribute>
+      <sch:pattern id="spare_part_fs" is-a="image_type">
+        <sch:param name="attr" value="spare_part_fs"/>
+        <sch:param name="types" value="oem vmx"/>
+      </sch:pattern>
+    </define>
+    <define name="k.type.spare_part_is_last.attribute">
+      <attribute name="spare_part_is_last">
+        <a:documentation>Specify if the spare partition should be the last one in
+the partition table. Can only be configured for the vmx
+disk image type. By default the root partition is the last
+one and the spare partition lives behind it. With this
+attribute that setup can be toggled.</a:documentation>
+        <data type="boolean"/>
+      </attribute>
+      <sch:pattern id="spare_part_is_last" is-a="image_type">
+        <sch:param name="attr" value="spare_part_is_last"/>
+        <sch:param name="types" value="vmx"/>
       </sch:pattern>
     </define>
     <define name="k.type.zipl_targettype.attribute">
@@ -2607,6 +2648,15 @@ default.</a:documentation>
         </optional>
         <optional>
           <ref name="k.type.spare_part.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.spare_part_mountpoint.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.spare_part_fs.attribute"/>
+        </optional>
+        <optional>
+          <ref name="k.type.spare_part_is_last.attribute"/>
         </optional>
         <optional>
           <ref name="k.type.target_blocksize.attribute"/>
@@ -3914,7 +3964,7 @@ packages are only installed if this build type is requested.</a:documentation>
     </define>
     <define name="k.packages.patternType.attribute">
       <attribute name="patternType">
-        <a:documentation>Selection type for patterns. Could be onlyRequired
+        <a:documentation>Selection type for patterns. Can be onlyRequired
 or plusRecommended</a:documentation>
         <choice>
           <value>onlyRequired</value>

--- a/kiwi/xml_parse.py
+++ b/kiwi/xml_parse.py
@@ -2542,7 +2542,7 @@ class type_(GeneratedsSuper):
     """The Image Type of the Logical Extend"""
     subclass = None
     superclass = None
-    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, boottimeout=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, vagrantconfig=None):
+    def __init__(self, boot=None, bootfilesystem=None, firmware=None, bootkernel=None, bootloader=None, bootloader_console=None, zipl_targettype=None, bootpartition=None, bootpartsize=None, efipartsize=None, efiparttable=None, bootprofile=None, boottimeout=None, btrfs_quota_groups=None, btrfs_root_is_snapshot=None, btrfs_root_is_readonly_snapshot=None, compressed=None, devicepersistency=None, editbootconfig=None, editbootinstall=None, filesystem=None, flags=None, format=None, formatoptions=None, fsmountoptions=None, gcelicense=None, hybridpersistent=None, hybridpersistent_filesystem=None, gpt_hybrid_mbr=None, force_mbr=None, initrd_system=None, image=None, installboot=None, install_continue_on_timeout=None, installprovidefailsafe=None, installiso=None, installstick=None, installpxe=None, mediacheck=None, kernelcmdline=None, luks=None, luksOS=None, mdraid=None, overlayroot=None, primary=None, ramonly=None, rootfs_label=None, spare_part=None, spare_part_mountpoint=None, spare_part_fs=None, spare_part_is_last=None, target_blocksize=None, target_removable=None, vga=None, vhdfixedtag=None, volid=None, wwid_wait_timeout=None, derived_from=None, xen_server=None, publisher=None, disk_start_sector=None, containerconfig=None, machine=None, oemconfig=None, size=None, systemdisk=None, vagrantconfig=None):
         self.original_tagname_ = None
         self.boot = _cast(None, boot)
         self.bootfilesystem = _cast(None, bootfilesystem)
@@ -2592,6 +2592,9 @@ class type_(GeneratedsSuper):
         self.ramonly = _cast(bool, ramonly)
         self.rootfs_label = _cast(None, rootfs_label)
         self.spare_part = _cast(None, spare_part)
+        self.spare_part_mountpoint = _cast(None, spare_part_mountpoint)
+        self.spare_part_fs = _cast(None, spare_part_fs)
+        self.spare_part_is_last = _cast(bool, spare_part_is_last)
         self.target_blocksize = _cast(int, target_blocksize)
         self.target_removable = _cast(bool, target_removable)
         self.vga = _cast(None, vga)
@@ -2763,6 +2766,12 @@ class type_(GeneratedsSuper):
     def set_rootfs_label(self, rootfs_label): self.rootfs_label = rootfs_label
     def get_spare_part(self): return self.spare_part
     def set_spare_part(self, spare_part): self.spare_part = spare_part
+    def get_spare_part_mountpoint(self): return self.spare_part_mountpoint
+    def set_spare_part_mountpoint(self, spare_part_mountpoint): self.spare_part_mountpoint = spare_part_mountpoint
+    def get_spare_part_fs(self): return self.spare_part_fs
+    def set_spare_part_fs(self, spare_part_fs): self.spare_part_fs = spare_part_fs
+    def get_spare_part_is_last(self): return self.spare_part_is_last
+    def set_spare_part_is_last(self, spare_part_is_last): self.spare_part_is_last = spare_part_is_last
     def get_target_blocksize(self): return self.target_blocksize
     def set_target_blocksize(self, target_blocksize): self.target_blocksize = target_blocksize
     def get_target_removable(self): return self.target_removable
@@ -2982,6 +2991,15 @@ class type_(GeneratedsSuper):
         if self.spare_part is not None and 'spare_part' not in already_processed:
             already_processed.add('spare_part')
             outfile.write(' spare_part=%s' % (quote_attrib(self.spare_part), ))
+        if self.spare_part_mountpoint is not None and 'spare_part_mountpoint' not in already_processed:
+            already_processed.add('spare_part_mountpoint')
+            outfile.write(' spare_part_mountpoint=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.spare_part_mountpoint), input_name='spare_part_mountpoint')), ))
+        if self.spare_part_fs is not None and 'spare_part_fs' not in already_processed:
+            already_processed.add('spare_part_fs')
+            outfile.write(' spare_part_fs=%s' % (self.gds_encode(self.gds_format_string(quote_attrib(self.spare_part_fs), input_name='spare_part_fs')), ))
+        if self.spare_part_is_last is not None and 'spare_part_is_last' not in already_processed:
+            already_processed.add('spare_part_is_last')
+            outfile.write(' spare_part_is_last="%s"' % self.gds_format_boolean(self.spare_part_is_last, input_name='spare_part_is_last'))
         if self.target_blocksize is not None and 'target_blocksize' not in already_processed:
             already_processed.add('target_blocksize')
             outfile.write(' target_blocksize="%s"' % self.gds_format_integer(self.target_blocksize, input_name='target_blocksize'))
@@ -3347,6 +3365,24 @@ class type_(GeneratedsSuper):
             self.spare_part = value
             self.spare_part = ' '.join(self.spare_part.split())
             self.validate_partition_size_type(self.spare_part)    # validate type partition-size-type
+        value = find_attr_value_('spare_part_mountpoint', node)
+        if value is not None and 'spare_part_mountpoint' not in already_processed:
+            already_processed.add('spare_part_mountpoint')
+            self.spare_part_mountpoint = value
+        value = find_attr_value_('spare_part_fs', node)
+        if value is not None and 'spare_part_fs' not in already_processed:
+            already_processed.add('spare_part_fs')
+            self.spare_part_fs = value
+            self.spare_part_fs = ' '.join(self.spare_part_fs.split())
+        value = find_attr_value_('spare_part_is_last', node)
+        if value is not None and 'spare_part_is_last' not in already_processed:
+            already_processed.add('spare_part_is_last')
+            if value in ('true', '1'):
+                self.spare_part_is_last = True
+            elif value in ('false', '0'):
+                self.spare_part_is_last = False
+            else:
+                raise_parse_error(node, 'Bad boolean attribute')
         value = find_attr_value_('target_blocksize', node)
         if value is not None and 'target_blocksize' not in already_processed:
             already_processed.add('target_blocksize')

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -53,7 +53,8 @@ class TestDiskBuilder(object):
             'readonly': MappedDevice('/dev/readonly-root-device', mock.Mock()),
             'boot': MappedDevice('/dev/boot-device', mock.Mock()),
             'prep': MappedDevice('/dev/prep-device', mock.Mock()),
-            'efi': MappedDevice('/dev/efi-device', mock.Mock())
+            'efi': MappedDevice('/dev/efi-device', mock.Mock()),
+            'spare': MappedDevice('/dev/spare-device', mock.Mock())
         }
         self.id_map = {
             'kiwi_RootPart': 1,
@@ -70,7 +71,7 @@ class TestDiskBuilder(object):
             return_value='blkid_result'
         )
         self.block_operation.get_filesystem = mock.Mock(
-            return_value='filesystem'
+            return_value='blkid_result_fs'
         )
         kiwi.builder.disk.BlockID = mock.Mock(
             return_value=self.block_operation
@@ -123,6 +124,8 @@ class TestDiskBuilder(object):
             return_value=self.disk
         )
         self.disk_setup = mock.Mock()
+        self.disk_setup.get_disksize_mbytes.return_value = 1024
+        self.disk_setup.boot_partition_size.return_value = 0
         self.disk_setup.get_efi_label = mock.Mock(
             return_value='EFI'
         )
@@ -162,6 +165,9 @@ class TestDiskBuilder(object):
             return_value=self.boot_image_task
         )
         self.firmware = mock.Mock()
+        self.firmware.get_legacy_bios_partition_size.return_value = 0
+        self.firmware.get_efi_partition_size.return_value = 0
+        self.firmware.get_prep_partition_size.return_value = 0
         self.firmware.efi_mode = mock.Mock(
             return_value='efi'
         )
@@ -724,17 +730,17 @@ class TestDiskBuilder(object):
         self.setup.create_fstab.assert_called_once_with(
             [
                 'fstab_volume_entries',
-                'UUID=blkid_result / filesystem ro 0 0',
-                'UUID=blkid_result /boot filesystem defaults 0 0',
-                'UUID=blkid_result /boot/efi filesystem defaults 0 0'
+                'UUID=blkid_result / blkid_result_fs ro 0 0',
+                'UUID=blkid_result /boot blkid_result_fs defaults 0 0',
+                'UUID=blkid_result /boot/efi blkid_result_fs defaults 0 0'
             ]
         )
         self.boot_image_task.setup.create_fstab.assert_called_once_with(
             [
                 'fstab_volume_entries',
-                'UUID=blkid_result / filesystem ro 0 0',
-                'UUID=blkid_result /boot filesystem defaults 0 0',
-                'UUID=blkid_result /boot/efi filesystem defaults 0 0'
+                'UUID=blkid_result / blkid_result_fs ro 0 0',
+                'UUID=blkid_result /boot blkid_result_fs defaults 0 0',
+                'UUID=blkid_result /boot/efi blkid_result_fs defaults 0 0'
             ]
         )
 
@@ -797,8 +803,33 @@ class TestDiskBuilder(object):
         self.disk_builder.volume_manager_name = None
         self.disk_builder.install_media = False
         self.disk_builder.spare_part_mbsize = 42
+        self.disk_builder.spare_part_fs = 'ext4'
+        self.disk_builder.spare_part_mountpoint = '/var'
+        self.disk_builder.spare_part_is_last = False
         self.disk_builder.create_disk()
         self.disk.create_spare_partition.assert_called_once_with(42)
+        assert mock_fs.call_args_list[0] == call(
+            self.disk_builder.spare_part_fs,
+            self.device_map['spare'],
+            'root_dir/var/'
+        )
+        assert filesystem.sync_data.call_args_list.pop() == call(
+            [
+                'image', '.profile', '.kconfig', '.buildenv',
+                'var/cache/kiwi', 'var/*', 'var/.*',
+                'boot/*', 'boot/.*', 'boot/efi/*', 'boot/efi/.*'
+            ]
+        )
+        assert 'UUID=blkid_result /var blkid_result_fs defaults 0 0' in \
+            self.disk_builder.generic_fstab_entries
+
+        self.disk.create_root_partition.reset_mock()
+        self.disk.create_spare_partition.reset_mock()
+        self.disk_builder.spare_part_is_last = True
+        self.disk_builder.create_disk()
+        self.disk.create_spare_partition.assert_called_once_with(
+            'all_free'
+        )
 
     @patch('kiwi.builder.disk.LoopDevice')
     @patch('kiwi.builder.disk.Partitioner')

--- a/test/unit/builder_disk_test.py
+++ b/test/unit/builder_disk_test.py
@@ -535,7 +535,7 @@ class TestDiskBuilder(object):
                 'boot/*', 'boot/.*', 'boot/efi/*', 'boot/efi/.*'
             ], filename='tempname')
         ]
-        self.disk.create_root_readonly_partition.assert_called_once_with(51)
+        self.disk.create_root_readonly_partition.assert_called_once_with(11)
         assert mock_command.call_args_list[2] == call(
             ['dd', 'if=tempname', 'of=/dev/readonly-root-device']
         )


### PR DESCRIPTION
The spare partition could be used to introduce one additional
partition table entry. With this patch the following new type
attributes will be added:

* spare_part_fs="fsname"
* spare_part_mountpoint="/location"
* spare_part_is_last="true|false"

Along with the setup of the partition size the filesystem and
its mountpoint can be specified. If set the contents of the
rootfs at the specified spare location will be synced to that
partition. The spare_part_is_last attribute will place the
spare partition at the end of the disk. Note this attribute
is only available for the simple vmx disk type. This is
related to bsc#1129566


