### PR TITLE
Fixed get_persistent_device_from_unix_node

### DIFF
--- a/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
+++ b/dracut/modules.d/99kiwi-lib/kiwi-lib.sh
@@ -83,6 +83,9 @@ function get_persistent_device_from_unix_node {
             return
         fi
     done
+    warn "Could not find ${schema} representation of ${node}"
+    warn "Using original device ${unix_device}"
+    echo "${unix_device}"
 }
 
 function deactivate_all_device_maps {


### PR DESCRIPTION
The method get_persistent_device_from_unix_node takes a device
path and looks up it's basename to be present as persistent
variant below the given schema, e.g by-id. However if the
method receives an already persistent device path e.g from
/dev/mapper the persistent schema representation will only
match a numbered dm-N device and not the map name. The method
then returns nothing but should return the original device
path. This caused bad after effects like reported in
Issue SUSE-Enceladus/azure-li-services#163


