### PR TITLE
Fix memory leak in OCI container tests

### DIFF
--- a/kiwi/container/oci.py
+++ b/kiwi/container/oci.py
@@ -72,7 +72,7 @@ class ContainerImageOCI(object):
         # buildservice.
         if Defaults.is_buildservice_worker():
             bs_label = 'org.openbuildservice.disturl'
-            # Do not label anything if any build service label is
+            # Do not label anything if the build service label is
             # already present
             if 'labels' not in self.oci_config or \
                     bs_label not in self.oci_config['labels']:

--- a/test/unit/container_image_oci_test.py
+++ b/test/unit/container_image_oci_test.py
@@ -53,11 +53,12 @@ class TestContainerImageOCI(object):
             'history': {'created_by': 'KIWI {0}'.format(__version__)}
         }
 
+    @patch('kiwi.container.oci.RuntimeConfig')
     @patch('kiwi.oci_tools.umoci.CommandCapabilities.has_option_in_help')
     @patch('kiwi.defaults.Defaults.is_buildservice_worker')
     @patch_open
     def test_init_in_buildservice(
-        self, mock_open, mock_buildservice, mock_cmd_caps
+        self, mock_open, mock_buildservice, mock_cmd_caps, mock_RuntimeConfig
     ):
         mock_buildservice.return_value = True
         mock_cmd_caps.return_value = True
@@ -71,12 +72,14 @@ class TestContainerImageOCI(object):
             'obs://build.opensuse.org/some:project'
         }
 
+    @patch('kiwi.container.oci.RuntimeConfig')
     @patch('kiwi.oci_tools.umoci.CommandCapabilities.has_option_in_help')
     @patch('kiwi.defaults.Defaults.is_buildservice_worker')
     @patch_open
     @patch('kiwi.logger.log.warning')
     def test_init_in_buildservice_without_disturl(
-        self, mock_warn, mock_open, mock_buildservice, mock_cmd_caps
+        self, mock_warn, mock_open, mock_buildservice,
+        mock_cmd_caps, mock_RuntimeConfig
     ):
         mock_buildservice.return_value = True
         mock_cmd_caps.return_value = True


### PR DESCRIPTION
This commit fixes a memory leak in container_image_oci_test caused
by partially mocking a file opening. A ContainerImageOci instance
tries to open and read two files: the runtime configuration, if
present, and the `/.buildenv`, if present. In order to test the
`/.buildenv` presence file opening is mocked causing the runtime
configuration reading fall in an infinite loop. This commit mocks the
the RuntimeConfig instances to avoid this issue.

Fixes #1110
