### PR TITLE
Refactor ISO boot, use grub in EFI mode

### DIFF
--- a/kiwi/bootloader/config/base.py
+++ b/kiwi/bootloader/config/base.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+import os
 import platform
 from collections import namedtuple
 
@@ -165,7 +166,9 @@ class BootLoaderConfigBase(object):
 
         :rtype: str
         """
-        efi_boot_path = self.root_dir + '/' + in_sub_dir + '/EFI/BOOT'
+        efi_boot_path = os.path.normpath(
+            os.sep.join([self.root_dir, in_sub_dir, 'EFI/BOOT'])
+        )
         Path.create(efi_boot_path)
         return efi_boot_path
 

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -622,7 +622,12 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 self._get_bios_modules_path(lookup_path) + '/cdboot.img',
                 grub_image or self._get_bios_image_name(lookup_path),
                 '>',
-                self._get_bios_modules_path(lookup_path) + '/eltorito.img',
+                os.sep.join(
+                    [
+                        self._get_bios_modules_path(lookup_path),
+                        Defaults.get_isolinux_bios_grub_loader()
+                    ]
+                )
             ]
         )
         Command.run(

--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -306,7 +306,8 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             'boot_timeout': self.timeout,
             'title': self.get_menu_entry_install_title(),
             'bootpath': self.get_boot_path('iso'),
-            'boot_directory_name': self.boot_directory_name
+            'boot_directory_name': self.boot_directory_name,
+            'efi_image_name': Defaults.get_efi_image_name(self.arch)
         }
         if self.multiboot:
             log.info('--> Using multiboot install template')
@@ -362,7 +363,8 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             'boot_timeout': self.timeout,
             'title': self.get_menu_entry_title(plain=True),
             'bootpath': self.get_boot_path('iso'),
-            'boot_directory_name': self.boot_directory_name
+            'boot_directory_name': self.boot_directory_name,
+            'efi_image_name': Defaults.get_efi_image_name(self.arch)
         }
         if self.multiboot:
             log.info('--> Using multiboot template')
@@ -413,6 +415,7 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
 
         if self._supports_bios_modules():
             self._copy_bios_modules_to_boot_directory(lookup_path)
+            self._setup_bios_image(mbrid=mbrid, lookup_path=lookup_path)
 
         if self.firmware.efi_mode():
             self._setup_EFI_path(lookup_path)
@@ -591,6 +594,33 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
                 uuid, mbrid, lookup_path
             )
 
+    def _setup_bios_image(self, mbrid=None, lookup_path=None):
+        """
+        Provide bios grub image
+        """
+        if not lookup_path:
+            lookup_path = self.root_dir
+        grub_image = Defaults.get_grub_bios_core_loader(lookup_path)
+        if grub_image:
+            log.info('--> Using prebuilt bios image')
+        else:
+            log.info('--> Creating bios image')
+            self._create_bios_image(
+                mbrid, lookup_path
+            )
+        bash_command = ' '.join(
+            [
+                'cat',
+                self._get_bios_modules_path(lookup_path) + '/cdboot.img',
+                grub_image or self._get_bios_image_name(lookup_path),
+                '>',
+                self._get_bios_modules_path(lookup_path) + '/eltorito.img',
+            ]
+        )
+        Command.run(
+            ['bash', '-c', bash_command]
+        )
+
     def _create_embedded_fat_efi_image(self):
         Path.create(self.root_dir + '/boot/' + self.arch)
         efi_fat_image = ''.join(
@@ -610,7 +640,9 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         )
 
     def _create_efi_image(self, uuid=None, mbrid=None, lookup_path=None):
-        early_boot_script = self.efi_boot_path + '/earlyboot.cfg'
+        early_boot_script = os.path.normpath(
+            os.sep.join([self.efi_boot_path, 'earlyboot.cfg'])
+        )
         if uuid:
             self._create_early_boot_script_for_uuid_search(
                 early_boot_script, uuid
@@ -642,6 +674,24 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             )
         with open(efi_boot_config, 'a') as config:
             config.write('normal{0}'.format(os.linesep))
+
+    def _create_bios_image(self, mbrid=None, lookup_path=None):
+        early_boot_script = os.path.normpath(
+            os.sep.join([self._get_grub2_boot_path(), 'earlyboot.cfg'])
+        )
+        self._create_early_boot_script_for_mbrid_search(
+            early_boot_script, mbrid
+        )
+        Command.run(
+            [
+                self._get_grub2_mkimage_tool() or 'grub2-mkimage',
+                '-O', Defaults.get_bios_module_directory_name(),
+                '-o', self._get_bios_image_name(lookup_path),
+                '-c', early_boot_script,
+                '-p', self.get_boot_path() + '/' + self.boot_directory_name,
+                '-d', self._get_bios_modules_path(lookup_path)
+            ] + Defaults.get_grub_bios_modules(multiboot=self.xen_guest)
+        )
 
     def _create_early_boot_script_for_uuid_search(self, filename, uuid):
         with open(filename, 'w') as early_boot:
@@ -682,7 +732,20 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
         return self.root_dir + '/boot/' + self.boot_directory_name
 
     def _get_efi_image_name(self):
-        return self.efi_boot_path + '/' + Defaults.get_efi_image_name(self.arch)
+        return os.sep.join(
+            [
+                self.efi_boot_path,
+                Defaults.get_efi_image_name(self.arch)
+            ]
+        )
+
+    def _get_bios_image_name(self, lookup_path):
+        return os.sep.join(
+            [
+                self._get_bios_modules_path(lookup_path),
+                Defaults.get_bios_image_name()
+            ]
+        )
 
     def _get_efi_modules_path(self, lookup_path=None):
         return self._get_module_path(

--- a/kiwi/bootloader/config/isolinux.py
+++ b/kiwi/bootloader/config/isolinux.py
@@ -17,21 +17,15 @@
 #
 import os
 import platform
-import shutil
 
 # project
 from kiwi.bootloader.config.base import BootLoaderConfigBase
 from kiwi.bootloader.template.isolinux import BootLoaderTemplateIsoLinux
-from kiwi.utils.sync import DataSync
 from kiwi.logger import log
 from kiwi.path import Path
 from kiwi.defaults import Defaults
-from kiwi.command import Command
 
-from kiwi.exceptions import (
-    KiwiTemplateError,
-    KiwiBootLoaderIsoLinuxPlatformError
-)
+from kiwi.exceptions import KiwiTemplateError
 
 
 class BootLoaderConfigIsoLinux(BootLoaderConfigBase):
@@ -45,15 +39,9 @@ class BootLoaderConfigIsoLinux(BootLoaderConfigBase):
         :param dict custom_args: custom isolinux config arguments
         """
         self.custom_args = custom_args
-        arch = platform.machine()
-        if arch == 'x86_64':
-            self.arch = arch
-        elif arch == 'i686' or arch == 'i586':
+        self.arch = platform.machine()
+        if self.arch == 'i686' or self.arch == 'i586':
             self.arch = 'ix86'
-        else:
-            raise KiwiBootLoaderIsoLinuxPlatformError(
-                'host architecture %s not supported for isolinux setup' % arch
-            )
 
         self.install_volid = self.xml_state.build_type.get_volid() or \
             Defaults.get_install_volume_id()
@@ -227,92 +215,23 @@ class BootLoaderConfigIsoLinux(BootLoaderConfigBase):
         """
         Provide isolinux boot metadata
 
-        The mbrid parameter is not used, because only isolinux
-        loader binary and possible theming files are copied
+        No extra boot images must be created for isolinux
 
         :param string mbrid: unused
-        :param string lookup_path: custom module lookup path
+        :param string lookup_path: unused
         """
-        self._copy_loader_data_to_boot_directory(lookup_path)
+        pass
 
     def setup_live_boot_images(self, mbrid, lookup_path=None):
         """
         Provide isolinux boot metadata
 
-        Calls setup_install_boot_images because no different action required
+        No extra boot images must be created for isolinux
+
+        :param string mbrid: unused
+        :param string lookup_path: unused
         """
-        self.setup_install_boot_images(mbrid, lookup_path)
-
-    def _copy_loader_data_to_boot_directory(self, lookup_path):
-        if not lookup_path:
-            lookup_path = self.root_dir
-        loader_data = lookup_path + '/image/loader/'
-        Path.wipe(loader_data)
-        Path.create(loader_data)
-
-        syslinux_file_names = [
-            'isolinux.bin',
-            'ldlinux.c32',
-            'libcom32.c32',
-            'libutil.c32',
-            'gfxboot.c32',
-            'gfxboot.com',
-            'menu.c32',
-            'chain.c32',
-            'mboot.c32'
-        ]
-        syslinux_dirs = [
-            '/usr/share/syslinux/',
-            '/usr/lib/syslinux/modules/bios/',
-            '/usr/lib/ISOLINUX/'
-        ]
-        for syslinux_file_name in syslinux_file_names:
-            for syslinux_dir in syslinux_dirs:
-                syslinux_file = ''.join(
-                    [lookup_path, syslinux_dir, syslinux_file_name]
-                )
-                if os.path.exists(syslinux_file):
-                    shutil.copy(syslinux_file, loader_data)
-
-        bash_command = ' '.join(
-            ['cp', lookup_path + '/boot/memtest*', loader_data + '/memtest']
-        )
-        Command.run(
-            command=['bash', '-c', bash_command], raise_on_error=False
-        )
-
-        if self.get_boot_theme():
-            theme_path = ''.join(
-                [lookup_path, '/etc/bootsplash/themes/', self.get_boot_theme()]
-            )
-            if os.path.exists(theme_path + '/cdrom/gfxboot.cfg'):
-                bash_command = ' '.join(
-                    ['cp', theme_path + '/cdrom/*', loader_data]
-                )
-                Command.run(
-                    ['bash', '-c', bash_command]
-                )
-                # don't move down one menu entry the first time a F-key is used
-                Command.run(
-                    [
-                        'gfxboot',
-                        '--config-file', loader_data + '/gfxboot.cfg',
-                        '--change-config', 'install::autodown=0'
-                    ]
-                )
-
-            if os.path.exists(theme_path + '/bootloader/message'):
-                Command.run(
-                    ['cp', theme_path + '/bootloader/message', loader_data]
-                )
-
-        Path.create(self._get_iso_boot_path())
-        data = DataSync(
-            loader_data, self._get_iso_boot_path()
-        )
-        data.sync_data(
-            options=['-z', '-a']
-        )
+        pass
 
     def _get_iso_boot_path(self):
         return self.root_dir + '/boot/' + self.arch + '/loader'

--- a/kiwi/bootloader/template/grub2.py
+++ b/kiwi/bootloader/template/grub2.py
@@ -300,8 +300,7 @@ class BootLoaderTemplateGrub2(object):
 
         self.menu_iso_harddisk_entry = dedent('''
             menuentry "Boot from Hard Disk" --class os --unrestricted {
-                search --set=root --label EFI
-                chainloader ($${root})/EFI/BOOT/${efi_image_name}
+                exit
             }
         ''').strip() + os.linesep
 

--- a/kiwi/bootloader/template/grub2.py
+++ b/kiwi/bootloader/template/grub2.py
@@ -301,7 +301,7 @@ class BootLoaderTemplateGrub2(object):
         self.menu_iso_harddisk_entry = dedent('''
             menuentry "Boot from Hard Disk" --class os --unrestricted {
                 search --set=root --label EFI
-                chainloader ($${root})/EFI/BOOT/bootx64.efi
+                chainloader ($${root})/EFI/BOOT/${efi_image_name}
             }
         ''').strip() + os.linesep
 

--- a/kiwi/builder/install.py
+++ b/kiwi/builder/install.py
@@ -35,6 +35,7 @@ from kiwi.system.kernel import Kernel
 from kiwi.utils.compress import Compress
 from kiwi.archive.tar import ArchiveTar
 from kiwi.system.setup import SystemSetup
+from kiwi.iso_tools.base import IsoToolsBase
 
 from kiwi.exceptions import (
     KiwiInstallBootImageError
@@ -178,34 +179,38 @@ class InstallImageBuilder(object):
             ['mv', squashed_image_file, self.media_dir]
         )
 
-        # setup bootloader config to boot the ISO via isolinux
-        log.info('Setting up install image bootloader configuration')
-        bootloader_config_isolinux = BootLoaderConfig(
-            'isolinux', self.xml_state, self.media_dir
+        log.info(
+            'Setting up install image bootloader configuration'
         )
-        bootloader_config_isolinux.setup_install_boot_images(
-            mbrid=None,
-            lookup_path=self.boot_image_task.boot_root_directory
+        if self.firmware.efi_mode():
+            # setup bootloader config to boot the ISO via EFI
+            # This also embedds an MBR and the respective BIOS modules
+            # for compat boot. The complete bootloader setup will be
+            # based on grub
+            bootloader_config = BootLoaderConfig(
+                'grub2', self.xml_state, self.media_dir, {
+                    'grub_directory_name':
+                        Defaults.get_grub_boot_directory_name(self.root_dir)
+                }
+            )
+            bootloader_config.setup_install_boot_images(
+                mbrid=self.mbrid, lookup_path=self.root_dir
+            )
+        else:
+            # setup bootloader config to boot the ISO via isolinux.
+            # This allows for booting on x86 platforms in BIOS mode
+            # only.
+            bootloader_config = BootLoaderConfig(
+                'isolinux', self.xml_state, self.media_dir
+            )
+        IsoToolsBase.setup_media_loader_directory(
+            self.boot_image_task.boot_root_directory, self.media_dir,
+            bootloader_config.get_boot_theme()
         )
-        bootloader_config_isolinux.setup_install_image_config(
-            mbrid=None
-        )
-        bootloader_config_isolinux.write()
-
-        # setup bootloader config to boot the ISO via EFI
-        bootloader_config_grub = BootLoaderConfig(
-            'grub2', self.xml_state, self.media_dir, {
-                'grub_directory_name':
-                    Defaults.get_grub_boot_directory_name(self.root_dir)
-            }
-        )
-        bootloader_config_grub.setup_install_boot_images(
-            mbrid=self.mbrid, lookup_path=self.root_dir
-        )
-        bootloader_config_grub.setup_install_image_config(
+        bootloader_config.setup_install_image_config(
             mbrid=self.mbrid
         )
-        bootloader_config_grub.write()
+        bootloader_config.write()
 
         # create initrd for install image
         log.info('Creating install image boot image')

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -602,7 +602,8 @@ class Defaults(object):
         signed_grub_file_patterns = [
             '/usr/share/efi/*/grub.efi',
             '/usr/lib64/efi/grub.efi',
-            '/boot/efi/EFI/*/grub*.efi'
+            '/boot/efi/EFI/*/grub*.efi',
+            '/usr/share/grub*/arm64-efi/grub.efi'
         ]
         for signed_grub_pattern in signed_grub_file_patterns:
             for signed_grub in glob.iglob(root_path + signed_grub_pattern):

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -586,6 +586,57 @@ class Defaults(object):
                 return bios_grub_core
 
     @staticmethod
+    def get_syslinux_modules():
+        """
+        Returns list of syslinux modules to include on ISO
+        images that boots via isolinux
+
+        :return: base file names
+
+        :rtype: list
+        """
+        return [
+            'isolinux.bin',
+            'ldlinux.c32',
+            'libcom32.c32',
+            'libutil.c32',
+            'gfxboot.c32',
+            'gfxboot.com',
+            'menu.c32',
+            'chain.c32',
+            'mboot.c32'
+        ]
+
+    @staticmethod
+    def get_syslinux_search_paths():
+        """
+        syslinux is packaged differently between distributions.
+        This method returns a list of directories to search for
+        syslinux data
+
+        :return: directory names
+
+        :rtype: list
+        """
+        return [
+            '/usr/share/syslinux',
+            '/usr/lib/syslinux/modules/bios',
+            '/usr/lib/ISOLINUX'
+        ]
+
+    @staticmethod
+    def get_isolinux_bios_grub_loader():
+        """
+        Return name of eltorito grub image used as isolinux loader
+        in BIOS mode if isolinux.bin should not be used
+
+        :return: file base name
+
+        :rtype: str
+        """
+        return 'eltorito.img'
+
+    @staticmethod
     def get_signed_grub_loader(root_path):
         """
         Provides shim signed grub loader file path

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -82,6 +82,21 @@ class Defaults(object):
         ]
 
     @staticmethod
+    def is_x86_arch(arch):
+        """
+        Checks if machine architecture is x86 based
+
+        Any arch that matches 32bit and 64bit x86 architecture
+        causes the method to return True. Anything else will
+        cause the method to return False
+
+        :rtype: bool
+        """
+        if arch == 'x86_64' or arch == 'i686' or arch == 'i586':
+            return True
+        return False
+
+    @staticmethod
     def is_buildservice_worker():
         """
         Checks if build host is an open buildservice machine
@@ -543,6 +558,34 @@ class Defaults(object):
                 return unsigned_grub_file
 
     @staticmethod
+    def get_grub_bios_core_loader(root_path):
+        """
+        Provides grub bios image
+
+        Searches distribution specific locations to find the
+        core bios image below the given root path
+
+        :param string root_path: image root path
+
+        :return: file path or None
+
+        :rtype: str
+        """
+        bios_grub_core_patterns = [
+            '/usr/share/grub*/i386-pc/{0}'.format(
+                Defaults.get_bios_image_name()
+            ),
+            '/usr/lib/grub*/i386-pc/{0}'.format(
+                Defaults.get_bios_image_name()
+            )
+        ]
+        for bios_grub_core_pattern in bios_grub_core_patterns:
+            for bios_grub_core in glob.iglob(
+                root_path + bios_grub_core_pattern
+            ):
+                return bios_grub_core
+
+    @staticmethod
     def get_signed_grub_loader(root_path):
         """
         Provides shim signed grub loader file path
@@ -828,6 +871,17 @@ class Defaults(object):
             return default_module_directory_names[arch]
 
     @staticmethod
+    def get_bios_module_directory_name():
+        """
+        Provides x86 BIOS directory name which stores the pc binaries
+
+        :return: directory name
+
+        :rtype: str
+        """
+        return 'i386-pc'
+
+    @staticmethod
     def get_efi_image_name(arch):
         """
         Provides architecture specific EFI boot binary name
@@ -849,6 +903,17 @@ class Defaults(object):
         }
         if arch in default_efi_image_names:
             return default_efi_image_names[arch]
+
+    @staticmethod
+    def get_bios_image_name():
+        """
+        Provides bios core boot binary name
+
+        :return: name
+
+        :rtype: str
+        """
+        return 'core.img'
 
     @staticmethod
     def get_default_boot_timeout_seconds():

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -603,7 +603,7 @@ class Defaults(object):
             '/usr/share/efi/*/grub.efi',
             '/usr/lib64/efi/grub.efi',
             '/boot/efi/EFI/*/grub*.efi',
-            '/usr/share/grub*/arm64-efi/grub.efi'
+            '/usr/share/grub*/*-efi/grub.efi'
         ]
         for signed_grub_pattern in signed_grub_file_patterns:
             for signed_grub in glob.iglob(root_path + signed_grub_pattern):

--- a/kiwi/exceptions.py
+++ b/kiwi/exceptions.py
@@ -113,13 +113,6 @@ class KiwiBootLoaderInstallSetupError(KiwiError):
     """
 
 
-class KiwiBootLoaderIsoLinuxPlatformError(KiwiError):
-    """
-    Exception raised if an attempt was made to use isolinux on
-    an unsupported platform.
-    """
-
-
 class KiwiBootLoaderTargetError(KiwiError):
     """
     Exception raised if the target to read the bootloader path

--- a/kiwi/filesystem/isofs.py
+++ b/kiwi/filesystem/isofs.py
@@ -15,9 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
-import platform
-import re
-
 # project
 from kiwi.filesystem.base import FileSystemBase
 from kiwi.iso_tools.iso import Iso
@@ -39,12 +36,12 @@ class FileSystemIsoFs(FileSystemBase):
         :param string label: unused
         :param string exclude: unused
         """
-        arch = platform.machine()
         meta_data = self.custom_args['meta_data']
+        efi_mode = meta_data.get('efi_mode')
         iso_tool = IsoTools(self.root_dir)
 
         iso = Iso(self.root_dir)
-        if re.match(r'x86_64|i[56]86', arch):
+        if not efi_mode:
             iso.setup_isolinux_boot_path()
 
         if not iso_tool.has_iso_hybrid_capability():
@@ -63,10 +60,8 @@ class FileSystemIsoFs(FileSystemBase):
             )
             iso.relocate_boot_catalog(filename)
             iso.fix_boot_catalog(filename)
-            efi_mode = meta_data['efi_mode'] if 'efi_mode' in meta_data else \
-                False
             mbr_id = meta_data['mbr_id'] if 'mbr_id' in meta_data else \
                 '0xffffffff'
             iso.create_hybrid(
-                hybrid_offset, mbr_id, filename, efi_mode
+                hybrid_offset, mbr_id, filename, bool(efi_mode)
             )

--- a/kiwi/iso_tools/base.py
+++ b/kiwi/iso_tools/base.py
@@ -111,26 +111,9 @@ class IsoToolsBase(object):
         )
         Path.wipe(loader_data)
         Path.create(loader_data)
-
-        syslinux_file_names = [
-            'isolinux.bin',
-            'ldlinux.c32',
-            'libcom32.c32',
-            'libutil.c32',
-            'gfxboot.c32',
-            'gfxboot.com',
-            'menu.c32',
-            'chain.c32',
-            'mboot.c32'
-        ]
         grub_image_file_names = [
-            'eltorito.img',
+            Defaults.get_isolinux_bios_grub_loader(),
             'boot_hybrid.img'
-        ]
-        syslinux_dirs = [
-            '/usr/share/syslinux/',
-            '/usr/lib/syslinux/modules/bios/',
-            '/usr/lib/ISOLINUX/'
         ]
         loader_files = []
         for grub_image_file_name in grub_image_file_names:
@@ -141,10 +124,12 @@ class IsoToolsBase(object):
             if grub_file and os.path.exists(grub_file):
                 loader_files.append(grub_file)
 
-        for syslinux_file_name in syslinux_file_names:
-            for syslinux_dir in syslinux_dirs:
-                syslinux_file = ''.join(
-                    [lookup_path, syslinux_dir, syslinux_file_name]
+        for syslinux_file_name in Defaults.get_syslinux_modules():
+            for syslinux_dir in Defaults.get_syslinux_search_paths():
+                syslinux_file = os.path.normpath(
+                    os.sep.join(
+                        [lookup_path, syslinux_dir, syslinux_file_name]
+                    )
                 )
                 if os.path.exists(syslinux_file):
                     loader_files.append(syslinux_file)

--- a/kiwi/iso_tools/base.py
+++ b/kiwi/iso_tools/base.py
@@ -15,8 +15,16 @@
 # You should have received a copy of the GNU General Public License
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
+import os
+import shutil
+import platform
+
 # project
 from kiwi.defaults import Defaults
+from kiwi.command import Command
+from kiwi.utils.sync import DataSync
+from kiwi.path import Path
+from kiwi.logger import log
 
 
 class IsoToolsBase(object):
@@ -29,6 +37,7 @@ class IsoToolsBase(object):
     :param str iso_loaders: list of ISO loaders to embed
     """
     def __init__(self, source_dir):
+        self.arch = platform.machine()
         self.source_dir = source_dir
 
         self.boot_path = Defaults.get_iso_boot_path()
@@ -93,3 +102,94 @@ class IsoToolsBase(object):
         Implementation in specialized tool class
         """
         raise NotImplementedError
+
+    @staticmethod
+    def setup_media_loader_directory(lookup_path, media_path, boot_theme):
+        loader_data = lookup_path + '/image/loader/'
+        media_boot_path = os.sep.join(
+            [media_path, Defaults.get_iso_boot_path(), 'loader']
+        )
+        Path.wipe(loader_data)
+        Path.create(loader_data)
+
+        syslinux_file_names = [
+            'isolinux.bin',
+            'ldlinux.c32',
+            'libcom32.c32',
+            'libutil.c32',
+            'gfxboot.c32',
+            'gfxboot.com',
+            'menu.c32',
+            'chain.c32',
+            'mboot.c32'
+        ]
+        grub_image_file_names = [
+            'eltorito.img',
+            'boot_hybrid.img'
+        ]
+        syslinux_dirs = [
+            '/usr/share/syslinux/',
+            '/usr/lib/syslinux/modules/bios/',
+            '/usr/lib/ISOLINUX/'
+        ]
+        loader_files = []
+        for grub_image_file_name in grub_image_file_names:
+            grub_file = Defaults.get_grub_path(
+                lookup_path, 'i386-pc/{0}'.format(grub_image_file_name),
+                raise_on_error=False
+            )
+            if grub_file and os.path.exists(grub_file):
+                loader_files.append(grub_file)
+
+        for syslinux_file_name in syslinux_file_names:
+            for syslinux_dir in syslinux_dirs:
+                syslinux_file = ''.join(
+                    [lookup_path, syslinux_dir, syslinux_file_name]
+                )
+                if os.path.exists(syslinux_file):
+                    loader_files.append(syslinux_file)
+
+        log.debug('Copying loader files to {0}'.format(loader_data))
+        for loader_file in loader_files:
+            log.debug('--> Copying {0}'.format(loader_file))
+            shutil.copy(loader_file, loader_data)
+
+        bash_command = ' '.join(
+            ['cp', lookup_path + '/boot/memtest*', loader_data + '/memtest']
+        )
+        Command.run(
+            command=['bash', '-c', bash_command], raise_on_error=False
+        )
+
+        if boot_theme:
+            theme_path = ''.join(
+                [lookup_path, '/etc/bootsplash/themes/', boot_theme]
+            )
+            if os.path.exists(theme_path + '/cdrom/gfxboot.cfg'):
+                bash_command = ' '.join(
+                    ['cp', theme_path + '/cdrom/*', loader_data]
+                )
+                Command.run(
+                    ['bash', '-c', bash_command]
+                )
+                # don't move down one menu entry the first time a F-key is used
+                Command.run(
+                    [
+                        'gfxboot',
+                        '--config-file', loader_data + '/gfxboot.cfg',
+                        '--change-config', 'install::autodown=0'
+                    ]
+                )
+
+            if os.path.exists(theme_path + '/bootloader/message'):
+                Command.run(
+                    ['cp', theme_path + '/bootloader/message', loader_data]
+                )
+
+        Path.create(media_boot_path)
+        data = DataSync(
+            loader_data, media_boot_path
+        )
+        data.sync_data(
+            options=['-z', '-a']
+        )

--- a/kiwi/iso_tools/xorriso.py
+++ b/kiwi/iso_tools/xorriso.py
@@ -92,7 +92,12 @@ class IsoToolsXorrIso(IsoToolsBase):
 
         if Defaults.is_x86_arch(self.arch):
             if efi_mode:
-                loader_file = self.boot_path + '/loader/eltorito.img'
+                loader_file = os.sep.join(
+                    [
+                        self.boot_path, 'loader',
+                        Defaults.get_isolinux_bios_grub_loader()
+                    ]
+                )
                 mbr_file = os.sep.join(
                     [self.source_dir, self.boot_path, '/loader/boot_hybrid.img']
                 )
@@ -103,14 +108,16 @@ class IsoToolsXorrIso(IsoToolsBase):
                 ]
             else:
                 loader_file = self.boot_path + '/loader/isolinux.bin'
-                syslinux_lookup_paths = [
-                    '/usr/share/syslinux', '/usr/lib/syslinux/modules/bios',
-                    '/usr/lib/ISOLINUX'
-                ]
-                mbr_file = Path.which('isohdpfx.bin', syslinux_lookup_paths)
+                mbr_file = Path.which(
+                    'isohdpfx.bin', Defaults.get_syslinux_search_paths()
+                )
                 self.iso_loaders += [
-                    '-boot_image', 'isolinux', 'bin_path={0}'.format(loader_file),
-                    '-boot_image', 'isolinux', 'system_area={0}'.format(mbr_file),
+                    '-boot_image', 'isolinux', 'bin_path={0}'.format(
+                        loader_file
+                    ),
+                    '-boot_image', 'isolinux', 'system_area={0}'.format(
+                        mbr_file
+                    ),
                     '-boot_image', 'isolinux', 'partition_table=on',
                 ]
 

--- a/kiwi/iso_tools/xorriso.py
+++ b/kiwi/iso_tools/xorriso.py
@@ -22,6 +22,7 @@ from kiwi.iso_tools.base import IsoToolsBase
 from kiwi.path import Path
 from kiwi.command import Command
 from kiwi.exceptions import KiwiIsoToolError
+from kiwi.defaults import Defaults
 
 
 class IsoToolsXorrIso(IsoToolsBase):
@@ -64,7 +65,10 @@ class IsoToolsXorrIso(IsoToolsBase):
 
         :param list custom_args: custom ISO meta data
         """
+        efi_mode = False
         if custom_args:
+            if custom_args.get('efi_mode'):
+                efi_mode = True
             if 'mbr_id' in custom_args:
                 self.iso_parameters += [
                     '-application_id', custom_args['mbr_id']
@@ -85,23 +89,33 @@ class IsoToolsXorrIso(IsoToolsBase):
         self.iso_parameters += [
             '-joliet', 'on', '-padding', '0'
         ]
-        loader_file = self.boot_path + '/loader/isolinux.bin'
 
-        syslinux_lookup_paths = [
-            '/usr/share/syslinux', '/usr/lib/syslinux/modules/bios',
-            '/usr/lib/ISOLINUX'
-        ]
-        mbr_file = Path.which('isohdpfx.bin', syslinux_lookup_paths)
-        if not mbr_file:
-            raise KiwiIsoToolError(
-                'isohdpfx.bin not found in {0}'.format(syslinux_lookup_paths)
-            )
+        if Defaults.is_x86_arch(self.arch):
+            if efi_mode:
+                loader_file = self.boot_path + '/loader/eltorito.img'
+                mbr_file = os.sep.join(
+                    [self.source_dir, self.boot_path, '/loader/boot_hybrid.img']
+                )
+                self.iso_loaders += [
+                    '-boot_image', 'grub', 'bin_path={0}'.format(loader_file),
+                    '-boot_image', 'grub', 'grub2_mbr={0}'.format(mbr_file),
+                    '-boot_image', 'grub', 'grub2_boot_info=on'
+                ]
+            else:
+                loader_file = self.boot_path + '/loader/isolinux.bin'
+                syslinux_lookup_paths = [
+                    '/usr/share/syslinux', '/usr/lib/syslinux/modules/bios',
+                    '/usr/lib/ISOLINUX'
+                ]
+                mbr_file = Path.which('isohdpfx.bin', syslinux_lookup_paths)
+                self.iso_loaders += [
+                    '-boot_image', 'isolinux', 'bin_path={0}'.format(loader_file),
+                    '-boot_image', 'isolinux', 'system_area={0}'.format(mbr_file),
+                    '-boot_image', 'isolinux', 'partition_table=on',
+                ]
 
         self.iso_loaders += [
             '-boot_image', 'any', 'partition_offset=16',
-            '-boot_image', 'isolinux', 'bin_path={0}'.format(loader_file),
-            '-boot_image', 'isolinux', 'system_area={0}'.format(mbr_file),
-            '-boot_image', 'isolinux', 'partition_table=on',
             '-boot_image', 'any', 'cat_path={0}'.format(catalog_file),
             '-boot_image', 'any', 'cat_hidden=on',
             '-boot_image', 'any', 'boot_info_table=on',

--- a/kiwi/runtime_checker.py
+++ b/kiwi/runtime_checker.py
@@ -61,12 +61,12 @@ class RuntimeChecker(object):
         """
         message = dedent('''\n
             The use of imageinclude="true" in the repository definition
-            for the Repository: {0} requires the repository to by publicly
-            available. The source locator of the repository however
-            indicates it is private to your local system. Therefore it
-            can't be included into the system image repository configuration.
-            Please define a publicly available repository in your image
-            XML description: {1}
+            for the Repository: {0}
+            requires the repository to by publicly available. The source
+            locator of the repository however indicates it is private to
+            your local system. Therefore it can't be included into the
+            system image repository configuration. Please define a publicly
+            available repository in your image XML description.
         ''')
 
         repository_sections = self.xml_state.get_repository_sections()
@@ -79,9 +79,7 @@ class RuntimeChecker(object):
                 uri = Uri(repo_source, repo_type)
                 if not uri.is_public():
                     raise KiwiRuntimeError(
-                        message.format(
-                            repo_source, self.xml_state.xml_data.description
-                        )
+                        message.format(repo_source)
                     )
 
     def check_target_directory_not_in_shared_cache(self, target_dir):

--- a/kiwi/tasks/base.py
+++ b/kiwi/tasks/base.py
@@ -84,7 +84,8 @@ class CliTask(object):
             'check_dracut_module_for_live_iso_in_package_list': [],
             'check_dracut_module_for_disk_overlay_in_package_list': [],
             'check_dracut_module_for_disk_oem_in_package_list': [],
-            'check_dracut_module_for_oem_install_in_package_list': []
+            'check_dracut_module_for_oem_install_in_package_list': [],
+            'check_architecture_supports_iso_firmware_setup': []
         }
         self.checks_after_command_args = {
             'check_repositories_configured': [],

--- a/kiwi/xml_state.py
+++ b/kiwi/xml_state.py
@@ -39,7 +39,7 @@ class XMLState(object):
     """
     **Implements methods to get stateful information from the XML data**
 
-    :param object xml_data: instance of XMLDescription
+    :param object xml_data: parse result from XMLDescription.load()
     :param list profiles: list of used profiles
     :param object build_type: build <type> section reference
     """

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -160,7 +160,12 @@ Requires:       tar >= 1.2.7
 %if %{_vendor} != "debbuild"
 # Not supported with debbuild yet
 %ifarch %arm aarch64
+%if 0%{?fedora} || 0%{?rhel}
+Requires:       uboot-tools
+%endif
+%if 0%{?suse_version}
 Requires:       u-boot-tools
+%endif
 %endif
 %ifarch s390 s390x
 Requires:       s390-tools
@@ -243,7 +248,12 @@ Requires:       kpartx
 Requires:       rsync
 Requires:       tar >= 1.2.7
 %ifarch %arm aarch64
+%if 0%{?fedora} || 0%{?rhel}
+Requires:       uboot-tools
+%endif
+%if 0%{?suse_version}
 Requires:       u-boot-tools
+%endif
 %endif
 %ifarch s390 s390x
 Requires:       s390-tools

--- a/test/data/example_runtime_checker_config.xml
+++ b/test/data/example_runtime_checker_config.xml
@@ -66,7 +66,7 @@
                 <vmnic interface=""/>
             </machine>
         </type>
-        <type image="oem" filesystem="ext3" boot="oemboot/example-distribution" bootprofile="xen" bootkernel="xenk" installiso="true" bootloader="grub2" kernelcmdline="splash" xen_server="true">
+        <type image="oem" filesystem="ext3" boot="oemboot/example-distribution" bootprofile="xen" bootkernel="xenk" installiso="true" bootloader="grub2" kernelcmdline="splash" xen_server="true" firmware="bios">
             <oemconfig>
                 <oem-systemsize>2048</oem-systemsize>
                 <oem-swap>true</oem-swap>
@@ -98,7 +98,7 @@
                 <oem-recovery>false</oem-recovery>
             </oemconfig>
         </type>
-        <type image="iso" mediacheck="true"/>
+        <type image="iso" mediacheck="true" firmware="bios"/>
     </preferences>
     <users>
         <user groups="root" pwdformat="plain" password="mypwd" shell="/bin/bash" id="815" realname="Bob" home="/root" name="root"/>

--- a/test/unit/bootloader_config_base_test.py
+++ b/test/unit/bootloader_config_base_test.py
@@ -71,7 +71,7 @@ class TestBootLoaderConfigBase(object):
     @patch('kiwi.path.Path.create')
     def test_create_efi_path_with_prefix(self, mock_path):
         self.bootloader.create_efi_path('')
-        mock_path.assert_called_once_with('root_dir//EFI/BOOT')
+        mock_path.assert_called_once_with('root_dir/EFI/BOOT')
 
     def test_get_boot_theme(self):
         assert self.bootloader.get_boot_theme() == 'openSUSE'

--- a/test/unit/bootloader_config_isolinux_test.py
+++ b/test/unit/bootloader_config_isolinux_test.py
@@ -1,19 +1,12 @@
-from mock import patch
-from mock import call
-
-import mock
-
 import kiwi
-
-from .test_helper import raises, patch_open
-
-from kiwi.xml_state import XMLState
-from kiwi.xml_description import XMLDescription
-from kiwi.exceptions import (
-    KiwiBootLoaderIsoLinuxPlatformError,
-    KiwiTemplateError
+import mock
+from mock import (
+    patch, call
 )
+from .test_helper import raises, patch_open
 from kiwi.bootloader.config.isolinux import BootLoaderConfigIsoLinux
+
+from kiwi.exceptions import KiwiTemplateError
 
 
 class TestBootLoaderConfigIsoLinux(object):
@@ -94,19 +87,10 @@ class TestBootLoaderConfigIsoLinux(object):
             self.state, 'root_dir'
         )
 
-    @raises(KiwiBootLoaderIsoLinuxPlatformError)
-    @patch('platform.machine')
-    def test_post_init_invalid_platform(self, mock_machine):
-        mock_machine.return_value = 'unsupported-arch'
-        BootLoaderConfigIsoLinux(mock.Mock(), 'root_dir')
-
     @patch('platform.machine')
     def test_post_init_ix86_platform(self, mock_machine):
-        xml_state = XMLState(
-            XMLDescription('../data/example_config.xml').load()
-        )
         mock_machine.return_value = 'i686'
-        bootloader = BootLoaderConfigIsoLinux(xml_state, 'root_dir')
+        bootloader = BootLoaderConfigIsoLinux(self.state, 'root_dir')
         assert bootloader.arch == 'ix86'
 
     @patch('os.path.exists')
@@ -181,175 +165,11 @@ class TestBootLoaderConfigIsoLinux(object):
         self.isolinux.get_install_message_template.side_effect = Exception
         self.bootloader.setup_install_image_config(mbrid=None)
 
-    @patch('kiwi.bootloader.config.isolinux.DataSync')
-    @patch('kiwi.bootloader.config.isolinux.shutil')
-    @patch('kiwi.bootloader.config.isolinux.Command.run')
-    @patch('os.path.exists')
-    def test_setup_install_boot_images(
-        self, mock_exists, mock_command, mock_shutil, mock_sync
-    ):
-        mock_exists.return_value = True
-        data = mock.Mock()
-        mock_sync.return_value = data
-        self.bootloader.setup_install_boot_images(
-            mbrid=None
-        )
-        assert mock_shutil.copy.call_args_list == [
-            call(
-                'root_dir/usr/share/syslinux/isolinux.bin',
-                'root_dir/image/loader/'
-            ),
-            call(
-                'root_dir/usr/lib/syslinux/modules/bios/isolinux.bin',
-                'root_dir/image/loader/'
-            ),
-            call(
-                'root_dir/usr/lib/ISOLINUX/isolinux.bin',
-                'root_dir/image/loader/'
-            ),
-            call(
-                'root_dir/usr/share/syslinux/ldlinux.c32',
-                'root_dir/image/loader/'
-            ),
-            call(
-                'root_dir/usr/lib/syslinux/modules/bios/ldlinux.c32',
-                'root_dir/image/loader/'
-            ),
-            call(
-                'root_dir/usr/lib/ISOLINUX/ldlinux.c32',
-                'root_dir/image/loader/'
-            ),
-            call(
-                'root_dir/usr/share/syslinux/libcom32.c32',
-                'root_dir/image/loader/'
-            ),
-            call(
-                'root_dir/usr/lib/syslinux/modules/bios/libcom32.c32',
-                'root_dir/image/loader/'
-            ),
-            call(
-                'root_dir/usr/lib/ISOLINUX/libcom32.c32',
-                'root_dir/image/loader/'
-            ),
-            call(
-                'root_dir/usr/share/syslinux/libutil.c32',
-                'root_dir/image/loader/'
-            ),
-            call(
-                'root_dir/usr/lib/syslinux/modules/bios/libutil.c32',
-                'root_dir/image/loader/'
-            ),
-            call(
-                'root_dir/usr/lib/ISOLINUX/libutil.c32',
-                'root_dir/image/loader/'
-            ),
-            call(
-                'root_dir/usr/share/syslinux/gfxboot.c32',
-                'root_dir/image/loader/'
-            ),
-            call(
-                'root_dir/usr/lib/syslinux/modules/bios/gfxboot.c32',
-                'root_dir/image/loader/'
-            ),
-            call(
-                'root_dir/usr/lib/ISOLINUX/gfxboot.c32',
-                'root_dir/image/loader/'
-            ),
-            call(
-                'root_dir/usr/share/syslinux/gfxboot.com',
-                'root_dir/image/loader/'
-            ),
-            call(
-                'root_dir/usr/lib/syslinux/modules/bios/gfxboot.com',
-                'root_dir/image/loader/'
-            ),
-            call(
-                'root_dir/usr/lib/ISOLINUX/gfxboot.com',
-                'root_dir/image/loader/'
-            ),
-            call(
-                'root_dir/usr/share/syslinux/menu.c32',
-                'root_dir/image/loader/'
-            ),
-            call(
-                'root_dir/usr/lib/syslinux/modules/bios/menu.c32',
-                'root_dir/image/loader/'
-            ),
-            call(
-                'root_dir/usr/lib/ISOLINUX/menu.c32',
-                'root_dir/image/loader/'
-            ),
-            call(
-                'root_dir/usr/share/syslinux/chain.c32',
-                'root_dir/image/loader/'
-            ),
-            call(
-                'root_dir/usr/lib/syslinux/modules/bios/chain.c32',
-                'root_dir/image/loader/'
-            ),
-            call(
-                'root_dir/usr/lib/ISOLINUX/chain.c32',
-                'root_dir/image/loader/'
-            ),
-            call(
-                'root_dir/usr/share/syslinux/mboot.c32',
-                'root_dir/image/loader/'
-            ),
-            call(
-                'root_dir/usr/lib/syslinux/modules/bios/mboot.c32',
-                'root_dir/image/loader/'
-            ),
-            call(
-                'root_dir/usr/lib/ISOLINUX/mboot.c32',
-                'root_dir/image/loader/'
-            )
-        ]
-        assert mock_command.call_args_list == [
-            call(
-                command=[
-                    'bash', '-c',
-                    'cp root_dir/boot/memtest* '
-                    'root_dir/image/loader//memtest'
-                ], raise_on_error=False
-            ),
-            call(
-                [
-                    'bash', '-c',
-                    'cp root_dir/etc/bootsplash/themes/openSUSE/'
-                    'cdrom/* root_dir/image/loader/'
-                ]
-            ),
-            call(
-                [
-                    'gfxboot',
-                    '--config-file', 'root_dir/image/loader//gfxboot.cfg',
-                    '--change-config', 'install::autodown=0'
-                ]
-            ),
-            call(
-                [
-                    'cp',
-                    'root_dir/etc/bootsplash/themes/openSUSE/'
-                    'bootloader/message', 'root_dir/image/loader/'
-                ]
-            )
-        ]
-        mock_sync.assert_called_once_with(
-            'root_dir/image/loader/',
-            'root_dir/boot/x86_64/loader'
-        )
-        data.sync_data.assert_called_once_with(
-            options=['-z', '-a']
-        )
+    def test_setup_install_boot_images(self):
+        assert self.bootloader.setup_install_boot_images(mbrid=None) is None
 
-    @patch.object(BootLoaderConfigIsoLinux, 'setup_install_boot_images')
-    def test_setup_live_boot_images(self, mock_install_boot_images):
-        self.bootloader.setup_live_boot_images(
-            mbrid=None, lookup_path='lookup_dir'
-        )
-        mock_install_boot_images.assert_called_once_with(
-            None, 'lookup_dir'
-        )
+    def test_setup_live_boot_images(self):
+        assert self.bootloader.setup_live_boot_images(mbrid=None) is None
 
     @raises(KiwiTemplateError)
     def test_setup_live_image_config_invalid_template(self):

--- a/test/unit/bootloader_template_grub2_test.py
+++ b/test/unit/bootloader_template_grub2_test.py
@@ -115,7 +115,8 @@ class TestBootLoaderTemplateGrub2(object):
             title='LimeJeOS-SLE12-Community [ VMX ]',
             bootpath='/boot',
             boot_directory_name='grub2',
-            hypervisor='xen.gz'
+            hypervisor='xen.gz',
+            efi_image_name='bootx64.efi'
         )
 
     def test_get_multiboot_install_template_console(self):
@@ -131,7 +132,8 @@ class TestBootLoaderTemplateGrub2(object):
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community [ VMX ]',
             bootpath='/boot',
-            hypervisor='xen.gz'
+            hypervisor='xen.gz',
+            efi_image_name='bootx64.efi'
         )
 
     def test_get_multiboot_install_template_serial(self):
@@ -147,7 +149,8 @@ class TestBootLoaderTemplateGrub2(object):
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community [ VMX ]',
             bootpath='/boot',
-            hypervisor='xen.gz'
+            hypervisor='xen.gz',
+            efi_image_name='bootx64.efi'
         )
 
     def test_get_install_template(self):
@@ -163,7 +166,8 @@ class TestBootLoaderTemplateGrub2(object):
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community [ VMX ]',
             bootpath='/boot',
-            boot_directory_name='grub2'
+            boot_directory_name='grub2',
+            efi_image_name='bootx64.efi'
         )
 
     def test_get_install_template_console_no_hybrid(self):
@@ -179,7 +183,8 @@ class TestBootLoaderTemplateGrub2(object):
             failsafe_boot_options='cdinst=1 splash',
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community [ VMX ]',
-            bootpath='/boot'
+            bootpath='/boot',
+            efi_image_name='bootx64.efi'
         )
 
     def test_get_install_template_serial_no_hybrid(self):
@@ -195,7 +200,8 @@ class TestBootLoaderTemplateGrub2(object):
             failsafe_boot_options='cdinst=1 splash',
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community [ VMX ]',
-            bootpath='/boot'
+            bootpath='/boot',
+            efi_image_name='bootx64.efi'
         )
 
     def test_get_iso_template(self):
@@ -211,7 +217,8 @@ class TestBootLoaderTemplateGrub2(object):
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community',
             bootpath='/boot',
-            boot_directory_name='grub2'
+            boot_directory_name='grub2',
+            efi_image_name='bootx64.efi'
         )
 
     def test_get_iso_template_console_no_hybrid(self):
@@ -227,7 +234,8 @@ class TestBootLoaderTemplateGrub2(object):
             failsafe_boot_options='splash',
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community',
-            bootpath='/boot'
+            bootpath='/boot',
+            efi_image_name='bootx64.efi'
         )
 
     def test_get_iso_template_serial_no_hybrid(self):
@@ -243,7 +251,8 @@ class TestBootLoaderTemplateGrub2(object):
             failsafe_boot_options='splash',
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community',
-            bootpath='/boot'
+            bootpath='/boot',
+            efi_image_name='bootx64.efi'
         )
 
     def test_get_iso_template_checkiso_no_hybrid(self):
@@ -261,7 +270,8 @@ class TestBootLoaderTemplateGrub2(object):
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community',
             bootpath='/boot',
-            boot_directory_name='grub2'
+            boot_directory_name='grub2',
+            efi_image_name='bootx64.efi'
         )
 
     def test_get_iso_template_checkiso(self):
@@ -277,7 +287,8 @@ class TestBootLoaderTemplateGrub2(object):
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community',
             bootpath='/boot',
-            boot_directory_name='grub2'
+            boot_directory_name='grub2',
+            efi_image_name='bootx64.efi'
         )
 
     def test_get_multiboot_iso_template(self):
@@ -294,7 +305,8 @@ class TestBootLoaderTemplateGrub2(object):
             title='LimeJeOS-SLE12-Community',
             bootpath='/boot',
             boot_directory_name='grub2',
-            hypervisor='xen.gz'
+            hypervisor='xen.gz',
+            efi_image_name='bootx64.efi'
         )
 
     def test_get_multiboot_iso_template_console(self):
@@ -310,7 +322,8 @@ class TestBootLoaderTemplateGrub2(object):
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community',
             bootpath='/boot',
-            hypervisor='xen.gz'
+            hypervisor='xen.gz',
+            efi_image_name='bootx64.efi'
         )
 
     def test_get_multiboot_iso_template_serial(self):
@@ -326,7 +339,8 @@ class TestBootLoaderTemplateGrub2(object):
             boot_timeout='10',
             title='LimeJeOS-SLE12-Community',
             bootpath='/boot',
-            hypervisor='xen.gz'
+            hypervisor='xen.gz',
+            efi_image_name='bootx64.efi'
         )
 
     def test_get_multiboot_iso_template_checkiso(self):
@@ -343,5 +357,6 @@ class TestBootLoaderTemplateGrub2(object):
             title='LimeJeOS-SLE12-Community',
             bootpath='/boot',
             boot_directory_name='grub2',
-            hypervisor='xen.gz'
+            hypervisor='xen.gz',
+            efi_image_name='bootx64.efi'
         )

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -93,3 +93,7 @@ class TestDefaults(object):
         assert Defaults.get_unsigned_grub_loader('root') == \
             mock_glob.return_value.pop()
         mock_glob.assert_called_once_with('root/usr/share/grub*/*-efi/grub.efi')
+
+    def test_is_x86_arch(self):
+        assert Defaults.is_x86_arch('x86_64') is True
+        assert Defaults.is_x86_arch('aarch64') is False

--- a/test/unit/filesystem_isofs_test.py
+++ b/test/unit/filesystem_isofs_test.py
@@ -20,11 +20,7 @@ class TestFileSystemIsoFs(object):
 
     @patch('kiwi.filesystem.isofs.IsoTools')
     @patch('kiwi.filesystem.isofs.Iso')
-    @patch('kiwi.filesystem.isofs.platform.machine')
-    def test_create_on_file(
-        self, mock_platform_machine, mock_iso, mock_cdrtools
-    ):
-        mock_platform_machine.return_value = 'x86_64'
+    def test_create_on_file(self, mock_iso, mock_cdrtools):
         iso_tool = mock.Mock()
         iso_tool.has_iso_hybrid_capability = mock.Mock(
             return_value=False

--- a/test/unit/iso_tools_base_test.py
+++ b/test/unit/iso_tools_base_test.py
@@ -1,4 +1,6 @@
-from mock import patch
+from mock import (
+    patch, Mock, call
+)
 from .test_helper import raises
 
 from kiwi.iso_tools.base import IsoToolsBase
@@ -33,3 +35,173 @@ class TestIsoToolsBase(object):
     @raises(NotImplementedError)
     def test_has_iso_hybrid_capability(self):
         self.iso_tool.has_iso_hybrid_capability()
+
+    @patch('kiwi.iso_tools.base.DataSync')
+    @patch('kiwi.iso_tools.base.shutil')
+    @patch('kiwi.iso_tools.base.Command.run')
+    @patch('kiwi.iso_tools.base.Path')
+    @patch('os.path.exists')
+    def test_setup_media_loader_directory(
+        self, mock_exists, mock_Path, mock_command, mock_shutil, mock_sync
+    ):
+        mock_exists.return_value = True
+        data = Mock()
+        mock_sync.return_value = data
+        self.iso_tool.setup_media_loader_directory(
+            'root_dir', 'media_dir', 'openSUSE'
+        )
+        assert mock_shutil.copy.call_args_list == [
+            call(
+                'root_dir/usr/share/grub2/i386-pc/eltorito.img',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/share/grub2/i386-pc/boot_hybrid.img',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/share/syslinux/isolinux.bin',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/lib/syslinux/modules/bios/isolinux.bin',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/lib/ISOLINUX/isolinux.bin',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/share/syslinux/ldlinux.c32',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/lib/syslinux/modules/bios/ldlinux.c32',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/lib/ISOLINUX/ldlinux.c32',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/share/syslinux/libcom32.c32',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/lib/syslinux/modules/bios/libcom32.c32',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/lib/ISOLINUX/libcom32.c32',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/share/syslinux/libutil.c32',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/lib/syslinux/modules/bios/libutil.c32',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/lib/ISOLINUX/libutil.c32',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/share/syslinux/gfxboot.c32',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/lib/syslinux/modules/bios/gfxboot.c32',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/lib/ISOLINUX/gfxboot.c32',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/share/syslinux/gfxboot.com',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/lib/syslinux/modules/bios/gfxboot.com',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/lib/ISOLINUX/gfxboot.com',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/share/syslinux/menu.c32',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/lib/syslinux/modules/bios/menu.c32',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/lib/ISOLINUX/menu.c32',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/share/syslinux/chain.c32',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/lib/syslinux/modules/bios/chain.c32',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/lib/ISOLINUX/chain.c32',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/share/syslinux/mboot.c32',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/lib/syslinux/modules/bios/mboot.c32',
+                'root_dir/image/loader/'
+            ),
+            call(
+                'root_dir/usr/lib/ISOLINUX/mboot.c32',
+                'root_dir/image/loader/'
+            )
+        ]
+        assert mock_command.call_args_list == [
+            call(
+                command=[
+                    'bash', '-c',
+                    'cp root_dir/boot/memtest* '
+                    'root_dir/image/loader//memtest'
+                ], raise_on_error=False
+            ),
+            call(
+                [
+                    'bash', '-c',
+                    'cp root_dir/etc/bootsplash/themes/openSUSE/'
+                    'cdrom/* root_dir/image/loader/'
+                ]
+            ),
+            call(
+                [
+                    'gfxboot',
+                    '--config-file', 'root_dir/image/loader//gfxboot.cfg',
+                    '--change-config', 'install::autodown=0'
+                ]
+            ),
+            call(
+                [
+                    'cp',
+                    'root_dir/etc/bootsplash/themes/openSUSE/'
+                    'bootloader/message', 'root_dir/image/loader/'
+                ]
+            )
+        ]
+        mock_sync.assert_called_once_with(
+            'root_dir/image/loader/',
+            'media_dir/boot/x86_64/loader'
+        )
+        data.sync_data.assert_called_once_with(
+            options=['-z', '-a']
+        )

--- a/test/unit/iso_tools_xorriso_test.py
+++ b/test/unit/iso_tools_xorriso_test.py
@@ -22,14 +22,8 @@ class TestIsoToolsXorrIso(object):
         mock_exists.return_value = False
         self.iso_tool.get_tool_name()
 
-    @raises(KiwiIsoToolError)
     @patch('kiwi.iso_tools.xorriso.Path.which')
-    def test_init_iso_creation_parameters_no_isohdpfx(self, mock_which):
-        mock_which.return_value = None
-        self.iso_tool.init_iso_creation_parameters('sortfile')
-
-    @patch('kiwi.iso_tools.xorriso.Path.which')
-    def test_init_iso_creation_parameters(self, mock_which):
+    def test_init_iso_creation_parameters_isolinux(self, mock_which):
         mock_which.return_value = '/usr/share/syslinux/isohdpfx.bin'
         self.iso_tool.init_iso_creation_parameters(
             {
@@ -55,12 +49,45 @@ class TestIsoToolsXorrIso(object):
             '-padding', '0'
         ]
         assert self.iso_tool.iso_loaders == [
-            '-boot_image', 'any', 'partition_offset=16',
             '-boot_image', 'isolinux',
             'bin_path=boot/x86_64/loader/isolinux.bin',
             '-boot_image', 'isolinux',
             'system_area=/usr/share/syslinux/isohdpfx.bin',
             '-boot_image', 'isolinux', 'partition_table=on',
+            '-boot_image', 'any', 'partition_offset=16',
+            '-boot_image', 'any', 'cat_path=boot/x86_64/boot.catalog',
+            '-boot_image', 'any', 'cat_hidden=on',
+            '-boot_image', 'any', 'boot_info_table=on',
+            '-boot_image', 'any', 'platform_id=0x00',
+            '-boot_image', 'any', 'emul_type=no_emulation',
+            '-boot_image', 'any', 'load_size=2048'
+        ]
+
+    def test_init_iso_creation_parameters_efi(self):
+        self.iso_tool.init_iso_creation_parameters(
+            {
+                'mbr_id': 'app_id',
+                'publisher': 'org',
+                'preparer': 'preparer',
+                'volume_id': 'vol_id',
+                'efi_mode': 'uefi'
+            }
+        )
+        assert self.iso_tool.iso_parameters == [
+            '-application_id', 'app_id',
+            '-publisher', 'org',
+            '-preparer_id', 'preparer',
+            '-volid', 'vol_id',
+            '-joliet', 'on',
+            '-padding', '0'
+        ]
+        assert self.iso_tool.iso_loaders == [
+            '-boot_image', 'grub',
+            'bin_path=boot/x86_64/loader/eltorito.img',
+            '-boot_image', 'grub',
+            'grub2_mbr=source-dir/boot/x86_64//loader/boot_hybrid.img',
+            '-boot_image', 'grub', 'grub2_boot_info=on',
+            '-boot_image', 'any', 'partition_offset=16',
             '-boot_image', 'any', 'cat_path=boot/x86_64/boot.catalog',
             '-boot_image', 'any', 'cat_hidden=on',
             '-boot_image', 'any', 'boot_info_table=on',

--- a/test/unit/runtime_checker_test.py
+++ b/test/unit/runtime_checker_test.py
@@ -1,11 +1,19 @@
+import sys
 from mock import patch
 import mock
-from .test_helper import raises
+from pytest import raises
 
 from kiwi.xml_state import XMLState
 from kiwi.xml_description import XMLDescription
 from kiwi.runtime_checker import RuntimeChecker
 from kiwi.exceptions import KiwiRuntimeError
+
+# default commandline used for any test, overwrite when needed
+sys.argv = [
+    sys.argv[0], 'system', 'prepare',
+    '--description', 'description', '--root', 'directory'
+]
+argv_kiwi_tests = sys.argv
 
 
 class TestRuntimeChecker(object):
@@ -18,35 +26,35 @@ class TestRuntimeChecker(object):
         )
         self.runtime_checker = RuntimeChecker(self.xml_state)
 
-    @raises(KiwiRuntimeError)
     def test_check_image_include_repos_publicly_resolvable(self):
-        self.runtime_checker.check_image_include_repos_publicly_resolvable()
+        with raises(KiwiRuntimeError):
+            self.runtime_checker.check_image_include_repos_publicly_resolvable()
 
-    @raises(KiwiRuntimeError)
     def test_invalid_target_dir_pointing_to_shared_cache_1(self):
-        self.runtime_checker.check_target_directory_not_in_shared_cache(
-            '/var/cache//kiwi/foo'
-        )
+        with raises(KiwiRuntimeError):
+            self.runtime_checker.check_target_directory_not_in_shared_cache(
+                '/var/cache//kiwi/foo'
+            )
 
-    @raises(KiwiRuntimeError)
     def test_invalid_target_dir_pointing_to_shared_cache_2(self):
-        self.runtime_checker.check_target_directory_not_in_shared_cache(
-            '/var/cache/kiwi'
-        )
+        with raises(KiwiRuntimeError):
+            self.runtime_checker.check_target_directory_not_in_shared_cache(
+                '/var/cache/kiwi'
+            )
 
-    @raises(KiwiRuntimeError)
     @patch('os.getcwd')
     def test_invalid_target_dir_pointing_to_shared_cache_3(self, mock_getcwd):
         mock_getcwd.return_value = '/'
-        self.runtime_checker.check_target_directory_not_in_shared_cache(
-            'var/cache/kiwi'
-        )
+        with raises(KiwiRuntimeError):
+            self.runtime_checker.check_target_directory_not_in_shared_cache(
+                'var/cache/kiwi'
+            )
 
-    @raises(KiwiRuntimeError)
     def test_invalid_target_dir_pointing_to_shared_cache_4(self):
-        self.runtime_checker.check_target_directory_not_in_shared_cache(
-            '//var/cache//kiwi/foo'
-        )
+        with raises(KiwiRuntimeError):
+            self.runtime_checker.check_target_directory_not_in_shared_cache(
+                '//var/cache//kiwi/foo'
+            )
 
     def test_valid_target_dir_1(self):
         assert self.runtime_checker.check_target_directory_not_in_shared_cache(
@@ -58,33 +66,32 @@ class TestRuntimeChecker(object):
             '/foo/bar'
         ) is None
 
-    @raises(KiwiRuntimeError)
     def test_check_repositories_configured(self):
         self.xml_state.delete_repository_sections()
-        self.runtime_checker.check_repositories_configured()
+        with raises(KiwiRuntimeError):
+            self.runtime_checker.check_repositories_configured()
 
-    @raises(KiwiRuntimeError)
     def test_check_volume_setup_defines_multiple_fullsize_volumes(self):
-        self.runtime_checker.\
-            check_volume_setup_defines_multiple_fullsize_volumes()
+        with raises(KiwiRuntimeError):
+            self.runtime_checker.\
+                check_volume_setup_defines_multiple_fullsize_volumes()
 
-    @raises(KiwiRuntimeError)
     def test_check_volume_setup_has_no_root_definition(self):
-        self.runtime_checker.check_volume_setup_has_no_root_definition()
+        with raises(KiwiRuntimeError):
+            self.runtime_checker.check_volume_setup_has_no_root_definition()
 
     @patch('kiwi.runtime_checker.Path.which')
-    @raises(KiwiRuntimeError)
     def test_check_container_tool_chain_installed(self, mock_which):
         mock_which.return_value = False
         xml_state = XMLState(
             self.description.load(), ['docker'], 'docker'
         )
         runtime_checker = RuntimeChecker(xml_state)
-        runtime_checker.check_container_tool_chain_installed()
+        with raises(KiwiRuntimeError):
+            runtime_checker.check_container_tool_chain_installed()
 
     @patch('kiwi.runtime_checker.RuntimeConfig.get_oci_archive_tool')
     @patch('kiwi.runtime_checker.Path.which')
-    @raises(KiwiRuntimeError)
     def test_check_container_tool_chain_installed_unknown_tool(
         self, mock_which, mock_oci_tool
     ):
@@ -94,11 +101,11 @@ class TestRuntimeChecker(object):
             self.description.load(), ['docker'], 'docker'
         )
         runtime_checker = RuntimeChecker(xml_state)
-        runtime_checker.check_container_tool_chain_installed()
+        with raises(KiwiRuntimeError):
+            runtime_checker.check_container_tool_chain_installed()
 
     @patch('kiwi.runtime_checker.RuntimeConfig.get_oci_archive_tool')
     @patch('kiwi.runtime_checker.Path.which')
-    @raises(KiwiRuntimeError)
     def test_check_container_tool_chain_installed_buildah(
         self, mock_which, mock_oci_tool
     ):
@@ -108,11 +115,11 @@ class TestRuntimeChecker(object):
             self.description.load(), ['docker'], 'docker'
         )
         runtime_checker = RuntimeChecker(xml_state)
-        runtime_checker.check_container_tool_chain_installed()
+        with raises(KiwiRuntimeError):
+            runtime_checker.check_container_tool_chain_installed()
 
     @patch('kiwi.runtime_checker.Path.which')
     @patch('kiwi.runtime_checker.CommandCapabilities.check_version')
-    @raises(KiwiRuntimeError)
     def test_check_container_tool_chain_installed_with_version(
         self, mock_cmdver, mock_which
     ):
@@ -122,12 +129,12 @@ class TestRuntimeChecker(object):
             self.description.load(), ['docker'], 'docker'
         )
         runtime_checker = RuntimeChecker(xml_state)
-        runtime_checker.check_container_tool_chain_installed()
+        with raises(KiwiRuntimeError):
+            runtime_checker.check_container_tool_chain_installed()
 
     @patch('kiwi.runtime_checker.Path.which')
     @patch('kiwi.runtime_checker.CommandCapabilities.check_version')
     @patch('kiwi.runtime_checker.CommandCapabilities.has_option_in_help')
-    @raises(KiwiRuntimeError)
     def test_check_container_tool_chain_installed_with_multitags(
         self, mock_cmdoptions, mock_cmdver, mock_which
     ):
@@ -138,9 +145,9 @@ class TestRuntimeChecker(object):
             self.description.load(), ['docker'], 'docker'
         )
         runtime_checker = RuntimeChecker(xml_state)
-        runtime_checker.check_container_tool_chain_installed()
+        with raises(KiwiRuntimeError):
+            runtime_checker.check_container_tool_chain_installed()
 
-    @raises(KiwiRuntimeError)
     @patch('platform.machine')
     @patch('kiwi.runtime_checker.Defaults.get_boot_image_description_path')
     def test_check_consistent_kernel_in_boot_and_system_image(
@@ -152,27 +159,27 @@ class TestRuntimeChecker(object):
             self.description.load(), ['vmxFlavour'], 'oem'
         )
         runtime_checker = RuntimeChecker(xml_state)
-        runtime_checker.check_consistent_kernel_in_boot_and_system_image()
+        with raises(KiwiRuntimeError):
+            runtime_checker.check_consistent_kernel_in_boot_and_system_image()
 
-    @raises(KiwiRuntimeError)
     def test_check_boot_description_exists_no_boot_ref(self):
         description = XMLDescription(
             '../data/example_runtime_checker_no_boot_reference.xml'
         )
         xml_state = XMLState(description.load())
         runtime_checker = RuntimeChecker(xml_state)
-        runtime_checker.check_boot_description_exists()
+        with raises(KiwiRuntimeError):
+            runtime_checker.check_boot_description_exists()
 
-    @raises(KiwiRuntimeError)
     def test_check_boot_description_exists_does_not_exist(self):
         description = XMLDescription(
             '../data/example_runtime_checker_boot_desc_not_found.xml'
         )
         xml_state = XMLState(description.load())
         runtime_checker = RuntimeChecker(xml_state)
-        runtime_checker.check_boot_description_exists()
+        with raises(KiwiRuntimeError):
+            runtime_checker.check_boot_description_exists()
 
-    @raises(KiwiRuntimeError)
     def test_check_xen_uniquely_setup_as_server_or_guest_for_ec2(self):
         self.xml_state.build_type.get_firmware = mock.Mock(
             return_value='ec2'
@@ -183,9 +190,9 @@ class TestRuntimeChecker(object):
         self.xml_state.is_xen_guest = mock.Mock(
             return_value=True
         )
-        self.runtime_checker.check_xen_uniquely_setup_as_server_or_guest()
+        with raises(KiwiRuntimeError):
+            self.runtime_checker.check_xen_uniquely_setup_as_server_or_guest()
 
-    @raises(KiwiRuntimeError)
     def test_check_xen_uniquely_setup_as_server_or_guest_for_xen(self):
         self.xml_state.build_type.get_firmware = mock.Mock(
             return_value=None
@@ -196,9 +203,9 @@ class TestRuntimeChecker(object):
         self.xml_state.is_xen_guest = mock.Mock(
             return_value=True
         )
-        self.runtime_checker.check_xen_uniquely_setup_as_server_or_guest()
+        with raises(KiwiRuntimeError):
+            self.runtime_checker.check_xen_uniquely_setup_as_server_or_guest()
 
-    @raises(KiwiRuntimeError)
     def test_check_dracut_module_for_disk_overlay_in_package_list(self):
         xml_state = XMLState(
             self.description.load(), ['vmxFlavour'], 'iso'
@@ -207,9 +214,10 @@ class TestRuntimeChecker(object):
             return_value=True
         )
         runtime_checker = RuntimeChecker(xml_state)
-        runtime_checker.check_dracut_module_for_disk_overlay_in_package_list()
+        with raises(KiwiRuntimeError):
+            runtime_checker.\
+                check_dracut_module_for_disk_overlay_in_package_list()
 
-    @raises(KiwiRuntimeError)
     def test_check_efi_mode_for_disk_overlay_correctly_setup(self):
         self.xml_state.build_type.get_overlayroot = mock.Mock(
             return_value=True
@@ -217,9 +225,10 @@ class TestRuntimeChecker(object):
         self.xml_state.build_type.get_firmware = mock.Mock(
             return_value='uefi'
         )
-        self.runtime_checker.check_efi_mode_for_disk_overlay_correctly_setup()
+        with raises(KiwiRuntimeError):
+            self.runtime_checker.\
+                check_efi_mode_for_disk_overlay_correctly_setup()
 
-    @raises(KiwiRuntimeError)
     @patch('kiwi.runtime_checker.Path.which')
     def test_check_mediacheck_installed_tagmedia_missing(self, mock_which):
         mock_which.return_value = False
@@ -227,48 +236,68 @@ class TestRuntimeChecker(object):
             self.description.load(), ['vmxFlavour'], 'iso'
         )
         runtime_checker = RuntimeChecker(xml_state)
-        runtime_checker.check_mediacheck_installed()
+        with raises(KiwiRuntimeError):
+            runtime_checker.check_mediacheck_installed()
 
-    @raises(KiwiRuntimeError)
     def test_check_dracut_module_for_live_iso_in_package_list(self):
         xml_state = XMLState(
             self.description.load(), ['vmxFlavour'], 'iso'
         )
         runtime_checker = RuntimeChecker(xml_state)
-        runtime_checker.check_dracut_module_for_live_iso_in_package_list()
+        with raises(KiwiRuntimeError):
+            runtime_checker.check_dracut_module_for_live_iso_in_package_list()
 
-    @raises(KiwiRuntimeError)
     def test_check_dracut_module_for_disk_oem_in_package_list(self):
         xml_state = XMLState(
             self.description.load(), ['vmxFlavour'], 'oem'
         )
         runtime_checker = RuntimeChecker(xml_state)
-        runtime_checker.check_dracut_module_for_disk_oem_in_package_list()
+        with raises(KiwiRuntimeError):
+            runtime_checker.check_dracut_module_for_disk_oem_in_package_list()
 
-    @raises(KiwiRuntimeError)
     def test_check_dracut_module_for_oem_install_in_package_list(self):
         xml_state = XMLState(
             self.description.load(), ['vmxFlavour'], 'oem'
         )
         runtime_checker = RuntimeChecker(xml_state)
-        runtime_checker.check_dracut_module_for_oem_install_in_package_list()
+        with raises(KiwiRuntimeError):
+            runtime_checker.\
+                check_dracut_module_for_oem_install_in_package_list()
 
-    @raises(KiwiRuntimeError)
     def test_check_volume_label_used_with_lvm(self):
-        self.runtime_checker.check_volume_label_used_with_lvm()
+        with raises(KiwiRuntimeError):
+            self.runtime_checker.check_volume_label_used_with_lvm()
 
-    @raises(KiwiRuntimeError)
     def test_check_preferences_data_no_version(self):
         xml_state = XMLState(
             self.description.load(), ['docker'], 'docker'
         )
         runtime_checker = RuntimeChecker(xml_state)
-        runtime_checker.check_minimal_required_preferences()
+        with raises(KiwiRuntimeError):
+            runtime_checker.check_minimal_required_preferences()
 
-    @raises(KiwiRuntimeError)
     def test_check_preferences_data_no_packagemanager(self):
         xml_state = XMLState(
             self.description.load(), ['xenFlavour'], 'vmx'
         )
         runtime_checker = RuntimeChecker(xml_state)
-        runtime_checker.check_minimal_required_preferences()
+        with raises(KiwiRuntimeError):
+            runtime_checker.check_minimal_required_preferences()
+
+    @patch('platform.machine')
+    def test_check_architecture_supports_iso_firmware_setup(
+        self, mock_machine
+    ):
+        mock_machine.return_value = 'aarch64'
+        xml_state = XMLState(
+            self.description.load(), ['vmxFlavour'], 'iso'
+        )
+        runtime_checker = RuntimeChecker(xml_state)
+        with raises(KiwiRuntimeError):
+            runtime_checker.check_architecture_supports_iso_firmware_setup()
+        xml_state = XMLState(
+            self.description.load(), ['xenFlavour'], 'oem'
+        )
+        runtime_checker = RuntimeChecker(xml_state)
+        with raises(KiwiRuntimeError):
+            runtime_checker.check_architecture_supports_iso_firmware_setup()

--- a/test/unit/tasks_system_build_test.py
+++ b/test/unit/tasks_system_build_test.py
@@ -142,6 +142,9 @@ class TestSystemBuildTask(object):
         self.runtime_checker.\
             check_efi_mode_for_disk_overlay_correctly_setup.\
             assert_called_once_with()
+        self.runtime_checker.\
+            check_architecture_supports_iso_firmware_setup.\
+            assert_called_once_with()
         self.system_prepare.setup_repositories.assert_called_once_with(
             False, None
         )

--- a/test/unit/tasks_system_prepare_test.py
+++ b/test/unit/tasks_system_prepare_test.py
@@ -132,6 +132,9 @@ class TestSystemPrepareTask(object):
         self.runtime_checker.\
             check_efi_mode_for_disk_overlay_correctly_setup.\
             assert_called_once_with()
+        self.runtime_checker.\
+            check_architecture_supports_iso_firmware_setup.\
+            assert_called_once_with()
         self.system_prepare.setup_repositories.assert_called_once_with(
             True, None
         )


### PR DESCRIPTION
Before this commit isolinux was used to boot an ISO and thus forms a hard requirement. isolinux. However only exists for the x86 platform. This limitation did not  allow to create ISO images for other platforms. With this commit a refactoring of the ISO boot setup is introduced.
    
* isolinux is only used if the bios firmware is requested and the platform matches the x86 architecture. A runtime check will check for this condition and exits early if not applicable
    
* in case of the EFI firmware we already used grub in EFI mode but still had isolinux in place for the legacy/CSM boot. That part is now also replaced by a platform specific grub eltorito image and grub's boot_hybrid.img for hybrid boot. On platforms that do not provide those modules the support for it will be skipped
    
With this change in place it's possible to control the ISO boot layout through the firmware setup and all platform specific modules are handled as such. Therefore we also deleted the syslinux requirement.

This Fixes #1092