### PR TITLE
Fixed zipl bootloader setup

### DIFF
--- a/kiwi/bootloader/config/grub2.py
+++ b/kiwi/bootloader/config/grub2.py
@@ -220,8 +220,8 @@ class BootLoaderConfigGrub2(BootLoaderConfigBase):
             sysconfig_bootloader.write()
 
     def setup_disk_image_config(
-        self, boot_uuid, root_uuid, hypervisor='xen.gz', kernel='linux.vmx',
-        initrd='initrd.vmx', boot_options=''
+        self, boot_uuid, root_uuid, hypervisor='xen.gz',
+        kernel=None, initrd=None, boot_options=''
     ):
         """
         Create the grub.cfg in memory from a template suitable to boot

--- a/kiwi/bootloader/config/zipl.py
+++ b/kiwi/bootloader/config/zipl.py
@@ -18,6 +18,7 @@
 
 import platform
 import re
+import os
 
 # project
 from kiwi.bootloader.config.base import BootLoaderConfigBase
@@ -103,15 +104,25 @@ class BootLoaderConfigZipl(BootLoaderConfigBase):
             Command.run(
                 [
                     'mv',
-                    self.root_dir + '/boot/initrd.vmx',
-                    self.root_dir + '/boot/linux.vmx',
+                    os.sep.join(
+                        [
+                            self.root_dir, 'boot',
+                            os.readlink(self.root_dir + '/boot/initrd')
+                        ]
+                    ),
+                    os.sep.join(
+                        [
+                            self.root_dir, 'boot',
+                            os.readlink(self.root_dir + '/boot/image')
+                        ]
+                    ),
                     self._get_zipl_boot_path()
                 ]
             )
 
     def setup_disk_image_config(
         self, boot_uuid=None, root_uuid=None, hypervisor=None,
-        kernel='linux.vmx', initrd='initrd.vmx', boot_options=''
+        kernel=None, initrd=None, boot_options=''
     ):
         """
         Create the zipl config in memory from a template suitable to

--- a/kiwi/path.py
+++ b/kiwi/path.py
@@ -85,7 +85,7 @@ class Path(object):
             is not accessible by the current user
         """
         if mode & ~(os.F_OK | os.X_OK | os.R_OK | os.W_OK) != 0:
-            raise ValueError("Invalid mode 0x{:X}".format(mode))
+            raise ValueError('Invalid mode 0x{:X}'.format(mode))
         try:
             os.stat(path)
         except Exception as exc:

--- a/test/unit/bootloader_config_grub2_test.py
+++ b/test/unit/bootloader_config_grub2_test.py
@@ -422,13 +422,14 @@ class TestBootLoaderConfigGrub2(object):
             return_value=template
         )
         self.bootloader.setup_disk_image_config(
-            boot_uuid='boot_uuid', root_uuid='root_uuid', boot_options='foo'
+            kernel='kernel', initrd='initrd', boot_uuid='boot_uuid',
+            root_uuid='root_uuid', boot_options='foo'
         )
         template.substitute.assert_called_once_with(
             {
                 'title': 'Bob',
                 'boot_directory_name': 'grub2',
-                'kernel_file': 'linux.vmx',
+                'kernel_file': 'kernel',
                 'failsafe_boot_options': 'splash foo ide=nodma apm=off '
                 'noresume edd=off nomodeset 3 foo',
                 'default_boot': '0',
@@ -437,7 +438,7 @@ class TestBootLoaderConfigGrub2(object):
                 'gfxmode': '800x600',
                 'bootpath': '/',
                 'search_params': '--fs-uuid --set=root boot_uuid',
-                'initrd_file': 'initrd.vmx',
+                'initrd_file': 'initrd',
                 'theme': None
             }
         )

--- a/test/unit/path_test.py
+++ b/test/unit/path_test.py
@@ -101,17 +101,15 @@ class TestPath(object):
         )
 
     def test_access_invalid_mode(self):
-        with raises(ValueError) as val_err_exc:
+        with raises(ValueError) as issue:
             Path.access("/some/non-existent-file/", 128)
-
-        assert "0x80" in str(val_err_exc)
+        assert '0x80' in format(issue.value)
 
     def test_access_with_non_existent_file(self):
         non_existent = "/some/file/that/should/not/exist"
-        with raises(KiwiFileAccessError) as kfae_exc:
+        with raises(KiwiFileAccessError) as issue:
             Path.access(non_existent, os.F_OK)
-
-        assert non_existent in str(kfae_exc)
+        assert non_existent in issue.value.message
 
     @patch('os.stat')
     @patch('os.access')


### PR DESCRIPTION
On zipl we manually move the kernel and initrd file to the
zipl boot path because symlinks can't be read. That move
operation used the wrong filenames and was broken since
baseCreateCommonKernelFile is only used in the legacy
custom kiwi boot images but not in the dracut case.

