### PR TITLE
Make kiwi installable in a venv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ from distutils.command import clean as distutils_clean
 import distutils
 import subprocess
 import os
+import sys
 
 import platform
 
@@ -18,6 +19,11 @@ from kiwi.version import __version__
 
 
 python_version = platform.python_version().split('.')[0]
+
+# sys.base_prefix points to the installation prefix set during python
+# compilation and sys.prefix points to the same path unless we are inside
+# a venv, in which case points to the $VIRTUAL_ENV value.
+is_venv = sys.base_prefix != sys.prefix if sys.version_info >= (3, 3) else False
 
 
 class sdist(setuptools_sdist.sdist):
@@ -151,6 +157,8 @@ class install(distutils_install.install):
         command = ['make']
         if self.root:
             command.append('buildroot={0}/'.format(self.root))
+        elif is_venv:
+            command.append('buildroot={0}/'.format(sys.prefix))
         command.append('python_version={0}'.format(python_version))
         command.append('tools')
         command.append('install')


### PR DESCRIPTION
This commit sets the buildroot to the venv `sys.prefix`. This way
all the binaries are installed in a path under the venv.

Fixes #1022
