### PR TITLE
Drop support for python2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,21 +53,6 @@ code_style_plus_unit_test:
     - tox -e unit_py3_7 "-n $(nproc)"
   <<: *set_cache_dir
 
-unit_test_2_and_34:
-  <<: *install_system_deps
-  script:
-    - >
-      dnf install -y
-      python34 python2 python2-devel python2-virtualenv
-      python2-pip xorriso genisoimage
-    # Python 2.7
-    - export PYTHON=python2.7
-    - tox -e unit_py2_7 "-n $(nproc)"
-    # Python 3.4
-    - export PYTHON=python3.4
-    - tox -e unit_py3_4 "-n $(nproc)"
-  <<: *set_cache_dir
-
 build_doc:
   <<: *install_system_deps
   script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ jobs:
     dist: xenial
     sudo: true
     env: TOXENV=check,unit_py3_7
-  - python: 2.7
-    env: TOXENV=check,unit_py2_7
   - stage: deploy
     python: 3.6
     env: TOXENV=doc_travis

--- a/.virtualenv.requirements.txt
+++ b/.virtualenv.requirements.txt
@@ -20,9 +20,5 @@ PyYAML
 # Python wrapper for extended filesystem attributes
 xattr==0.9.3
 
-# Python 2 compatibility
-future
-six
-
 # Network request/response library
 requests

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ version := $(shell \
 
 .PHONY: test
 test:
-	tox -e unit_py3_4
 	tox -e unit_py3_6
 
 flake:

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -85,9 +85,7 @@ To use and run KIWI, you need:
 * Enough free disk space to build and store the image. We recommend a
   minimum of 15GB.
 
-* Python version 2.7, 3.4 or higher; as KIWI supports both Python
-  versions, the information in this guide applies to both packages, be it
-  ``python3-kiwi`` or ``python2-kiwi``.
+* Python version 3.4 or higher
 
 * Git (package ``git``) to clone a repository.
 

--- a/helper/completion_generator.py
+++ b/helper/completion_generator.py
@@ -248,6 +248,5 @@ function __comp_reply {
 
 complete -F _kiwi -o default kiwi
 complete -F _kiwi -o default kiwi-ng
-complete -F _kiwi -o default kiwi-ng-2
 complete -F _kiwi -o default kiwi-ng-3
 ''').strip())

--- a/kiwi/cli.py
+++ b/kiwi/cli.py
@@ -65,7 +65,6 @@ global options for services: image, system
         image build type. If not set the default XML specified
         build type will be used
 """
-from __future__ import print_function
 import sys
 import glob
 import re
@@ -231,7 +230,9 @@ class Cli(object):
         if not os.path.exists(command_source_file):
             prefix = 'usage:'
             for service_command in self._get_command_implementations(service):
-                print('%s kiwi %s' % (prefix, service_command))
+                print(
+                    '{0} kiwi {1}'.format(prefix, service_command)
+                )
                 prefix = '      '
             raise SystemExit(1)
         self.command_loaded = importlib.import_module(

--- a/kiwi/command.py
+++ b/kiwi/command.py
@@ -20,11 +20,6 @@ import os
 import subprocess
 from collections import namedtuple
 
-# In python2 bytes is string which is different from
-# the bytes type in python3. The bytes type from the
-# builtins generalizes this type to be bytes always
-from builtins import bytes
-
 # project
 from .utils.codec import Codec
 

--- a/kiwi/command_process.py
+++ b/kiwi/command_process.py
@@ -16,11 +16,6 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import six
-
-# In python2 bytes is string which is different from
-# the bytes type in python3. The bytes type from the
-# builtins generalizes this type to be bytes always
-from builtins import bytes
 from collections import namedtuple
 
 # project

--- a/kiwi/defaults.py
+++ b/kiwi/defaults.py
@@ -17,8 +17,6 @@
 #
 import os
 import glob
-import sys
-from six.moves import reload_module
 from collections import namedtuple
 import platform
 from pkg_resources import resource_filename
@@ -1365,22 +1363,6 @@ class Defaults(object):
         :rtype: str
         """
         return 'KIWI {0}'.format(__version__)
-
-    @staticmethod
-    def set_python_default_encoding_to_utf8():
-        """
-        Set python default encoding to utf-8 if not already done
-
-        This is not a safe operation since sys.setdefaultencoding()
-        was removed from sys on purpose when Python starts. Reenabling
-        it and changing the default encoding can break code that relies
-        on ascii being the default. Within the scope of kiwi the
-        operation is safe because all data is expected to be utf-8
-        everywhere and considered a bug if this is not the case
-        """
-        if sys.version_info.major < 3:
-            reload_module(sys)  # Reload required to get setdefaultencoding back
-            sys.setdefaultencoding('utf-8')
 
     @staticmethod
     def get_custom_rpm_macros_path():

--- a/kiwi/iso_tools/iso.py
+++ b/kiwi/iso_tools/iso.py
@@ -19,11 +19,6 @@ import os
 import struct
 from collections import namedtuple
 
-# In python2 bytes is string which is different from
-# the bytes type in python3. The bytes type from the
-# builtins generalizes this type to be bytes always
-from builtins import bytes
-
 # project
 from kiwi.iso_tools.cdrtools import IsoToolsCdrTools
 from kiwi.logger import log

--- a/kiwi/repository/apt.py
+++ b/kiwi/repository/apt.py
@@ -17,7 +17,7 @@
 #
 import os
 from tempfile import NamedTemporaryFile
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 
 # project
 from kiwi.repository.template.apt import PackageManagerTemplateAptGet

--- a/kiwi/repository/dnf.py
+++ b/kiwi/repository/dnf.py
@@ -17,7 +17,7 @@
 #
 import os
 import glob
-from six.moves.configparser import ConfigParser
+from configparser import ConfigParser
 from tempfile import NamedTemporaryFile
 
 # project

--- a/kiwi/repository/zypper.py
+++ b/kiwi/repository/zypper.py
@@ -16,7 +16,7 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 import os
-from six.moves.configparser import ConfigParser
+from configparser import ConfigParser
 from tempfile import NamedTemporaryFile
 
 # project

--- a/kiwi/solver/repository/base.py
+++ b/kiwi/solver/repository/base.py
@@ -16,8 +16,8 @@
 # along with kiwi.  If not, see <http://www.gnu.org/licenses/>
 #
 from base64 import b64encode
-from six.moves.urllib.request import urlopen
-from six.moves.urllib.request import Request
+from urllib.request import urlopen
+from urllib.request import Request
 from tempfile import NamedTemporaryFile
 from tempfile import mkdtemp
 from lxml import etree

--- a/kiwi/storage/subformat/vmdk.py
+++ b/kiwi/storage/subformat/vmdk.py
@@ -17,11 +17,6 @@
 #
 import os
 
-# In python2 bytes is string which is different from
-# the bytes type in python3. The bytes type from the
-# builtins generalizes this type to be bytes always
-from builtins import bytes
-
 # project
 from kiwi.storage.subformat.base import DiskFormatBase
 from kiwi.command import Command

--- a/kiwi/system/profile.py
+++ b/kiwi/system/profile.py
@@ -69,8 +69,6 @@ class Profile(object):
 
         :rtype: str
         """
-        Defaults.set_python_default_encoding_to_utf8()
-
         sorted_profile = collections.OrderedDict(
             sorted(self.dot_profile.items())
         )

--- a/kiwi/system/uri.py
+++ b/kiwi/system/uri.py
@@ -17,7 +17,7 @@
 #
 import os
 from tempfile import mkdtemp
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 import requests
 import hashlib
 

--- a/kiwi/xml_description.py
+++ b/kiwi/xml_description.py
@@ -22,12 +22,7 @@ from lxml import (
 )
 from tempfile import NamedTemporaryFile
 import os
-from six import BytesIO
-
-# In python2 bytes is string which is different from
-# the bytes type in python3. The bytes type from the
-# builtins generalizes this type to be bytes always
-from builtins import bytes
+from io import BytesIO
 
 # project
 from .defaults import Defaults

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -25,17 +25,21 @@
 %global python3_sitelib %(%{__python3} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
 %endif
 
+%if 0%{?el7}
+%global python3_pkgversion 36
+%else
+%{!?python3_pkgversion:%global python3_pkgversion 3}
+%endif
+
 %if 0%{?debian} || 0%{?ubuntu}
 %global is_deb 1
 %global pygroup python
 %global sysgroup admin
 %global develsuffix dev
-%global update_alternatives %{_bindir}/update-alternatives
 %else
 %global pygroup Development/Languages/Python
 %global sysgroup System/Management
 %global develsuffix devel
-%global update_alternatives %{_sbindir}/update-alternatives
 %endif
 
 Name:           python-kiwi
@@ -53,19 +57,12 @@ Group:          %{pygroup}
 Source:         %{name}.tar.gz
 Source1:        %{name}-rpmlintrc
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-%if 0%{?fedora} || 0%{?suse_version}
 BuildRequires:  gcc
-BuildRequires:  python3-devel
-%endif
-%if 0%{?fedora} || 0%{?suse_version} || 0%{?ubuntu} >= 1804 || 0%{?debian} >= 9
-BuildRequires:  python3-setuptools
+BuildRequires:  python%{python3_pkgversion}-%{develsuffix}
+BuildRequires:  python%{python3_pkgversion}-setuptools
 BuildRequires:  fdupes
-%endif
-BuildRequires:  python-%{develsuffix}
-BuildRequires:  python-setuptools
 %if 0%{?suse_version}
 BuildRequires:  shadow
-BuildRequires:  update-alternatives
 %endif
 %if 0%{?debian} || 0%{?ubuntu}
 BuildRequires:  passwd
@@ -79,27 +76,23 @@ The KIWI Image System provides an operating system image builder
 for Linux supported hardware platforms as well as for virtualization
 and cloud systems like Xen, KVM, VMware, EC2 and more.
 
-%if 0%{?fedora} || 0%{?suse_version} || 0%{?ubuntu} >= 1804 || 0%{?debian} >= 9
 # python3-kiwi
-%package -n python3-kiwi
+%package -n python%{python3_pkgversion}-kiwi
 Summary:        KIWI - Appliance Builder Next Generation
 Group:          Development/Languages/Python
 Recommends:     jing
 %if 0%{?ubuntu} || 0%{?debian}
-Requires:       python3-yaml
+Requires:       python%{python3_pkgversion}-yaml
 %else
-Requires:       python3-PyYAML
+Requires:       python%{python3_pkgversion}-PyYAML
 %endif
-Requires:       python3-docopt
-Requires:       python3-lxml
-Requires:       python3-requests
-Requires:       python3-setuptools
-Requires:       python3-xattr
+Requires:       python%{python3_pkgversion}-docopt
+Requires:       python%{python3_pkgversion}-lxml
+Requires:       python%{python3_pkgversion}-requests
+Requires:       python%{python3_pkgversion}-setuptools
+Requires:       python%{python3_pkgversion}-xattr
 # tools used by kiwi
 %if 0%{?suse_version}
-Requires:       update-alternatives
-Requires(post): update-alternatives
-Requires(postun): update-alternatives
 %ifarch x86_64
 Requires:       grub2-x86_64-efi
 %endif
@@ -159,12 +152,10 @@ Requires:       u-boot-tools
 Requires:       s390-tools
 %endif
 
-%description -n python3-kiwi
+%description -n python%{python3_pkgversion}-kiwi
 Python 3 library of the KIWI Image System. Provides an operating system
 image builder for Linux supported hardware platforms as well as for
 virtualization and cloud systems like Xen, KVM, VMware, EC2 and more.
-
-%endif
 
 %package -n kiwi-tools
 Summary:        KIWI - Collection of Boot Helper Tools
@@ -359,16 +350,12 @@ Provides manual pages to describe the kiwi commands
 sed -e "s|#!/usr/bin/env python||" -i kiwi/xml_parse.py
 
 %build
-%if 0%{?fedora} || 0%{?suse_version} || 0%{?ubuntu} >= 1804 || 0%{?debian} >= 9
 # Build Python 3 version
 python3 setup.py build --cflags="${RPM_OPT_FLAGS}"
-%endif
 
 %install
-%if 0%{?fedora} || 0%{?suse_version} || 0%{?ubuntu} >= 1804 || 0%{?debian} >= 9
 # Install Python 3 version
 python3 setup.py install --prefix=%{_prefix} --root=%{buildroot} %{?is_deb:--install-layout=deb}
-%endif
 
 # Install dracut modules
 make buildroot=%{buildroot}/ install_dracut
@@ -376,25 +363,12 @@ make buildroot=%{buildroot}/ install_dracut
 # Install documentation in PDF format
 make buildroot=%{buildroot}/ docdir=%{_defaultdocdir}/ install_package_docs
 
+# Create symlinks for correct binaries
+ln -sr %{buildroot}%{_bindir}/kiwi-ng %{buildroot}%{_bindir}/kiwi
+ln -sr %{buildroot}%{_bindir}/kiwi-ng-3 %{buildroot}%{_bindir}/kiwi-ng
+ln -sr %{buildroot}%{_bindir}/kiwicompat-3 %{buildroot}%{_bindir}/kiwicompat
+
 %if %{_vendor} != "debbuild"
-# init alternatives setup
-mkdir -p %{buildroot}%{_sysconfdir}/alternatives
-
-# alternatives setup for kiwi -> kiwi-ng-py_ver binary
-touch %{buildroot}%{_sysconfdir}/alternatives/kiwi
-ln -s %{_sysconfdir}/alternatives/kiwi \
-    %{buildroot}%_bindir/kiwi
-
-# alternatives setup for kiwi-ng -> kiwi-ng-py_ver binary
-touch %{buildroot}%{_sysconfdir}/alternatives/kiwi-ng
-ln -s %{_sysconfdir}/alternatives/kiwi-ng \
-    %{buildroot}%_bindir/kiwi-ng
-
-# alternatives setup for kiwicompat -> kiwicompat-py_ver binary
-touch %{buildroot}%{_sysconfdir}/alternatives/kiwicompat
-ln -s %{_sysconfdir}/alternatives/kiwicompat \
-    %{buildroot}%_bindir/kiwicompat
-
 # kiwi pxeboot directory structure to be packed in kiwi-pxeboot
 %ifarch %{ix86} x86_64
 for i in KIWI pxelinux.cfg image upload boot; do \
@@ -405,26 +379,6 @@ done
 
 %if 0%{?fedora} || 0%{?suse_version}
 %fdupes %{buildroot}/srv/tftpboot
-%endif
-
-%if 0%{?fedora} || 0%{?suse_version} || 0%{?ubuntu} >= 1804 || 0%{?debian} >= 9
-%post -n python3-kiwi
-%{update_alternatives} \
-    --install %_bindir/kiwi kiwi %_bindir/kiwi-ng-3 10
-%{update_alternatives} \
-    --install %_bindir/kiwi-ng kiwi-ng %_bindir/kiwi-ng-3 10
-%{update_alternatives} \
-    --install %_bindir/kiwicompat kiwicompat %_bindir/kiwicompat-3 10
-%endif
-
-%if 0%{?fedora} || 0%{?suse_version} || 0%{?ubuntu} >= 1804 || 0%{?debian} >= 9
-%preun -n python3-kiwi
-%{update_alternatives} \
-    --remove kiwi %_bindir/kiwi
-%{update_alternatives} \
-    --remove kiwi %_bindir/kiwi-ng
-%{update_alternatives} \
-    --remove kiwicompat %_bindir/kiwicompat
 %endif
 
 %if %{_vendor} != "debbuild"
@@ -442,22 +396,15 @@ fi
 %endif
 %endif
 
-%if 0%{?fedora} || 0%{?suse_version} || 0%{?ubuntu} >= 1804 || 0%{?debian} >= 9
-%files -n python3-kiwi
-%defattr(-,root,root,-)
+%files -n python%{python3_pkgversion}-kiwi
+%{_bindir}/kiwi
+%{_bindir}/kiwi-ng
+%{_bindir}/kiwicompat
 %{_bindir}/kiwi-ng-3*
 %{_bindir}/kiwicompat-3*
-%ghost %{_bindir}/kiwi
-%ghost %{_bindir}/kiwi-ng
-%ghost %{_bindir}/kiwicompat
-%ghost %_sysconfdir/alternatives/kiwi
-%ghost %_sysconfdir/alternatives/kiwi-ng
-%ghost %_sysconfdir/alternatives/kiwicompat
-%{python3_sitelib}/*
-%endif
+%{python3_sitelib}/kiwi*
 
 %files -n kiwi-man-pages
-%defattr(-, root, root)
 %dir %{_defaultdocdir}/python-kiwi
 %{_defaultdocdir}/python-kiwi/kiwi.pdf
 %{_defaultdocdir}/python-kiwi/LICENSE
@@ -466,36 +413,29 @@ fi
 %doc %{_mandir}/man8/*
 
 %files -n kiwi-tools
-%defattr(-, root, root)
 %{_bindir}/dcounter
 %{_bindir}/isconsole
 %{_bindir}/kversion
 %{_bindir}/utimer
 
 %files -n dracut-kiwi-lib
-%defattr(-, root, root)
 %{_usr}/lib/dracut/modules.d/99kiwi-lib
 
 %files -n dracut-kiwi-oem-repart
-%defattr(-, root, root)
 %{_usr}/lib/dracut/modules.d/90kiwi-repart
 
 %files -n dracut-kiwi-oem-dump
-%defattr(-, root, root)
 %{_usr}/lib/dracut/modules.d/90kiwi-dump
 
 %files -n dracut-kiwi-live
-%defattr(-, root, root)
 %{_usr}/lib/dracut/modules.d/90kiwi-live
 
 %files -n dracut-kiwi-overlay
-%defattr(-, root, root)
 %{_usr}/lib/dracut/modules.d/90kiwi-overlay
 
 %if %{_vendor} != "debbuild"
 %ifarch %{ix86} x86_64
 %files -n kiwi-pxeboot
-%defattr(-, root, root)
 %dir %attr(0755,tftp,tftp) /srv/tftpboot
 %dir /srv/tftpboot/KIWI
 %dir /srv/tftpboot/pxelinux.cfg

--- a/package/python-kiwi-spec-template
+++ b/package/python-kiwi-spec-template
@@ -19,13 +19,7 @@
 
 # If they aren't provided by a system installed macro, define them
 %{!?_defaultdocdir: %global _defaultdocdir %{_datadir}/doc}
-%{!?__python2: %global __python2 /usr/bin/python2}
 %{!?__python3: %global __python3 /usr/bin/python3}
-
-# Expanded form required for debbuild's simpler engine
-%if %{undefined python2_sitelib}
-%global python2_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
-%endif
 
 %if %{undefined python3_sitelib}
 %global python3_sitelib %(%{__python3} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
@@ -46,7 +40,7 @@
 
 Name:           python-kiwi
 Version:        %%VERSION
-Provides:       kiwi-schema = 6.6
+Provides:       kiwi-schema = 7.1
 Release:        0
 Url:            https://github.com/SUSE/kiwi
 Summary:        KIWI - Appliance Builder Next Generation
@@ -85,98 +79,6 @@ The KIWI Image System provides an operating system image builder
 for Linux supported hardware platforms as well as for virtualization
 and cloud systems like Xen, KVM, VMware, EC2 and more.
 
-# python2-kiwi
-%package -n python2-kiwi
-Summary:        KIWI - Appliance Builder Next Generation
-Group:          %{pygroup}
-Provides:       python-kiwi = %{version}-%{release}
-%if 0%{?fedora} || 0%{?suse_version}
-Recommends:     jing
-%endif
-%if 0%{?debian} || 0%{?ubuntu} || 0%{?fedora} || 0%{?rhel}
-Requires:       python-yaml
-%else
-Requires:       python-PyYAML
-%endif
-Requires:       python-docopt
-Requires:       python-future
-Requires:       python-lxml
-Requires:       python-requests
-Requires:       python-setuptools
-Requires:       python-six
-Requires:       python-xattr
-# tools used by kiwi
-%if 0%{?suse_version}
-Requires:       update-alternatives
-Requires(post): update-alternatives
-Requires(postun): update-alternatives
-%ifarch x86_64
-Requires:       grub2-x86_64-efi
-%endif
-%ifarch %{ix86} x86_64
-Recommends:     gfxboot
-%endif
-Requires:       qemu-tools
-Requires:       squashfs
-Requires:       gptfdisk
-%endif
-%if 0%{?fedora} || 0%{?rhel}
-Requires:         chkconfig
-Requires(post):   chkconfig
-Requires(postun): chkconfig
-Requires:       qemu-img
-Requires:       squashfs-tools
-Requires:       gdisk
-Requires:       dnf
-Provides:       kiwi-packagemanager:dnf
-Provides:       kiwi-packagemanager:yum
-%endif
-%if 0%{?suse_version}
-# If it's available, let's pull it in
-Recommends:     dnf
-%endif
-%if 0%{?fedora} >= 26 || 0%{?suse_version}
-Requires:       zypper
-Provides:       kiwi-packagemanager:zypper
-%endif
-%if 0%{?debian} || 0%{?ubuntu}
-Requires:       debootstrap
-Requires:       qemu-utils
-Requires:       squashfs-tools
-Requires:       gdisk
-%endif
-Requires:       dosfstools
-Requires:       e2fsprogs
-Requires:       xorriso
-Requires:       grub2
-Requires:       kiwi-man-pages
-Requires:       kiwi-tools
-Requires:       lvm2
-Requires:       mtools
-Requires:       parted
-Requires:       kpartx
-Requires:       rsync
-Requires:       tar >= 1.2.7
-%if %{_vendor} != "debbuild"
-# Not supported with debbuild yet
-%ifarch %arm aarch64
-%if 0%{?fedora} || 0%{?rhel}
-Requires:       uboot-tools
-%endif
-%if 0%{?suse_version}
-Requires:       u-boot-tools
-%endif
-%endif
-%ifarch s390 s390x
-Requires:       s390-tools
-%endif
-%endif
-
-%description -n python2-kiwi
-Python 2 library of the KIWI Image System. Provides an operating system
-image builder for Linux supported hardware platforms as well as for
-virtualization and cloud systems like Xen, KVM, VMware, EC2 and more.
-
 %if 0%{?fedora} || 0%{?suse_version} || 0%{?ubuntu} >= 1804 || 0%{?debian} >= 9
 # python3-kiwi
 %package -n python3-kiwi
@@ -189,11 +91,9 @@ Requires:       python3-yaml
 Requires:       python3-PyYAML
 %endif
 Requires:       python3-docopt
-Requires:       python3-future
 Requires:       python3-lxml
 Requires:       python3-requests
 Requires:       python3-setuptools
-Requires:       python3-six
 Requires:       python3-xattr
 # tools used by kiwi
 %if 0%{?suse_version}
@@ -459,18 +359,12 @@ Provides manual pages to describe the kiwi commands
 sed -e "s|#!/usr/bin/env python||" -i kiwi/xml_parse.py
 
 %build
-# Build Python 2 version
-python2 setup.py build --cflags="${RPM_OPT_FLAGS}"
-
 %if 0%{?fedora} || 0%{?suse_version} || 0%{?ubuntu} >= 1804 || 0%{?debian} >= 9
 # Build Python 3 version
 python3 setup.py build --cflags="${RPM_OPT_FLAGS}"
 %endif
 
 %install
-# Install Python 2 version
-python2 setup.py install --prefix=%{_prefix} --root=%{buildroot} %{?is_deb:--install-layout=deb}
-
 %if 0%{?fedora} || 0%{?suse_version} || 0%{?ubuntu} >= 1804 || 0%{?debian} >= 9
 # Install Python 3 version
 python3 setup.py install --prefix=%{_prefix} --root=%{buildroot} %{?is_deb:--install-layout=deb}
@@ -513,14 +407,6 @@ done
 %fdupes %{buildroot}/srv/tftpboot
 %endif
 
-%post -n python2-kiwi
-%{update_alternatives} \
-    --install %_bindir/kiwi kiwi %_bindir/kiwi-ng-2 10
-%{update_alternatives} \
-    --install %_bindir/kiwi-ng kiwi-ng %_bindir/kiwi-ng-2 10
-%{update_alternatives} \
-    --install %_bindir/kiwicompat kiwicompat %_bindir/kiwicompat-2 10
-
 %if 0%{?fedora} || 0%{?suse_version} || 0%{?ubuntu} >= 1804 || 0%{?debian} >= 9
 %post -n python3-kiwi
 %{update_alternatives} \
@@ -530,14 +416,6 @@ done
 %{update_alternatives} \
     --install %_bindir/kiwicompat kiwicompat %_bindir/kiwicompat-3 10
 %endif
-
-%preun -n python2-kiwi
-%{update_alternatives} \
-    --remove kiwi %_bindir/kiwi
-%{update_alternatives} \
-    --remove kiwi %_bindir/kiwi-ng
-%{update_alternatives} \
-    --remove kiwicompat %_bindir/kiwicompat
 
 %if 0%{?fedora} || 0%{?suse_version} || 0%{?ubuntu} >= 1804 || 0%{?debian} >= 9
 %preun -n python3-kiwi
@@ -563,18 +441,6 @@ if ! /usr/bin/getent passwd tftp >/dev/null; then
 fi
 %endif
 %endif
-
-%files -n python2-kiwi
-%defattr(-,root,root,-)
-%{_bindir}/kiwi-ng-2*
-%{_bindir}/kiwicompat-2*
-%ghost %{_bindir}/kiwi
-%ghost %{_bindir}/kiwi-ng
-%ghost %{_bindir}/kiwicompat
-%ghost %_sysconfdir/alternatives/kiwi
-%ghost %_sysconfdir/alternatives/kiwi-ng
-%ghost %_sysconfdir/alternatives/kiwicompat
-%{python2_sitelib}/*
 
 %if 0%{?fedora} || 0%{?suse_version} || 0%{?ubuntu} >= 1804 || 0%{?debian} >= 9
 %files -n python3-kiwi

--- a/setup.py
+++ b/setup.py
@@ -187,8 +187,6 @@ config = {
         'docopt>=0.6.2',
         'lxml',
         'xattr',
-        'future',
-        'six',
         'requests',
         'PyYAML'
     ],
@@ -213,9 +211,8 @@ config = {
        'Intended Audience :: Developers',
        'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
        'Operating System :: POSIX :: Linux',
-       'Programming Language :: Python :: 2.7',
-       'Programming Language :: Python :: 3.4',
-       'Programming Language :: Python :: 3.5',
+       'Programming Language :: Python :: 3.6',
+       'Programming Language :: Python :: 3.7',
        'Topic :: System :: Operating System',
     ]
 }

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -64,14 +64,6 @@ class TestDefaults(object):
             lookup_path='lookup_path'
         ) == 'grub'
 
-    @patch('kiwi.defaults.sys')
-    @patch('kiwi.defaults.reload_module')
-    def test_set_python_default_encoding_to_utf8(self, mock_reload, mock_sys):
-        mock_sys.version_info.major = 2
-        Defaults.set_python_default_encoding_to_utf8()
-        mock_reload.assert_called_once_with(mock_sys)
-        mock_sys.setdefaultencoding.assert_called_once_with('utf-8')
-
     def test_get_live_dracut_module_from_flag(self):
         assert Defaults.get_live_dracut_module_from_flag('foo') == \
             'kiwi-live'

--- a/test/unit/test_helper.py
+++ b/test/unit/test_helper.py
@@ -17,9 +17,7 @@ sys.argv = [
 argv_kiwi_tests = sys.argv
 
 # mock open calls
-patch_open = patch("{0}.open".format(
-    sys.version_info.major < 3 and "__builtin__" or "builtins")
-)
+patch_open = patch('builtins.open')
 
 
 class raises(object):

--- a/test/unit/utils_codec_test.py
+++ b/test/unit/utils_codec_test.py
@@ -1,6 +1,4 @@
 from mock import patch
-import sys
-import pytest
 
 from .test_helper import raises
 
@@ -52,15 +50,6 @@ class TestCodec(object):
         Codec.decode(self.literal)
         assert mock_warn.called
 
-    @pytest.mark.skipif(sys.version_info > (3, 0), reason="requires Python2")
-    @patch('kiwi.logger.log.warning')
-    def test_real_decode_non_ascii(self, mock_warn):
-        reload(sys)  # noqa:F821
-        sys.setdefaultencoding('ASCII')
-        assert unichr(252) == Codec.decode(self.literal)  # noqa:F821
-        assert mock_warn.called
-
-    @pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
     def test_wrapped_decode(self):
         assert self.literal.decode() == Codec._wrapped_decode(
             self.literal, 'utf-8'

--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,6 @@ envlist =
     check,
     unit_py3_7,
     unit_py3_6,
-    unit_py3_4,
-    unit_py2_7,
     packagedoc
 
 
@@ -28,57 +26,15 @@ basepython =
     {check,packagedoc,doc,doc_travis}: python3
     unit_py3_7: python3.7
     unit_py3_6: python3.6
-    unit_py3_4: python3.4
-    unit_py2_7: python2.7
 envdir =
     {check,packagedoc,doc,doc_travis}: {toxworkdir}/3
     unit_py3_7: {toxworkdir}/3.7
     unit_py3_6: {toxworkdir}/3.6
-    unit_py3_4: {toxworkdir}/3.4
-    unit_py2_7: {toxworkdir}/2.7
 passenv =
     *
 usedevelop = True
 deps =
     -r.virtualenv.dev-requirements.txt
-
-
-# Unit Test run with basepython set to 2.7
-[testenv:unit_py2_7]
-skip_install = True
-usedevelop = True
-setenv =
-    PYTHONPATH={toxinidir}/test
-    PYTHONUNBUFFERED=yes
-    WITH_COVERAGE=yes
-passenv =
-    *
-deps = {[testenv]deps}
-changedir=test/unit
-commands =
-    bash -c 'cd ../../ && ./setup.py develop'
-    pytest --no-cov-on-fail --cov=kiwi \
-        --cov-report=term-missing \
-        --cov-fail-under=100 --cov-config .coveragerc {posargs}
-
-
-# Unit Test run with basepython set to 3.4
-[testenv:unit_py3_4]
-skip_install = True
-usedevelop = True
-setenv =
-    PYTHONPATH={toxinidir}/test
-    PYTHONUNBUFFERED=yes
-    WITH_COVERAGE=yes
-passenv =
-    *
-deps = {[testenv]deps}
-changedir=test/unit
-commands =
-    bash -c 'cd ../../ && ./setup.py develop'
-    pytest --no-cov-on-fail --cov=kiwi \
-        --cov-report=term-missing \
-        --cov-fail-under=100 --cov-config .coveragerc {posargs}
 
 
 # Unit Test run with basepython set to 3.6
@@ -99,6 +55,7 @@ commands =
         --cov-report=term-missing \
         --cov-fail-under=100 --cov-config .coveragerc {posargs}
 
+
 # Unit Test run with basepython set to 3.7
 [testenv:unit_py3_7]
 skip_install = True
@@ -116,6 +73,7 @@ commands =
     pytest --doctest-modules --no-cov-on-fail --cov=kiwi \
         --cov-report=term-missing --cov-fail-under=100 \
         --cov-config .coveragerc {posargs}
+
 
 # Documentation build run suitable for doc deployment in package(rpm)
 [testenv:packagedoc]


### PR DESCRIPTION
Python2 is announced to be unmaintained from Jan 2020.
KIWI supports Python 2.7 and it should not support any python version that
is not maintained upstream. This Fixes #1036

