### PR TITLE
Remove '^' which break BaseStripFirmware function (boo#1132455)

### DIFF
--- a/kiwi/config/functions.sh
+++ b/kiwi/config/functions.sh
@@ -749,7 +749,7 @@ function baseStripFirmware {
         for fname in $name ; do
             for match in /lib/firmware/"${fname}" /lib/firmware/*/"${fname}";do
                 if [ -e "${match}" ];then
-                    match="${match//^\/lib\/firmware\//}"
+                    match="${match//\/lib\/firmware\//}"
                     bmdir=$(dirname "${match}")
                     mkdir -p "/lib/firmware-required/${bmdir}"
                     mv "/lib/firmware/${match}" "/lib/firmware-required/${bmdir}"


### PR DESCRIPTION
The `^` in `BaseStripFirmware` function make the firmware end in `/lib/firmware/lib/firmware` instead of `/lib/firmware`
It fixes https://github.com/SUSE/kiwi/commit/3a8e31b26dc8b317d35f55a5390d3a731f1aac65