### PR TITLE
Do not supress output for dracut call

### DIFF
--- a/kiwi/boot/image/dracut.py
+++ b/kiwi/boot/image/dracut.py
@@ -98,7 +98,7 @@ class BootImageDracut(BootImageBase):
             else:
                 included_files = self.included_files
             dracut_initrd_basename += '.xz'
-            Command.run(
+            dracut_call = Command.run(
                 [
                     'chroot', self.boot_root_directory,
                     'dracut', '--force',
@@ -108,8 +108,10 @@ class BootImageDracut(BootImageBase):
                 ] + self.dracut_options + included_files + [
                     dracut_initrd_basename,
                     kernel_details.version
-                ]
+                ],
+                stderr_to_stdout=True
             )
+            log.debug(dracut_call.output)
             Command.run(
                 [
                     'mv',

--- a/kiwi/command.py
+++ b/kiwi/command.py
@@ -43,7 +43,9 @@ class Command(object):
     stdout and stderr is given to the caller
     """
     @staticmethod
-    def run(command, custom_env=None, raise_on_error=True):
+    def run(
+        command, custom_env=None, raise_on_error=True, stderr_to_stdout=False
+    ):
         """
         Execute a program and block the caller. The return value
         is a hash containing the stdout, stderr and return code
@@ -60,6 +62,7 @@ class Command(object):
         :param list command: command and arguments
         :param list custom_env: custom os.environ
         :param bool raise_on_error: control error behaviour
+        :param bool stderr_to_stdout: redirects stderr to stdout
 
         :return:
             Contains call results in command type
@@ -92,11 +95,12 @@ class Command(object):
                 )
             else:
                 raise KiwiCommandNotFound(message)
+        stderr = subprocess.STDOUT if stderr_to_stdout else subprocess.PIPE
         try:
             process = subprocess.Popen(
                 command,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                stderr=stderr,
                 env=environment
             )
         except Exception as e:

--- a/kiwi/utils/codec.py
+++ b/kiwi/utils/codec.py
@@ -35,6 +35,8 @@ class Codec(object):
         :return: decoded string
         :rtype: str
         """
+        if literal is None:
+            return ''
         try:
             return Codec._wrapped_decode(literal)
         except Exception:

--- a/test/unit/boot_image_dracut_test.py
+++ b/test/unit/boot_image_dracut_test.py
@@ -90,7 +90,7 @@ class TestBootImageKiwi(object):
                 '--install', 'system-directory/etc/foo',
                 '--install', '/system-directory/var/lib/bar',
                 'LimeJeOS-openSUSE-13.2.x86_64-1.13.2.initrd.xz', '1.2.3'
-            ]),
+            ], stderr_to_stdout=True),
             call([
                 'mv',
                 'system-directory/LimeJeOS-openSUSE-13.2.x86_64-1.13.2.initrd.xz',
@@ -106,7 +106,7 @@ class TestBootImageKiwi(object):
                 '--no-hostonly-cmdline', '--xz',
                 '--install', '/system-directory/var/lib/bar',
                 'foo.xz', '1.2.3'
-            ]),
+            ], stderr_to_stdout=True),
             call([
                 'mv',
                 'system-directory/foo.xz',

--- a/test/unit/utils_codec_test.py
+++ b/test/unit/utils_codec_test.py
@@ -28,6 +28,9 @@ class TestCodec(object):
         assert msg == Codec.decode(self.literal)
         assert mock_warn.called
 
+    def test_decode_None_literal(self):
+        assert '' == Codec.decode(None)
+
     @patch('kiwi.utils.codec.Codec._wrapped_decode')
     def test_decode(self, mock_decode):
         msg = 'utf-8 compatible string'


### PR DESCRIPTION
This commit adds an option to CommandProcess class to redirect stderr
to stdout at python level. CommandProcess object still keeps the stdout
and stderr as separate attributes, however the output iterator, that used
to return stdout only lines, now is capable to return both. If
stderr_to_stdout flag is set to True, CommandProcess iterator will
return both, stdout and stderr output lines.

This is usefull to watch all output, stderr and stdout, on real time.

Fixes #1114
